### PR TITLE
Bump GitJob v0.1.22 and Dapper dependencies

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -132,3 +132,12 @@ Ensure that clusters are in an "Active" state after migration.
 
 The controller should be running in your terminal window/pane!
 You can now create [GitRepo](https://fleet.rancher.io/gitrepo-structure/) custom resource objects and test Fleet locally.
+
+## Updating Fleet Components
+
+1. Update and tag [rancher/build-tekton](https://github.com/rancher/build-tekton)
+1. Update the `rancher/tekton-utils` tag in the `GitJob` helm chart in [rancher/gitjob](https://github.com/rancher/gitjob)
+1. Update and tag [rancher/gitjob](https://github.com/rancher/gitjob)
+1. Copy the `GitJob` helm chart to `./charts/fleet/charts/gitjob` in [rancher/fleet](https://github.com/rancher/fleet)
+1. Generate the `GitJob` CRD into a file in [rancher/fleet](https://github.com/rancher/fleet): `go run $GITJOB_REPO/pkg/crdgen/main.go > $FLEET_REPO/charts/fleet-crd/templates/gitjobs-crds.yaml`
+1. Update and tag [rancher/fleet](https://github.com/rancher/fleet) (usually as a release candidate) to use those components in a released version of Fleet

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,4 +1,4 @@
-FROM golang:1.16.4
+FROM golang:1.16.10
 
 ARG DAPPER_HOST_ARCH
 ENV ARCH $DAPPER_HOST_ARCH
@@ -6,7 +6,7 @@ ENV ARCH $DAPPER_HOST_ARCH
 RUN apt update && \
     apt install -y bash git gcc docker.io vim less file curl wget ca-certificates
 RUN if [ "${ARCH}" = "amd64" ]; then \
-        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.30.0; \
+        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.41.1; \
     fi
 RUN curl -sL https://get.helm.sh/helm-v3.3.0-linux-${ARCH}.tar.gz | tar xvzf - -C /usr/local/bin --strip-components=1
 

--- a/charts/fleet-crd/templates/gitjobs-crds.yaml
+++ b/charts/fleet-crd/templates/gitjobs-crds.yaml
@@ -49,6 +49,9 @@ spec:
                     type: string
                   insecureSkipTLSVerify:
                     type: boolean
+                  onTag:
+                    nullable: true
+                    type: string
                   provider:
                     nullable: true
                     type: string
@@ -3486,6 +3489,9 @@ spec:
                   type: string
                 insecureSkipTLSVerify:
                   type: boolean
+                onTag:
+                  nullable: true
+                  type: string
                 provider:
                   nullable: true
                   type: string

--- a/charts/fleet/charts/gitjob/Chart.yaml
+++ b/charts/fleet/charts/gitjob/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: gitjob
 description: Controller that run jobs based on git events
-version: v0.1.21
-appVersion: v0.1.21
+version: v0.1.22
+appVersion: v0.1.22

--- a/charts/fleet/charts/gitjob/values.yaml
+++ b/charts/fleet/charts/gitjob/values.yaml
@@ -1,10 +1,10 @@
 gitjob:
   repository: rancher/gitjob
-  tag: v0.1.21
+  tag: v0.1.22
 
 tekton:
   repository: rancher/tekton-utils
-  tag: v0.1.2
+  tag: v0.1.3
 
 global:
   cattle:

--- a/pkg/apis/go.mod
+++ b/pkg/apis/go.mod
@@ -1,6 +1,6 @@
 module github.com/rancher/fleet/pkg/apis
 
-go 1.15
+go 1.16
 
 require (
 	github.com/rancher/wrangler v0.6.2-0.20200829053106-7e1dd4260224


### PR DESCRIPTION
Relevant issue: https://github.com/rancher/fleet/issues/573
Note to reviewers: `golangci-lint` version was chosen to be the one that works with Go 1.16.x by default