### PR TITLE
Fix overlays definition in example fleet.yaml in docs

### DIFF
--- a/docs/gitrepo-structure.md
+++ b/docs/gitrepo-structure.md
@@ -130,9 +130,10 @@ targetCustomizations:
   # A file named ./overlays/myoverlay/subdir/resource_patch.yaml will patch the base file.
   # A patch can in JSON Patch or JSON Merge format or a strategic merge patch for builtin
   # Kubernetes types. Refer to "Raw YAML Resource Customization" below for more information.
-  overlays:
-  - custom2
-  - custom3
+  yaml:
+    overlays:
+    - custom2
+    - custom3
   # A selector used to match clusters.  The structure is the standard
   # metav1.LabelSelector format. If clusterGroupSelector or clusterGroup is specified,
   # clusterSelector will be used only to further refine the selection after


### PR DESCRIPTION
In fleet 0.3.0 the list of yaml overlays must be in a yaml object instead of directly in the customization object (https://github.com/rancher/fleet/blob/786b72d2c0093f21f3a565efc86d083e7555dd1a/pkg/apis/fleet.cattle.io/v1alpha1/bundle.go#L175)
