### PR TITLE
Allow mkdocs development on Mac

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ TARGETS := $(shell ls scripts)
 	@mv .dapper.tmp .dapper
 
 serve-docs: mkdocs
-	docker run --net=host --rm -it -v $${PWD}:/docs mkdocs serve
+	docker run -p 8000:8000 --rm -it -v $${PWD}:/docs mkdocs serve -a 0.0.0.0:8000
 
 mkdocs:
 	docker build -t mkdocs -f Dockerfile.docs .

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: Fleet - GitOps at Scale
 repo_url: https://github.com/rancher/fleet
-strict: true
+strict: false
 theme:
   name: material
   palette:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,7 @@
 site_name: Fleet - GitOps at Scale
 repo_url: https://github.com/rancher/fleet
-strict: false
+# Set to false for local docs development
+strict: true
 theme:
   name: material
   palette:


### PR DESCRIPTION
(because Linux desktop users only care about themselves)

Couldn't run the docs from a mac using `make serve-docs`. There were a
couple problems:
- --net=host wouldn't allow for port forwarding, needed to use a
specific port instead
- mkdocs serve only listens on localhost by default, needed to tell it
to listen on all interfaces
- listening on all interfaces caused mkdocs to emit a warning and
strict=true means that would cause it to immediately exit, needed to
turn off strict mode :grimace: