### PR TITLE
Docs: use correct artifact version

### DIFF
--- a/docs/agent-initiated.md
+++ b/docs/agent-initiated.md
@@ -116,7 +116,7 @@ Finally, install the agent using Helm.
 helm -n fleet-system install --create-namespace --wait \
     --set clientID="${CLUSTER_CLIENT_ID}" \
     --values values.yaml \
-    fleet-agent https://github.com/rancher/fleet/releases/download/{{fleet.version}}/fleet-agent-{{fleet.helmversion}}.tgz
+    fleet-agent https://github.com/rancher/fleet/releases/download/{{fleet.version}}/fleet-agent-{{fleet.version}}.tgz
 ```
 
 The agent should now be deployed.  You can check that status of the fleet pods by running the below commands.


### PR DESCRIPTION
It seems to me that the current link is not correct because the same version number is used both for fleet and the agent helm chart.

Current docs say:
```sh
helm -n fleet-system install --create-namespace --wait \
    ${CLUSTER_LABELS} \
    --values values.yaml \
    fleet-agent https://github.com/rancher/fleet/releases/download/v0.3.9/fleet-agent-0.3.3.tgz
```

But:

```
% curl https://github.com/rancher/fleet/releases/download/v0.3.9/fleet-agent-0.3.3.tgz
Not Found
```

It is my understanding the proposed fix should work!