### PR TITLE
Add SOPS decryption flag

### DIFF
--- a/charts/fleet/templates/configmap.yaml
+++ b/charts/fleet/templates/configmap.yaml
@@ -11,6 +11,7 @@ data:
       "apiServerCA": "{{b64enc .Values.apiServerCA}}",
       "agentCheckinInterval": "{{.Values.agentCheckinInterval}}",
       "ignoreClusterRegistrationLabels": {{.Values.ignoreClusterRegistrationLabels}},
+      "disableSopsDecryption": {{.Values.disableSopsDecryption}},
       "bootstrap": {
         "paths": "{{.Values.bootstrap.paths}}",
         "repo": "{{.Values.bootstrap.repo}}",

--- a/charts/fleet/values.yaml
+++ b/charts/fleet/values.yaml
@@ -33,6 +33,9 @@ bootstrap:
   branch: master
   paths: ""
 
+# If set to "true", rely on a downstream SOPS operator or handler for SOPS decryption instead of Fleet.
+disableSopsDecryption: false
+
 global:
   cattle:
     systemDefaultRegistry: ""

--- a/modules/cli/agentmanifest/agent.go
+++ b/modules/cli/agentmanifest/agent.go
@@ -123,7 +123,7 @@ func AgentManifest(ctx context.Context, systemNamespace, controllerNamespace str
 		return err
 	}
 
-	objs = append(objs, agent.Manifest(controllerNamespace, cfg.AgentImage, cfg.AgentImagePullPolicy, opts.Generation, opts.CheckinInterval)...)
+	objs = append(objs, agent.Manifest(controllerNamespace, cfg.AgentImage, cfg.AgentImagePullPolicy, opts.Generation, opts.CheckinInterval, cfg.DisableSopsDecryption)...)
 
 	data, err := yaml.Export(objs...)
 	if err != nil {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -43,6 +43,7 @@ type Config struct {
 	Bootstrap                       Bootstrap         `json:"bootstrap,omitempty"`
 	IgnoreClusterRegistrationLabels bool              `json:"ignoreClusterRegistrationLabels,omitempty"`
 	IgnoreAgentNamespaceCheck       bool              `json:"ignoreAgentNamespaceCheck,omitempty"`
+	DisableSopsDecryption           bool              `json:"disableSopsDecryption,omitempty"`
 }
 
 type Bootstrap struct {

--- a/pkg/controllers/bootstrap/bootstrap.go
+++ b/pkg/controllers/bootstrap/bootstrap.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"regexp"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -112,6 +113,10 @@ func (h *handler) OnConfig(config *config.Config) error {
 				Paths:            paths,
 			},
 		})
+	}
+
+	if config.DisableSopsDecryption {
+		os.Setenv("DISABLE_SOPS_DECRYPTION", "true")
 	}
 
 	return h.apply.ApplyObjects(objs...)

--- a/pkg/controllers/manageagent/manageagent.go
+++ b/pkg/controllers/manageagent/manageagent.go
@@ -89,7 +89,7 @@ func (h *handler) getAgentBundle(ns string) ([]runtime.Object, error) {
 		return nil, nil
 	}
 
-	objs := agent.Manifest(h.systemNamespace, cfg.AgentImage, cfg.AgentImagePullPolicy, "bundle", cfg.AgentCheckinInternal.Duration.String())
+	objs := agent.Manifest(h.systemNamespace, cfg.AgentImage, cfg.AgentImagePullPolicy, "bundle", cfg.AgentCheckinInternal.Duration.String(), cfg.DisableSopsDecryption)
 	agentYAML, err := yaml.Export(objs...)
 	if err != nil {
 		return nil, err

--- a/pkg/manifest/output.go
+++ b/pkg/manifest/output.go
@@ -6,6 +6,7 @@ import (
 	"compress/gzip"
 	"fmt"
 	"io"
+	"os"
 	"time"
 
 	"github.com/rancher/fleet/pkg/content"
@@ -24,9 +25,11 @@ func (m *Manifest) ToTarGZ() (io.Reader, error) {
 			return nil, err
 		}
 
-		bytes, err = decryptSOPS(bytes)
-		if err != nil {
-			return nil, err
+		if os.Getenv("DISABLE_SOPS_DECRYPTION") != "true" {
+			bytes, err = decryptSOPS(bytes)
+			if err != nil {
+				return nil, err
+			}
 		}
 
 		if err := w.WriteHeader(&tar.Header{


### PR DESCRIPTION
Add SOPS decryption flag. This is managed by an environment variable
rather than the API.

- Original idea from @mumblez https://github.com/rancher/fleet/pull/298
- Will re-add @mumblez as co-author once all commits are squashed

Relevant issue: https://github.com/rancher/fleet/issues/306