### PR TITLE
Adding the case where paths field is empty when updating manifests

### DIFF
--- a/pkg/controllers/image/image.go
+++ b/pkg/controllers/image/image.go
@@ -237,7 +237,14 @@ func (h handler) onChangeGitRepo(gitrepo *v1alpha1.GitRepo, status v1alpha1.GitR
 		return status, err
 	}
 
-	for _, path := range gitrepo.Spec.Paths {
+	// Checking if paths field is empty
+	// if yes, using the default value "/"
+	paths := gitrepo.Spec.Paths
+	if len(paths) == 0 {
+		paths = []string{"/"}
+	}
+
+	for _, path := range paths {
 		updatePath := filepath.Join(tmp, path)
 		if err := update.WithSetters(updatePath, updatePath, scans); err != nil {
 			kstatus.SetError(gitrepo, err.Error())


### PR DESCRIPTION
This PR aims at integrating an overseen case in the ImageScan feature, when the `paths` field is empty. 

The PR adds the default value for the `paths` array, which is `[1]string{"/"}`  in an intermediate `paths` variable that is then iterated on.

This is linked to the issue #650 