### PR TITLE
disable sops check and decryption

### DIFF
--- a/charts/fleet-crd/templates/crds.yaml
+++ b/charts/fleet-crd/templates/crds.yaml
@@ -24,6 +24,9 @@ spec:
         properties:
           spec:
             properties:
+              decrypt:
+                nullable: true
+                type: boolean
               defaultNamespace:
                 nullable: true
                 type: string
@@ -391,6 +394,9 @@ spec:
                           nullable: true
                           type: object
                       type: object
+                    decrypt:
+                      nullable: true
+                      type: boolean
                     defaultNamespace:
                       nullable: true
                       type: string
@@ -861,6 +867,9 @@ spec:
                 type: string
               options:
                 properties:
+                  decrypt:
+                    nullable: true
+                    type: boolean
                   defaultNamespace:
                     nullable: true
                     type: string
@@ -1004,6 +1013,9 @@ spec:
                 type: string
               stagedOptions:
                 properties:
+                  decrypt:
+                    nullable: true
+                    type: boolean
                   defaultNamespace:
                     nullable: true
                     type: string

--- a/docs/gitrepo-structure.md
+++ b/docs/gitrepo-structure.md
@@ -85,6 +85,10 @@ helm:
 # Default: false
 paused: false
 
+# Decrypt SOPS encrypted resources / fields
+# Default: true
+decrypt: true
+
 rolloutStrategy:
     # A number or percentage of clusters that can be unavailable during an update
     # of a bundle. This follows the same basic approach as a deployment rollout
@@ -266,3 +270,4 @@ For Clusters:
 **Modified**: There are bundles in this cluster that are in Modified state.
 
 **Ready**: Bundles in this cluster have been deployed and all resources are ready.
+

--- a/pkg/apis/fleet.cattle.io/v1alpha1/bundle.go
+++ b/pkg/apis/fleet.cattle.io/v1alpha1/bundle.go
@@ -186,6 +186,7 @@ type BundleDeploymentOptions struct {
 	ForceSyncGeneration int64             `json:"forceSyncGeneration,omitempty"`
 	YAML                *YAMLOptions      `json:"yaml,omitempty"`
 	Diff                *DiffOptions      `json:"diff,omitempty"`
+	Decrypt             *bool             `json:"decrypt,omitempty"`
 }
 
 type DiffOptions struct {

--- a/pkg/apis/fleet.cattle.io/v1alpha1/zz_generated_deepcopy.go
+++ b/pkg/apis/fleet.cattle.io/v1alpha1/zz_generated_deepcopy.go
@@ -183,6 +183,11 @@ func (in *BundleDeploymentOptions) DeepCopyInto(out *BundleDeploymentOptions) {
 		*out = new(DiffOptions)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.Decrypt != nil {
+		in, out := &in.Decrypt, &out.Decrypt
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/controllers/manageagent/manageagent.go
+++ b/pkg/controllers/manageagent/manageagent.go
@@ -109,6 +109,9 @@ func (h *handler) getAgentBundle(ns string, cluster *fleet.Cluster) (runtime.Obj
 		Spec: fleet.BundleSpec{
 			BundleDeploymentOptions: fleet.BundleDeploymentOptions{
 				DefaultNamespace: h.systemNamespace,
+				// https://stackoverflow.com/a/28818489 - create reference to bool
+				// Decrypt: true,
+				Decrypt: &[]bool{true}[0],
 				Helm: &fleet.HelmOptions{
 					TakeOwnership: true,
 				},

--- a/pkg/manifest/output.go
+++ b/pkg/manifest/output.go
@@ -13,7 +13,7 @@ import (
 	"go.mozilla.org/sops/v3/decrypt"
 )
 
-func (m *Manifest) ToTarGZ() (io.Reader, error) {
+func (m *Manifest) ToTarGZ(decrypt bool) (io.Reader, error) {
 	buf := &bytes.Buffer{}
 	gz := gzip.NewWriter(buf)
 	w := tar.NewWriter(gz)
@@ -24,9 +24,12 @@ func (m *Manifest) ToTarGZ() (io.Reader, error) {
 			return nil, err
 		}
 
-		bytes, err = decryptSOPS(bytes)
-		if err != nil {
-			return nil, err
+		if decrypt {
+			bytes, err = decryptSOPS(bytes)
+
+			if err != nil {
+				return nil, err
+			}
 		}
 
 		if err := w.WriteHeader(&tar.Header{

--- a/pkg/render/helm.go
+++ b/pkg/render/helm.go
@@ -32,5 +32,12 @@ func ToChart(name string, m *manifest.Manifest, options fleet.BundleDeploymentOp
 		return nil, err
 	}
 
-	return m.ToTarGZ()
+	decrypt := false
+	if options.Decrypt == nil || *options.Decrypt {
+		decrypt = true
+	} else {
+		decrypt = false
+	}
+
+	return m.ToTarGZ(decrypt)
 }


### PR DESCRIPTION
Fixes https://github.com/rancher/fleet/issues/144

Ignores `sops` related resources (allow downstream to handle)

Currently there is no way to configure sops via fleet (to pass in cloud KMS details) so would be good to allow downstream to handle, e.g. with https://github.com/isindir/sops-secrets-operator