### PR TITLE
Adding fixes to pass hardened profile of CIS scan 

### DIFF
--- a/charts/fleet-agent/templates/network_policy_allow_all.yaml
+++ b/charts/fleet-agent/templates/network_policy_allow_all.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-allow-all
+  namespace: {{ .Values.internal.systemNamespace }}
+spec:
+  podSelector: {}
+  ingress:
+  - {}
+  egress:
+  - {}
+  policyTypes:
+  - Ingress
+  - Egress

--- a/charts/fleet-agent/templates/patch_default_serviceaccount.yaml
+++ b/charts/fleet-agent/templates/patch_default_serviceaccount.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: patch-fleet-sa
+  annotations:
+    "helm.sh/hook": post-install, post-upgrade
+    "helm.sh/hook-delete-policy": hook-succeeded, before-hook-creation
+spec:
+  template:
+    spec:
+      serviceAccountName: fleet-agent
+      restartPolicy: Never
+      containers:
+      - name: sa
+        image: "{{ template "system_default_registry" . }}{{ .Values.global.kubectl.repository }}:{{ .Values.global.kubectl.tag }}"
+        imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+        command: ["kubectl", "patch", "serviceaccount", "default", "-p", "{\"automountServiceAccountToken\": false}"]
+        args: ["-n", {{ .Values.internal.systemNamespace }}]
+  backoffLimit: 1

--- a/charts/fleet-agent/values.yaml
+++ b/charts/fleet-agent/values.yaml
@@ -34,4 +34,6 @@ internal:
 global:
   cattle:
     systemDefaultRegistry: ""
-
+  kubectl:
+    repository: rancher/kubectl
+    tag: v1.18.6


### PR DESCRIPTION
1) Adding a post-install hook to patch the default serviceaccount of fleet-system namespace
2) Adding a default network_policy to the namespace to pass CIS

https://github.com/rancher/cis-operator/issues/11