### PR TITLE
Redeploy agent on import cluster during upgrade

### DIFF
--- a/charts/fleet-agent/Chart.yaml
+++ b/charts/fleet-agent/Chart.yaml
@@ -7,6 +7,6 @@ icon: https://charts.rancher.io/assets/logos/fleet.svg
 annotations:
   catalog.cattle.io/certified: rancher
   catalog.cattle.io/hidden: "true"
-  catalog.cattle.io/namespace: fleet-system
+  catalog.cattle.io/namespace: cattle-fleet-system
   catalog.cattle.io/release-name: fleet-agent
   catalog.cattle.io/os: linux

--- a/charts/fleet-crd/Chart.yaml
+++ b/charts/fleet-crd/Chart.yaml
@@ -7,6 +7,6 @@ icon: https://charts.rancher.io/assets/logos/fleet.svg
 annotations:
   catalog.cattle.io/certified: rancher
   catalog.cattle.io/hidden: "true"
-  catalog.cattle.io/namespace: fleet-system
+  catalog.cattle.io/namespace: cattle-fleet-system
   catalog.cattle.io/release-name: fleet-crd
   catalog.cattle.io/os: linux

--- a/charts/fleet-crd/templates/crds.yaml
+++ b/charts/fleet-crd/templates/crds.yaml
@@ -1718,6 +1718,8 @@ spec:
                 type: integer
               agentMigrated:
                 type: boolean
+              cattleNamespaceMigrated:
+                type: boolean
               conditions:
                 items:
                   properties:

--- a/charts/fleet/Chart.yaml
+++ b/charts/fleet/Chart.yaml
@@ -9,7 +9,7 @@ annotations:
   catalog.cattle.io/certified: rancher
   catalog.cattle.io/hidden: "true"
   catalog.cattle.io/experimental: "true"
-  catalog.cattle.io/namespace: fleet-system
+  catalog.cattle.io/namespace: cattle-fleet-system
   catalog.cattle.io/release-name: fleet
   catalog.cattle.io/provides-gvr: clusters.fleet.cattle.io/v1alpha1
   catalog.cattle.io/os: linux

--- a/pkg/apis/fleet.cattle.io/v1alpha1/target.go
+++ b/pkg/apis/fleet.cattle.io/v1alpha1/target.go
@@ -2,7 +2,7 @@ package v1alpha1
 
 import (
 	"github.com/rancher/wrangler/pkg/genericcondition"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -78,6 +78,7 @@ type ClusterStatus struct {
 
 	AgentDeployedGeneration *int64 `json:"agentDeployedGeneration,omitempty"`
 	AgentMigrated           bool   `json:"agentMigrated,omitempty"`
+	CattleNamespaceMigrated bool   `json:"cattleNamespaceMigrated,omitempty"`
 
 	Display ClusterDisplay `json:"display,omitempty"`
 	Agent   AgentStatus    `json:"agent,omitempty"`

--- a/pkg/controllers/cluster/import.go
+++ b/pkg/controllers/cluster/import.go
@@ -65,6 +65,10 @@ func agentDeployed(cluster *fleet.Cluster) bool {
 		return false
 	}
 
+	if !cluster.Status.CattleNamespaceMigrated {
+		return false
+	}
+
 	if cluster.Status.AgentDeployedGeneration == nil {
 		return false
 	}
@@ -238,6 +242,7 @@ func (i *importHandler) importCluster(cluster *fleet.Cluster, status fleet.Clust
 
 	status.AgentDeployedGeneration = &cluster.Spec.RedeployAgentGeneration
 	status.AgentMigrated = true
+	status.CattleNamespaceMigrated = true
 	status.Agent = fleet.AgentStatus{}
 	return status, nil
 }


### PR DESCRIPTION
Add new condition so that during the upgrade the fleet-agent will get
redeployed into the correct namespace. This is for migrating fleet
rancher install to cattle-fleet-system

https://github.com/rancher/fleet/issues/395