### PR TITLE
Do not git ignore the charts/fleet folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,4 @@
 *.swp
 .idea
 *.DS_Store
-fleet
+/fleet


### PR DESCRIPTION
This also affects tools like ripgrep, which would not report any findings in the main helm chart.

Note: There is a check for a dirty repo in `scripts/validate-ci`. If some part of the build system creates a fleet binary in a sub-director, then we need to adapt this PR. However all binaries seem to have suffixes.