### PR TITLE
Adding capability for tolerations in the agent

### DIFF
--- a/charts/fleet-crd/templates/crds.yaml
+++ b/charts/fleet-crd/templates/crds.yaml
@@ -1753,6 +1753,27 @@ spec:
               agentNamespace:
                 nullable: true
                 type: string
+              agentTolerations:
+                items:
+                  properties:
+                    effect:
+                      nullable: true
+                      type: string
+                    key:
+                      nullable: true
+                      type: string
+                    operator:
+                      nullable: true
+                      type: string
+                    tolerationSeconds:
+                      nullable: true
+                      type: integer
+                    value:
+                      nullable: true
+                      type: string
+                  type: object
+                nullable: true
+                type: array
               clientID:
                 nullable: true
                 type: string
@@ -4428,6 +4449,27 @@ spec:
             agentNamespace:
               nullable: true
               type: string
+            agentTolerations:
+              items:
+                properties:
+                  effect:
+                    nullable: true
+                    type: string
+                  key:
+                    nullable: true
+                    type: string
+                  operator:
+                    nullable: true
+                    type: string
+                  tolerationSeconds:
+                    nullable: true
+                    type: integer
+                  value:
+                    nullable: true
+                    type: string
+                type: object
+              nullable: true
+              type: array
             clientID:
               nullable: true
               type: string

--- a/charts/fleet/templates/configmap.yaml
+++ b/charts/fleet/templates/configmap.yaml
@@ -20,5 +20,6 @@ data:
         "agentNamespace": "{{.Values.bootstrap.agentNamespace}}",
       },
       "webhookReceiverURL": "{{.Values.webhookReceiverURL}}",
-      "githubURLPrefix": "{{.Values.githubURLPrefix}}"
+      "githubURLPrefix": "{{.Values.githubURLPrefix}}",
+      "controllerTolerations": {{ toJson .Values.tolerations }}
     }

--- a/charts/fleet/values.yaml
+++ b/charts/fleet/values.yaml
@@ -58,5 +58,12 @@ tolerations:
 gitops:
   enabled: true
 
+# when gitops is enabled, you can use a gitjob block like the below to specify options for the gitjob subchart
+# e.x.
+# gitjob:
+#   tolerations:
+#     - key: mykey
+
+
 debug: false
 debugLevel: 0

