### PR TITLE
Make sure setID is consistent across fleet-agent bundle

### DIFF
--- a/modules/agent/pkg/controllers/bundledeployment/controller.go
+++ b/modules/agent/pkg/controllers/bundledeployment/controller.go
@@ -3,6 +3,7 @@ package bundledeployment
 import (
 	"context"
 	"errors"
+	"strings"
 	"sync"
 	"time"
 
@@ -106,7 +107,7 @@ func (h *handler) Trigger(key string, bd *fleet.BundleDeployment) (*fleet.Bundle
 }
 
 func shouldRedeploy(bd *fleet.BundleDeployment) bool {
-	if bd.Name == "fleet-agent" {
+	if strings.HasPrefix(bd.Name, "fleet-agent") {
 		return true
 	}
 	if bd.Spec.Options.ForceSyncGeneration <= 0 {

--- a/modules/agent/pkg/deployer/monitor.go
+++ b/modules/agent/pkg/deployer/monitor.go
@@ -3,6 +3,7 @@ package deployer
 import (
 	"encoding/json"
 	"sort"
+	"strings"
 
 	"github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1"
 	"github.com/argoproj/argo-cd/util/argo"
@@ -142,9 +143,14 @@ func (m *Manager) normalizers(live objectset.ObjectByGVK, bd *fleet.BundleDeploy
 
 func (m *Manager) getApply(bd *fleet.BundleDeployment, ns string) (apply.Apply, error) {
 	apply := m.apply
+	// bundle is fleet-agent bundle, we need to use setID fleet-agent-bootstrap since it was applied with import controller
+	setID := name.SafeConcatName(m.labelPrefix, bd.Name)
+	if strings.HasPrefix(bd.Name, "fleet-agent") {
+		setID = "fleet-agent-bootstrap"
+	}
 	return apply.
 		WithIgnorePreviousApplied().
-		WithSetID(name.SafeConcatName(m.labelPrefix, bd.Name)).
+		WithSetID(setID).
 		WithDefaultNamespace(ns), nil
 }
 

--- a/pkg/helmdeployer/deployer.go
+++ b/pkg/helmdeployer/deployer.go
@@ -117,7 +117,12 @@ func (p *postRender) Run(renderedManifests *bytes.Buffer) (modifiedManifests *by
 	}
 	objs = append(objs, yamlObjs...)
 
-	labels, annotations, err := apply.GetLabelsAndAnnotations(name.SafeConcatName(p.labelPrefix, p.bundleID), nil)
+	// bundle is fleet-agent bundle, we need to use setID fleet-agent-bootstrap since it was applied with import controller
+	setID := name.SafeConcatName(p.labelPrefix, p.bundleID)
+	if strings.HasPrefix(p.bundleID, "fleet-agent") {
+		setID = "fleet-agent-bootstrap"
+	}
+	labels, annotations, err := apply.GetLabelsAndAnnotations(setID, nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
We need to make sure setID is consistent across fleet-agent bundle, since in import controller we use a different setID and that would include extra field that shouldn't be applied to the original fleet-agent bundle.

https://github.com/rancher/fleet/issues/422