### PR TITLE
Introduce kustomize build options

### DIFF
--- a/charts/fleet-crd/templates/crds.yaml
+++ b/charts/fleet-crd/templates/crds.yaml
@@ -179,6 +179,9 @@ spec:
               kustomize:
                 nullable: true
                 properties:
+                  buildOptions:
+                    nullable: true
+                    type: string
                   dir:
                     nullable: true
                     type: string
@@ -546,6 +549,9 @@ spec:
                     kustomize:
                       nullable: true
                       properties:
+                        buildOptions:
+                          nullable: true
+                          type: string
                         dir:
                           nullable: true
                           type: string
@@ -1053,6 +1059,9 @@ spec:
                   kustomize:
                     nullable: true
                     properties:
+                      buildOptions:
+                        nullable: true
+                        type: string
                       dir:
                         nullable: true
                         type: string
@@ -1196,6 +1205,9 @@ spec:
                   kustomize:
                     nullable: true
                     properties:
+                      buildOptions:
+                        nullable: true
+                        type: string
                       dir:
                         nullable: true
                         type: string
@@ -2850,6 +2862,9 @@ spec:
             kustomize:
               nullable: true
               properties:
+                buildOptions:
+                  nullable: true
+                  type: string
                 dir:
                   nullable: true
                   type: string
@@ -3217,6 +3232,9 @@ spec:
                   kustomize:
                     nullable: true
                     properties:
+                      buildOptions:
+                        nullable: true
+                        type: string
                       dir:
                         nullable: true
                         type: string
@@ -3725,6 +3743,9 @@ spec:
                 kustomize:
                   nullable: true
                   properties:
+                    buildOptions:
+                      nullable: true
+                      type: string
                     dir:
                       nullable: true
                       type: string
@@ -3868,6 +3889,9 @@ spec:
                 kustomize:
                   nullable: true
                   properties:
+                    buildOptions:
+                      nullable: true
+                      type: string
                     dir:
                       nullable: true
                       type: string

--- a/docs/gitrepo-structure.md
+++ b/docs/gitrepo-structure.md
@@ -57,6 +57,9 @@ kustomize:
   # Use a custom folder for kustomize resources. This folder must contain
   # a kustomization.yaml file.
   dir: ./kustomize
+  # Specify build options for kustomize build.
+  # Default: ""
+  buildOptions: --load-restrictor LoadRestrictionsNone
 
 helm:
   # Use a custom location for the Helm chart. This can refer to any go-getter URL.

--- a/go.mod
+++ b/go.mod
@@ -63,6 +63,7 @@ require (
 	rsc.io/letsencrypt v0.0.3 // indirect
 	sigs.k8s.io/cli-utils v0.23.1
 	sigs.k8s.io/kustomize/api v0.8.8
+	sigs.k8s.io/kustomize/kustomize/v4 v4.1.2
 	sigs.k8s.io/kustomize/kyaml v0.10.17
 	sigs.k8s.io/yaml v1.2.0
 )

--- a/go.sum
+++ b/go.sum
@@ -2063,6 +2063,7 @@ sigs.k8s.io/kustomize v2.0.3+incompatible/go.mod h1:MkjgH3RdOWrievjo6c9T245dYlB5
 sigs.k8s.io/kustomize/api v0.8.8 h1:G2z6JPSSjtWWgMeWSoHdXqyftJNmMmyxXpwENGoOtGE=
 sigs.k8s.io/kustomize/api v0.8.8/go.mod h1:He1zoK0nk43Pc6NlV085xDXDXTNprtcyKZVm3swsdNY=
 sigs.k8s.io/kustomize/cmd/config v0.9.10/go.mod h1:Mrby0WnRH7hA6OwOYnYpfpiY0WJIMgYrEDfwOeFdMK0=
