### PR TITLE
Delete bundleDeployment for the fleet bundle that do not match to the updated cluster

### DIFF
--- a/pkg/controllers/bundle/controller.go
+++ b/pkg/controllers/bundle/controller.go
@@ -14,6 +14,7 @@ import (
 	"github.com/rancher/wrangler/pkg/apply"
 	"github.com/rancher/wrangler/pkg/generic"
 	"github.com/rancher/wrangler/pkg/relatedresource"
+	"github.com/sirupsen/logrus"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -26,11 +27,12 @@ const (
 )
 
 type handler struct {
-	targets *target.Manager
-	gitRepo fleetcontrollers.GitRepoCache
-	images  fleetcontrollers.ImageScanController
-	bundles fleetcontrollers.BundleController
-	mapper  meta.RESTMapper
+	targets           *target.Manager
+	gitRepo           fleetcontrollers.GitRepoCache
+	images            fleetcontrollers.ImageScanController
+	bundles           fleetcontrollers.BundleController
+	mapper            meta.RESTMapper
+	bundleDeployments fleetcontrollers.BundleDeploymentController
 }
 
 func Register(ctx context.Context,
@@ -44,11 +46,12 @@ func Register(ctx context.Context,
 	bundleDeployments fleetcontrollers.BundleDeploymentController,
 ) {
 	h := &handler{
-		mapper:  mapper,
-		targets: targets,
-		bundles: bundles,
-		images:  images,
-		gitRepo: gitRepo,
+		mapper:            mapper,
+		targets:           targets,
+		bundles:           bundles,
+		images:            images,
+		gitRepo:           gitRepo,
+		bundleDeployments: bundleDeployments,
 	}
 
 	fleetcontrollers.RegisterBundleGeneratingHandler(ctx,
@@ -87,9 +90,13 @@ func (h *handler) OnClusterChange(_ string, cluster *fleet.Cluster) (*fleet.Clus
 		return nil, nil
 	}
 
-	bundles, err := h.targets.BundlesForCluster(cluster)
+	bundles, bdCleanupSet, err := h.targets.BundlesForCluster(cluster)
 	if err != nil {
 		return nil, err
+	}
+	for _, bundleDeployment := range bdCleanupSet {
+		logrus.Debugf("Deleting bundleDeployment: %v %v", bundleDeployment.Namespace, bundleDeployment.Name)
+		h.bundleDeployments.Delete(bundleDeployment.Namespace, bundleDeployment.Name, nil)
 	}
 
 	for _, bundle := range bundles {


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/36241

Modifying/Deleting a cluster's label doesn't remove the bundles applied via clusterSelector previously. The root cause is that when the cluster update event is processed by Fleet, the controller lists all the bundles that match the cluster, but skips those bundles that do not match the updated cluster after the update. The bundleDeployments for these bundles need to be deleted for the updated cluster.