### PR TITLE
Add HTTP proxy settings to fleet gitjob subchart

### DIFF
--- a/charts/fleet/charts/gitjob/templates/deployment.yaml
+++ b/charts/fleet/charts/gitjob/templates/deployment.yaml
@@ -24,3 +24,11 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+{{- if .Values.proxy }}
+            - name: HTTP_PROXY
+              value: {{ .Values.proxy }}
+            - name: HTTPS_PROXY
+              value: {{ .Values.proxy }}
+            - name: NO_PROXY
+              value: {{ .Values.noProxy }}
+{{- end }}

--- a/charts/fleet/charts/gitjob/values.yaml
+++ b/charts/fleet/charts/gitjob/values.yaml
@@ -14,4 +14,4 @@ global:
 # proxy: http://<username>@<password>:<url>:<port>
 
 # comma separated list of domains or ip addresses that will not use the proxy
-noProxy: 127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16
+noProxy: 127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,.svc,.cluster.local

--- a/charts/fleet/charts/gitjob/values.yaml
+++ b/charts/fleet/charts/gitjob/values.yaml
@@ -9,3 +9,9 @@ tekton:
 global:
   cattle:
     systemDefaultRegistry: ""
+
+# http[s] proxy server
+# proxy: http://<username>@<password>:<url>:<port>
+
+# comma separated list of domains or ip addresses that will not use the proxy
+noProxy: 127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16


### PR DESCRIPTION
This PR adds support for HTTP proxy settings to [`gitjob`](https://github.com/rancher/gitjob) controller.
The change complements https://github.com/rancher/gitjob/pull/20, as `gitjob` is deployed together with `fleet` as subchart.