### PR TITLE
added logic to parse array structs. GH Issue 363

### DIFF
--- a/pkg/target/target.go
+++ b/pkg/target/target.go
@@ -528,6 +528,17 @@ func processLabelValues(valuesMap map[string]interface{}, clusterLabels map[stri
 				return err
 			}
 		}
+
+		if valArr, ok := val.([]interface{}); ok {
+			for _, item := range valArr {
+				if itemMap, ok := item.(map[string]interface{}); ok {
+					err := processLabelValues(itemMap, clusterLabels)
+					if err != nil {
+						return err
+					}
+				}
+			}
+		}
 	}
 
 	return nil

--- a/pkg/target/target_test.go
+++ b/pkg/target/target_test.go
@@ -1,0 +1,106 @@
+package target
+
+import (
+	"testing"
+
+	"github.com/rancher/wrangler/pkg/yaml"
+
+	"github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
+)
+
+const bundleYaml = `namespace: default
+helm:
+  releaseName: labels
+  values:
+    clusterName: global.fleet.clusterLabels.name
+    customStruct:
+      - name: global.fleet.clusterLabels.name
+        key1: value1
+        key2: value2
+      - element1: global.fleet.clusterLabels.envType
+      - element2: global.fleet.clusterLabels.name
+diff:
+  comparePatches:
+  - apiVersion: networking.k8s.io/v1
+    kind: Ingress
+    name: labels-fleetlabelsdemo
+    namespace: default
+    operations:
+    - op: remove
+      path: /spec/rules/0/host
+`
+
+func TestProcessLabelValues(t *testing.T) {
+
+	bundle := &v1alpha1.BundleSpec{}
+
+	clusterLabels := make(map[string]string)
+	clusterLabels["name"] = "local"
+	clusterLabels["envType"] = "dev"
+
+	err := yaml.Unmarshal([]byte(bundleYaml), bundle)
+	if err != nil {
+		t.Fatalf("error during yaml parsing %v", err)
+	}
+
+	err = processLabelValues(bundle.Helm.Values.Data, clusterLabels)
+	if err != nil {
+		t.Fatalf("error during label processing %v", err)
+	}
+
+	clusterName, ok := bundle.Helm.Values.Data["clusterName"]
+	if !ok {
+		t.Fatal("key clusterName not found")
+	}
+
+	if clusterName != "local" {
+		t.Fatal("unable to assert correct clusterName")
+	}
+
+	customStruct, ok := bundle.Helm.Values.Data["customStruct"].([]interface{})
+	if !ok {
+		t.Fatal("key customStruct not found")
+	}
+
+	firstMap, ok := customStruct[0].(map[string]interface{})
+	if !ok {
+		t.Fatal("unable to assert first element to map[string]interface{}")
+	}
+
+	firstElemVal, ok := firstMap["name"]
+	if !ok {
+		t.Fatal("unable to find key name in the first element of customStruct")
+	}
+
+	if firstElemVal.(string) != "local" {
+		t.Fatal("label replacement not performed in first element")
+	}
+
+	secondElement, ok := customStruct[1].(map[string]interface{})
+	if !ok {
+		t.Fatal("unable to assert second element of customStruct to map[string]interface{}")
+	}
+
+	secondElemVal, ok := secondElement["element1"]
+	if !ok {
+		t.Fatal("unable to find key element1")
+	}
+
+	if secondElemVal.(string) != "dev" {
+		t.Fatal("label replacement not performed in second element")
+	}
+
+	thirdElement, ok := customStruct[2].(map[string]interface{})
+	if !ok {
+		t.Fatal("unable to assert third element of customStruct to map[string]interface{}")
+	}
+
+	thirdElemVal, ok := thirdElement["element2"]
+	if !ok {
+		t.Fatal("unable to find key element2")
+	}
+
+	if thirdElemVal.(string) != "local" {
+		t.Fatal("label replacement not performed in third element")
+	}
+}


### PR DESCRIPTION
Fix for parsing structs types in values.

Related to https://github.com/rancher/fleet/issues/363

Prior to this change if the label names were embedded in array struct's in values section, they would not be parsed.

```
▶ more fleetlabelsdemo/fleet.yaml
namespace: default
helm:
  releaseName: labels
  values:
    clusterName: global.fleet.clusterLabels.name
    customStruct:
      - name: global.fleet.clusterLabels.name
        key1: value1
        key2: value2
```

The additional logic handles the same. Post processing the labels are rendered correctly

```
▶ helm get values labels -n default
USER-SUPPLIED VALUES:
clusterName: local
customStruct:
- key1: value1
  key2: value2
  name: local
global:
  fleet:
    clusterLabels:
      name: local
```