### PR TITLE
Bump gitjob to v0.1.26 and tekton-utils to v0.1.5 and update gitjob CRDs

### DIFF
--- a/charts/fleet-crd/templates/gitjobs-crds.yaml
+++ b/charts/fleet-crd/templates/gitjobs-crds.yaml
@@ -49,9 +49,6 @@ spec:
                     type: string
                   insecureSkipTLSVerify:
                     type: boolean
-                  onTag:
-                    nullable: true
-                    type: string
                   provider:
                     nullable: true
                     type: string
@@ -59,6 +56,9 @@ spec:
                     nullable: true
                     type: string
                   revision:
+                    nullable: true
+                    type: string
+                  secret:
                     nullable: true
                     type: string
                 type: object
@@ -70,6 +70,9 @@ spec:
                   backoffLimit:
                     nullable: true
                     type: integer
+                  completionMode:
+                    nullable: true
+                    type: string
                   completions:
                     nullable: true
                     type: integer
@@ -107,6 +110,9 @@ spec:
                         nullable: true
                         type: object
                     type: object
+                  suspend:
+                    nullable: true
+                    type: boolean
                   template:
                     properties:
                       metadata:
@@ -351,6 +357,34 @@ spec:
                                                   nullable: true
                                                   type: object
                                               type: object
+                                            namespaceSelector:
+                                              nullable: true
+                                              properties:
+                                                matchExpressions:
+                                                  items:
+                                                    properties:
+                                                      key:
+                                                        nullable: true
+                                                        type: string
+                                                      operator:
+                                                        nullable: true
+                                                        type: string
+                                                      values:
+                                                        items:
+                                                          nullable: true
+                                                          type: string
+                                                        nullable: true
+                                                        type: array
+                                                    type: object
+                                                  nullable: true
+                                                  type: array
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    nullable: true
+                                                    type: string
+                                                  nullable: true
+                                                  type: object
+                                              type: object
                                             namespaces:
                                               items:
                                                 nullable: true
@@ -370,6 +404,34 @@ spec:
                                     items:
                                       properties:
                                         labelSelector:
+                                          nullable: true
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    nullable: true
+                                                    type: string
+                                                  operator:
+                                                    nullable: true
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      nullable: true
+                                                      type: string
+                                                    nullable: true
+                                                    type: array
+                                                type: object
+                                              nullable: true
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                nullable: true
+                                                type: string
+                                              nullable: true
+                                              type: object
+                                          type: object
+                                        namespaceSelector:
                                           nullable: true
                                           properties:
                                             matchExpressions:
@@ -446,6 +508,34 @@ spec:
                                                   nullable: true
                                                   type: object
                                               type: object
+                                            namespaceSelector:
+                                              nullable: true
+                                              properties:
+                                                matchExpressions:
+                                                  items:
+                                                    properties:
+                                                      key:
+                                                        nullable: true
+                                                        type: string
+                                                      operator:
+                                                        nullable: true
+                                                        type: string
+                                                      values:
+                                                        items:
+                                                          nullable: true
+                                                          type: string
+                                                        nullable: true
+                                                        type: array
+                                                    type: object
+                                                  nullable: true
+                                                  type: array
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    nullable: true
+                                                    type: string
+                                                  nullable: true
+                                                  type: object
+                                              type: object
                                             namespaces:
                                               items:
                                                 nullable: true
@@ -465,6 +555,34 @@ spec:
                                     items:
                                       properties:
                                         labelSelector:
+                                          nullable: true
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    nullable: true
+                                                    type: string
+                                                  operator:
+                                                    nullable: true
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      nullable: true
+                                                      type: string
+                                                    nullable: true
+                                                    type: array
+                                                type: object
+                                              nullable: true
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                nullable: true
+                                                type: string
+                                              nullable: true
+                                              type: object
+                                          type: object
+                                        namespaceSelector:
                                           nullable: true
                                           properties:
                                             matchExpressions:
@@ -791,6 +909,9 @@ spec:
                                           nullable: true
                                           type: string
                                       type: object
+                                    terminationGracePeriodSeconds:
+                                      nullable: true
+                                      type: integer
                                     timeoutSeconds:
                                       type: integer
                                   type: object
