### PR TITLE
Add Windows support and consolidate drone pipelines

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,22 +1,19 @@
 ---
 kind: pipeline
-name: amd64
-
+name: linux-amd64
 platform:
   os: linux
   arch: amd64
-
 steps:
 - name: build
-  image: rancher/dapper:v0.4.1
+  image: rancher/dapper:v0.5.5
   environment:
-    CROSS: "true"
+    CROSS: "windows"
   commands:
   - dapper ci
   volumes:
   - name: docker
     path: /var/run/docker.sock
-
 - name: github_binary_release
   image: plugins/github-release
   settings:
@@ -37,7 +34,34 @@ steps:
     - refs/tags/*
     event:
     - tag
-
+- name: upload-tag
+  pull: default
+  image: plugins/gcs
+  settings:
+    acl:
+      - allUsers:READER
+    cache_control: "no-cache,must-revalidate"
+    source: ./dist/artifacts
+    target: releases.rancher.com/fleet/${DRONE_TAG}
+    token:
+      from_secret: google_auth_key
+  when:
+    event:
+      - tag
+- name: upload-latest
+  pull: default
+  image: plugins/gcs
+  settings:
+    acl:
+      - allUsers:READER
+    cache_control: "no-cache,must-revalidate"
+    source: ./dist/artifacts
+    target: releases.rancher.com/fleet/latest
+    token:
+      from_secret: google_auth_key
+  when:
+    event:
+      - tag
 - name: docker-publish-agent
   image: plugins/docker
   settings:
@@ -45,9 +69,11 @@ steps:
     password:
       from_secret: docker_password
     repo: "rancher/fleet-agent"
-    tag: "${DRONE_TAG}-amd64"
+    tag: "${DRONE_TAG}-linux-amd64"
     username:
       from_secret: docker_username
+    build_args:
+      - "ARCH=amd64"
   when:
     instance:
     - drone-publish.rancher.io
@@ -56,7 +82,6 @@ steps:
     - refs/tags/*
     event:
     - tag
-
 - name: docker-publish
   image: plugins/docker
   settings:
@@ -64,9 +89,11 @@ steps:
     password:
       from_secret: docker_password
     repo: "rancher/fleet"
-    tag: "${DRONE_TAG}-amd64"
+    tag: "${DRONE_TAG}-linux-amd64"
     username:
       from_secret: docker_username
+    build_args:
+      - "ARCH=amd64"
   when:
     instance:
     - drone-publish.rancher.io
@@ -75,29 +102,24 @@ steps:
     - refs/tags/*
     event:
     - tag
-
 volumes:
 - name: docker
   host:
     path: /var/run/docker.sock
-
 ---
 kind: pipeline
-name: arm64
-
+name: linux-arm64
 platform:
   os: linux
   arch: arm64
-
 steps:
 - name: build
-  image: rancher/dapper:v0.4.1
+  image: rancher/dapper:v0.5.5
   commands:
-  - dapper ci
+  - dapper build
   volumes:
   - name: docker
     path: /var/run/docker.sock
-
 - name: github_binary_release
   image: plugins/github-release
   settings:
@@ -118,7 +140,6 @@ steps:
     - refs/tags/*
     event:
     - tag
-
 - name: docker-publish-agent
   image: plugins/docker
   settings:
@@ -126,9 +147,11 @@ steps:
     password:
       from_secret: docker_password
     repo: "rancher/fleet-agent"
-    tag: "${DRONE_TAG}-arm64"
+    tag: "${DRONE_TAG}-linux-arm64"
     username:
       from_secret: docker_username
+    build_args:
+      - "ARCH=arm64"
   when:
     instance:
     - drone-publish.rancher.io
@@ -137,7 +160,6 @@ steps:
     - refs/tags/*
     event:
     - tag
-
 - name: docker-publish
   image: plugins/docker
   settings:
@@ -145,9 +167,11 @@ steps:
     password:
       from_secret: docker_password
     repo: "rancher/fleet"
-    tag: "${DRONE_TAG}-arm64"
+    tag: "${DRONE_TAG}-linux-arm64"
     username:
       from_secret: docker_username
+    build_args:
+      - "ARCH=arm64"
   when:
     instance:
     - drone-publish.rancher.io
@@ -156,29 +180,25 @@ steps:
     - refs/tags/*
     event:
     - tag
-
 volumes:
 - name: docker
   host:
     path: /var/run/docker.sock
-
 ---
 kind: pipeline
-name: arm
-
+name: linux-arm
 platform:
   os: linux
   arch: arm
-
 steps:
+# Update this tag once dapper arm v7 works on drone.
 - name: build
   image: rancher/dapper:v0.4.1
   commands:
-  - dapper ci
+  - dapper build
   volumes:
   - name: docker
     path: /var/run/docker.sock
-
 - name: github_binary_release
   image: plugins/github-release
   settings:
@@ -199,7 +219,6 @@ steps:
     - refs/tags/*
     event:
     - tag
-
 - name: docker-publish-agent
   image: plugins/docker
   settings:
@@ -207,9 +226,11 @@ steps:
     password:
       from_secret: docker_password
     repo: "rancher/fleet-agent"
-    tag: "${DRONE_TAG}-arm"
+    tag: "${DRONE_TAG}-linux-arm"
     username:
       from_secret: docker_username
+    build_args:
+      - "ARCH=arm"
   when:
     instance:
     - drone-publish.rancher.io
@@ -218,7 +239,6 @@ steps:
     - refs/tags/*
     event:
     - tag
-
 - name: docker-publish
   image: plugins/docker
   settings:
@@ -226,9 +246,11 @@ steps:
     password:
       from_secret: docker_password
     repo: "rancher/fleet"
-    tag: "${DRONE_TAG}-arm"
+    tag: "${DRONE_TAG}-linux-arm"
     username:
       from_secret: docker_username
+    build_args:
+      - "ARCH=arm"
   when:
     instance:
     - drone-publish.rancher.io
@@ -237,20 +259,194 @@ steps:
     - refs/tags/*
     event:
     - tag
-
 volumes:
 - name: docker
   host:
     path: /var/run/docker.sock
-
+---
+kind: pipeline
+name: windows-amd64-1809
+platform:
+  os: windows
+  arch: amd64
+  version: 1809
+steps:
+- name: docker-publish-agent
+  image: plugins/docker
+  settings:
+    dockerfile: package/windows/Dockerfile.agent
+    password:
+      from_secret: docker_password
+    repo: "rancher/fleet-agent"
+    tag: "${DRONE_TAG}-windows-amd64-1809"
+    username:
+      from_secret: docker_username
+    build_args:
+      - "SERVERCORE_VERSION=1809"
+      - "RELEASES=releases.rancher.com"
+      - "VERSION=${DRONE_TAG}"
+    context: package/
+    custom_dns: 1.1.1.1
+  volumes:
+    - name: docker
+      path: \\\\.\\pipe\\docker_engine
+  when:
+    instance:
+    - drone-publish.rancher.io
+    ref:
+    - refs/head/master
+    - refs/tags/*
+    event:
+    - tag
+volumes:
+  - name: docker
+    host:
+      path: \\\\.\\pipe\\docker_engine
+depends_on:
+- linux-amd64
+---
+kind: pipeline
+name: windows-amd64-1909
+platform:
+  os: windows
+  arch: amd64
+  version: 1909
+steps:
+- name: docker-publish-agent
+  image: plugins/docker
+  settings:
+    dockerfile: package/windows/Dockerfile.agent
+    password:
+      from_secret: docker_password
+    repo: "rancher/fleet-agent"
+    tag: "${DRONE_TAG}-windows-amd64-1909"
+    username:
+      from_secret: docker_username
+    build_args:
+      - "SERVERCORE_VERSION=1909"
+      - "RELEASES=releases.rancher.com"
+      - "VERSION=${DRONE_TAG}"
+    context: package/
+    custom_dns: 1.1.1.1
+  volumes:
+    - name: docker
+      path: \\\\.\\pipe\\docker_engine
+  when:
+    instance:
+    - drone-publish.rancher.io
+    ref:
+    - refs/head/master
+    - refs/tags/*
+    event:
+    - tag
+volumes:
+  - name: docker
+    host:
+      path: \\\\.\\pipe\\docker_engine
+depends_on:
+- linux-amd64
+---
+kind: pipeline
+name: windows-amd64-2004
+platform:
+  os: windows
+  arch: amd64
+  version: 2004
+# remove this and use upstream images when https://github.com/drone/drone-git/pull/25 is merged
+clone:
+  disable: true
+steps:
+- name: clone
+  image: luthermonson/drone-git:windows-2004-amd64
+  settings:
+    depth: 1
+- name: docker-publish-agent
+  image: luthermonson/drone-docker:2004
+  settings:
+    dockerfile: package/windows/Dockerfile.agent
+    password:
+      from_secret: docker_password
+    repo: "rancher/fleet-agent"
+    tag: "${DRONE_TAG}-windows-amd64-2004"
+    username:
+      from_secret: docker_username
+    build_args:
+      - "SERVERCORE_VERSION=2004"
+      - "RELEASES=releases.rancher.com"
+      - "VERSION=${DRONE_TAG}"
+    context: package/
+    custom_dns: 1.1.1.1
+  volumes:
+    - name: docker
+      path: \\\\.\\pipe\\docker_engine
+  when:
+    instance:
+    - drone-publish.rancher.io
+    ref:
+    - refs/head/master
+    - refs/tags/*
+    event:
+    - tag
+volumes:
+  - name: docker
+    host:
+      path: \\\\.\\pipe\\docker_engine
+depends_on:
+- linux-amd64
+---
+kind: pipeline
+name: windows-amd64-20H2
+platform:
+  os: windows
+  arch: amd64
+  version: 20H2
+# remove this and use upstream images when https://github.com/drone/drone-git/pull/25 is merged
+clone:
+  disable: true
+steps:
+- name: clone
+  image: luthermonson/drone-git:windows-20H2-amd64
+  settings:
+    depth: 1
+- name: docker-publish-agent
+  image: luthermonson/drone-docker:20H2
+  settings:
+    dockerfile: package/windows/Dockerfile.agent
+    password:
+      from_secret: docker_password
+    repo: "rancher/fleet-agent"
+    tag: "${DRONE_TAG}-windows-amd64-20H2"
+    username:
+      from_secret: docker_username
+    build_args:
+      - "SERVERCORE_VERSION=20H2"
+      - "RELEASES=releases.rancher.com"
+      - "VERSION=${DRONE_TAG}"
+    context: package/
+    custom_dns: 1.1.1.1
+  volumes:
+    - name: docker
+      path: \\\\.\\pipe\\docker_engine
+  when:
+    instance:
+    - drone-publish.rancher.io
+    ref:
+    - refs/head/master
+    - refs/tags/*
+    event:
+    - tag
+volumes:
+  - name: docker
+    host:
+      path: \\\\.\\pipe\\docker_engine
+depends_on:
+- linux-amd64
 ---
 kind: pipeline
 name: manifest
-
 platform:
   os: linux
   arch: amd64
-
 steps:
 - name: manifest
   image: plugins/manifest:1.0.2
@@ -259,12 +455,7 @@ steps:
       from_secret: docker_username
     password:
       from_secret: docker_password
-    platforms:
-      - linux/amd64
-      - linux/arm64
-      - linux/arm
-    target: "rancher/fleet:${DRONE_TAG}"
-    template: "rancher/fleet:${DRONE_TAG}-ARCH"
+    spec: manifest.tmpl
   when:
     instance:
     - drone-publish.rancher.io
@@ -280,12 +471,7 @@ steps:
       from_secret: docker_username
     password:
       from_secret: docker_password
-    platforms:
-      - linux/amd64
-      - linux/arm64
-      - linux/arm
-    target: "rancher/fleet-agent:${DRONE_TAG}"
-    template: "rancher/fleet-agent:${DRONE_TAG}-ARCH"
+    spec: manifest-agent.tmpl
   when:
     instance:
     - drone-publish.rancher.io
@@ -294,22 +480,22 @@ steps:
     - refs/tags/*
     event:
     - tag
-
 depends_on:
-- amd64
-- arm64
-- arm
-
+- linux-amd64
+- linux-arm64
+- linux-arm
+- windows-amd64-1809
+- windows-amd64-1909
+- windows-amd64-2004
+- windows-amd64-20H2
 ---
 kind: pipeline
 name: gorelease
-
 steps:
   - name: fetch
     image: docker:git
     commands:
       - git fetch --tags
-
   - name: release
     image: golang
     environment:
@@ -325,6 +511,5 @@ steps:
         - refs/tags/*
       event:
         - tag
-
 depends_on:
-  - manifest
+- manifest

--- a/charts/fleet-agent/templates/deployment.yaml
+++ b/charts/fleet-agent/templates/deployment.yaml
@@ -20,3 +20,11 @@ spec:
         image: '{{ template "system_default_registry" . }}{{.Values.image.repository}}:{{.Values.image.tag}}'
         name: fleet-agent
       serviceAccountName: fleet-agent
+      {{- with .Values.fleetAgent.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.fleetAgent.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/fleet-agent/templates/patch_default_serviceaccount.yaml
+++ b/charts/fleet-agent/templates/patch_default_serviceaccount.yaml
@@ -17,4 +17,12 @@ spec:
         imagePullPolicy: {{ .Values.global.imagePullPolicy }}
         command: ["kubectl", "patch", "serviceaccount", "default", "-p", "{\"automountServiceAccountToken\": false}"]
         args: ["-n", {{ .Values.internal.systemNamespace }}]
+      {{- with .Values.kubectl.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.kubectl.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
   backoffLimit: 1

--- a/charts/fleet-agent/values.yaml
+++ b/charts/fleet-agent/values.yaml
@@ -31,6 +31,19 @@ internal:
   systemNamespace: fleet-system
   managedReleaseName: fleet-agent
 
+# The nodeSelector and tolerations for the agent deployment
+fleetAgent:
+  nodeSelector: {}
+  tolerations: []
+kubectl:
+  nodeSelector:
+    kubernetes.io/os: linux
+  tolerations:
+    - key: cattle.io/os
+      operator: "Equal"
+      value: "linux"
+      effect: NoSchedule
+
 global:
   cattle:
     systemDefaultRegistry: ""

--- a/charts/fleet/templates/deployment.yaml
+++ b/charts/fleet/templates/deployment.yaml
@@ -21,3 +21,11 @@ spec:
         name: fleet-controller
         imagePullPolicy: "{{ .Values.image.imagePullPolicy }}"
       serviceAccountName: fleet-controller
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/fleet/values.yaml
+++ b/charts/fleet/values.yaml
@@ -36,3 +36,12 @@ bootstrap:
 global:
   cattle:
     systemDefaultRegistry: ""
+
+nodeSelector:
+  kubernetes.io/os: linux
+
+tolerations:
+  - key: cattle.io/os
+    operator: "Equal"
+    value: "linux"
+    effect: NoSchedule

--- a/manifest-agent.tmpl
+++ b/manifest-agent.tmpl
@@ -1,0 +1,41 @@
+image: rancher/fleet-agent:{{#if build.tag}}{{build.tag}}{{else}}{{replace "release/" "" build.branch }}-head{{/if}}
+manifests:
+  -
+    image: rancher/fleet-agent:{{#if build.tag}}{{build.tag}}{{else}}{{replace "release/" "" build.branch }}-head{{/if}}-linux-amd64
+    platform:
+      architecture: amd64
+      os: linux
+  -
+    image: rancher/fleet-agent:{{#if build.tag}}{{build.tag}}{{else}}{{replace "release/" "" build.branch }}-head{{/if}}-linux-arm
+    platform:
+      architecture: arm
+      os: linux
+  -
+    image: rancher/fleet-agent:{{#if build.tag}}{{build.tag}}{{else}}{{replace "release/" "" build.branch }}-head{{/if}}-linux-arm64
+    platform:
+      architecture: arm64
+      os: linux
+  -
+    image: rancher/fleet-agent:{{#if build.tag}}{{build.tag}}{{else}}{{replace "release/" "" build.branch }}-head{{/if}}-windows-amd64-1809
+    platform:
+      architecture: amd64
+      os: windows
+      version: 1809
+  -
+    image: rancher/fleet-agent:{{#if build.tag}}{{build.tag}}{{else}}{{replace "release/" "" build.branch }}-head{{/if}}-windows-amd64-1909
+    platform:
+      architecture: amd64
+      os: windows
+      version: 1909
+  -
+    image: rancher/fleet-agent:{{#if build.tag}}{{build.tag}}{{else}}{{replace "release/" "" build.branch }}-head{{/if}}-windows-amd64-2004
+    platform:
+      architecture: amd64
+      os: windows
+      version: 2004
+  -
+    image: rancher/fleet-agent:{{#if build.tag}}{{build.tag}}{{else}}{{replace "release/" "" build.branch }}-head{{/if}}-windows-amd64-20H2
+    platform:
+      architecture: amd64
+      os: windows
+      version: 20H2

--- a/manifest.tmpl
+++ b/manifest.tmpl
@@ -1,0 +1,17 @@
+image: rancher/fleet:{{#if build.tag}}{{build.tag}}{{else}}{{replace "release/" "" build.branch }}-head{{/if}}
+manifests:
+  -
+    image: rancher/fleet:{{#if build.tag}}{{build.tag}}{{else}}{{replace "release/" "" build.branch }}-head{{/if}}-linux-amd64
+    platform:
+      architecture: amd64
+      os: linux
+  -
+    image: rancher/fleet:{{#if build.tag}}{{build.tag}}{{else}}{{replace "release/" "" build.branch }}-head{{/if}}-linux-arm
+    platform:
+      architecture: arm
+      os: linux
+  -
+    image: rancher/fleet:{{#if build.tag}}{{build.tag}}{{else}}{{replace "release/" "" build.branch }}-head{{/if}}-linux-arm64
+    platform:
+      architecture: arm64
+      os: linux

--- a/modules/cli/controllermanifest/template.go
+++ b/modules/cli/controllermanifest/template.go
@@ -63,7 +63,7 @@ func objects(namespace, controllerImage string, cfg string, crdsOnly bool) ([]ru
 	objs := []runtime.Object{
 		basic.Namespace(namespace),
 		serviceAccount,
-		basic.Deployment(namespace, genericName, controllerImage, "", serviceAccount.Name),
+		basic.Deployment(namespace, genericName, controllerImage, "", serviceAccount.Name, true),
 		basic.ConfigMap(namespace, config.ManagerConfigName, config.Key, cfg),
 	}
 

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,4 +1,6 @@
 FROM alpine:3.12.3
-COPY bin/fleetcontroller /usr/bin/
+ARG ARCH
+ENV ARCH=$ARCH
+COPY bin/fleetcontroller-linux-${ARCH} /usr/bin/fleetcontroller
 USER 1000
 CMD ["fleetcontroller"]

--- a/package/Dockerfile-windows.agent
+++ b/package/Dockerfile-windows.agent
@@ -1,0 +1,28 @@
+ARG SERVERCORE_VERSION
+FROM mcr.microsoft.com/windows/servercore:${SERVERCORE_VERSION}
+ARG RELEASES
+ARG VERSION
+ENV RELEASES=$RELEASES
+ENV VERSION=$VERSION
+SHELL ["powershell", "-NoLogo", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+RUN pushd c:\; \
+    $URL = 'https://github.com/git-for-windows/git/releases/download/v2.29.2.windows.3/MinGit-2.29.2.3-64-bit.zip'; \
+    \
+    Write-Host ('Downloading git from {0} ...' -f $URL); \
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+    Invoke-WebRequest -UseBasicParsing -OutFile c:\git.zip -Uri $URL; \
+    \
+    Write-Host 'Expanding ...'; \
+    Expand-Archive -Force -Path c:\git.zip -DestinationPath c:\git\.; \
+    \
+    Write-Host 'Cleaning ...'; \
+    Remove-Item -Force -Recurse -Path c:\git.zip; \
+    \
+    Write-Host 'Complete.'; \
+    popd;
+RUN $URL = 'https://{0}/fleet/{1}/fleetagent-windows-amd64.exe' -f $env:RELEASES, $env:VERSION; \
+    New-Item -Path 'c:\\' -Name 'fleet' -ItemType 'directory'; \
+    Write-Host ('Downloading dapper from {0} ...' -f $URL); \
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+    Invoke-WebRequest -UseBasicParsing -OutFile c:/fleet/fleetagent-windows.exe -Uri $URL;
+CMD ["C:\fleet\fleetagent-windows.exe"]

--- a/package/Dockerfile.agent
+++ b/package/Dockerfile.agent
@@ -1,4 +1,8 @@
 FROM alpine:3.12.3
+ARG ARCH
+ENV ARCH=$ARCH
 RUN apk add -U --no-cache git bash
-COPY bin/fleetagent bin/fleet package/log.sh /usr/bin/
+COPY bin/fleetagent-linux-$ARCH /usr/bin/fleetagent
+COPY bin/fleet-linux-$ARCH /usr/bin/fleet
+COPY package/log.sh /usr/bin/
 CMD ["fleetagent"]

--- a/pkg/agent/manifest.go
+++ b/pkg/agent/manifest.go
@@ -32,7 +32,7 @@ func Manifest(namespace, image, pullPolicy, generation, checkInInterval string) 
 		},
 	)
 
-	dep := basic.Deployment(namespace, DefaultName, image, pullPolicy, DefaultName)
+	dep := basic.Deployment(namespace, DefaultName, image, pullPolicy, DefaultName, false)
 	dep.Spec.Template.Spec.Containers[0].Env = append(dep.Spec.Template.Spec.Containers[0].Env,
 		corev1.EnvVar{
 			Name:  "CHECKIN_INTERVAL",

--- a/pkg/basic/objects.go
+++ b/pkg/basic/objects.go
@@ -40,8 +40,9 @@ func Namespace(name string) *corev1.Namespace {
 	}
 
 }
-func Deployment(namespace, name, image, imagePullPolicy, serviceAccount string) *appsv1.Deployment {
-	return &appsv1.Deployment{
+
+func Deployment(namespace, name, image, imagePullPolicy, serviceAccount string, linuxOnly bool) *appsv1.Deployment {
+	deployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
 			Name:      name,
@@ -81,6 +82,16 @@ func Deployment(namespace, name, image, imagePullPolicy, serviceAccount string) 
 			},
 		},
 	}
+	if linuxOnly {
+		deployment.Spec.Template.Spec.NodeSelector = map[string]string{"kubernetes.io/os": "linux"}
+		deployment.Spec.Template.Spec.Tolerations = []corev1.Toleration{{
+			Key:      "cattle.io/os",
+			Operator: "Equal",
+			Value:    "linux",
+			Effect:   "NoSchedule",
+		}}
+	}
+	return deployment
 }
 
 func ServiceAccount(namespace, name string) *corev1.ServiceAccount {

--- a/pkg/controllers/git/git.go
+++ b/pkg/controllers/git/git.go
@@ -426,6 +426,13 @@ func (h *handler) OnChange(gitrepo *fleet.GitRepo, status fleet.GitRepoStatus) (
 									},
 								},
 							},
+							NodeSelector: map[string]string{"kubernetes.io/os": "linux"},
+							Tolerations: []corev1.Toleration{{
+								Key:      "cattle.io/os",
+								Operator: "Equal",
+								Value:    "linux",
+								Effect:   "NoSchedule",
+							}},
 						},
 					},
 				},

--- a/scripts/build
+++ b/scripts/build
@@ -6,16 +6,50 @@ source $(dirname $0)/version
 cd $(dirname $0)/..
 
 mkdir -p bin
-if [ "$(uname)" = "Linux" ]; then
-    OTHER_LINKFLAGS="-extldflags -static"
-fi
+
 LINKFLAGS="-X github.com/rancher/fleet/pkg/version.Version=$VERSION"
 LINKFLAGS="-X github.com/rancher/fleet/pkg/version.GitCommit=$COMMIT $LINKFLAGS"
 LINKFLAGS="-s -w $LINKFLAGS"
-CGO_ENABLED=0 go build -ldflags "$LINKFLAGS $OTHER_LINKFLAGS" -o bin/fleet
-CGO_ENABLED=0 go build -ldflags "$LINKFLAGS $OTHER_LINKFLAGS" -o bin/fleetcontroller ./cmd/fleetcontroller
-CGO_ENABLED=0 go build -ldflags "$LINKFLAGS $OTHER_LINKFLAGS" -o bin/fleetagent ./cmd/fleetagent
-if [ "$CROSS" = "true" ] && [ "$ARCH" = "amd64" ]; then
-    GOOS=darwin go build -ldflags "$LINKFLAGS" -o bin/fleet-darwin${SUFFIX}
-    GOOS=windows go build -ldflags "$LINKFLAGS" -o bin/fleet-windows${SUFFIX}
+OTHER_LINKFLAGS="-extldflags -static"
+
+function build-binaries() {
+    printf "Building for ${1}-${2} ...\n"
+    TEMP_GOARM=""
+    if [ $1 = "arm" ]; then
+        # The whitespace is intentional.
+        TEMP_GOARM=" GOARM=7"
+    fi
+    TEMP_LINKFLAGS=$LINKFLAGS
+    if [ $1 = "linux" ]; then
+        TEMP_LINKFLAGS="$LINKFLAGS $OTHER_LINKFLAGS"
+    fi
+    TEMP_SUFFIX=""
+    if [ $1 = "windows" ]; then
+        TEMP_SUFFIX=".exe"
+    fi
+    GOOS=${1} GOARCH=${2}${TEMP_GOARCH} CGO_ENABLED=0 go build -ldflags "$TEMP_LINKFLAGS" -o bin/fleet-${1}-${2}${TEMP_SUFFIX}
+    if ! [ $1 = "darwin" ]; then
+        GOOS=${1} GOARCH=${2}${TEMP_GOARM} CGO_ENABLED=0 go build -ldflags "$TEMP_LINKFLAGS" -o bin/fleetcontroller-${1}-${2}${TEMP_SUFFIX} ./cmd/fleetcontroller
+        GOOS=${1} GOARCH=${2}${TEMP_GOARM} CGO_ENABLED=0 go build -ldflags "$TEMP_LINKFLAGS" -o bin/fleetagent-${1}-${2}${TEMP_SUFFIX} ./cmd/fleetagent
+    fi
+}
+
+if [ "$CROSS" = "true" ]; then
+    # If local (host) is unset, we default to false since we are already cross-compiling for all platforms.
+    if [ -z "$LOCAL" ]; then
+        LOCAL="false"
+    fi
+    OS_ARCH=( "linux amd64" "linux arm" "linux arm64" "darwin amd64" "windows amd64" )
+    for i in "${OS_ARCH[@]}"; do
+        set -- $i
+        build-binaries ${1} ${2}
+    done
+elif [ "$CROSS" = "windows" ]; then
+   build-binaries "windows" "amd64"
+fi
+
+# Always build for the host (local) OS and ARCH unless otherwise specified (setting LOCAL to "false").
+# LOCAL will be set to "false" if CROSS is "true" (avoids compiling the host OS and ARCH twice).
+if ! [ "$LOCAL" = "false" ]; then
+    build-binaries ${OS} ${ARCH}
 fi

--- a/scripts/package
+++ b/scripts/package
@@ -12,7 +12,7 @@ function build-image() {
       DOCKERFILE=${DOCKERFILE}.${ARCH}
   fi
 
-  docker build -f ${DOCKERFILE} -t ${IMAGE} .
+  docker build -f ${DOCKERFILE} -t ${IMAGE} --build-arg ARCH=${ARCH} .
   echo Built ${IMAGE}
 
   if [ "$PUSH" = "true" ]; then
@@ -21,16 +21,7 @@ function build-image() {
 }
 
 mkdir -p dist/artifacts
-cp bin/fleet dist/artifacts/fleet-linux${SUFFIX}
-for i in bin/fleet-*; do
-    if [ -e "$i" ]; then
-        if [ "$i" = fleet-windows-amd64 ]; then
-            cp $i dist/artifacts/fleet-windows-amd64.exe
-        else
-            cp $i dist/artifacts
-        fi
-    fi
-done
+cp -r bin/fleet* dist/artifacts/
 
 build-image fleet
 build-image fleet-agent .agent

--- a/scripts/version
+++ b/scripts/version
@@ -17,6 +17,10 @@ if [ -z "$ARCH" ]; then
     ARCH=$(go env GOHOSTARCH)
 fi
 
+if [ -z "$OS" ]; then
+    OS=$(go env GOHOSTOS)
+fi
+
 SUFFIX="-${ARCH}"
 
 HELM_TAG=${TAG:-${VERSION}}


### PR DESCRIPTION
Relevant issue: https://github.com/rancher/rancher/issues/30516

This PR adds preliminary Windows support. The `fleet-agent` has a Windows manifest, and all other components use `tolerations` and `nodeSelector` settings to be scheduled on Linux nodes.  