### PR TITLE
Add Github actions workflow to lint PRs

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,45 @@
+name: golangci-lint
+
+env:
+  SETUP_GO_VERSION: '^1.17.2'
+
+on:
+  schedule:
+    - cron:  '0 5 * * *'
+  pull_request:
+    paths-ignore:
+    - 'docs/**'
+    - 'charts/**'
+    - 'scripts/**'
+    - '*.md'
+
+jobs:
+  golangci:
+    name: golangci-lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - name: Setup Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ env.SETUP_GO_VERSION }}
+
+      - name: Generate Golang
+        run: |
+          export PATH=$PATH:/home/runner/go/bin/
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3.1.0
+        with:
+          # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
+          version: v1.45
+
+          args: --timeout=10m --config=.golangci-full.json
+
+          # Optional: show only new issues if it's a pull request. The default value is `false`.
+          # The condition sets this to true for PR events.
+          only-new-issues: "${{ github.event_name == 'pull_request'}}"

--- a/.golangci-full.json
+++ b/.golangci-full.json
@@ -1,0 +1,50 @@
+{
+  "run": {
+    "deadline": "20s",
+    "skip-files": [
+      "/zz_generated_"
+    ]
+  },
+  "linters-settings": {
+    "revive": {
+      "rules": [
+        {
+          "name": "blank-imports",
+          "severity": "warning"
+        },
+        {
+          "name": "unexported-return",
+          "severity": "warning"
+        }
+      ]
+    },
+    "funlen": {
+      "lines": 270,
+      "statements": 110
+    }
+  },
+  "linters": {
+    "disable-all": true,
+    "enable": [
+      "misspell",
+      "structcheck",
+      "govet",
+      "staticcheck",
+      "deadcode",
+      "errcheck",
+      "varcheck",
+      "unparam",
+      "ineffassign",
+      "nakedret",
+      "gocyclo",
+      "dupl",
+      "goimports",
+      "revive",
+      "gosec",
+      "gosimple",
+      "typecheck",
+      "unused",
+      "funlen"
+    ]
+  }
+}


### PR DESCRIPTION
This adds more linters in a separate golangci config.

Does not affect the existing linter, used by drone/dapper during release. However that linter does find an error with golangci-lint 1.45.2, so I'm unclear how `scripts/validate` passes. 


This new check should not be made required for merging, until we fixed/ignored all linter warnings. Otherwise PRs would have to deal with unrelated warnings.