@@ -875,6 +996,9 @@ spec:
                                           nullable: true
                                           type: string
                                       type: object
+                                    terminationGracePeriodSeconds:
+                                      nullable: true
+                                      type: integer
                                     timeoutSeconds:
                                       type: integer
                                   type: object
@@ -1032,6 +1156,9 @@ spec:
                                           nullable: true
                                           type: string
                                       type: object
+                                    terminationGracePeriodSeconds:
+                                      nullable: true
+                                      type: integer
                                     timeoutSeconds:
                                       type: integer
                                   type: object
@@ -1404,6 +1531,9 @@ spec:
                                           nullable: true
                                           type: string
                                       type: object
+                                    terminationGracePeriodSeconds:
+                                      nullable: true
+                                      type: integer
                                     timeoutSeconds:
                                       type: integer
                                   type: object
@@ -1488,6 +1618,9 @@ spec:
                                           nullable: true
                                           type: string
                                       type: object
+                                    terminationGracePeriodSeconds:
+                                      nullable: true
+                                      type: integer
                                     timeoutSeconds:
                                       type: integer
                                   type: object
@@ -1645,6 +1778,9 @@ spec:
                                           nullable: true
                                           type: string
                                       type: object
+                                    terminationGracePeriodSeconds:
+                                      nullable: true
+                                      type: integer
                                     timeoutSeconds:
                                       type: integer
                                   type: object
@@ -2019,6 +2155,9 @@ spec:
                                           nullable: true
                                           type: string
                                       type: object
+                                    terminationGracePeriodSeconds:
+                                      nullable: true
+                                      type: integer
                                     timeoutSeconds:
                                       type: integer
                                   type: object
@@ -2103,6 +2242,9 @@ spec:
                                           nullable: true
                                           type: string
                                       type: object
+                                    terminationGracePeriodSeconds:
+                                      nullable: true
+                                      type: integer
                                     timeoutSeconds:
                                       type: integer
                                   type: object
@@ -2260,6 +2402,9 @@ spec:
                                           nullable: true
                                           type: string
                                       type: object
+                                    terminationGracePeriodSeconds:
+                                      nullable: true
+                                      type: integer
                                     timeoutSeconds:
                                       type: integer
                                   type: object
@@ -2721,8 +2866,6 @@ spec:
                                 ephemeral:
                                   nullable: true
                                   properties:
-                                    readOnly:
-                                      type: boolean
                                     volumeClaimTemplate:
                                       nullable: true
                                       properties:
@@ -3422,9 +3565,6 @@ spec:
               lastExecutedCommit:
                 nullable: true
                 type: string
-              lastSyncedTime:
-                nullable: true
-                type: string
               observedGeneration:
                 type: integer
               secretToken:
@@ -3489,9 +3629,6 @@ spec:
                   type: string
                 insecureSkipTLSVerify:
                   type: boolean
-                onTag:
-                  nullable: true
-                  type: string
                 provider:
                   nullable: true
                   type: string
@@ -3499,6 +3636,9 @@ spec:
                   nullable: true
                   type: string
                 revision:
+                  nullable: true
+                  type: string
+                secret:
                   nullable: true
                   type: string
               type: object
@@ -3510,6 +3650,9 @@ spec:
                 backoffLimit:
                   nullable: true
                   type: integer
+                completionMode:
+                  nullable: true
+                  type: string
                 completions:
                   nullable: true
                   type: integer
@@ -3547,6 +3690,9 @@ spec:
                       nullable: true
                       type: object
                   type: object
+                suspend:
+                  nullable: true
+                  type: boolean
                 template:
                   properties:
                     metadata:
@@ -3791,6 +3937,34 @@ spec:
                                                 nullable: true
                                                 type: object
                                             type: object
+                                          namespaceSelector:
+                                            nullable: true
+                                            properties:
+                                              matchExpressions:
+                                                items:
+                                                  properties:
+                                                    key:
+                                                      nullable: true
+                                                      type: string
+                                                    operator:
+                                                      nullable: true
+                                                      type: string
+                                                    values:
+                                                      items:
+                                                        nullable: true
+                                                        type: string
+                                                      nullable: true
+                                                      type: array
+                                                  type: object
+                                                nullable: true
+                                                type: array
+                                              matchLabels:
+                                                additionalProperties:
+                                                  nullable: true
+                                                  type: string
+                                                nullable: true
+                                                type: object
+                                            type: object
                                           namespaces:
                                             items:
                                               nullable: true