--- a/modules/cli/agentmanifest/agent.go
+++ b/modules/cli/agentmanifest/agent.go
@@ -34,14 +34,15 @@ var (
 )
 
 type Options struct {
-	CA              []byte
-	Host            string
-	NoCA            bool
-	Labels          map[string]string
-	ClientID        string
-	Generation      string
-	CheckinInterval string
-	AgentEnvVars    []v1.EnvVar
+	CA               []byte
+	Host             string
+	NoCA             bool
+	Labels           map[string]string
+	ClientID         string
+	Generation       string
+	CheckinInterval  string
+	AgentEnvVars     []v1.EnvVar
+	AgentTolerations []v1.Toleration
 }
 
 func AgentToken(ctx context.Context, agentNamespace, controllerNamespace string, client *client.Client, tokenName string, opts *Options) ([]runtime.Object, error) {
@@ -107,7 +108,7 @@ func AgentManifest(ctx context.Context, agentNamespace, controllerNamespace, age
 		return err
 	}
 
-	objs = append(objs, agent.Manifest(agentNamespace, agentScope, cfg.AgentImage, cfg.AgentImagePullPolicy, opts.Generation, opts.CheckinInterval, opts.AgentEnvVars)...)
+	objs = append(objs, agent.Manifest(agentNamespace, agentScope, cfg.AgentImage, cfg.AgentImagePullPolicy, opts.Generation, opts.CheckinInterval, opts.AgentEnvVars, opts.AgentTolerations)...)
 
 	data, err := yaml.Export(objs...)
 	if err != nil {

--- a/modules/cli/controllermanifest/template.go
+++ b/modules/cli/controllermanifest/template.go
@@ -63,7 +63,7 @@ func objects(namespace, controllerImage string, cfg string, crdsOnly bool) ([]ru
 	objs := []runtime.Object{
 		basic.Namespace(namespace),
 		serviceAccount,
-		basic.Deployment(namespace, genericName, controllerImage, "", serviceAccount.Name, true),
+		basic.Deployment(namespace, genericName, controllerImage, "", serviceAccount.Name, true, nil),
 		basic.ConfigMap(namespace, config.ManagerConfigName, config.Key, cfg),
 	}
 

--- a/pkg/agent/manifest.go
+++ b/pkg/agent/manifest.go
@@ -21,7 +21,7 @@ const (
 	DefaultName = "fleet-agent"
 )
 
-func Manifest(namespace, agentScope, image, pullPolicy, generation, checkInInterval string, agentEnvVars []corev1.EnvVar) []runtime.Object {
+func Manifest(namespace, agentScope, image, pullPolicy, generation, checkInInterval string, agentEnvVars []corev1.EnvVar, additionalTolerations []corev1.Toleration) []runtime.Object {
 	if image == "" {
 		image = config.DefaultAgentImage
 	}
@@ -39,7 +39,7 @@ func Manifest(namespace, agentScope, image, pullPolicy, generation, checkInInter
 		},
 	)
 
-	dep := basic.Deployment(namespace, DefaultName, image, pullPolicy, DefaultName, false)
+	dep := basic.Deployment(namespace, DefaultName, image, pullPolicy, DefaultName, false, additionalTolerations)
 	dep.Spec.Template.Spec.Containers[0].Env = append(dep.Spec.Template.Spec.Containers[0].Env,
 		corev1.EnvVar{
 			Name:  "AGENT_SCOPE",

--- a/pkg/apis/fleet.cattle.io/v1alpha1/target.go
+++ b/pkg/apis/fleet.cattle.io/v1alpha1/target.go
@@ -61,12 +61,13 @@ type Cluster struct {
 }
 
 type ClusterSpec struct {
-	Paused                  bool        `json:"paused,omitempty"`
-	ClientID                string      `json:"clientID,omitempty"`
-	KubeConfigSecret        string      `json:"kubeConfigSecret,omitempty"`
-	RedeployAgentGeneration int64       `json:"redeployAgentGeneration,omitempty"`
-	AgentEnvVars            []v1.EnvVar `json:"agentEnvVars,omitempty"`
-	AgentNamespace          string      `json:"agentNamespace,omitempty"`
+	Paused                  bool            `json:"paused,omitempty"`
+	ClientID                string          `json:"clientID,omitempty"`
+	KubeConfigSecret        string          `json:"kubeConfigSecret,omitempty"`
+	RedeployAgentGeneration int64           `json:"redeployAgentGeneration,omitempty"`
+	AgentEnvVars            []v1.EnvVar     `json:"agentEnvVars,omitempty"`
+	AgentTolerations        []v1.Toleration `json:"agentTolerations,omitempty"`
+	AgentNamespace          string          `json:"agentNamespace,omitempty"`
 }
 
 type ClusterStatus struct {

--- a/pkg/apis/fleet.cattle.io/v1alpha1/zz_generated_deepcopy.go
+++ b/pkg/apis/fleet.cattle.io/v1alpha1/zz_generated_deepcopy.go
@@ -1006,6 +1006,13 @@ func (in *ClusterSpec) DeepCopyInto(out *ClusterSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.AgentTolerations != nil {
+		in, out := &in.AgentTolerations, &out.AgentTolerations
+		*out = make([]corev1.Toleration, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	return
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -43,6 +43,7 @@ type Config struct {
 	APIServerCA                     []byte            `json:"apiServerCA,omitempty"`
 	Bootstrap                       Bootstrap         `json:"bootstrap,omitempty"`
 	IgnoreClusterRegistrationLabels bool              `json:"ignoreClusterRegistrationLabels,omitempty"`
+	ControllerTolerations           []v1.Toleration   `json:"controllerTolerations,omitempty"`
 }
 
 type Bootstrap struct {

--- a/pkg/controllers/bootstrap/bootstrap.go
+++ b/pkg/controllers/bootstrap/bootstrap.go
@@ -78,9 +78,11 @@ func (h *handler) OnConfig(config *config.Config) error {
 				"name": "local",
 			},
 		},
+		// for the local cluster, set the Agent's tolerations to the controller's tolerations
 		Spec: fleet.ClusterSpec{
 			KubeConfigSecret: secret.Name,
 			AgentNamespace:   config.Bootstrap.AgentNamespace,
+			AgentTolerations: config.ControllerTolerations,
 		},
 	}, &fleet.ClusterGroup{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/controllers/cluster/import.go
+++ b/pkg/controllers/cluster/import.go
@@ -247,12 +247,13 @@ func (i *importHandler) importCluster(cluster *fleet.Cluster, status fleet.Clust
 	// Notice we only set the agentScope when it's a non-default agentNamespace. This is for backwards compatibility
 	// for when we didn't have agent scope before
 	err = agentmanifest.AgentManifest(i.ctx, agentNamespace, i.systemNamespace, cluster.Spec.AgentNamespace, &client.Getter{Namespace: cluster.Namespace}, output, token.Name, &agentmanifest.Options{
-		CA:              apiServerCA,
-		Host:            apiServerURL,
-		ClientID:        cluster.Spec.ClientID,
-		AgentEnvVars:    cluster.Spec.AgentEnvVars,
-		CheckinInterval: cfg.AgentCheckinInternal.Duration.String(),
-		Generation:      string(cluster.UID) + "-" + strconv.FormatInt(cluster.Generation, 10),
+		CA:               apiServerCA,
+		Host:             apiServerURL,
+		ClientID:         cluster.Spec.ClientID,
+		AgentEnvVars:     cluster.Spec.AgentEnvVars,
+		AgentTolerations: cluster.Spec.AgentTolerations,
+		CheckinInterval:  cfg.AgentCheckinInternal.Duration.String(),
+		Generation:       string(cluster.UID) + "-" + strconv.FormatInt(cluster.Generation, 10),
 	})
 	if err != nil {
 		return status, err

--- a/pkg/controllers/git/git.go
+++ b/pkg/controllers/git/git.go
@@ -432,12 +432,7 @@ func (h *handler) OnChange(gitrepo *fleet.GitRepo, status fleet.GitRepoStatus) (
 								},
 							},
 							NodeSelector: map[string]string{"kubernetes.io/os": "linux"},
-							Tolerations: []corev1.Toleration{{
-								Key:      "cattle.io/os",
-								Operator: "Equal",
-								Value:    "linux",
-								Effect:   "NoSchedule",
-							}},
+							Tolerations:  config.Get().ControllerTolerations,
 						},
 					},
 				},

--- a/pkg/controllers/manageagent/manageagent.go
+++ b/pkg/controllers/manageagent/manageagent.go
@@ -144,7 +144,7 @@ func (h *handler) getAgentBundle(ns string, cluster *fleet.Cluster) (runtime.Obj
 
 	// Notice we only set the agentScope when it's a non-default agentNamespace. This is for backwards compatibility
 	// for when we didn't have agent scope before
-	objs := agent.Manifest(agentNamespace, cluster.Spec.AgentNamespace, cfg.AgentImage, cfg.AgentImagePullPolicy, "bundle", cfg.AgentCheckinInternal.Duration.String(), cluster.Spec.AgentEnvVars)
+	objs := agent.Manifest(agentNamespace, cluster.Spec.AgentNamespace, cfg.AgentImage, cfg.AgentImagePullPolicy, "bundle", cfg.AgentCheckinInternal.Duration.String(), cluster.Spec.AgentEnvVars, cluster.Spec.AgentTolerations)
 	agentYAML, err := yaml.Export(objs...)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Related to [rancher/rancher#34159](https://github.com/rancher/rancher/issues/34159) . When the fleet controller is deployed, it deploys the fleet agent (both in the cluster which it is deployed in and in downstream clusters which use fleet). Currently, neither of these deployments allow specification of [tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/), making them difficult/impossible to use in a tainted cluster.

Goals of this PR:
- For the agent deployed in the same cluster as the controller, use the same tolerations which were specified for the controller
- For any agents deployed in the downstream cluster, allow custom specification of the tolerations. This custom specification is stored, like the agent env vars, on the spec of the imported fleet cluster. 