### PR TITLE
Update quickstart.md to use fleet.version

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -15,9 +15,9 @@ Install the Fleet Helm charts (there's two because we separate out CRDs for ulti
 
 ```shell
 helm -n fleet-system install --create-namespace --wait \
-    fleet-crd https://github.com/rancher/fleet/releases/download/{{fleet.version}}/fleet-crd-{{fleet.helmversion}}.tgz
+    fleet-crd https://github.com/rancher/fleet/releases/download/{{fleet.version}}/fleet-crd-{{fleet.version}}.tgz
 helm -n fleet-system install --create-namespace --wait \
-    fleet https://github.com/rancher/fleet/releases/download/{{fleet.version}}/fleet-{{fleet.helmversion}}.tgz
+    fleet https://github.com/rancher/fleet/releases/download/{{fleet.version}}/fleet-{{fleet.version}}.tgz
 ```
 
 ## Add a Git Repo to watch


### PR DESCRIPTION
At time of writing (20220512), the instructions available at fleet.rancher.io/quickstart/ do not work, due to fleet.helmversion expanding to 0.3.3.

The correct version for both CRD and 'main' helm charts on github, for release 0.3.9, is 0.3.9 (e.g. https://github.com/rancher/fleet/releases/download/v0.3.9/fleet-crd-0.3.9.tgz is the download URL for the CRD chart for 0.3.9). 
The project README (https://github.com/rancher/fleet/blob/master/README.md) confirms that using a single version string is currently the correct approach.
This change follows that document by using fleet.version throughout.