@@ -3810,6 +3984,34 @@ spec:
                                   items:
                                     properties:
                                       labelSelector:
+                                        nullable: true
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  nullable: true
+                                                  type: string
+                                                operator:
+                                                  nullable: true
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    nullable: true
+                                                    type: string
+                                                  nullable: true
+                                                  type: array
+                                              type: object
+                                            nullable: true
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              nullable: true
+                                              type: string
+                                            nullable: true
+                                            type: object
+                                        type: object
+                                      namespaceSelector:
                                         nullable: true
                                         properties:
                                           matchExpressions:
@@ -3886,6 +4088,34 @@ spec:
                                                 nullable: true
                                                 type: object
                                             type: object
+                                          namespaceSelector:
+                                            nullable: true
+                                            properties:
+                                              matchExpressions:
+                                                items:
+                                                  properties:
+                                                    key:
+                                                      nullable: true
+                                                      type: string
+                                                    operator:
+                                                      nullable: true
+                                                      type: string
+                                                    values:
+                                                      items:
+                                                        nullable: true
+                                                        type: string
+                                                      nullable: true
+                                                      type: array
+                                                  type: object
+                                                nullable: true
+                                                type: array
+                                              matchLabels:
+                                                additionalProperties:
+                                                  nullable: true
+                                                  type: string
+                                                nullable: true
+                                                type: object
+                                            type: object
                                           namespaces:
                                             items:
                                               nullable: true
@@ -3905,6 +4135,34 @@ spec:
                                   items:
                                     properties:
                                       labelSelector:
+                                        nullable: true
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  nullable: true
+                                                  type: string
+                                                operator:
+                                                  nullable: true
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    nullable: true
+                                                    type: string
+                                                  nullable: true
+                                                  type: array
+                                              type: object
+                                            nullable: true
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              nullable: true
+                                              type: string
+                                            nullable: true
+                                            type: object
+                                        type: object
+                                      namespaceSelector:
                                         nullable: true
                                         properties:
                                           matchExpressions:
@@ -4231,6 +4489,9 @@ spec:
                                         nullable: true
                                         type: string
                                     type: object
+                                  terminationGracePeriodSeconds:
+                                    nullable: true
+                                    type: integer
                                   timeoutSeconds:
                                     type: integer
                                 type: object
@@ -4315,6 +4576,9 @@ spec:
                                         nullable: true
                                         type: string
                                     type: object
+                                  terminationGracePeriodSeconds:
+                                    nullable: true
+                                    type: integer
                                   timeoutSeconds:
                                     type: integer
                                 type: object
@@ -4472,6 +4736,9 @@ spec:
                                         nullable: true
                                         type: string
                                     type: object
+                                  terminationGracePeriodSeconds:
+                                    nullable: true
+                                    type: integer
                                   timeoutSeconds:
                                     type: integer
                                 type: object
@@ -4844,6 +5111,9 @@ spec:
                                         nullable: true
                                         type: string
                                     type: object
+                                  terminationGracePeriodSeconds:
+                                    nullable: true
+                                    type: integer
                                   timeoutSeconds:
                                     type: integer
                                 type: object
@@ -4928,6 +5198,9 @@ spec:
                                         nullable: true
                                         type: string
                                     type: object
+                                  terminationGracePeriodSeconds:
+                                    nullable: true
+                                    type: integer
                                   timeoutSeconds:
                                     type: integer
                                 type: object
@@ -5085,6 +5358,9 @@ spec:
                                         nullable: true
                                         type: string
                                     type: object
+                                  terminationGracePeriodSeconds:
+                                    nullable: true
+                                    type: integer
                                   timeoutSeconds:
                                     type: integer
                                 type: object
@@ -5459,6 +5735,9 @@ spec:
                                         nullable: true
                                         type: string
                                     type: object
+                                  terminationGracePeriodSeconds:
+                                    nullable: true
+                                    type: integer
                                   timeoutSeconds:
                                     type: integer
                                 type: object
