### PR TITLE
Fix CLI helper menu fleet name

### DIFF
--- a/modules/cli/cmds/root.go
+++ b/modules/cli/cmds/root.go
@@ -13,7 +13,7 @@ var (
 )
 
 func App() *cobra.Command {
-	root := command.Command(&Flt{}, cobra.Command{
+	root := command.Command(&Fleet{}, cobra.Command{
 		Version: version.FriendlyVersion(),
 	})
 
@@ -27,16 +27,16 @@ func App() *cobra.Command {
 	return root
 }
 
-type Flt struct {
+type Fleet struct {
 	Namespace  string `usage:"namespace" env:"NAMESPACE" default:"default" short:"n" env:"NAMESPACE"`
 	Kubeconfig string `usage:"kubeconfig for authentication" short:"k"`
 }
 
-func (r *Flt) Run(cmd *cobra.Command, args []string) error {
+func (r *Fleet) Run(cmd *cobra.Command, args []string) error {
 	return cmd.Help()
 }
 
-func (r *Flt) PersistentPre(cmd *cobra.Command, args []string) error {
+func (r *Fleet) PersistentPre(cmd *cobra.Command, args []string) error {
 	Debug.MustSetupDebug()
 	Client = client.NewGetter(r.Kubeconfig, r.Namespace)
 	return nil


### PR DESCRIPTION
Ref: https://github.com/rancher/fleet/issues/18
 
# Before
```
Usage:
  flt [flags]
  flt [command]

Available Commands:
  apply       Render a bundle into a Kubernetes resource and apply it in the Fleet Manager
  help        Help about any command
  install     Generate manifests for installing server and agent
  test        Match a bundle to a target and render the output

Flags:
      --debug               Turn on debug logging
      --debug-level int     If debugging is enabled, set klog -v=X
  -h, --help                help for flt
  -k, --kubeconfig string   kubeconfig for authentication
  -n, --namespace string    namespace (default "default")
  -v, --version             version for flt

Use "flt [command] --help" for more information about a command.
```

# After
```
Usage:
  fleet [flags]
  fleet [command]

Available Commands:
  apply       Render a bundle into a Kubernetes resource and apply it in the Fleet Manager
  help        Help about any command
  install     Generate manifests for installing server and agent
  test        Match a bundle to a target and render the output

Flags:
      --debug               Turn on debug logging
      --debug-level int     If debugging is enabled, set klog -v=X
  -h, --help                help for fleet
  -k, --kubeconfig string   kubeconfig for authentication
  -n, --namespace string    namespace (default "default")
  -v, --version             version for fleet

Use "fleet [command] --help" for more information about a command.
```

Signed-off-by: Chin-Ya Huang <chin-ya.huang@suse.com>