### PR TITLE
Fix packaging script that does tag replacement to only replace dev tag

### DIFF
--- a/scripts/package-helm
+++ b/scripts/package-helm
@@ -33,7 +33,7 @@ sed -i \
     build/charts/fleet-agent/Chart.yaml
 
 sed -i \
-    -e 's/tag:.*/tag: '${HELM_TAG}'/' \
+    -e 's/tag: dev/tag: '${HELM_TAG}'/' \
     build/charts/fleet-agent/values.yaml
 
 go run ./pkg/codegen crds ./build/charts/fleet-crd/templates/crds.yaml


### PR DESCRIPTION
https://github.com/rancher/fleet/issues/94

Following kubectl image's tag in the  fleet-agent chart should not be replaced when we package fleet-agent chart:

```
  kubectl:
    repository: rancher/kubectl
    tag: v1.18.6
```

Otherwise the fleet-agent chart gets the wrong kubectl image tag which cause the post install hook to not work. 

Currently this is what gets generated under rancher/charts/fleet-agent/Values.yaml
```
  kubectl:
    repository: rancher/kubectl
    tag: v0.3.0-beta3
```

Hence fixing the script to only replace tags `dev` 
