### PR TITLE
Fix double agent creation and add developer documentation

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -1,0 +1,52 @@
+# Developing
+
+This document contains tips, workflows, and more for developing within this repository.
+
+## Local Development
+
+All steps in this guide assume your current working directory is the root of the repository.
+Moreover, this guide was written for Unix-like developer environments, so you may need to modify some steps if you are using a non-Unix-like developer environment (i.e. Windows).
+
+### Preparation
+
+We need to use a registry to store `fleet-agent` developer builds.
+Using a personal [DockerHub](https://hub.docker.com/) repository is usually a suitable choice.
+The full repository name must be `<your-choice>/fleet-agent`.
+
+Now, we need export an environment variable with our repository name as the value.
+This will be used when building, pushing, and deploying our agent.
+
+> Note: the value for this variable should not include `/fleet-agent`.
+> For example, if your full DockerHub repository name is `foobar/fleet-agent`, the value used below should be `foobar`.
+
+Export the new `AGENT_REPO` variable and use the aforementioned value.
+
+```
+export AGENT_REPO=<your-OCI-image-repository>
+```
+
+### Live Controller Development
+
+Create a local cluster.
+For this guide, we will use [k3d](https://github.com/rancher/k3d).
+
+```sh
+k3d cluster create <NAME>
+```
+
+Now, we will build and push our `fleet-agent`, install our Fleet charts, and then replace the controller deployment with our local controller build.
+
+```sh
+(
+    REPO=$AGENT_REPO make agent-dev
+    docker push $AGENT_REPO/fleet-agent:dev
+    for i in fleet-system fleet-default fleet-local; do kubectl create namespace $i; done
+    helm install -n fleet-system fleet-crd ./charts/fleet-crd
+    helm install -n fleet-system fleet --set agentImage.repository=$AGENT_REPO/fleet-agent --set agentImage.imagePullPolicy=Always ./charts/fleet
+    kubectl delete deployment -n fleet-system fleet-controller
+    go run cmd/fleetcontroller/main.go
+)
+```
+
+The controller should be running in your terminal window/pane!
+You can now create [GitRepo](https://fleet.rancher.io/gitrepo-structure/) custom resource objects and test Fleet locally.

--- a/modules/agent/pkg/deployer/monitor.go
+++ b/modules/agent/pkg/deployer/monitor.go
@@ -143,14 +143,9 @@ func (m *Manager) normalizers(live objectset.ObjectByGVK, bd *fleet.BundleDeploy
 
 func (m *Manager) getApply(bd *fleet.BundleDeployment, ns string) (apply.Apply, error) {
 	apply := m.apply
-	// bundle is fleet-agent bundle, we need to use setID fleet-agent-bootstrap since it was applied with import controller
-	setID := name.SafeConcatName(m.labelPrefix, bd.Name)
-	if strings.HasPrefix(bd.Name, "fleet-agent") {
-		setID = "fleet-agent-bootstrap"
-	}
 	return apply.
 		WithIgnorePreviousApplied().
-		WithSetID(setID).
+		WithSetID(GetSetID(bd.Name, m.labelPrefix)).
 		WithDefaultNamespace(ns), nil
 }
 
@@ -180,6 +175,14 @@ func (m *Manager) MonitorBundle(bd *fleet.BundleDeployment) (DeploymentStatus, e
 	}
 
 	return status, nil
+}
+
+func GetSetID(bundleID, labelPrefix string) string {
+	// bundle is fleet-agent bundle, we need to use setID fleet-agent-bootstrap since it was applied with import controller
+	if strings.HasPrefix(bundleID, "fleet-agent") {
+		return "fleet-agent-bootstrap"
+	}
+	return name.SafeConcatName(labelPrefix, bundleID)
 }
 
 func sortKey(f fleet.ModifiedStatus) string {

--- a/pkg/helmdeployer/deployer.go
+++ b/pkg/helmdeployer/deployer.go
@@ -110,12 +110,7 @@ func (p *postRender) Run(renderedManifests *bytes.Buffer) (modifiedManifests *by
 	}
 	objs = append(objs, yamlObjs...)
 
-	// bundle is fleet-agent bundle, we need to use setID fleet-agent-bootstrap since it was applied with import controller
-	setID := name.SafeConcatName(p.labelPrefix, p.bundleID)
-	if strings.HasPrefix(p.bundleID, "fleet-agent") {
-		setID = "fleet-agent-bootstrap"
-	}
-	labels, annotations, err := apply.GetLabelsAndAnnotations(setID, nil)
+	labels, annotations, err := apply.GetLabelsAndAnnotations(p.GetSetID(), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -147,6 +142,10 @@ func (p *postRender) Run(renderedManifests *bytes.Buffer) (modifiedManifests *by
 
 	data, err = yaml.ToBytes(objs)
 	return bytes.NewBuffer(data), err
+}
+
+func (p *postRender) GetSetID() string {
+	return deployer.GetSetID(p.bundleID, p.labelPrefix)
 }
 
 func (h *helm) Deploy(bundleID string, manifest *manifest.Manifest, options fleet.BundleDeploymentOptions) (*deployer.Resources, error) {

--- a/scripts/agent-dev
+++ b/scripts/agent-dev
@@ -1,0 +1,39 @@
+#!/bin/bash
+set -e
+
+source $(dirname $0)/version
+
+cd $(dirname $0)/..
+
+mkdir -p bin
+mkdir -p dist/artifacts
+
+LINKFLAGS="-X github.com/rancher/fleet/pkg/version.Version=$VERSION"
+LINKFLAGS="-X github.com/rancher/fleet/pkg/version.GitCommit=$COMMIT $LINKFLAGS"
+LINKFLAGS="-s -w $LINKFLAGS"
+LINKFLAGS="$LINKFLAGS -extldflags -static"
+
+function build-binary() {
+    local BINARY=${1}-linux-${2}
+    local OUT="bin/${BINARY}"
+    if [ "$1" = "fleetagent" ]; then
+        OUT="$OUT ./cmd/${1}"
+    fi
+
+    printf "Building binary: ${BINARY} ...\n"
+    GOOS=linux GOARCH=${2} CGO_ENABLED=0 go build -ldflags "$LINKFLAGS" -o $OUT
+    cp bin/${BINARY} dist/artifacts/
+}
+
+function build-agent-image() {
+    build-binary fleet $1
+    build-binary fleetagent $1
+
+    IMAGE=${REPO}/fleet-agent:${TAG}
+    printf "Building fleet-agent image for linux-${1}: ${IMAGE}  ...\n"
+    docker build -f package/Dockerfile.agent -t ${IMAGE} --build-arg ARCH=${1} .
+}
+
+for i in "amd64" "arm64"; do
+    build-agent-image $i
+done

--- a/scripts/build
+++ b/scripts/build
@@ -27,7 +27,7 @@ function build-binaries() {
     if [ $1 = "windows" ]; then
         TEMP_SUFFIX=".exe"
     fi
-    GOOS=${1} GOARCH=${2}${TEMP_GOARCH} CGO_ENABLED=0 go build -ldflags "$TEMP_LINKFLAGS" -o bin/fleet-${1}-${2}${TEMP_SUFFIX}
+    GOOS=${1} GOARCH=${2}${TEMP_GOARM} CGO_ENABLED=0 go build -ldflags "$TEMP_LINKFLAGS" -o bin/fleet-${1}-${2}${TEMP_SUFFIX}
     if ! [ $1 = "darwin" ]; then
         GOOS=${1} GOARCH=${2}${TEMP_GOARM} CGO_ENABLED=0 go build -ldflags "$TEMP_LINKFLAGS" -o bin/fleetcontroller-${1}-${2}${TEMP_SUFFIX} ./cmd/fleetcontroller
         GOOS=${1} GOARCH=${2}${TEMP_GOARM} CGO_ENABLED=0 go build -ldflags "$TEMP_LINKFLAGS" -o bin/fleetagent-${1}-${2}${TEMP_SUFFIX} ./cmd/fleetagent


### PR DESCRIPTION
```
- Fix double agent creation when creating a GitRepo CR by ensuring a
  bad update results in the error being returned.
- Add developer documentation along with agent-dev for local agent
  builds.
- Fix an armv7 bug where the wrong ENV variable was used for the build
  script.
- Consolidate agent bootstrap setID to one function
```

Relevant issue: https://github.com/rancher/fleet/issues/437