### PR TITLE
Ability to specify custom CA bundle in fleet.yaml

### DIFF
--- a/charts/fleet-crd/templates/crds.yaml
+++ b/charts/fleet-crd/templates/crds.yaml
@@ -113,6 +113,9 @@ spec:
               helm:
                 nullable: true
                 properties:
+                  caBundle:
+                    nullable: true
+                    type: string
                   chart:
                     nullable: true
                     type: string
@@ -480,6 +483,9 @@ spec:
                     helm:
                       nullable: true
                       properties:
+                        caBundle:
+                          nullable: true
+                          type: string
                         chart:
                           nullable: true
                           type: string
@@ -987,6 +993,9 @@ spec:
                   helm:
                     nullable: true
                     properties:
+                      caBundle:
+                        nullable: true
+                        type: string
                       chart:
                         nullable: true
                         type: string
@@ -1130,6 +1139,9 @@ spec:
                   helm:
                     nullable: true
                     properties:
+                      caBundle:
+                        nullable: true
+                        type: string
                       chart:
                         nullable: true
                         type: string
@@ -2784,6 +2796,9 @@ spec:
             helm:
               nullable: true
               properties:
+                caBundle:
+                  nullable: true
+                  type: string
                 chart:
                   nullable: true
                   type: string
@@ -3151,6 +3166,9 @@ spec:
                   helm:
                     nullable: true
                     properties:
+                      caBundle:
+                        nullable: true
+                        type: string
                       chart:
                         nullable: true
                         type: string
@@ -3659,6 +3677,9 @@ spec:
                 helm:
                   nullable: true
                   properties:
+                    caBundle:
+                      nullable: true
+                      type: string
                     chart:
                       nullable: true
                       type: string
@@ -3802,6 +3823,9 @@ spec:
                 helm:
                   nullable: true
                   properties:
+                    caBundle:
+                      nullable: true
+                      type: string
                     chart:
                       nullable: true
                       type: string

--- a/pkg/apis/fleet.cattle.io/v1alpha1/bundle.go
+++ b/pkg/apis/fleet.cattle.io/v1alpha1/bundle.go
@@ -233,6 +233,7 @@ type HelmOptions struct {
 	TakeOwnership  bool         `json:"takeOwnership,omitempty"`
 	MaxHistory     int          `json:"maxHistory,omitempty"`
 	ValuesFiles    []string     `json:"valuesFiles,omitempty"`
+	CABundle       string       `json:"caBundle,omitempty`
 }
 
 // Define helm values that can come from configmap, secret or external. Credit: https://github.com/fluxcd/helm-operator/blob/0cfea875b5d44bea995abe7324819432070dfbdc/pkg/apis/helm.fluxcd.io/v1/types_helmrelease.go#L439

--- a/pkg/bundle/resources.go
+++ b/pkg/bundle/resources.go
@@ -58,6 +58,17 @@ func readResources(ctx context.Context, spec *fleet.BundleSpec, compress bool, b
 		}
 	}
 
+	// if auth doesnt have a CA cert but bundle helm Options do then
+	// lets add them here
+
+	if len(auth.CABundle) == 0 && spec.Helm.CABundle != "" {
+		cert, err := base64.StdEncoding.DecodeString(spec.Helm.CABundle)
+		if err != nil {
+			return nil, err
+		}
+		auth.CABundle = cert
+	}
+
 	directories, err = addCharts(directories, base, chartDirs, auth)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Minor tweak to allow an encoded CA cert to be provided in the Helm Options.

The included CA bundle is used to override the CA bundle available via the auth secret.

For example with a helm repo running a cert signed by a custom CA, the following bundle fails:

```yaml
namespace: default
helm:
  releaseName: demobundle
  repo: https://chartmuseum.chartmuseum.172.16.132.80.sslip.io
  chart: testchart
```

```
fleet apply --kubeconfig $KUBECONFIG --namespace fleet-local insecure ./insecurebundle
FATA[0000] Get "https://chartmuseum.chartmuseum.172.16.132.80.sslip.io/index.yaml": x509: certificate signed by unknown authority
```

We can now provide a base64 encoded CA Cert in the HelmOptions to allow fleet to work with this Helm repo.

```yaml
namespace: default
helm:
  releaseName: demobundle
  repo: https://chartmuseum.chartmuseum.172.16.132.80.sslip.io
  chart: testchart
  caBundle: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUMrVENDQWVHZ0F3SUJBZ0lKQUtQR3dLRGwvNUhuTUEwR0NTcUdTSWIzRFFFQkN3VUFNQk14RVRBUEJnTlYKQkFNTUNHcHZjMmgyWVc1c01CNFhEVEU1TURneU1qRTJNRFUxT0ZvWERUSTVNRGd4T1RFMk1EVTFPRm93RXpFUgpNQThHQTFVRUF3d0lhbTl6YUhaaGJtd3dnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCRHdBd2dnRUtBb0lCCkFRQ3doU0IvcVc2L2tMYjJ6cHUrRUp2RDl3SEZhcStRQS8wSkgvTGxseW83ekFGeCtISHErQ09BYmsrQzhCNHQKL0hVRXNuczVSTDA5Q1orWDRqNnBiSkZkS2R1UHhYdTVaVllua3hZcFVEVTd5ZzdPU0tTWnpUbklaNzIzc01zMApSNmpZbi9Ecmo0eFhNSkVmSFVEcVllU1dsWnIzcWkxRUZhMGM3ZlZEeEgrNHh0WnROTkZPakg3YzZEL3ZXa0lnCldRVXhpd3Vzc2U2S01PV2pEbnYvNFZyamVsMlFnVVlVYkhDeWVaSG1jdGkrSzBMV0Nmby9SZzZQdWx3cmJEa2gKam1PZ1l0MzBwZGhYME9aa0F1a2xmVURIZnA4YmpiQ29JMnRhWUFCQTZBS2pLc08zNUxBRVU3OUNMMW1MVkh1WgpBQ0k1VWppamEzVlBXVkhTd21KUEp5dXhBZ01CQUFHalVEQk9NQjBHQTFVZERnUVdCQlFtbDVkVEFaaXhGS2hqCjkzd3VjUldoYW8vdFFqQWZCZ05WSFNNRUdEQVdnQlFtbDVkVEFaaXhGS2hqOTN3dWNSV2hhby90UWpBTUJnTlYKSFJNRUJUQURBUUgvTUEwR0NTcUdTSWIzRFFFQkN3VUFBNElCQVFCK2tsa1JOSlVLQkxYOHlZa3l1VTJSSGNCdgpHaG1tRGpKSXNPSkhac29ZWGRMbEcxcFpORmpqUGFPTDh2aDQ0Vmw5OFJoRVpCSHNMVDFLTWJwMXN1NkNxajByClVHMWtwUkJlZitJT01UNE1VN3ZSSUNpN1VPbFJMcDFXcDBGOGxhM2hQT2NSYjJ5T2ZGcVhYeVpXWGY0dDBCNDUKdEhpK1pDTkhCOUZ4alNSeWNiR1lWaytUS3B2aEphU1lOTUdKM2R4REthUDcrRHgzWGNLNnNBbklBa2h5SThhagpOVSttdzgvdG1Sa1A0SW4va1hBUitSaTBxVW1Iai92d3ZuazRLbTdaVXkxRllIOERNZVM1TmtzbisvdUhsUnhSClY3RG5uMDM5VFJtZ0tiQXFONzJnS05MbzVjWit5L1lxREFZSFlybjk4U1FUOUpEZ3RJL0svQVRwVzhkWAotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==
```

Helps address: https://github.com/rancher/fleet/issues/235
