### PR TITLE
Added bundle lifecycle in examples, added link from concepts page

### DIFF
--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -1,7 +1,7 @@
 # Core Concepts
 
 Fleet is fundamentally a set of Kubernetes custom resource definitions (CRDs) and controllers
-to manage GitOps for a single Kubernetes cluster or a large scale deployments of Kubernetes clusters
+to manage GitOps for a single Kubernetes cluster or a large scale deployment of Kubernetes clusters
 (up to one million). Below are some of the concepts of Fleet that will be useful through out this documentation.
 
 * **Fleet Manager**: The centralized component that orchestrates the deployments of Kubernetes assets
@@ -22,6 +22,9 @@ to manage GitOps for a single Kubernetes cluster or a large scale deployments of
     contents of a `Bundle` may be Kubernetes manifests, Kustomize configuration, or Helm charts.
     Regardless of the source the contents are dynamically rendered into a Helm chart by the agent
     and installed into the downstream cluster as a helm release.
+
+    - To see the **lifecycle of a bundle**, click [here](./examples.md#lifecycle-of-a-fleet-bundle).
+
 * **BundleDeployment**: When a `Bundle` is deployed to a cluster an instance of a `Bundle` is called a `BundleDeployment`.
     A `BundleDeployment` represents the state of that `Bundle` on a specific cluster with it's cluster specific
     customizations. The Fleet agent is only aware of `BundleDeployment` resources that are created for 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,4 +1,16 @@
 # Examples
 
-Examples using raw Kubernetes YAML, Helm charts, Kustomize and combinations
+### Lifecycle of a Fleet Bundle
+
+To demonstrate the lifecycle of a Fleet bundle, we will use multi-cluster/helm as a case study.
+
+1. User creates a [GitRepo](./gitrepo-add.md#create-gitrepo-instance) that points to the [multi-cluster/helm](https://github.com/rancher/fleet-examples/tree/master/multi-cluster/helm) repository.
+2. The Gitjob controller will sync changes from the GitRepo and detect changes from the poll/webhook. With every commit change, the Gitjob controller will create a job that clones the git repository, reads content from the repo such as fleet.yaml and other manifests, and creates the Fleet [bundle](./cluster-bundles-state.md#bundles).
+3. The Fleet-controller then syncs changes from the bundle. According to the targets, the Fleet-controller will create `BundleDeployment` resources, which are a combination of a bundle and a target cluster.
+4. The Fleet-agent will then pull the `BundleDeployment` from the Fleet controlplane. The agent deploys a real application and configuration as a [Helm chart](https://helm.sh/docs/intro/install/) from the `BundleDeployment` into the downstream clusters.
+5. The Fleet-agent will continue to monitor the application bundle and report statuses back in the following order: bundledeployment > bundle > GitRepo > cluster.
+
+### Additional Examples
+
+Examples using raw Kubernetes YAML, Helm charts, Kustomize, and combinations
 of the three are in the [Fleet Examples repo](https://github.com/rancher/fleet-examples/).

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -10,7 +10,7 @@ To demonstrate the lifecycle of a Fleet bundle, we will use [multi-cluster/helm]
 >**Note:** The job pod with the image name `rancher/tekton-utils` will be under the same namespace as the GitRepo.
 
 3. The `fleet-controller` then syncs changes from the bundle. According to the targets, the `fleet-controller` will create `BundleDeployment` resources, which are a combination of a bundle and a target cluster.
-4. The `fleet-agent` will then pull the `BundleDeployment` from the Fleet controlplane. The agent deploys a real application and configuration as a [Helm chart](https://helm.sh/docs/intro/install/) from the `BundleDeployment` into the downstream clusters.
+4. The `fleet-agent` will then pull the `BundleDeployment` from the Fleet controlplane. The agent deploys bundle manifests as a [Helm chart](https://helm.sh/docs/intro/install/) from the `BundleDeployment` into the downstream clusters.
 5. The `fleet-agent` will continue to monitor the application bundle and report statuses back in the following order: bundledeployment > bundle > GitRepo > cluster.
 
 ### Additional Examples

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -5,7 +5,7 @@
 To demonstrate the lifecycle of a Fleet bundle, we will use [multi-cluster/helm](https://github.com/rancher/fleet-examples/tree/master/multi-cluster/helm) as a case study.
 
 1. User will create a [GitRepo](./gitrepo-add.md#create-gitrepo-instance) that points to the multi-cluster/helm repository.
-2. The `gitjob-controller` will sync changes from the GitRepo and detect changes from the poll/webhook. With every commit change, the `gitjob-controller` will create a job that clones the git repository, reads content from the repo such as `fleet.yaml` and other manifests, and creates the Fleet [bundle](./cluster-bundles-state.md#bundles).
+2. The `gitjob-controller` will sync changes from the GitRepo and detect changes from the polling or [webhook event](./webhook.md). With every commit change, the `gitjob-controller` will create a job that clones the git repository, reads content from the repo such as `fleet.yaml` and other manifests, and creates the Fleet [bundle](./cluster-bundles-state.md#bundles).
 
 >**Note:** The job pod with the image name `rancher/tekton-utils` will be under the same namespace as the GitRepo.
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -2,13 +2,16 @@
 
 ### Lifecycle of a Fleet Bundle
 
-To demonstrate the lifecycle of a Fleet bundle, we will use multi-cluster/helm as a case study.
+To demonstrate the lifecycle of a Fleet bundle, we will use [multi-cluster/helm](https://github.com/rancher/fleet-examples/tree/master/multi-cluster/helm) as a case study.
 
-1. User creates a [GitRepo](./gitrepo-add.md#create-gitrepo-instance) that points to the [multi-cluster/helm](https://github.com/rancher/fleet-examples/tree/master/multi-cluster/helm) repository.
-2. The Gitjob controller will sync changes from the GitRepo and detect changes from the poll/webhook. With every commit change, the Gitjob controller will create a job that clones the git repository, reads content from the repo such as fleet.yaml and other manifests, and creates the Fleet [bundle](./cluster-bundles-state.md#bundles).
-3. The Fleet-controller then syncs changes from the bundle. According to the targets, the Fleet-controller will create `BundleDeployment` resources, which are a combination of a bundle and a target cluster.
-4. The Fleet-agent will then pull the `BundleDeployment` from the Fleet controlplane. The agent deploys a real application and configuration as a [Helm chart](https://helm.sh/docs/intro/install/) from the `BundleDeployment` into the downstream clusters.
-5. The Fleet-agent will continue to monitor the application bundle and report statuses back in the following order: bundledeployment > bundle > GitRepo > cluster.
+1. User will create a [GitRepo](./gitrepo-add.md#create-gitrepo-instance) that points to the multi-cluster/helm repository.
+2. The `gitjob-controller` will sync changes from the GitRepo and detect changes from the poll/webhook. With every commit change, the `gitjob-controller` will create a job that clones the git repository, reads content from the repo such as `fleet.yaml` and other manifests, and creates the Fleet [bundle](./cluster-bundles-state.md#bundles).
+
+>**Note:** The job pod with the image name `rancher/tekton-utils` will be under the same namespace as the GitRepo.
+
+3. The `fleet-controller` then syncs changes from the bundle. According to the targets, the `fleet-controller` will create `BundleDeployment` resources, which are a combination of a bundle and a target cluster.
+4. The `fleet-agent` will then pull the `BundleDeployment` from the Fleet controlplane. The agent deploys a real application and configuration as a [Helm chart](https://helm.sh/docs/intro/install/) from the `BundleDeployment` into the downstream clusters.
+5. The `fleet-agent` will continue to monitor the application bundle and report statuses back in the following order: bundledeployment > bundle > GitRepo > cluster.
 
 ### Additional Examples
 


### PR DESCRIPTION
Closes #627

References: 
https://fleet.rancher.io/examples/ - added lifecycle under examples page
https://fleet.rancher.io/concepts/ - added link to new section 