### PR TITLE
minor tweak to how values files are merged

### DIFF
--- a/pkg/bundle/resources.go
+++ b/pkg/bundle/resources.go
@@ -17,13 +17,12 @@ import (
 	"sync"
 	"unicode/utf8"
 
-	"github.com/rancher/wrangler/pkg/data"
-
 	"github.com/hashicorp/go-getter"
 	"github.com/pkg/errors"
 	"github.com/rancher/fleet/modules/cli/pkg/progress"
 	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
 	"github.com/rancher/fleet/pkg/content"
+	"github.com/rancher/wrangler/pkg/data"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/sync/semaphore"
 	"helm.sh/helm/v3/pkg/repo"

--- a/pkg/bundle/resources_test.go
+++ b/pkg/bundle/resources_test.go
@@ -1,0 +1,95 @@
+package bundle
+
+import (
+	"testing"
+
+	"github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
+	"github.com/rancher/wrangler/pkg/yaml"
+)
+
+const (
+	valuesOneYaml = `microService1:
+  resources:
+    limits:
+      cpu: 500m
+      memory: 500Mi
+    requests:
+      cpu: 256m
+      memory: 256Mi
+
+microService2:
+  resources:
+    limits:
+      cpu: 500m
+      memory: 500Mi
+    requests:
+      cpu: 256m
+      memory: 256Mi
+`
+	valuesTwoYaml = `microService1:
+  replicas: 1
+microService2:
+  replicas: 2`
+)
+
+func TestValueMerge(t *testing.T) {
+	first := &v1alpha1.GenericMap{}
+	second := &v1alpha1.GenericMap{}
+
+	err := yaml.Unmarshal([]byte(valuesOneYaml), first)
+	if err != nil {
+		t.Fatalf("error during valuesOneYaml parsing %v", err)
+	}
+
+	err = yaml.Unmarshal([]byte(valuesTwoYaml), second)
+	if err != nil {
+		t.Fatalf("error during valuesTwoYaml parsing %v", err)
+	}
+
+	mergeMap := mergeGenericMap(first, second)
+
+	for _, serviceName := range []string{"microService1", "microService2"} {
+		serviceVals, ok := mergeMap.Data[serviceName]
+		if !ok {
+			t.Fatalf("unable to find parent key for service %s", serviceName)
+		}
+		resourceVals, ok := serviceVals.(map[string]interface{})["resources"]
+		if !ok {
+			t.Fatalf("unable to find key resources in values for service %s", serviceName)
+		}
+
+		limitVals, ok := resourceVals.(map[string]interface{})["limits"]
+		if !ok {
+			t.Fatalf("unable to find key limits in resources for service %s", serviceName)
+		}
+
+		_, ok = limitVals.(map[string]interface{})["cpu"]
+		if !ok {
+			t.Fatalf("unable to find key cpu in limits for service %s", serviceName)
+		}
+
+		_, ok = limitVals.(map[string]interface{})["memory"]
+		if !ok {
+			t.Fatalf("unable to find key memory in limits for service %s", serviceName)
+		}
+
+		requestVals, ok := resourceVals.(map[string]interface{})["requests"]
+		if !ok {
+			t.Fatalf("unable to find key requests in resources for service %s", serviceName)
+		}
+
+		_, ok = requestVals.(map[string]interface{})["cpu"]
+		if !ok {
+			t.Fatalf("unable to find key cpu in requests for service %s", serviceName)
+		}
+
+		_, ok = requestVals.(map[string]interface{})["memory"]
+		if !ok {
+			t.Fatalf("unable to find key memory in requests for service %s", serviceName)
+		}
+		_, ok = serviceVals.(map[string]interface{})["replicas"]
+		if !ok {
+			t.Fatalf("unable to find key replicas in values for service %s", serviceName)
+		}
+	}
+}


### PR DESCRIPTION
Minor tweak to how we are performing valuesFile merge when a helm options are being processed.

Related to: https://github.com/rancher/fleet/issues/416

A sample fleet.yaml referencing two values files:

```
namespace: default
helm:
  chart: ./demo
  valuesFiles:
    - values1.yaml
    - values2.yaml
targets:
- clusterSelector: {}
```

values1.yaml
```
microService1:
  resources:
    limits:
      cpu: 500m
      memory: 500Mi
    requests:
      cpu: 256m
      memory: 256Mi

microService2:
  resources:
    limits:
      cpu: 500m
      memory: 500Mi
    requests:
      cpu: 256m
      memory: 256Mi
```

and values2.yaml

```
microService1:
  replicas: 1
microService2:
  replicas: 2
```

Will now be rendered as

```
apiVersion: fleet.cattle.io/v1alpha1
kind: Bundle
metadata:
  name: values-valuetest
  namespace: fleet-local
spec:
  helm:
    chart: ./demo
    values:
      microService1:
        replicas: 1
        resources:
          limits:
            cpu: 500m
            memory: 500Mi
          requests:
            cpu: 256m
            memory: 256Mi
      microService2:
        replicas: 2
        resources:
          limits:
            cpu: 500m
            memory: 500Mi
          requests:
            cpu: 256m
            memory: 256Mi
    valuesFiles:
    - values1.yaml
    - values2.yaml
 ``` 
