### PR TITLE
Ensure deleteHistory is called when a bundle is deleted

### DIFF
--- a/pkg/helmdeployer/deployer.go
+++ b/pkg/helmdeployer/deployer.go
@@ -496,9 +496,14 @@ func (h *helm) delete(bundleID string, options fleet.BundleDeploymentOptions, dr
 		return err
 	}
 
+	// Never uninstall the fleet-agent, just "forget" it
 	if bundleID == "fleet-agent" {
-		// Never uninstall the fleet-agent, just "forget" it
-		return deleteHistory(cfg, bundleID)
+		return nil
+	}
+
+	err = deleteHistory(cfg, bundleID)
+	if err != nil {
+		return err
 	}
 
 	u := action.NewUninstall(&cfg)

--- a/pkg/helmdeployer/deployer.go
+++ b/pkg/helmdeployer/deployer.go
@@ -501,8 +501,7 @@ func (h *helm) delete(bundleID string, options fleet.BundleDeploymentOptions, dr
 		return nil
 	}
 
-	err = deleteHistory(cfg, bundleID)
-	if err != nil {
+	if err = deleteHistory(cfg, bundleID); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Signed-off-by: Matthew DeVenny <matt@boxboat.com>

The helm deployer is currently never calling`deleteHistory` to delete the helm release history when a bundle is deleted.