### PR TITLE
remove windows 2004 SAC, bump versions

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -6,7 +6,7 @@ platform:
   arch: amd64
 steps:
 - name: build
-  image: rancher/dapper:v0.5.5
+  image: rancher/dapper:v0.5.7
   environment:
     CROSS: "windows"
   commands:
@@ -136,7 +136,7 @@ platform:
   arch: arm64
 steps:
 - name: build
-  image: rancher/dapper:v0.5.5
+  image: rancher/dapper:v0.5.7
   commands:
   - dapper build
   volumes:
@@ -332,57 +332,6 @@ depends_on:
 - linux-amd64
 
 ---
-
-kind: pipeline
-name: windows-2004
-platform:
-  os: windows
-  arch: amd64
-  version: 2004
-# remove this and use upstream images when https://github.com/drone/drone-git/pull/25 is merged
-clone:
-  disable: true
-steps:
-- name: clone
-  image: rancher/drone-images:git-2004
-  settings:
-    depth: 1
-- name: docker-publish-agent
-  image: rancher/drone-images:docker-2004
-  settings:
-    dockerfile: package/Dockerfile-windows.agent
-    password:
-      from_secret: docker_password
-    repo: "rancher/fleet-agent"
-    tag: "${DRONE_TAG}-windows-2004"
-    username:
-      from_secret: docker_username
-    build_args:
-      - "SERVERCORE_VERSION=2004"
-      - "RELEASES=releases.rancher.com"
-      - "VERSION=${DRONE_TAG}"
-    context: package/
-    custom_dns: 1.1.1.1
-  volumes:
-    - name: docker
-      path: \\\\.\\pipe\\docker_engine
-  when:
-    instance:
-    - drone-publish.rancher.io
-    ref:
-    - refs/head/master
-    - refs/tags/*
-    event:
-    - tag
-volumes:
-  - name: docker
-    host:
-      path: \\\\.\\pipe\\docker_engine
-depends_on:
-- linux-amd64
-
----
-
 kind: pipeline
 name: windows-20H2
 platform:
@@ -476,5 +425,4 @@ depends_on:
 - linux-arm64
 - linux-arm
 - windows-1809
-- windows-2004
 - windows-20H2

--- a/manifest-agent.tmpl
+++ b/manifest-agent.tmpl
@@ -22,12 +22,6 @@ manifests:
       os: windows
       version: 1809
   -
-    image: rancher/fleet-agent:{{#if build.tag}}{{build.tag}}{{else}}{{replace "release/" "" build.branch }}-head{{/if}}-windows-2004
-    platform:
-      architecture: amd64
-      os: windows
-      version: 2004
-  -
     image: rancher/fleet-agent:{{#if build.tag}}{{build.tag}}{{else}}{{replace "release/" "" build.branch }}-head{{/if}}-windows-20H2
     platform:
       architecture: amd64

--- a/package/Dockerfile-windows.agent
+++ b/package/Dockerfile-windows.agent
@@ -6,7 +6,7 @@ ENV RELEASES=$RELEASES
 ENV VERSION=$VERSION
 SHELL ["powershell", "-NoLogo", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 RUN pushd c:\; \
-    $URL = 'https://github.com/git-for-windows/git/releases/download/v2.30.1.windows.1/MinGit-2.30.1-64-bit.zip'; \
+    $URL = 'https://github.com/git-for-windows/git/releases/download/v2.33.1.windows.1/MinGit-2.33.1-64-bit.zip'; \
     \
     Write-Host ('Downloading git from {0} ...' -f $URL); \
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \


### PR DESCRIPTION
- bump to dapper 0.5.7
- remove windows server 2004 SAC from drone build steps and agent manifest templates