### PR TITLE
fixed config template error in agent-initiated.md

### DIFF
--- a/docs/agent-initiated.md
+++ b/docs/agent-initiated.md
@@ -90,7 +90,7 @@ kind: Cluster
 apiVersion: {{fleet.apiVersion}}
 metadata:
   name: my-cluster
-  namespaces: clusters
+  namespace: clusters
 spec:
   clientID: "really-random"
 ```


### PR DESCRIPTION
Dear Fleet-Team,

I just came across a small typo in the agent registration docs where the metadata section of the described cluster CRD contained the key `namespaces` instead of `namespace`.

Hope this small fix can get merged.