### PR TITLE
ignore the .DS_Store file in macOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /dist
 *.swp
 .idea
+*.DS_Store


### PR DESCRIPTION
ignore the `.DS_Store` file in macOS by adding it to `.gitignore` 