### PR TITLE
Don't force to redeploy fleet agent

### DIFF
--- a/modules/agent/pkg/controllers/bundledeployment/controller.go
+++ b/modules/agent/pkg/controllers/bundledeployment/controller.go
@@ -106,9 +106,6 @@ func (h *handler) Trigger(key string, bd *fleet.BundleDeployment) (*fleet.Bundle
 }
 
 func shouldRedeploy(bd *fleet.BundleDeployment) bool {
-	if bd.Name == "fleet-agent" {
-		return true
-	}
 	if bd.Spec.Options.ForceSyncGeneration <= 0 {
 		return false
 	}


### PR DESCRIPTION
Looks like we are force to reploy agent, which is causing https://github.com/rancher/fleet/issues/267. This can cause rapid CPU increase to fleet-agent as it is trying redeploying fleet-agent with no backoff.