### PR TITLE
Ability to use cluster labels as helm values

### DIFF
--- a/pkg/target/target.go
+++ b/pkg/target/target.go
@@ -281,14 +281,11 @@ func addClusterLabels(opts *fleet.BundleDeploymentOptions, labels map[string]str
 		return nil
 	}
 
-	err = processLabelValues(opts.Helm.Values.Data, clusterLabels)
-
-	if err != nil {
+	if err := processLabelValues(opts.Helm.Values.Data, clusterLabels); err != nil {
 		return err
 	}
 
 	opts.Helm.Values.Data = data.MergeMaps(opts.Helm.Values.Data, newValues)
-
 	return nil
 
 }

--- a/pkg/target/target.go
+++ b/pkg/target/target.go
@@ -278,7 +278,21 @@ func addClusterLabels(opts *fleet.BundleDeploymentOptions, labels map[string]str
 		return
 	}
 
+	prefix := "global.fleet.clusterLabels."
+
+	for key, val := range opts.Helm.Values.Data {
+		valStr, ok := val.(string)
+		if ok && strings.HasPrefix(valStr, prefix) {
+			label := strings.TrimPrefix(valStr, prefix)
+			labelVal, labelPresent := clusterLabels[label]
+			if labelPresent {
+				opts.Helm.Values.Data[key] = labelVal
+			}
+		}
+	}
+
 	opts.Helm.Values.Data = data.MergeMaps(opts.Helm.Values.Data, newValues)
+
 }
 
 func (m *Manager) foldInDeployments(app *fleet.Bundle, targets []*Target) error {


### PR DESCRIPTION
The PR allows users to pass values to helm charts via labels on the cluster objects.

This can include cluster specific information such as name to the downstream helm chart.

fleet already applies cluster labels as helm values to all charts on the downstream cluster.

Once this change is merged, the users will be able to refer these labels directly in the values section.

```
namespace: default
helm:
  releaseName: labels
  values:
    clusterName: global.fleet.clusterLabels.management.cattle.io/cluster-display-name
```

The fleet controller will render the bundle deployment objects after performing the replacement, which can then be picked up by the fleet-agents on the downstream cluster.

This should help address the issue: https://github.com/rancher/fleet/issues/152