### PR TITLE
Add migration logic, drop deployment check

### DIFF
--- a/charts/fleet-crd/templates/crds.yaml
+++ b/charts/fleet-crd/templates/crds.yaml
@@ -1583,6 +1583,8 @@ spec:
             agentDeployedGeneration:
               nullable: true
               type: integer
+            agentMigrated:
+              type: boolean
             conditions:
               items:
                 properties:

--- a/pkg/apis/fleet.cattle.io/v1alpha1/target.go
+++ b/pkg/apis/fleet.cattle.io/v1alpha1/target.go
@@ -77,6 +77,7 @@ type ClusterStatus struct {
 	DesiredReadyGitRepos int                                 `json:"desiredReadyGitRepos"`
 
 	AgentDeployedGeneration *int64 `json:"agentDeployedGeneration,omitempty"`
+	AgentMigrated           bool   `json:"agentMigrated,omitempty"`
 
 	Display ClusterDisplay `json:"display,omitempty"`
 	Agent   AgentStatus    `json:"agent,omitempty"`

--- a/pkg/controllers/cluster/import.go
+++ b/pkg/controllers/cluster/import.go
@@ -60,23 +60,16 @@ func RegisterImport(
 	fleetcontrollers.RegisterClusterStatusHandler(ctx, clusters, "Imported", "import-cluster", h.importCluster)
 }
 
-func agentDeployed(ctx context.Context, namespace string, kc kubernetes.Interface, cluster *fleet.Cluster) bool {
+func agentDeployed(cluster *fleet.Cluster) bool {
+	if !cluster.Status.AgentMigrated {
+		return false
+	}
+
 	if cluster.Status.AgentDeployedGeneration == nil {
 		return false
 	}
 
-	if *cluster.Status.AgentDeployedGeneration != cluster.Spec.RedeployAgentGeneration {
-		return false
-	}
-
-	if kc != nil {
-		dp, err := kc.AppsV1().Deployments(namespace).Get(ctx, "fleet-agent", metav1.GetOptions{})
-		if err != nil || dp.DeletionTimestamp != nil {
-			return false
-		}
-	}
-
-	return true
+	return *cluster.Status.AgentDeployedGeneration == cluster.Spec.RedeployAgentGeneration
 }
 
 func (i *importHandler) OnChange(key string, cluster *fleet.Cluster) (_ *fleet.Cluster, err error) {
@@ -84,7 +77,7 @@ func (i *importHandler) OnChange(key string, cluster *fleet.Cluster) (_ *fleet.C
 		return cluster, nil
 	}
 
-	if cluster.Spec.KubeConfigSecret == "" || agentDeployed(i.ctx, i.systemNamespace, nil, cluster) {
+	if cluster.Spec.KubeConfigSecret == "" || agentDeployed(cluster) {
 		return cluster, nil
 	}
 
@@ -144,6 +137,7 @@ func (i *importHandler) deleteOldAgent(cluster *fleet.Cluster, kc kubernetes.Int
 
 func (i *importHandler) importCluster(cluster *fleet.Cluster, status fleet.ClusterStatus) (_ fleet.ClusterStatus, err error) {
 	if cluster.Spec.KubeConfigSecret == "" ||
+		agentDeployed(cluster) ||
 		cluster.Spec.ClientID == "" {
 		return status, nil
 	}
@@ -178,10 +172,6 @@ func (i *importHandler) importCluster(cluster *fleet.Cluster, status fleet.Clust
 	kc, err := kubernetes.NewForConfig(restConfig)
 	if err != nil {
 		return status, err
-	}
-
-	if agentDeployed(i.ctx, i.systemNamespace, kc, cluster) {
-		return status, nil
 	}
 
 	if _, err = kc.Discovery().ServerVersion(); err != nil {
@@ -247,6 +237,7 @@ func (i *importHandler) importCluster(cluster *fleet.Cluster, status fleet.Clust
 	logrus.Infof("Deployed new agent for cluster %s/%s", cluster.Namespace, cluster.Name)
 
 	status.AgentDeployedGeneration = &cluster.Spec.RedeployAgentGeneration
+	status.AgentMigrated = true
 	status.Agent = fleet.AgentStatus{}
 	return status, nil
 }


### PR DESCRIPTION
We need to drop the previous deployment check logic, as it is causing chatty connection to downstream cluster when cluster is updated. Instead we will add `agentMigrated` in cluster.status to force upgrade fleet-agent on imported clusters. This is to handle the case where we migrate from one `fleet-agent` bundle per workspace to `fleet-agent` bundle per cluster, and fleet will delete fleet-agent deployment when deleting `fleet-agent` bundle, which will cause a outage(see https://github.com/rancher/rancher/issues/32317). This is fixed in https://github.com/rancher/fleet/pull/351/files#diff-7657d93aa6e7023c8a3230bb999b94845f6b607b146c9bc7e137620032683f0fR481-R485. Once agent is fully migrated to new version, we would not need to worry about this.

So, adding a new status `agentMigrated` to cluster and if status is false then force upgrade to new agent version using import controller. This will only impact upgrade since all the clusters druing the upgrade will be forced to new fleet-agent using import controller, but this is already happening during a normal fleet upgrade.