### PR TITLE
Added blurb on Helm chart dependencies, linked back to Rancher

### DIFF
--- a/docs/gitrepo-structure.md
+++ b/docs/gitrepo-structure.md
@@ -29,6 +29,9 @@ the resources are deployed and customized.  The `fleet.yaml` is always at the ro
 and if a subdirectory is found with a `fleet.yaml` a new [bundle](./concepts.md) is defined that will then be
 configured differently from the parent bundle.
 
+!!! warning "Helm chart dependencies"
+    It is up to the user to fulfill the dependency list for the Helm charts. As such, you must manually run `helm dependencies update $chart` OR run `helm dependencies build $chart` prior to install. See the [Fleet docs](https://rancher.com/docs/rancher/v2.6/en/deploy-across-clusters/fleet/#helm-chart-dependencies) in Rancher for more information.
+
 ### Reference
 
 ```yaml

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -7,8 +7,6 @@ Who needs documentation, lets just run this thing!
 Get helm if you don't have it.  Helm 3 is just a CLI and won't do bad insecure
 things to your cluster.
 
->**Warning on Helm Chart Dependencies:** Before you install Helm, you must either manually run `helm dependencies update` OR run `helm dependencies build` locally, then commit the complete charts directory to your git repository. This tells Fleet where to retrieve the dependencies. For more information, see the [Fleet docs](https://rancher.com/docs/rancher/v2.6/en/en/deploy-across-clusters/fleet/#fleet-helm-chart-dependencies) in Rancher.
-
 ```
 brew install helm
 ```

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -7,6 +7,8 @@ Who needs documentation, lets just run this thing!
 Get helm if you don't have it.  Helm 3 is just a CLI and won't do bad insecure
 things to your cluster.
 
+>**Warning on Helm Chart Dependencies:** Before you install Helm, you must either manually run `helm dependencies update` OR run `helm dependencies build` locally, then commit the complete charts directory to your git repository. This tells Fleet where to retrieve the dependencies. For more information, see the [Fleet docs](https://rancher.com/docs/rancher/v2.6/en/en/deploy-across-clusters/fleet/#fleet-helm-chart-dependencies) in Rancher.
+
 ```
 brew install helm
 ```


### PR DESCRIPTION
Closes #250; see also https://github.com/rancher/docs/issues/3705 for Rancher docs issue.