### PR TITLE
Converts Windows Agent container builds to nanoserver and multistage.

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -313,7 +313,7 @@ steps:
     username:
       from_secret: docker_username
     build_args:
-      - "SERVERCORE_VERSION=1809"
+      - "SERVER_VERSION=1809"
       - "RELEASES=releases.rancher.com"
       - "VERSION=${DRONE_TAG}"
     context: package/
@@ -363,7 +363,7 @@ steps:
     username:
       from_secret: docker_username
     build_args:
-      - "SERVERCORE_VERSION=20H2"
+      - "SERVER_VERSION=20H2"
       - "RELEASES=releases.rancher.com"
       - "VERSION=${DRONE_TAG}"
     context: package/

--- a/package/Dockerfile-windows.agent
+++ b/package/Dockerfile-windows.agent
@@ -1,16 +1,16 @@
-ARG SERVERCORE_VERSION
-FROM mcr.microsoft.com/windows/servercore:${SERVERCORE_VERSION}
+ARG SERVER_VERSION
+FROM mcr.microsoft.com/powershell:lts-nanoserver-${SERVER_VERSION} AS BUILD
 ARG RELEASES
 ARG VERSION
 ENV RELEASES=$RELEASES
 ENV VERSION=$VERSION
-SHELL ["powershell", "-NoLogo", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+SHELL ["pwsh", "-NoLogo", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 RUN pushd c:\; \
     $URL = 'https://github.com/git-for-windows/git/releases/download/v2.33.1.windows.1/MinGit-2.33.1-64-bit.zip'; \
     \
     Write-Host ('Downloading git from {0} ...' -f $URL); \
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-    Invoke-WebRequest -UseBasicParsing -OutFile c:\git.zip -Uri $URL; \
+    Invoke-RestMethod -UseBasicParsing -OutFile c:\git.zip -Uri $URL; \
     \
     Write-Host 'Expanding ...'; \
     Expand-Archive -Force -Path c:\git.zip -DestinationPath c:\git\.; \
@@ -22,7 +22,14 @@ RUN pushd c:\; \
     popd;
 RUN $URL = 'https://{0}/fleet/{1}/fleetagent-windows-amd64.exe' -f $env:RELEASES, $env:VERSION; \
     New-Item -Path 'c:\\' -Name 'fleet' -ItemType 'directory'; \
-    Write-Host ('Downloading dapper from {0} ...' -f $URL); \
+    Write-Host ('Downloading fleet-agent from {0} ...' -f $URL); \
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-    Invoke-WebRequest -UseBasicParsing -OutFile c:/fleet/fleetagent-windows.exe -Uri $URL;
+    Invoke-RestMethod -UseBasicParsing -OutFile c:/fleet/fleetagent-windows.exe -Uri $URL;
+
+FROM mcr.microsoft.com/windows/nanoserver:${SERVER_VERSION}
+
+RUN mkdir "git" "fleet"
+COPY --from=build c:/git/. c:/git/.
+COPY --from=build c:/fleet/. c:/fleet/.
+
 CMD ["C:\\fleet\\fleetagent-windows.exe"]

--- a/package/Dockerfile-windows.agent
+++ b/package/Dockerfile-windows.agent
@@ -1,10 +1,10 @@
 ARG SERVER_VERSION
-FROM mcr.microsoft.com/powershell:lts-nanoserver-${SERVER_VERSION} AS BUILD
+FROM mcr.microsoft.com/windows/servercore:${SERVER_VERSION} AS BUILD
 ARG RELEASES
 ARG VERSION
 ENV RELEASES=$RELEASES
 ENV VERSION=$VERSION
-SHELL ["pwsh", "-NoLogo", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+SHELL ["powershell", "-NoLogo", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 RUN pushd c:\; \
     $URL = 'https://github.com/git-for-windows/git/releases/download/v2.33.1.windows.1/MinGit-2.33.1-64-bit.zip'; \
     \
@@ -26,7 +26,7 @@ RUN $URL = 'https://{0}/fleet/{1}/fleetagent-windows-amd64.exe' -f $env:RELEASES
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
     Invoke-RestMethod -UseBasicParsing -OutFile c:/fleet/fleetagent-windows.exe -Uri $URL;
 
-FROM mcr.microsoft.com/windows/nanoserver:${SERVER_VERSION}
+FROM mcr.microsoft.com/windows/servercore:${SERVER_VERSION}
 
 RUN mkdir "git" "fleet"
 COPY --from=build c:/git/. c:/git/.

--- a/package/README.md
+++ b/package/README.md
@@ -21,5 +21,5 @@ Finally, you can build the image with an uploaded binary from a tagged release.
 This is useful when testing the `agent` in a Windows cluster.
 
 ```powershell
-docker build -t test -f package\Dockerfile-windows.agent --build-arg SERVERCORE_VERSION=1909 --build-arg RELEASES=releases.rancher.com --build-arg VERSION=v0.3.4-rc4 .
+docker build -t test -f package\Dockerfile-windows.agent --build-arg SERVER_VERSION=1909 --build-arg RELEASES=releases.rancher.com --build-arg VERSION=v0.3.4-rc4 .
 ```


### PR DESCRIPTION
This converts it to nanoserver and multistage producing a smaller image.

* https://github.com/rancher/windows/issues/78

Signed-off-by: Jamie Phillips <jamie.phillips@suse.com>