### PR TITLE
Added example config management use case, links, and example install instructions

### DIFF
--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -1,8 +1,8 @@
 # Core Concepts
 
 Fleet is fundamentally a set of Kubernetes custom resource definitions (CRDs) and controllers
-to manage GitOps for a single Kubernetes cluster or a large scale deployment of Kubernetes clusters
-(up to one million). 
+to manage GitOps for a single Kubernetes cluster or a large-scale deployment of Kubernetes clusters. 
+Note that Fleet is designed for mass horizontal scaling, but to date, scaling up to one million clusters has only been done in a test environment, not in production.
 
 Below are some of the concepts of Fleet that will be useful throughout this documentation:
 
@@ -19,12 +19,12 @@ Below are some of the concepts of Fleet that will be useful throughout this docu
     This agent is just another set of Kubernetes controllers running in the downstream cluster.
 * **GitRepo**: Git repositories that are watched by Fleet are represented by the type `GitRepo`.
 
->**Example installation order via `GitRepo` custom resources when using Fleet for the configuration management behind clusters:**
+>**Example installation order via `GitRepo` custom resources when using Fleet for the configuration management of downstream clusters:**
 >
-> 1. Install Calico CRDs and controllers.
-> 2. Set the global network policy at a cluster level.
-> 3. Install GateKeeper. Note that **cluster labels** and **overlays** are critical features in Fleet as they determine which clusters will get each part of the bundle.
-> 4. Set up and configure the ingress and system daemons.
+> 1. Install [Calico](https://github.com/projectcalico/calico) CRDs and controllers.
+> 2. Set one or multiple cluster-level global network policies.
+> 3. Install [GateKeeper](https://github.com/open-policy-agent/gatekeeper). Note that **cluster labels** and **overlays** are critical features in Fleet as they determine which clusters will get each part of the bundle.
+> 4. Set up and configure ingress and system daemons.
 
 * **Bundle**: An internal unit used for the orchestration of resources from git.
     When a `GitRepo` is scanned it will produce one or more bundles. Bundles are a collection of

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -2,13 +2,15 @@
 
 Fleet is fundamentally a set of Kubernetes custom resource definitions (CRDs) and controllers
 to manage GitOps for a single Kubernetes cluster or a large scale deployment of Kubernetes clusters
-(up to one million). Below are some of the concepts of Fleet that will be useful through out this documentation.
+(up to one million). 
+
+Below are some of the concepts of Fleet that will be useful throughout this documentation:
 
 * **Fleet Manager**: The centralized component that orchestrates the deployments of Kubernetes assets
-    from git. In a multi-cluster setup this will typically be a dedicated Kubernetes cluster. In a
-    single cluster setup the Fleet manager will be running on the same cluster you are managing with GitOps.
-* **Fleet controller**: The controller(s) running on the Fleet manager orchestrating GitOps. In practice
-    Fleet manager and Fleet controllers is used fairly interchangeably.
+    from git. In a multi-cluster setup, this will typically be a dedicated Kubernetes cluster. In a
+    single cluster setup, the Fleet manager will be running on the same cluster you are managing with GitOps.
+* **Fleet controller**: The controller(s) running on the Fleet manager orchestrating GitOps. In practice,
+    the Fleet manager and Fleet controllers are used fairly interchangeably.
 * **Single Cluster Style**: This is a style of installing Fleet in which the manager and downstream cluster are the
     same cluster.  This is a very simple pattern to quickly get up and running with GitOps.
 * **Multi Cluster Style**: This is a style of running Fleet in which you have a central manager that manages a large
@@ -16,6 +18,14 @@ to manage GitOps for a single Kubernetes cluster or a large scale deployment of 
 * **Fleet agent**: Every managed downstream cluster will run an agent that communicates back to the Fleet manager.
     This agent is just another set of Kubernetes controllers running in the downstream cluster.
 * **GitRepo**: Git repositories that are watched by Fleet are represented by the type `GitRepo`.
+
+>**Example installation order via `GitRepo` custom resources when using Fleet for the configuration management behind clusters:**
+>
+> 1. Install Calico CRDs and controllers.
+> 2. Set the global network policy at a cluster level.
+> 3. Install GateKeeper. Note that **cluster labels** and **overlays** are critical features in Fleet as they determine which clusters will get each part of the bundle.
+> 4. Set up and configure the ingress and system daemons.
+
 * **Bundle**: An internal unit used for the orchestration of resources from git.
     When a `GitRepo` is scanned it will produce one or more bundles. Bundles are a collection of
     resources that get deployed to a cluster. `Bundle` is the fundamental deployment unit used in Fleet. The
@@ -26,9 +36,11 @@ to manage GitOps for a single Kubernetes cluster or a large scale deployment of 
     - To see the **lifecycle of a bundle**, click [here](./examples.md#lifecycle-of-a-fleet-bundle).
 
 * **BundleDeployment**: When a `Bundle` is deployed to a cluster an instance of a `Bundle` is called a `BundleDeployment`.
-    A `BundleDeployment` represents the state of that `Bundle` on a specific cluster with it's cluster specific
+    A `BundleDeployment` represents the state of that `Bundle` on a specific cluster with its cluster specific
     customizations. The Fleet agent is only aware of `BundleDeployment` resources that are created for 
     the cluster the agent is managing.
-* **Downstream Cluster**: Clusters to which Fleet deploys manifests are referred to as downstream clusters. In the single
-    cluster use case the Fleet manager Kubernetes cluster is both the manager and downstream cluster at the same time.
+
+    - For an example of how to deploy Kubernetes manifests across clusters using Fleet customization, click [here](./examples.md#deploy-kubernetes-manifests-across-clusters-with-customization).
+
+* **Downstream Cluster**: Clusters to which Fleet deploys manifests are referred to as downstream clusters. In the single cluster use case, the Fleet manager Kubernetes cluster is both the manager and downstream cluster at the same time.
 * **Cluster Registration Token**: Tokens used by agents to register a new cluster.

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -13,6 +13,62 @@ To demonstrate the lifecycle of a Fleet bundle, we will use [multi-cluster/helm]
 4. The `fleet-agent` will then pull the `BundleDeployment` from the Fleet controlplane. The agent deploys bundle manifests as a [Helm chart](https://helm.sh/docs/intro/install/) from the `BundleDeployment` into the downstream clusters.
 5. The `fleet-agent` will continue to monitor the application bundle and report statuses back in the following order: bundledeployment > bundle > GitRepo > cluster.
 
+### Deploy Kubernetes Manifests Across Clusters with Customization
+
+[Fleet in Rancher](https://rancher.com/docs/rancher/v2.6/en/deploy-across-clusters/fleet/) allows users to manage clusters easily as if they were one cluster. Users can deploy bundles, which can be comprised of deployment manifests or any other Kubernetes resource, across clusters using grouping configuration.
+
+To demonstrate how to deploy Kubernetes manifests across different clusters using Fleet, we will use [multi-cluster/helm/fleet.yaml](https://github.com/rancher/fleet-examples/blob/master/multi-cluster/helm/fleet.yaml) as a case study.
+
+**Situation:** User has three clusters with three different labels: `env=dev`, `env=test`, and `env=prod`. User wants to deploy a frontend application with a backend database across these clusters. 
+
+**Expected behavior:** 
+
+- After deploying to the `dev` cluster, database replication is not enabled.
+- After deploying to the `test` cluster, database replication is enabled.
+- After deploying to the `prod` cluster, database replication is enabled and Load balancer services are exposed.
+
+**Advantage of Fleet:**
+
+Instead of deploying the app on each cluster, Fleet allows you to deploy across all clusters following these steps:
+
+1. Deploy gitRepo `https://github.com/rancher/fleet-examples.git` and specify the path `multi-cluster/helm`.
+2. Under `multi-cluster/helm`, a Helm chart will deploy the frontend app service and backend database service.
+3. The following rule will be defined in `fleet.yaml`: 
+
+```
+targetCustomizations:
+- name: dev
+  helm:
+    values:
+      replication: false
+  clusterSelector:
+    matchLabels:
+      env: dev
+
+- name: test
+  helm:
+    values:
+      replicas: 3
+  clusterSelector:
+    matchLabels:
+      env: test
+
+- name: prod
+  helm:
+    values:
+      serviceType: LoadBalancer
+      replicas: 3
+  clusterSelector:
+    matchLabels:
+      env: prod
+```
+
+**Result:**
+
+Fleet will deploy the Helm chart with your customized `values.yaml` to the different clusters.
+
+>**Note:** Configuration management is not limited to deployments but can be expanded to general configuration management. Fleet is able to apply configuration management through customization among any set of clusters automatically.
+
 ### Additional Examples
 
 Examples using raw Kubernetes YAML, Helm charts, Kustomize, and combinations


### PR DESCRIPTION
Closes #623 

Added to the examples with https://github.com/rancher/fleet-examples/blob/master/multi-cluster/helm/fleet.yaml use case. Also added example install directions for `GitRepo` CRs.

References:
https://fleet.rancher.io/examples/#deploy-kubernetes-manifests-across-clusters-with-customization
https://fleet.rancher.io/concepts/