+sigs.k8s.io/kustomize/kustomize/v4 v4.1.2 h1:iP3ckqMIftwsIKnMqtztReSkkPJvhqNc5QiOpMoFpbY=
 sigs.k8s.io/kustomize/kustomize/v4 v4.1.2/go.mod h1:PxBvo4WGYlCLeRPL+ziT64wBXqbgfcalOS/SXa/tcyo=
 sigs.k8s.io/kustomize/kyaml v0.4.0/go.mod h1:XJL84E6sOFeNrQ7CADiemc1B0EjIxHo3OhW4o1aJYNw=
 sigs.k8s.io/kustomize/kyaml v0.10.7/go.mod h1:K9yg1k/HB/6xNOf5VH3LhTo1DK9/5ykSZO5uIv+Y/1k=

--- a/pkg/apis/fleet.cattle.io/v1alpha1/bundle.go
+++ b/pkg/apis/fleet.cattle.io/v1alpha1/bundle.go
@@ -218,7 +218,8 @@ type YAMLOptions struct {
 }
 
 type KustomizeOptions struct {
-	Dir string `json:"dir,omitempty"`
+	Dir          string `json:"dir,omitempty"`
+	BuildOptions string `json:"buildOptions,omitempty"`
 }
 
 type HelmOptions struct {

--- a/pkg/helmdeployer/deployer.go
+++ b/pkg/helmdeployer/deployer.go
@@ -99,7 +99,7 @@ func (p *postRender) Run(renderedManifests *bytes.Buffer) (modifiedManifests *by
 		data = nil
 	}
 
-	newObjs, processed, err := kustomize.Process(p.manifest, data, p.opts.Kustomize.Dir)
+	newObjs, processed, err := kustomize.Process(p.manifest, data, *p.opts.Kustomize)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kustomize/kustomize_test.go
+++ b/pkg/kustomize/kustomize_test.go
@@ -1,0 +1,245 @@
+package kustomize
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/rancher/wrangler/pkg/yaml"
+	"github.com/stretchr/testify/assert"
+
+	kusttest_test "sigs.k8s.io/kustomize/api/testutils/kusttest"
+	"sigs.k8s.io/kustomize/api/types"
+)
+
+func assertActualTrimSpaceEqualsExpected(t *testing.T, actual string, expected string) {
+	assert.Equal(t, strings.TrimSpace(expected), strings.TrimSpace(actual))
+}
+
+func writeSmallBase(th kusttest_test.Harness) {
+	th.WriteK("/app/base", `
+namePrefix: a-
+commonLabels:
+  app: myApp
+resources:
+- deployment.yaml
+- service.yaml
+`)
+	th.WriteF("/app/base/service.yaml", `
+apiVersion: v1
+kind: Service
+metadata:
+  name: myService
+spec:
+  selector:
+    backend: bungie
+  ports:
+    - port: 7002
+`)
+	th.WriteF("/app/base/deployment.yaml", `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: myDeployment
+spec:
+  template:
+    metadata:
+      labels:
+        backend: awesome
+    spec:
+      containers:
+      - name: whatever
+        image: whatever
+`)
+}
+
+func TestSmallOverlay(t *testing.T) {
+	th := kusttest_test.MakeHarness(t)
+	writeSmallBase(th)
+	th.WriteK("/app/overlay", `
+namePrefix: b-
+commonLabels:
+  env: prod
+  quotedFruit: "peach"
+  quotedBoolean: "true"
+resources:
+- ../base
+patchesStrategicMerge:
+- deployment/deployment.yaml
+images:
+- name: whatever
+  newTag: 1.8.0
+`)
+
+	th.WriteF("/app/overlay/configmap/app.env", `
+DB_USERNAME=admin
+DB_PASSWORD=somepw
+`)
+	th.WriteF("/app/overlay/configmap/app-init.ini", `
+FOO=bar
+BAR=baz
+`)
+	th.WriteF("/app/overlay/deployment/deployment.yaml", `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: myDeployment
+spec:
+  replicas: 1000
+`)
+	result, err := kustomize(th.GetFSys(), "/app/overlay", "")
+	if err != nil {
+		t.Fatalf("kustomize failed: %v", err)
+	}
+	data, err := yaml.ToBytes(result)
+	if err != nil {
+		t.Fatalf("yaml.ToBytes failed: %v", err)
+	}
+	assertActualTrimSpaceEqualsExpected(t, string(data), `
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: myApp
+    env: prod
+    quotedBoolean: "true"
+    quotedFruit: peach
+  name: b-a-myService
+spec:
+  ports:
+  - port: 7002
+  selector:
+    app: myApp
+    backend: bungie
+    env: prod
+    quotedBoolean: "true"
+    quotedFruit: peach
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: myApp
+    env: prod
+    quotedBoolean: "true"
+    quotedFruit: peach
+  name: b-a-myDeployment
+spec:
+  replicas: 1000
+  selector:
+    matchLabels:
+      app: myApp
+      env: prod
+      quotedBoolean: "true"
+      quotedFruit: peach
+  template:
+    metadata:
+      labels:
+        app: myApp
+        backend: awesome
+        env: prod
+        quotedBoolean: "true"
+        quotedFruit: peach
+    spec:
+      containers:
+      - image: whatever:1.8.0
+        name: whatever
+`)
+}
+
+func TestSharedPatchDisAllowed(t *testing.T) {
+	th := kusttest_test.MakeHarness(t)
+	writeSmallBase(th)
+	th.WriteK("/app/overlay", `
+commonLabels:
+  env: prod
+resources:
+- ../base
+patchesStrategicMerge:
+- ../shared/deployment-patch.yaml
+`)
+	th.WriteF("/app/shared/deployment-patch.yaml", `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: myDeployment
+spec:
+  replicas: 1000
+`)
+	_, err := kustomize(th.GetFSys(), "/app/overlay", "")
+	if !strings.Contains(
+		err.Error(),
+		"security; file '/app/shared/deployment-patch.yaml' is not in or below '/app/overlay'") {
+		t.Fatalf("unexpected error: %s", err)
+	}
+}
+
+func TestSharedPatchAllowed(t *testing.T) {
+	th := kusttest_test.MakeHarness(t)
+	writeSmallBase(th)
+	th.WriteK("/app/overlay", `
+commonLabels:
+  env: prod
+resources:
+- ../base
+patchesStrategicMerge:
+- ../shared/deployment-patch.yaml
+`)
+	th.WriteF("/app/shared/deployment-patch.yaml", `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: myDeployment
+spec:
+  replicas: 1000
+`)
+	result, err := kustomize(th.GetFSys(), "/app/overlay", "--load-restrictor "+types.LoadRestrictionsNone.String())
+	if err != nil {
+		t.Fatalf("kustomize failed: %v", err)
+	}
+	data, err := yaml.ToBytes(result)
+	if err != nil {
+		t.Fatalf("yaml.ToBytes failed: %v", err)
+	}
+	assertActualTrimSpaceEqualsExpected(t, string(data), `
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: myApp
+    env: prod
+  name: a-myService
+spec:
+  ports:
+  - port: 7002
+  selector:
+    app: myApp
+    backend: bungie
+    env: prod
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: myApp
+    env: prod
+  name: a-myDeployment
+spec:
+  replicas: 1000
+  selector:
+    matchLabels:
+      app: myApp
+      env: prod
+  template:
+    metadata:
+      labels:
+        app: myApp
+        backend: awesome
+        env: prod
+    spec:
+      containers:
+      - image: whatever
+        name: whatever
+`)
+}

--- a/pkg/options/calculate.go
+++ b/pkg/options/calculate.go
@@ -83,6 +83,9 @@ func merge(base, next fleet.BundleDeploymentOptions) fleet.BundleDeploymentOptio
 		if next.Kustomize.Dir != "" {
 			result.Kustomize.Dir = next.Kustomize.Dir
 		}
+		if next.Kustomize.BuildOptions != "" {
+			result.Kustomize.BuildOptions = next.Kustomize.BuildOptions
+		}
 	}
 	if next.Diff != nil {
 		if result.Diff == nil {


### PR DESCRIPTION
This PR resolves https://github.com/rancher/fleet/issues/155 and has a dependency on forked kustomize v3 tag https://github.com/ron1/kustomize/releases/tag/kustomize%2Fv3.8.10-fleet4. Once Fleet and the Kustomize community move to kustomize v4, the dependency on a forked kustomize repo will be no longer since the build cmd in kustomize v4 exposes the apis needed by Fleet.