### PR TITLE
Use `cluster.Name` as the context override for `ClientConfig`

### DIFF
--- a/pkg/controllers/cluster/import.go
+++ b/pkg/controllers/cluster/import.go
@@ -266,8 +266,12 @@ func (i *importHandler) restConfigFromKubeConfig(clusterName string, data []byte
 			if err == nil {
 				raw.Clusters[cluster].CertificateAuthorityData = nil
 			}
+
+			return clientcmd.NewDefaultClientConfig(raw, &clientcmd.ConfigOverrides{CurrentContext: clusterName}).ClientConfig()
 		}
-	} else if raw.Contexts[raw.CurrentContext] != nil {
+	}
+
+	if raw.Contexts[raw.CurrentContext] != nil {
 		cluster := raw.Contexts[raw.CurrentContext].Cluster
 		if raw.Clusters[cluster] != nil {
 			_, err := http.Get(raw.Clusters[cluster].Server)
@@ -277,5 +281,5 @@ func (i *importHandler) restConfigFromKubeConfig(clusterName string, data []byte
 		}
 	}
 
-	return clientcmd.NewDefaultClientConfig(raw, &clientcmd.ConfigOverrides{CurrentContext: clusterName}).ClientConfig()
+	return clientcmd.NewDefaultClientConfig(raw, &clientcmd.ConfigOverrides{}).ClientConfig()
 }


### PR DESCRIPTION
## What

Use `cluster.Name` as the context override for `ClientConfig`

## Why 

This is to accommodate the use case of sharing a single kubeconfig secret between many clusters. 

Currently we cannot share a single kubeconfig as the `ClientConfig` defaults to the `CurrentContext`
```go
// getContextName returns the default, or user-set context name, and a boolean that indicates
// whether the default context name has been overwritten by a user-set flag, or left as its default value
func (config *DirectClientConfig) getContextName() (string, bool) {
	if config.overrides != nil && len(config.overrides.CurrentContext) != 0 {
		return config.overrides.CurrentContext, true
	}
	if len(config.contextName) != 0 {
		return config.contextName, false
	}

	return config.config.CurrentContext, false
}
```