### PR TITLE
Allow two agents to run on the same cluster

### DIFF
--- a/charts/fleet-crd/templates/crds.yaml
+++ b/charts/fleet-crd/templates/crds.yaml
@@ -1694,6 +1694,9 @@ spec:
                   type: object
                 nullable: true
                 type: array
+              agentNamespace:
+                nullable: true
+                type: string
               clientID:
                 nullable: true
                 type: string
@@ -1739,6 +1742,8 @@ spec:
                 nullable: true
                 type: string
               agentMigrated:
+                type: boolean
+              agentNamespaceMigrated:
                 type: boolean
               cattleNamespaceMigrated:
                 type: boolean
@@ -4308,6 +4313,9 @@ spec:
                 type: object
               nullable: true
               type: array
+            agentNamespace:
+              nullable: true
+              type: string
             clientID:
               nullable: true
               type: string
@@ -4353,6 +4361,8 @@ spec:
               nullable: true
               type: string
             agentMigrated:
+              type: boolean
+            agentNamespaceMigrated:
               type: boolean
             cattleNamespaceMigrated:
               type: boolean

--- a/cmd/fleetagent/main.go
+++ b/cmd/fleetagent/main.go
@@ -21,6 +21,7 @@ var (
 type FleetAgent struct {
 	Kubeconfig      string `usage:"kubeconfig file"`
 	Namespace       string `usage:"namespace to watch" env:"NAMESPACE"`
+	AgentScope      string `usage:"An identifier used to scope the agent bundleID names, typically the same as namespace" env:"AGENT_SCOPE"`
 	Simulators      int    `usage:"Numbers of simulators to run"`
 	CheckinInterval string `usage:"How often to post cluster status" env:"CHECKIN_INTERVAL"`
 }
@@ -47,7 +48,7 @@ func (a *FleetAgent) Run(cmd *cobra.Command, args []string) error {
 	if a.Simulators > 0 {
 		return simulator.Simulate(cmd.Context(), a.Simulators, a.Kubeconfig, a.Namespace, "default", opts)
 	}
-	if err := agent.Start(cmd.Context(), a.Kubeconfig, a.Namespace, &opts); err != nil {
+	if err := agent.Start(cmd.Context(), a.Kubeconfig, a.Namespace, a.AgentScope, &opts); err != nil {
 		return err
 	}
 	<-cmd.Context().Done()

--- a/modules/agent/pkg/agent/app.go
+++ b/modules/agent/pkg/agent/app.go
@@ -39,7 +39,7 @@ func Register(ctx context.Context, kubeConfig, namespace, clusterID string) erro
 	return err
 }
 
-func Start(ctx context.Context, kubeConfig, namespace string, opts *Options) error {
+func Start(ctx context.Context, kubeConfig, namespace, agentScope string, opts *Options) error {
 	if opts == nil {
 		opts = &Options{}
 	}
@@ -78,6 +78,7 @@ func Start(ctx context.Context, kubeConfig, namespace string, opts *Options) err
 		fleetNamespace,
 		namespace,
 		opts.DefaultNamespace,
+		agentScope,
 		agentInfo.ClusterNamespace,
 		agentInfo.ClusterName,
 		opts.CheckinInterval,

--- a/modules/agent/pkg/controllers/controllers.go
+++ b/modules/agent/pkg/controllers/controllers.go
@@ -76,7 +76,7 @@ func (a *appContext) start(ctx context.Context) error {
 }
 
 func Register(ctx context.Context, leaderElect bool,
-	fleetNamespace, agentNamespace, defaultNamespace, clusterNamespace, clusterName string,
+	fleetNamespace, agentNamespace, defaultNamespace, agentScope, clusterNamespace, clusterName string,
 	checkinInterval time.Duration,
 	fleetConfig *rest.Config, clientConfig clientcmd.ClientConfig,
 	fleetMapper, mapper meta.RESTMapper,
@@ -93,7 +93,7 @@ func Register(ctx context.Context, leaderElect bool,
 		labelPrefix = defaultNamespace
 	}
 
-	helmDeployer, err := helmdeployer.NewHelm(agentNamespace, defaultNamespace, labelPrefix, appCtx,
+	helmDeployer, err := helmdeployer.NewHelm(agentNamespace, defaultNamespace, labelPrefix, agentScope, appCtx,
 		appCtx.Core.ServiceAccount().Cache(), appCtx.Core.ConfigMap().Cache(), appCtx.Core.Secret().Cache())
 	if err != nil {
 		return err
@@ -101,10 +101,13 @@ func Register(ctx context.Context, leaderElect bool,
 
 	bundledeployment.Register(ctx,
 		trigger.New(ctx, appCtx.restMapper, appCtx.Dynamic),
+		appCtx.restMapper,
+		appCtx.Dynamic,
 		deployer.NewManager(
 			fleetNamespace,
 			defaultNamespace,
 			labelPrefix,
+			agentScope,
 			appCtx.Fleet.BundleDeployment().Cache(),
 			manifest.NewLookup(appCtx.Fleet.Content()),
 			helmDeployer,

--- a/modules/agent/pkg/deployer/manager.go
+++ b/modules/agent/pkg/deployer/manager.go
@@ -19,11 +19,12 @@ type Manager struct {
 	deployer              Deployer
 	apply                 apply.Apply
 	labelPrefix           string
+	labelSuffix           string
 }
 
 func NewManager(fleetNamespace string,
 	defaultNamespace string,
-	labelPrefix string,
+	labelPrefix, labelSuffix string,
 	bundleDeploymentCache fleetcontrollers.BundleDeploymentCache,
 	lookup manifest.Lookup,
 	deployer Deployer,
@@ -32,6 +33,7 @@ func NewManager(fleetNamespace string,
 		fleetNamespace:        fleetNamespace,
 		defaultNamespace:      defaultNamespace,
 		labelPrefix:           labelPrefix,
+		labelSuffix:           labelSuffix,
 		bundleDeploymentCache: bundleDeploymentCache,
 		lookup:                lookup,
 		deployer:              deployer,

--- a/modules/agent/pkg/deployer/monitor.go
+++ b/modules/agent/pkg/deployer/monitor.go
@@ -145,7 +145,7 @@ func (m *Manager) getApply(bd *fleet.BundleDeployment, ns string) (apply.Apply, 
 	apply := m.apply
 	return apply.
 		WithIgnorePreviousApplied().
-		WithSetID(GetSetID(bd.Name, m.labelPrefix)).
+		WithSetID(GetSetID(bd.Name, m.labelPrefix, m.labelSuffix)).
 		WithDefaultNamespace(ns), nil
 }
 
@@ -177,10 +177,16 @@ func (m *Manager) MonitorBundle(bd *fleet.BundleDeployment) (DeploymentStatus, e
 	return status, nil
 }
 
-func GetSetID(bundleID, labelPrefix string) string {
+func GetSetID(bundleID, labelPrefix, labelSuffix string) string {
 	// bundle is fleet-agent bundle, we need to use setID fleet-agent-bootstrap since it was applied with import controller
 	if strings.HasPrefix(bundleID, "fleet-agent") {
-		return "fleet-agent-bootstrap"
+		if labelSuffix == "" {
+			return "fleet-agent-bootstrap"
+		}
+		return name.SafeConcatName("fleet-agent-bootstrap", labelSuffix)
+	}
+	if labelSuffix != "" {
+		return name.SafeConcatName(labelPrefix, bundleID, labelSuffix)
 	}
 	return name.SafeConcatName(labelPrefix, bundleID)
 }

--- a/modules/agent/pkg/register/register.go
+++ b/modules/agent/pkg/register/register.go
@@ -33,7 +33,6 @@ const (
 	Values              = "values"
 	APIServerURL        = "apiServerURL"
 	APIServerCA         = "apiServerCA"
-	SystemNamespace     = "systemNamespace"
 	DeploymentNamespace = "deploymentNamespace"
 	ClusterNamespace    = "clusterNamespace"
 	ClusterName         = "clusterName"
@@ -187,12 +186,7 @@ func createClusterSecret(ctx context.Context, clusterID string, k8s corecontroll
 		newToken := newSecret.Data[Token]
 		clusterNamespace := newSecret.Data[ClusterNamespace]
 		clusterName := newSecret.Data[ClusterName]
-		systemNamespace := string(newSecret.Data[SystemNamespace])
 		deploymentNamespace := newSecret.Data[DeploymentNamespace]
-
-		if !cfg.IgnoreAgentNamespaceCheck && systemNamespace != secret.Namespace {
-			return nil, fmt.Errorf("fleet-agent must be installed in the namespace %s", systemNamespace)
-		}
 
 		newKubeconfig, err := updateClientConfig(clientConfig, string(newToken), string(deploymentNamespace))
 		if err != nil {

--- a/modules/agent/pkg/simulator/simulator.go
+++ b/modules/agent/pkg/simulator/simulator.go
@@ -76,7 +76,7 @@ func simulateAgent(ctx context.Context, i int, kubeConfig, namespace, defaultNam
 	opts.DefaultNamespace = simDefaultNamespace
 	opts.ClusterID = clusterID
 	opts.NoLeaderElect = true
-	return agent.Start(ctx, kubeConfig, simNamespace, &opts)
+	return agent.Start(ctx, kubeConfig, simNamespace, simNamespace, &opts)
 }
 
 func setupNamespace(ctx context.Context, kubeConfig, namespace, simNamespace string) (string, error) {
@@ -159,7 +159,6 @@ func injectConfig(cm *corev1.ConfigMap, simNamespace string) (*corev1.ConfigMap,
 	if err != nil {
 		return nil, err
 	}
-	cfg.IgnoreAgentNamespaceCheck = true
 	if cfg.Labels == nil {
 		cfg.Labels = map[string]string{}
 	}

--- a/modules/cli/agentconfig/agent.go
+++ b/modules/cli/agentconfig/agent.go
@@ -14,7 +14,7 @@ type Options struct {
 	ClientID string
 }
 
-func AgentConfig(ctx context.Context, controllerNamespace string, cg *client.Getter, opts *Options) ([]runtime.Object, error) {
+func AgentConfig(ctx context.Context, agentNamespace, controllerNamespace string, cg *client.Getter, opts *Options) ([]runtime.Object, error) {
 	if opts == nil {
 		opts = &Options{}
 	}
@@ -30,7 +30,7 @@ func AgentConfig(ctx context.Context, controllerNamespace string, cg *client.Get
 		return nil, err
 	}
 
-	return Objects(controllerNamespace, opts.Labels, opts.ClientID)
+	return Objects(agentNamespace, opts.Labels, opts.ClientID)
 }
 
 func Objects(controllerNamespace string, clusterLabels map[string]string, clientID string) ([]runtime.Object, error) {

--- a/pkg/agent/manifest.go
+++ b/pkg/agent/manifest.go
@@ -14,7 +14,7 @@ const (
 	DefaultName = "fleet-agent"
 )
 
-func Manifest(namespace, image, pullPolicy, generation, checkInInterval string, agentEnvVars []corev1.EnvVar) []runtime.Object {
+func Manifest(namespace, agentScope, image, pullPolicy, generation, checkInInterval string, agentEnvVars []corev1.EnvVar) []runtime.Object {
 	if image == "" {
 		image = config.DefaultAgentImage
 	}
@@ -34,6 +34,10 @@ func Manifest(namespace, image, pullPolicy, generation, checkInInterval string, 
 
 	dep := basic.Deployment(namespace, DefaultName, image, pullPolicy, DefaultName, false)
 	dep.Spec.Template.Spec.Containers[0].Env = append(dep.Spec.Template.Spec.Containers[0].Env,
+		corev1.EnvVar{
+			Name:  "AGENT_SCOPE",
+			Value: agentScope,
+		},
 		corev1.EnvVar{
 			Name:  "CHECKIN_INTERVAL",
 			Value: checkInInterval,

--- a/pkg/apis/fleet.cattle.io/v1alpha1/target.go
+++ b/pkg/apis/fleet.cattle.io/v1alpha1/target.go
@@ -66,6 +66,7 @@ type ClusterSpec struct {
 	KubeConfigSecret        string      `json:"kubeConfigSecret,omitempty"`
 	RedeployAgentGeneration int64       `json:"redeployAgentGeneration,omitempty"`
 	AgentEnvVars            []v1.EnvVar `json:"agentEnvVars,omitempty"`
+	AgentNamespace          string      `json:"agentNamespace,omitempty"`
 }
 
 type ClusterStatus struct {
@@ -79,6 +80,7 @@ type ClusterStatus struct {
 	AgentEnvVarsHash        string `json:"agentEnvVarsHash,omitempty"`
 	AgentDeployedGeneration *int64 `json:"agentDeployedGeneration,omitempty"`
 	AgentMigrated           bool   `json:"agentMigrated,omitempty"`
+	AgentNamespaceMigrated  bool   `json:"agentNamespaceMigrated,omitempty"`
 	CattleNamespaceMigrated bool   `json:"cattleNamespaceMigrated,omitempty"`
 
 	Display ClusterDisplay `json:"display,omitempty"`

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -43,7 +43,6 @@ type Config struct {
 	APIServerCA                     []byte            `json:"apiServerCA,omitempty"`
 	Bootstrap                       Bootstrap         `json:"bootstrap,omitempty"`
 	IgnoreClusterRegistrationLabels bool              `json:"ignoreClusterRegistrationLabels,omitempty"`
-	IgnoreAgentNamespaceCheck       bool              `json:"ignoreAgentNamespaceCheck,omitempty"`
 }
 
 type Bootstrap struct {

--- a/pkg/controllers/controllers.go
+++ b/pkg/controllers/controllers.go
@@ -110,7 +110,9 @@ func Register(ctx context.Context, systemNamespace string, cfg clientcmd.ClientC
 		systemNamespace,
 		appCtx.Core.Secret().Cache(),
 		appCtx.Cluster(),
-		appCtx.ClusterRegistrationToken())
+		appCtx.ClusterRegistrationToken(),
+		appCtx.Bundle(),
+		appCtx.Core.Namespace())
 
 	bundle.Register(ctx,
 		appCtx.Apply,

--- a/pkg/helmdeployer/deployer.go
+++ b/pkg/helmdeployer/deployer.go
@@ -46,6 +46,7 @@ var (
 
 type postRender struct {
 	labelPrefix string
+	labelSuffix string
 	bundleID    string
 	manifest    *manifest.Manifest
 	chart       *chart.Chart
@@ -64,9 +65,10 @@ type helm struct {
 	template            bool
 	defaultNamespace    string
 	labelPrefix         string
+	labelSuffix         string
 }
 
-func NewHelm(namespace, defaultNamespace, labelPrefix string, getter genericclioptions.RESTClientGetter,
+func NewHelm(namespace, defaultNamespace, labelPrefix, labelSuffix string, getter genericclioptions.RESTClientGetter,
 	serviceAccountCache corecontrollers.ServiceAccountCache, configmapCache corecontrollers.ConfigMapCache, secretCache corecontrollers.SecretCache) (deployer.Deployer, error) {
 	h := &helm{
 		getter:              getter,
@@ -76,6 +78,7 @@ func NewHelm(namespace, defaultNamespace, labelPrefix string, getter genericclio
 		configmapCache:      configmapCache,
 		secretCache:         secretCache,
 		labelPrefix:         labelPrefix,
+		labelSuffix:         labelSuffix,
 	}
 	if err := h.globalCfg.Init(getter, "", "secrets", logrus.Infof); err != nil {
 		return nil, err
@@ -145,7 +148,7 @@ func (p *postRender) Run(renderedManifests *bytes.Buffer) (modifiedManifests *by
 }
 
 func (p *postRender) GetSetID() string {
-	return deployer.GetSetID(p.bundleID, p.labelPrefix)
+	return deployer.GetSetID(p.bundleID, p.labelPrefix, p.labelSuffix)
 }
 
 func (h *helm) Deploy(bundleID string, manifest *manifest.Manifest, options fleet.BundleDeploymentOptions) (*deployer.Resources, error) {
@@ -299,6 +302,7 @@ func (h *helm) install(bundleID string, manifest *manifest.Manifest, chart *char
 
 	pr := &postRender{
 		labelPrefix: h.labelPrefix,
+		labelSuffix: h.labelSuffix,
 		bundleID:    bundleID,
 		manifest:    manifest,
 		opts:        options,


### PR DESCRIPTION
The change opens up the ability to run two or more agents pointed to
different fleet-controllers. The specific use case where this is useful
is for fleet managing a cluster that is running fleet to manage other
clusters. More concretely we have this with Rancher managing Rancher.
In this situation you want two fleet agents, one that is running for
fleet-local and one that is run for the upstream fleet-controller.