@@ -5543,6 +5822,9 @@ spec:
                                         nullable: true
                                         type: string
                                     type: object
+                                  terminationGracePeriodSeconds:
+                                    nullable: true
+                                    type: integer
                                   timeoutSeconds:
                                     type: integer
                                 type: object
@@ -5700,6 +5982,9 @@ spec:
                                         nullable: true
                                         type: string
                                     type: object
+                                  terminationGracePeriodSeconds:
+                                    nullable: true
+                                    type: integer
                                   timeoutSeconds:
                                     type: integer
                                 type: object
@@ -6161,8 +6446,6 @@ spec:
                               ephemeral:
                                 nullable: true
                                 properties:
-                                  readOnly:
-                                    type: boolean
                                   volumeClaimTemplate:
                                     nullable: true
                                     properties:
@@ -6860,9 +7143,6 @@ spec:
               nullable: true
               type: string
             lastExecutedCommit:
-              nullable: true
-              type: string
-            lastSyncedTime:
               nullable: true
               type: string
             observedGeneration:

--- a/charts/fleet-crd/templates/gitjobs-crds.yaml
+++ b/charts/fleet-crd/templates/gitjobs-crds.yaml
@@ -49,6 +49,9 @@ spec:
                     type: string
                   insecureSkipTLSVerify:
                     type: boolean
+                  onTag:
+                    nullable: true
+                    type: string
                   provider:
                     nullable: true
                     type: string
@@ -56,9 +59,6 @@ spec:
                     nullable: true
                     type: string
                   revision:
-                    nullable: true
-                    type: string
-                  secret:
                     nullable: true
                     type: string
                 type: object
@@ -70,9 +70,6 @@ spec:
                   backoffLimit:
                     nullable: true
                     type: integer
-                  completionMode:
-                    nullable: true
-                    type: string
                   completions:
                     nullable: true
                     type: integer
@@ -110,9 +107,6 @@ spec:
                         nullable: true
                         type: object
                     type: object
-                  suspend:
-                    nullable: true
-                    type: boolean
                   template:
                     properties:
                       metadata:
@@ -357,34 +351,6 @@ spec:
                                                   nullable: true
                                                   type: object
                                               type: object
-                                            namespaceSelector:
-                                              nullable: true
-                                              properties:
-                                                matchExpressions:
-                                                  items:
-                                                    properties:
-                                                      key:
-                                                        nullable: true
-                                                        type: string
-                                                      operator:
-                                                        nullable: true
-                                                        type: string
-                                                      values:
-                                                        items:
-                                                          nullable: true
-                                                          type: string
-                                                        nullable: true
-                                                        type: array
-                                                    type: object
-                                                  nullable: true
-                                                  type: array
-                                                matchLabels:
-                                                  additionalProperties:
-                                                    nullable: true
-                                                    type: string
-                                                  nullable: true
-                                                  type: object
-                                              type: object
                                             namespaces:
                                               items:
                                                 nullable: true
@@ -404,34 +370,6 @@ spec:
                                     items:
                                       properties:
                                         labelSelector:
-                                          nullable: true
-                                          properties:
-                                            matchExpressions:
-                                              items:
-                                                properties:
-                                                  key:
-                                                    nullable: true
-                                                    type: string
-                                                  operator:
-                                                    nullable: true
-                                                    type: string
-                                                  values:
-                                                    items:
-                                                      nullable: true
-                                                      type: string
-                                                    nullable: true
-                                                    type: array
-                                                type: object
-                                              nullable: true
-                                              type: array
-                                            matchLabels:
-                                              additionalProperties:
-                                                nullable: true
-                                                type: string
-                                              nullable: true
-                                              type: object
-                                          type: object
-                                        namespaceSelector:
                                           nullable: true
                                           properties:
                                             matchExpressions:
@@ -508,34 +446,6 @@ spec:
                                                   nullable: true
                                                   type: object
                                               type: object
