### PR TITLE
Move fleet-content and flet-agent-cred rolebinding to use specific serviceAccount

### DIFF
--- a/pkg/controllers/clusterregistration/controller.go
+++ b/pkg/controllers/clusterregistration/controller.go
@@ -284,6 +284,41 @@ func (h *handler) OnChange(request *fleet.ClusterRegistration, status fleet.Clus
 				Kind:     "Role",
 				Name:     request.Name,
 			},
+		},
+		&rbacv1.RoleBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "fleet-agent-get-cred",
+				Namespace: h.systemRegistrationNamespace,
+			},
+			Subjects: []rbacv1.Subject{
+				{
+					Kind:      "ServiceAccount",
+					Name:      saName,
+					Namespace: cluster.Status.Namespace,
+				},
+			},
+			RoleRef: rbacv1.RoleRef{
+				APIGroup: "rbac.authorization.k8s.io",
+				Kind:     "Role",
+				Name:     "fleet-agent-get-cred",
+			},
+		},
+		&rbacv1.ClusterRoleBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "fleet-agent-get-content",
+			},
+			Subjects: []rbacv1.Subject{
+				{
+					Kind:      "ServiceAccount",
+					Name:      saName,
+					Namespace: cluster.Status.Namespace,
+				},
+			},
+			RoleRef: rbacv1.RoleRef{
+				APIGroup: "rbac.authorization.k8s.io",
+				Kind:     "ClusterRole",
+				Name:     "fleet-content",
+			},
 		}), status, nil
 }
 

--- a/pkg/controllers/data.go
+++ b/pkg/controllers/data.go
@@ -67,40 +67,5 @@ func addData(systemNamespace, systemRegistrationNamespace string, appCtx *appCon
 					},
 				},
 			},
-			&rbacv1.RoleBinding{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "fleet-agent-get-cred",
-					Namespace: systemRegistrationNamespace,
-				},
-				Subjects: []rbacv1.Subject{
-					{
-						Kind:     "Group",
-						APIGroup: "rbac.authorization.k8s.io",
-						Name:     "system:serviceaccounts",
-					},
-				},
-				RoleRef: rbacv1.RoleRef{
-					APIGroup: "rbac.authorization.k8s.io",
-					Kind:     "Role",
-					Name:     "fleet-agent-get-cred",
-				},
-			},
-			&rbacv1.ClusterRoleBinding{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "fleet-agent-get-content",
-				},
-				Subjects: []rbacv1.Subject{
-					{
-						Kind:     "Group",
-						APIGroup: "rbac.authorization.k8s.io",
-						Name:     "system:serviceaccounts",
-					},
-				},
-				RoleRef: rbacv1.RoleRef{
-					APIGroup: "rbac.authorization.k8s.io",
-					Kind:     "ClusterRole",
-					Name:     "fleet-content",
-				},
-			},
 		)
 }


### PR DESCRIPTION
Previously they were created statically to use all serviceAccounts.