### PR TITLE
Redeploy agent when fleet-agent deployment is deleted

### DIFF
--- a/pkg/apis/fleet.cattle.io/v1alpha1/target.go
+++ b/pkg/apis/fleet.cattle.io/v1alpha1/target.go
@@ -61,11 +61,11 @@ type Cluster struct {
 }
 
 type ClusterSpec struct {
-	Paused                  bool   `json:"paused,omitempty"`
-	ClientID                string `json:"clientID,omitempty"`
-	KubeConfigSecret        string `json:"kubeConfigSecret,omitempty"`
-	RedeployAgentGeneration int64  `json:"redeployAgentGeneration,omitempty"`
-	AgentEnvVars []v1.EnvVar	`json:"agentEnvVars,omitempty"`
+	Paused                  bool        `json:"paused,omitempty"`
+	ClientID                string      `json:"clientID,omitempty"`
+	KubeConfigSecret        string      `json:"kubeConfigSecret,omitempty"`
+	RedeployAgentGeneration int64       `json:"redeployAgentGeneration,omitempty"`
+	AgentEnvVars            []v1.EnvVar `json:"agentEnvVars,omitempty"`
 }
 
 type ClusterStatus struct {

--- a/pkg/controllers/manageagent/manageagent.go
+++ b/pkg/controllers/manageagent/manageagent.go
@@ -49,9 +49,9 @@ func Register(ctx context.Context,
 	relatedresource.WatchClusterScoped(ctx, "manage-agent-resolver", h.resolveNS, namespace, clusters)
 }
 
-func (h *handler) resolveNS(namespace, name string, obj runtime.Object) ([]relatedresource.Key, error) {
-	if _, ok := obj.(*fleet.Cluster); ok {
-		if _, err := h.bundleCache.Get(namespace, agentBundleName); err != nil {
+func (h *handler) resolveNS(namespace, _ string, obj runtime.Object) ([]relatedresource.Key, error) {
+	if cluster, ok := obj.(*fleet.Cluster); ok {
+		if _, err := h.bundleCache.Get(namespace, name.SafeConcatName(agentBundleName, cluster.Name)); err != nil {
 			return []relatedresource.Key{{Name: namespace}}, nil
 		}
 	}

--- a/pkg/helmdeployer/deployer.go
+++ b/pkg/helmdeployer/deployer.go
@@ -478,6 +478,11 @@ func (h *helm) deleteByRelease(bundleID, releaseName string) error {
 		return err
 	}
 
+	if strings.HasPrefix(bundleID, "fleet-agent") {
+		// Never uninstall the fleet-agent, just "forget" it
+		return deleteHistory(cfg, bundleID)
+	}
+
 	u := action.NewUninstall(&cfg)
 	_, err = u.Run(releaseName)
 	return err
@@ -514,7 +519,7 @@ func (h *helm) delete(bundleID string, options fleet.BundleDeploymentOptions, dr
 		return err
 	}
 
-	if bundleID == "fleet-agent" {
+	if strings.HasPrefix(bundleID, "fleet-agent") {
 		// Never uninstall the fleet-agent, just "forget" it
 		return deleteHistory(cfg, bundleID)
 	}


### PR DESCRIPTION
Context:
We switched from one fleet-agent bundle per workspace to one fleet bundle per cluster in order to support agentEnvVars per cluster https://github.com/rancher/rancher/issues/29993. This has caused a problem because we have to delete old `fleet-agent` bundle and use the new name `fleet-agent-$clustername`. When deleting the `fleet-agent` bundle, `fleet-agent` deployment will also get deleted in downstream cluster, causing https://github.com/rancher/rancher/issues/32317. We need to deploy the agent if downstream cluster doesn't have the fleet-agent deployment.