-                                            namespaceSelector:
-                                              nullable: true
-                                              properties:
-                                                matchExpressions:
-                                                  items:
-                                                    properties:
-                                                      key:
-                                                        nullable: true
-                                                        type: string
-                                                      operator:
-                                                        nullable: true
-                                                        type: string
-                                                      values:
-                                                        items:
-                                                          nullable: true
-                                                          type: string
-                                                        nullable: true
-                                                        type: array
-                                                    type: object
-                                                  nullable: true
-                                                  type: array
-                                                matchLabels:
-                                                  additionalProperties:
-                                                    nullable: true
-                                                    type: string
-                                                  nullable: true
-                                                  type: object
-                                              type: object
                                             namespaces:
                                               items:
                                                 nullable: true
@@ -555,34 +465,6 @@ spec:
                                     items:
                                       properties:
                                         labelSelector:
-                                          nullable: true
-                                          properties:
-                                            matchExpressions:
-                                              items:
-                                                properties:
-                                                  key:
-                                                    nullable: true
-                                                    type: string
-                                                  operator:
-                                                    nullable: true
-                                                    type: string
-                                                  values:
-                                                    items:
-                                                      nullable: true
-                                                      type: string
-                                                    nullable: true
-                                                    type: array
-                                                type: object
-                                              nullable: true
-                                              type: array
-                                            matchLabels:
-                                              additionalProperties:
-                                                nullable: true
-                                                type: string
-                                              nullable: true
-                                              type: object
-                                          type: object
-                                        namespaceSelector:
                                           nullable: true
                                           properties:
                                             matchExpressions:
@@ -909,9 +791,6 @@ spec:
                                           nullable: true
                                           type: string
                                       type: object
-                                    terminationGracePeriodSeconds:
-                                      nullable: true
-                                      type: integer
                                     timeoutSeconds:
                                       type: integer
                                   type: object
@@ -996,9 +875,6 @@ spec:
                                           nullable: true
                                           type: string
                                       type: object
-                                    terminationGracePeriodSeconds:
-                                      nullable: true
-                                      type: integer
                                     timeoutSeconds:
                                       type: integer
                                   type: object
@@ -1156,9 +1032,6 @@ spec:
                                           nullable: true
                                           type: string
                                       type: object
-                                    terminationGracePeriodSeconds:
-                                      nullable: true
-                                      type: integer
                                     timeoutSeconds:
                                       type: integer
                                   type: object
@@ -1531,9 +1404,6 @@ spec:
                                           nullable: true
                                           type: string
                                       type: object
-                                    terminationGracePeriodSeconds:
-                                      nullable: true
-                                      type: integer
                                     timeoutSeconds:
                                       type: integer
                                   type: object
@@ -1618,9 +1488,6 @@ spec:
                                           nullable: true
                                           type: string
                                       type: object
-                                    terminationGracePeriodSeconds:
-                                      nullable: true
-                                      type: integer
                                     timeoutSeconds:
                                       type: integer
                                   type: object
@@ -1778,9 +1645,6 @@ spec:
                                           nullable: true
                                           type: string
                                       type: object
-                                    terminationGracePeriodSeconds:
-                                      nullable: true
-                                      type: integer
                                     timeoutSeconds:
                                       type: integer
                                   type: object
@@ -2155,9 +2019,6 @@ spec:
                                           nullable: true
                                           type: string
                                       type: object
-                                    terminationGracePeriodSeconds:
-                                      nullable: true
-                                      type: integer
                                     timeoutSeconds:
                                       type: integer
                                   type: object
@@ -2242,9 +2103,6 @@ spec:
                                           nullable: true
                                           type: string
                                       type: object
-                                    terminationGracePeriodSeconds:
-                                      nullable: true
-                                      type: integer
                                     timeoutSeconds:
                                       type: integer
                                   type: object
@@ -2402,9 +2260,6 @@ spec:
                                           nullable: true
                                           type: string
                                       type: object
-                                    terminationGracePeriodSeconds:
-                                      nullable: true
-                                      type: integer
                                     timeoutSeconds:
                                       type: integer
                                   type: object
@@ -2866,6 +2721,8 @@ spec:
                                 ephemeral:
                                   nullable: true
                                   properties:
+                                    readOnly:
+                                      type: boolean
                                     volumeClaimTemplate:
                                       nullable: true
                                       properties:
@@ -3565,6 +3422,9 @@ spec:
               lastExecutedCommit:
                 nullable: true
                 type: string
+              lastSyncedTime:
+                nullable: true
+                type: string
               observedGeneration:
                 type: integer
               secretToken:
