### PR TITLE
Consolidate kube client tests and remove unused client test

### DIFF
--- a/modules/cli/agentmanifest/agent.go
+++ b/modules/cli/agentmanifest/agent.go
@@ -25,7 +25,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
-	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
@@ -76,24 +75,6 @@ func insecurePing(host string) {
 	if err == nil {
 		resp.Body.Close()
 	}
-}
-
-func testKubeConfig(kubeConfig, host string) error {
-	insecurePing(host)
-
-	restConfig, err := clientcmd.RESTConfigFromKubeConfig([]byte(kubeConfig))
-	if err != nil {
-		return fmt.Errorf("failed to test kubeconfig: %w", err)
-	}
-	client, err := kubernetes.NewForConfig(restConfig)
-	if err != nil {
-		return fmt.Errorf("failed to test build client from kubeconfig: %w", err)
-	}
-	_, err = client.Discovery().ServerVersion()
-	if err != nil {
-		return fmt.Errorf("failed to test connection to %s: %w", host, err)
-	}
-	return nil
 }
 
 func AgentManifest(ctx context.Context, agentNamespace, controllerNamespace, agentScope string, cg *client.Getter, output io.Writer, tokenName string, opts *Options) error {

--- a/pkg/connection/connection.go
+++ b/pkg/connection/connection.go
@@ -1,0 +1,10 @@
+package connection
+
+import (
+	"k8s.io/client-go/kubernetes"
+)
+
+func SmokeTestKubeClientConnection(client *kubernetes.Clientset) error {
+	_, err := client.Discovery().ServerVersion()
+	return err
+}

--- a/pkg/controllers/cluster/import.go
+++ b/pkg/controllers/cluster/import.go
@@ -13,6 +13,7 @@ import (
 	"github.com/rancher/fleet/modules/cli/pkg/client"
 	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
 	"github.com/rancher/fleet/pkg/config"
+	"github.com/rancher/fleet/pkg/connection"
 	"github.com/rancher/fleet/pkg/controllers/manageagent"
 	fleetcontrollers "github.com/rancher/fleet/pkg/generated/controllers/fleet.cattle.io/v1alpha1"
 	fleetns "github.com/rancher/fleet/pkg/namespace"
@@ -203,7 +204,7 @@ func (i *importHandler) importCluster(cluster *fleet.Cluster, status fleet.Clust
 		return status, err
 	}
 
-	if _, err = kc.Discovery().ServerVersion(); err != nil {
+	if err := connection.SmokeTestKubeClientConnection(kc); err != nil {
 		return status, err
 	}
 


### PR DESCRIPTION
> "In an internal knowledge transfer for Fleet development, it was evident that the kube client connection smoke tests were difficult to understand without an explicitly named function or comment. We should consolidate them to one function."

Relevant issue: https://github.com/rancher/fleet/issues/658