### PR TITLE
fix(docs): controller -> manager in CLI examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Combining Fleet with a Git based workflow like Github Actions one can automate m
    to access the cluster.
     ```shell
     # Kubeconfig should point to CONTROLLER cluster
-    fleet install controller | kubectl apply -f -
+    fleet install manager | kubectl apply -f -
     ```
 3. Generate cluster group token to register clusters
     ```shell script

--- a/docs/install.md
+++ b/docs/install.md
@@ -46,14 +46,14 @@ a Kubernetes controller based architecture to 100's of millions of objects and b
 ### Manager installation
 
 The controller is just a deployment that runs in a Kubernetes cluster.  It is assumed you already have a Kubernetes
-cluster available.  The `fleet install controller` command is used to generate a manifest for installation.
-The `fleet install controller` command does not need a live connection to a Kubernetes cluster.
+cluster available.  The `fleet install manager` command is used to generate a manifest for installation.
+The `fleet install manager` command does not need a live connection to a Kubernetes cluster.
 
 ```
 Generate deployment manifest to run the fleet controller
 
 Usage:
-  fleet install controller [flags]
+  fleet install manager [flags]
 
 Flags:
       --agent-image string        Image to use for all agents
@@ -67,7 +67,7 @@ Global Flags:
   -n, --namespace string    namespace (default "default")
 ```
 
-Installation is accomplished typically by doing `fleet install controller | kubectl apply -f -`. The `agent-image` and
+Installation is accomplished typically by doing `fleet install manager | kubectl apply -f -`. The `agent-image` and
 `controller-image` fields are important if you wish to run Fleet from a private registry.  The `system-namespace` is the
 namespace the fleet controller runs in and also the namespace the cluster agents will run in all clusters.  This is
 by default `fleet-system` and it is recommended to keep the default value.


### PR DESCRIPTION
Signed-off-by: danmx <daniel@iziourov.info>

There is not `controller` command available anymore

```console
$ fleet help install
Generate manifests for installing server and agent

Usage:
  flt install [command]

Available Commands:
  agent-config Generate cluster specific agent config
  agent-token  Generate cluster group token and render manifest to register clusters into a specific cluster group
  manager      Generate deployment manifest to run the fleet controller
  simulator    Generate manifest to install a cluster simulator

Flags:
  -h, --help   help for install

Global Flags:
  -k, --kubeconfig string   kubeconfig for authentication
  -n, --namespace string    namespace (default "default")

Use "flt install [command] --help" for more information about a command.
```

```console
$ fleet help install manager
Generate deployment manifest to run the fleet controller

Usage:
  flt install manager [flags]

Flags:
      --agent-image string        Image to use for all agents
      --crds-only                 Output CustomResourceDefinitions only
  -h, --help                      help for manager
      --manager-image string      Image to use for controller
      --system-namespace string   Namespace that will be use in controller and agent cluster (default "fleet-system")

Global Flags:
  -k, --kubeconfig string   kubeconfig for authentication
  -n, --namespace string    namespace (default "default")
```