@@ -3629,6 +3489,9 @@ spec:
                   type: string
                 insecureSkipTLSVerify:
                   type: boolean
+                onTag:
+                  nullable: true
+                  type: string
                 provider:
                   nullable: true
                   type: string
@@ -3636,9 +3499,6 @@ spec:
                   nullable: true
                   type: string
                 revision:
-                  nullable: true
-                  type: string
-                secret:
                   nullable: true
                   type: string
               type: object
@@ -3650,9 +3510,6 @@ spec:
                 backoffLimit:
                   nullable: true
                   type: integer
-                completionMode:
-                  nullable: true
-                  type: string
                 completions:
                   nullable: true
                   type: integer
@@ -3690,9 +3547,6 @@ spec:
                       nullable: true
                       type: object
                   type: object
-                suspend:
-                  nullable: true
-                  type: boolean
                 template:
                   properties:
                     metadata:
@@ -3937,34 +3791,6 @@ spec:
                                                 nullable: true
                                                 type: object
                                             type: object
-                                          namespaceSelector:
-                                            nullable: true
-                                            properties:
-                                              matchExpressions:
-                                                items:
-                                                  properties:
-                                                    key:
-                                                      nullable: true
-                                                      type: string
-                                                    operator:
-                                                      nullable: true
-                                                      type: string
-                                                    values:
-                                                      items:
-                                                        nullable: true
-                                                        type: string
-                                                      nullable: true
-                                                      type: array
-                                                  type: object
-                                                nullable: true
-                                                type: array
-                                              matchLabels:
-                                                additionalProperties:
-                                                  nullable: true
-                                                  type: string
-                                                nullable: true
-                                                type: object
-                                            type: object
                                           namespaces:
                                             items:
                                               nullable: true
@@ -3984,34 +3810,6 @@ spec:
                                   items:
                                     properties:
                                       labelSelector:
-                                        nullable: true
-                                        properties:
-                                          matchExpressions:
-                                            items:
-                                              properties:
-                                                key:
-                                                  nullable: true
-                                                  type: string
-                                                operator:
-                                                  nullable: true
-                                                  type: string
-                                                values:
-                                                  items:
-                                                    nullable: true
-                                                    type: string
-                                                  nullable: true
-                                                  type: array
-                                              type: object
-                                            nullable: true
-                                            type: array
-                                          matchLabels:
-                                            additionalProperties:
-                                              nullable: true
-                                              type: string
-                                            nullable: true
-                                            type: object
-                                        type: object
-                                      namespaceSelector:
                                         nullable: true
                                         properties:
                                           matchExpressions:
@@ -4088,34 +3886,6 @@ spec:
                                                 nullable: true
                                                 type: object
                                             type: object
-                                          namespaceSelector:
-                                            nullable: true
-                                            properties:
-                                              matchExpressions:
-                                                items:
-                                                  properties:
-                                                    key:
-                                                      nullable: true
-                                                      type: string
-                                                    operator:
-                                                      nullable: true
-                                                      type: string
-                                                    values:
-                                                      items:
-                                                        nullable: true
-                                                        type: string
-                                                      nullable: true
-                                                      type: array
-                                                  type: object
-                                                nullable: true
-                                                type: array
-                                              matchLabels:
-                                                additionalProperties:
-                                                  nullable: true
-                                                  type: string
-                                                nullable: true
-                                                type: object
-                                            type: object
                                           namespaces:
                                             items:
                                               nullable: true
@@ -4135,34 +3905,6 @@ spec:
                                   items:
                                     properties:
                                       labelSelector:
-                                        nullable: true
-                                        properties:
-                                          matchExpressions:
-                                            items:
-                                              properties:
-                                                key:
-                                                  nullable: true
-                                                  type: string
-                                                operator:
-                                                  nullable: true
-                                                  type: string
-                                                values:
-                                                  items:
-                                                    nullable: true
-                                                    type: string
-                                                  nullable: true
-                                                  type: array
-                                              type: object
-                                            nullable: true
-                                            type: array
-                                          matchLabels:
-                                            additionalProperties:
-                                              nullable: true
-                                              type: string
-                                            nullable: true
-                                            type: object
-                                        type: object
-                                      namespaceSelector:
                                         nullable: true
                                         properties:
                                           matchExpressions:
