### PR TITLE
Fix unicode in Windows Fleet agent and upgrade Git to 2.30

### DIFF
--- a/package/Dockerfile-windows.agent
+++ b/package/Dockerfile-windows.agent
@@ -6,7 +6,7 @@ ENV RELEASES=$RELEASES
 ENV VERSION=$VERSION
 SHELL ["powershell", "-NoLogo", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 RUN pushd c:\; \
-    $URL = 'https://github.com/git-for-windows/git/releases/download/v2.29.2.windows.3/MinGit-2.29.2.3-64-bit.zip'; \
+    $URL = 'https://github.com/git-for-windows/git/releases/download/v2.30.1.windows.1/MinGit-2.30.1-64-bit.zip'; \
     \
     Write-Host ('Downloading git from {0} ...' -f $URL); \
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
@@ -25,4 +25,4 @@ RUN $URL = 'https://{0}/fleet/{1}/fleetagent-windows-amd64.exe' -f $env:RELEASES
     Write-Host ('Downloading dapper from {0} ...' -f $URL); \
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
     Invoke-WebRequest -UseBasicParsing -OutFile c:/fleet/fleetagent-windows.exe -Uri $URL;
-CMD ["C:\fleet\fleetagent-windows.exe"]
+CMD ["C:\\fleet\\fleetagent-windows.exe"]

--- a/package/README.md
+++ b/package/README.md
@@ -1,0 +1,25 @@
+ # Packages
+
+ This directory contains all the files needed for packaging Fleet images.
+
+ ## Testing Windows
+
+Testing Windows images locally can be done using an SAC/LTSC host.
+You can clone your Git repository and checkout your developer branch to get started.
+
+First, enter `powershell` and install Git.
+You can use [Chocolatey](https://chocolatey.org/install) to [install the package](https://chocolatey.org/packages/git).
+
+Next, clone the repository and checkout your branch.
+
+```powershell
+& 'C:\Program Files\Git\bin\git.exe' clone https://github.com/<user>/<fleet-fork>.git
+& 'C:\Program Files\Git\bin\git.exe' checkout --track origin/<dev-branch>
+```
+
+Finally, you can build the image with an uploaded binary from a tagged release.
+This is useful when testing the `agent` in a Windows cluster.
+
+```powershell
+docker build -t test -f package\Dockerfile-windows.agent --build-arg SERVERCORE_VERSION=1909 --build-arg RELEASES=releases.rancher.com --build-arg VERSION=v0.3.4-rc4 .
+```


### PR DESCRIPTION
Relevant issue: https://github.com/rancher/rancher/issues/30516

A/B test before this change...
```powershell
PS C:\Users\Administrator\rancher-fleet> docker run test
docker: Error response from daemon: container 0b8fb491c233356bdf95208fb8bcfbc51e77f4b13d50634c6e64da26d6c8c215 encountered an error during hcsshim::System::CreateProcess: failure in a Windows system call: The system cannot find the file specified. (0x2) extra info: {"CommandLine":"C:\u000cleet\u000cleetagent-windows.exe","WorkingDirectory":"C:\\","Environment":{"RELEASES":"releases.rancher.com","VERSION":"v0.3.4-rc4"},"CreateStdInPipe":true,"CreateStdOutPipe":true,"CreateStdErrPipe":true,"ConsoleSize":[0,0]}.
```

...after this change...
```powershell
PS C:\Users\Administrator\rancher-fleet> docker run test
Error: --namespace or env NAMESPACE is required to be set
Usage:
  fleet-agent [flags]
Flags:
      --checkin-interval string   How often to post cluster status
  -h, --help                      help for fleet-agent
      --kubeconfig string         kubeconfig file
      --namespace string          namespace to watch
      --simulators int            Numbers of simulators to run
  -v, --version                   version for fleet-agent
time="2021-02-11T17:32:25Z" level=fatal msg="--namespace or env NAMESPACE is required to be set"
```
