### PR TITLE
valuesFiles support

### DIFF
--- a/charts/fleet-crd/templates/crds.yaml
+++ b/charts/fleet-crd/templates/crds.yaml
@@ -94,6 +94,12 @@ spec:
                 values:
                   nullable: true
                   type: object
+                valuesFiles:
+                  items:
+                    nullable: true
+                    type: string
+                  nullable: true
+                  type: array
                 version:
                   nullable: true
                   type: string
@@ -413,6 +419,12 @@ spec:
                       values:
                         nullable: true
                         type: object
+                      valuesFiles:
+                        items:
+                          nullable: true
+                          type: string
+                        nullable: true
+                        type: array
                       version:
                         nullable: true
                         type: string
@@ -844,6 +856,12 @@ spec:
                     values:
                       nullable: true
                       type: object
+                    valuesFiles:
+                      items:
+                        nullable: true
+                        type: string
+                      nullable: true
+                      type: array
                     version:
                       nullable: true
                       type: string
@@ -948,6 +966,12 @@ spec:
                     values:
                       nullable: true
                       type: object
+                    valuesFiles:
+                      items:
+                        nullable: true
+                        type: string
+                      nullable: true
+                      type: array
                     version:
                       nullable: true
                       type: string

--- a/go.mod
+++ b/go.mod
@@ -47,6 +47,7 @@ require (
 	github.com/spf13/cobra v1.1.1
 	go.mozilla.org/sops/v3 v3.6.1
 	golang.org/x/sync v0.0.0-20201207232520-09787c993a3a
+	gopkg.in/yaml.v2 v2.3.0
 	helm.sh/helm/v3 v3.5.1
 	k8s.io/api v0.20.2
 	k8s.io/apimachinery v0.20.2

--- a/pkg/apis/fleet.cattle.io/v1alpha1/bundle.go
+++ b/pkg/apis/fleet.cattle.io/v1alpha1/bundle.go
@@ -222,6 +222,7 @@ type HelmOptions struct {
 	Force          bool        `json:"force,omitempty"`
 	TakeOwnership  bool        `json:"takeOwnership,omitempty"`
 	MaxHistory     int         `json:"maxHistory,omitempty"`
+	ValuesFiles    []string    `json:"valuesFiles,omitempty"`
 }
 
 type BundleDeploymentSpec struct {

--- a/pkg/apis/fleet.cattle.io/v1alpha1/zz_generated_deepcopy.go
+++ b/pkg/apis/fleet.cattle.io/v1alpha1/zz_generated_deepcopy.go
@@ -1418,6 +1418,11 @@ func (in *HelmOptions) DeepCopyInto(out *HelmOptions) {
 		in, out := &in.Values, &out.Values
 		*out = (*in).DeepCopy()
 	}
+	if in.ValuesFiles != nil {
+		in, out := &in.ValuesFiles, &out.ValuesFiles
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/bundle/resources.go
+++ b/pkg/bundle/resources.go
@@ -24,6 +24,7 @@ import (
 	"github.com/rancher/fleet/pkg/content"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/sync/semaphore"
+	v2 "gopkg.in/yaml.v2"
 )
 
 func readResources(ctx context.Context, spec *fleet.BundleSpec, compress bool, base string) ([]fleet.BundleResource, error) {
@@ -34,7 +35,7 @@ func readResources(ctx context.Context, spec *fleet.BundleSpec, compress bool, b
 		return nil, err
 	}
 
-	var chartDirs []*fleet.HelmOptions
+	var chartDirs, parsedChartDirs []*fleet.HelmOptions
 
 	if spec.Helm != nil && spec.Helm.Chart != "" {
 		chartDirs = append(chartDirs, spec.Helm)
@@ -44,9 +45,26 @@ func readResources(ctx context.Context, spec *fleet.BundleSpec, compress bool, b
 		if target.Helm != nil && target.Helm.Chart != "" {
 			chartDirs = append(chartDirs, target.Helm)
 		}
+		if target.Helm != nil && target.Helm.Chart == "" && len(target.Helm.ValuesFiles) != 0 {
+			// generate values //
+			parsedChart, err := parseValueFiles(base, target.Helm)
+			if err != nil {
+				return nil, err
+			}
+			target.Helm.Values = parsedChart.Values
+		}
 	}
 
-	directories, err = addCharts(directories, base, chartDirs)
+	// append helm valuesFiles into values
+	for _, chart := range chartDirs {
+		parsedChart, err := parseValueFiles(base, chart)
+		if err != nil {
+			return nil, err
+		}
+		parsedChartDirs = append(parsedChartDirs, parsedChart)
+	}
+
+	directories, err = addCharts(directories, base, parsedChartDirs)
 	if err != nil {
 		return nil, err
 	}
@@ -305,4 +323,53 @@ func readContent(ctx context.Context, progress *progress.Progress, base, name st
 	}
 
 	return files, nil
+}
+
+func parseValueFiles(base string, chart *fleet.HelmOptions) (parsedChart *fleet.HelmOptions, err error) {
+	parsedChart = chart
+	if len(chart.ValuesFiles) != 0 {
+		valuesMap, err := generateValues(base, chart)
+		if err != nil {
+			return nil, err
+		}
+		if parsedChart.Values == nil {
+			parsedChart.Values = &fleet.GenericMap{}
+		}
+		parsedChart.Values.Data = valuesMap
+	}
+
+	return parsedChart, nil
+}
+
+func generateValues(base string, chart *fleet.HelmOptions) (valuesMap map[string]interface{}, err error) {
+
+	valuesMap = make(map[string]interface{})
+	if chart.Values != nil {
+		valuesMap = chart.Values.Data
+	}
+	for _, value := range chart.ValuesFiles {
+		valuesByte, err := ioutil.ReadFile(base + "/" + value)
+		if err != nil {
+			return nil, err
+		}
+		tmpMap := make(map[string]interface{})
+		err = v2.Unmarshal(valuesByte, tmpMap)
+		if err != nil {
+			return nil, err
+		}
+		valuesMap = mergeGenericMap(valuesMap, tmpMap)
+	}
+
+	return valuesMap, nil
+}
+
+func mergeGenericMap(first, second map[string]interface{}) map[string]interface{} {
+	result := make(map[string]interface{})
+	for k, v := range first {
+		result[k] = v
+	}
+	for k, v := range second {
+		result[k] = v
+	}
+	return result
 }

--- a/pkg/bundle/resources.go
+++ b/pkg/bundle/resources.go
@@ -339,7 +339,6 @@ func parseValueFiles(base string, chart *fleet.HelmOptions) (err error) {
 }
 
 func generateValues(base string, chart *fleet.HelmOptions) (valuesMap map[string]interface{}, err error) {
-
 	valuesMap = make(map[string]interface{})
 	if chart.Values != nil {
 		valuesMap = chart.Values.Data

--- a/pkg/bundle/resources.go
+++ b/pkg/bundle/resources.go
@@ -44,10 +44,13 @@ func readResources(ctx context.Context, spec *fleet.BundleSpec, compress bool, b
 	}
 
 	for _, target := range spec.Targets {
-		err := parseValueFiles(base, target.Helm)
-		if err != nil {
-			return nil, err
+		if target.Helm != nil {
+			err := parseValueFiles(base, target.Helm)
+			if err != nil {
+				return nil, err
+			}
 		}
+
 		if target.Helm.Chart != "" {
 			chartDirs = append(chartDirs, target.Helm)
 		}

--- a/pkg/bundle/resources.go
+++ b/pkg/bundle/resources.go
@@ -49,10 +49,9 @@ func readResources(ctx context.Context, spec *fleet.BundleSpec, compress bool, b
 			if err != nil {
 				return nil, err
 			}
-		}
-
-		if target.Helm.Chart != "" {
-			chartDirs = append(chartDirs, target.Helm)
+			if target.Helm.Chart != "" {
+				chartDirs = append(chartDirs, target.Helm)
+			}
 		}
 	}
 

--- a/pkg/bundle/resources.go
+++ b/pkg/bundle/resources.go
@@ -38,6 +38,9 @@ func readResources(ctx context.Context, spec *fleet.BundleSpec, compress bool, b
 	var chartDirs []*fleet.HelmOptions
 
 	if spec.Helm != nil && spec.Helm.Chart != "" {
+		if err := parseValueFiles(base, spec.Helm); err != nil {
+			return nil, err
+		}
 		chartDirs = append(chartDirs, spec.Helm)
 	}
 

--- a/pkg/bundle/resources.go
+++ b/pkg/bundle/resources.go
@@ -45,7 +45,7 @@ func readResources(ctx context.Context, spec *fleet.BundleSpec, compress bool, b
 		if target.Helm != nil && target.Helm.Chart != "" {
 			chartDirs = append(chartDirs, target.Helm)
 		}
-		if target.Helm != nil && target.Helm.Chart == "" && len(target.Helm.ValuesFiles) != 0 {
+		if target.Helm != nil && target.Helm.Chart == "" {
 			// generate values //
 			err := parseValueFiles(base, target.Helm)
 			if err != nil {

--- a/pkg/bundle/resources.go
+++ b/pkg/bundle/resources.go
@@ -42,23 +42,12 @@ func readResources(ctx context.Context, spec *fleet.BundleSpec, compress bool, b
 	}
 
 	for _, target := range spec.Targets {
-		if target.Helm != nil && target.Helm.Chart != "" {
-			chartDirs = append(chartDirs, target.Helm)
-		}
-		if target.Helm != nil && target.Helm.Chart == "" {
-			// generate values //
-			err := parseValueFiles(base, target.Helm)
-			if err != nil {
-				return nil, err
-			}
-		}
-	}
-
-	// append helm valuesFiles into values
-	for _, chart := range chartDirs {
-		err := parseValueFiles(base, chart)
+		err := parseValueFiles(base, target.Helm)
 		if err != nil {
 			return nil, err
+		}
+		if target.Helm.Chart != "" {
+			chartDirs = append(chartDirs, target.Helm)
 		}
 	}
 


### PR DESCRIPTION
Minor tweak to `fleet apply` logic to support valuesFiles in HelmOptions.

The `fleet apply` will now parse the list in valuesFiles and merge them into the `values` for the HelmOptions.

This allows users to specify values files to better organize their GitRepos rather than having all values inline.

If the same value override is defined in multiple valuesFiles, then the one in the last file will take precedence.

Helm handles setting the same variable multiple times in the same manner.

This allows user to reference valuesFiles in the fleet.yaml

For example:

```
defaultNamespace: loki
helm:
  releaseName: loki
  repo: https://kubernetes-charts.banzaicloud.com
  chart: loki
  values:
    key1: value1
  valuesFiles:
  - values/override.yaml
targetCustomizations:
- name: dev
  helm:
    valuesFiles:
    - values/override2.yaml
  clusterSelector:
    matchLabels:
      name: local
```

When the bundle is generated the valuesFiles are read and appended to the existing override values passed to the helm chart.

The generated bundle would look like..

```
apiVersion: fleet.cattle.io/v1alpha1
kind: Bundle
metadata:
  labels:
    fleet.cattle.io/commit: 3b641674c670c621e9e1828dab22faffc71d341e
  name: loki-loki
  namespace: fleet-default
spec:
  defaultNamespace: loki
  helm:
    chart: loki
    releaseName: loki
    repo: https://kubernetes-charts.banzaicloud.com
    values:
      key1: value1
      car: honda
      fuel: petrol
      some: value
    valuesFiles:
    - values/override.yaml
  .....
```

Where the contents of the values/override.yaml are

```
some: value
car: honda
fuel: petrol
```