@@ -4489,9 +4231,6 @@ spec:
                                         nullable: true
                                         type: string
                                     type: object
-                                  terminationGracePeriodSeconds:
-                                    nullable: true
-                                    type: integer
                                   timeoutSeconds:
                                     type: integer
                                 type: object
@@ -4576,9 +4315,6 @@ spec:
                                         nullable: true
                                         type: string
                                     type: object
-                                  terminationGracePeriodSeconds:
-                                    nullable: true
-                                    type: integer
                                   timeoutSeconds:
                                     type: integer
                                 type: object
@@ -4736,9 +4472,6 @@ spec:
                                         nullable: true
                                         type: string
                                     type: object
-                                  terminationGracePeriodSeconds:
-                                    nullable: true
-                                    type: integer
                                   timeoutSeconds:
                                     type: integer
                                 type: object
@@ -5111,9 +4844,6 @@ spec:
                                         nullable: true
                                         type: string
                                     type: object
-                                  terminationGracePeriodSeconds:
-                                    nullable: true
-                                    type: integer
                                   timeoutSeconds:
                                     type: integer
                                 type: object
@@ -5198,9 +4928,6 @@ spec:
                                         nullable: true
                                         type: string
                                     type: object
-                                  terminationGracePeriodSeconds:
-                                    nullable: true
-                                    type: integer
                                   timeoutSeconds:
                                     type: integer
                                 type: object
@@ -5358,9 +5085,6 @@ spec:
                                         nullable: true
                                         type: string
                                     type: object
-                                  terminationGracePeriodSeconds:
-                                    nullable: true
-                                    type: integer
                                   timeoutSeconds:
                                     type: integer
                                 type: object
@@ -5735,9 +5459,6 @@ spec:
                                         nullable: true
                                         type: string
                                     type: object
-                                  terminationGracePeriodSeconds:
-                                    nullable: true
-                                    type: integer
                                   timeoutSeconds:
                                     type: integer
                                 type: object
@@ -5822,9 +5543,6 @@ spec:
                                         nullable: true
                                         type: string
                                     type: object
-                                  terminationGracePeriodSeconds:
-                                    nullable: true
-                                    type: integer
                                   timeoutSeconds:
                                     type: integer
                                 type: object
@@ -5982,9 +5700,6 @@ spec:
                                         nullable: true
                                         type: string
                                     type: object
-                                  terminationGracePeriodSeconds:
-                                    nullable: true
-                                    type: integer
                                   timeoutSeconds:
                                     type: integer
                                 type: object
@@ -6446,6 +6161,8 @@ spec:
                               ephemeral:
                                 nullable: true
                                 properties:
+                                  readOnly:
+                                    type: boolean
                                   volumeClaimTemplate:
                                     nullable: true
                                     properties:
@@ -7143,6 +6860,9 @@ spec:
               nullable: true
               type: string
             lastExecutedCommit:
+              nullable: true
+              type: string
+            lastSyncedTime:
               nullable: true
               type: string
             observedGeneration:

--- a/charts/fleet/charts/gitjob/Chart.yaml
+++ b/charts/fleet/charts/gitjob/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 0.1.25
+appVersion: 0.1.26
 description: Controller that run jobs based on git events
 name: gitjob
-version: 0.1.25
+version: 0.1.26

--- a/charts/fleet/charts/gitjob/values.yaml
+++ b/charts/fleet/charts/gitjob/values.yaml
@@ -1,10 +1,10 @@
 gitjob:
   repository: rancher/gitjob
-  tag: v0.1.25
+  tag: v0.1.26
 
 tekton:
   repository: rancher/tekton-utils
-  tag: v0.1.4
+  tag: v0.1.5
 
 global:
   cattle:


### PR DESCRIPTION
Bump gitjob to v0.1.26 and tekton-utils to v0.1.5. Also update gitjob CRDs according to the [developing docs](https://github.com/rancher/fleet/blob/master/DEVELOPING.md#updating-fleet-components).

Gitjob and tekton-utils bumps are related to updates in Alpine base images.

Signed-off-by: Guilherme Macedo <guilherme.macedo@suse.com>