### PR TITLE
Added documentation for migrating the local cluster to fleet-default 

### DIFF
--- a/docs/namespaces.md
+++ b/docs/namespaces.md
@@ -25,7 +25,7 @@ When fleet is installed the `fleet-local` namespace is created along with one `C
 automatically target the `local` `Cluster`.  The `local` `Cluster` refers to the cluster the Fleet manager is running
 on.
 
-**Note:** If you would like to migrate your cluster and its resources from `fleet-local` to `default`, please see this [documentation](./troubleshooting.md#migrate-the-local-cluster-to-the-fleet-default-cluster).
+**Note:** If you would like to migrate your cluster from `fleet-local` to `default`, please see this [documentation](./troubleshooting.md#migrate-the-local-cluster-to-the-fleet-default-cluster).
 
 ### fleet-system
 

--- a/docs/namespaces.md
+++ b/docs/namespaces.md
@@ -25,6 +25,8 @@ When fleet is installed the `fleet-local` namespace is created along with one `C
 automatically target the `local` `Cluster`.  The `local` `Cluster` refers to the cluster the Fleet manager is running
 on.
 
+**Note:** If you would like to migrate your cluster and its resources from `fleet-local` to `default`, please see this [documentation](./troubleshooting.md#migrate-the-local-cluster-to-the-fleet-default-cluster).
+
 ### fleet-system
 
 The Fleet controller and Fleet agent run in this namespace. All service accounts referenced by `GitRepos` are expected

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -69,7 +69,7 @@ fleet-controller-64f49d756b-n57wq   1/1     Running   0          3m21s
 
 ### Migrate the local cluster to the Fleet default cluster
 
-For users who want to deploy to the local cluster as well, they may move the cluster and its resources from `fleet-local` to `fleet-default` in the Rancher UI as follows:
+For users who want to deploy to the local cluster as well, they may move the cluster from `fleet-local` to `fleet-default` in the Rancher UI as follows:
 
 - To get to Fleet in Rancher, click ☰ > Continuous Delivery.
 - Under the **Clusters** menu, select the **local** cluster by checking the box to the left.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -67,6 +67,17 @@ NAME                                READY   STATUS    RESTARTS   AGE
 fleet-controller-64f49d756b-n57wq   1/1     Running   0          3m21s
 ```
 
+### Migrate the local cluster to the Fleet default cluster
+
+For users who want to deploy to the local cluster as well, they may move the cluster and its resources from `fleet-local` to `fleet-default` in the Rancher UI as follows:
+
+- To get to Fleet in Rancher, click ☰ > Continuous Delivery.
+- Under the **Clusters** menu, select the **local** cluster by checking the box to the left.
+- Select **Assign to** from the tabs above the cluster.
+- Select **`fleet-default`** from the **Assign Cluster To** dropdown.
+
+**Result**: The cluster and its resources will be migrated to `fleet-default`.
+
 ## Additional Solutions for Other Fleet Errors
 
 ### Fleet fails with bad response code: 403

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -76,7 +76,7 @@ For users who want to deploy to the local cluster as well, they may move the clu
 - Select **Assign to** from the tabs above the cluster.
 - Select **`fleet-default`** from the **Assign Cluster To** dropdown.
 
-**Result**: The cluster and its resources will be migrated to `fleet-default`.
+**Result**: The cluster will be migrated to `fleet-default`.
 
 ## Additional Solutions for Other Fleet Errors
 


### PR DESCRIPTION
Closes #489

References:
https://fleet.rancher.io/troubleshooting/#migrate-the-local-cluster-to-the-fleet-default-cluster
https://fleet.rancher.io/namespaces/ 
