### PR TITLE
Fix comparePatches running only last operation

### DIFF
--- a/modules/agent/pkg/deployer/monitor.go
+++ b/modules/agent/pkg/deployer/monitor.go
@@ -126,7 +126,7 @@ func (m *Manager) normalizers(live objectset.ObjectByGVK, bd *fleet.BundleDeploy
 				key := objectset.ObjectKey{
 					Name:      patch.Name,
 					Namespace: patch.Namespace,
-					Index: i
+					Index: i,
 				}
 				jsonPatchNorm.Add(gvk, key, patchData)
 			}

--- a/modules/agent/pkg/deployer/monitor.go
+++ b/modules/agent/pkg/deployer/monitor.go
@@ -116,7 +116,7 @@ func (m *Manager) normalizers(live objectset.ObjectByGVK, bd *fleet.BundleDeploy
 				JSONPointers: patch.JsonPointers,
 			})
 
-			for _, op := range patch.Operations {
+			for i, op := range patch.Operations {
 				// compile each operation by itself so that one failing operation doesn't block the others
 				patchData, err := json.Marshal([]interface{}{op})
 				if err != nil {
@@ -126,6 +126,7 @@ func (m *Manager) normalizers(live objectset.ObjectByGVK, bd *fleet.BundleDeploy
 				key := objectset.ObjectKey{
 					Name:      patch.Name,
 					Namespace: patch.Namespace,
+					Index: i
 				}
 				jsonPatchNorm.Add(gvk, key, patchData)
 			}


### PR DESCRIPTION
closes #371 

This is a proposal and should be tested.
The goal is to allow JSON patch for each of the operations such as describe in https://fleet.rancher.io/bundle-diffs/

This PR adds the index element in the key object so that not only the last operation of the list is run, but also all of them.


