### PR TITLE
Fix linter issues

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,45 @@
+name: golangci-lint
+
+env:
+  SETUP_GO_VERSION: '^1.17.2'
+
+on:
+  schedule:
+    - cron:  '0 5 * * *'
+  pull_request:
+    paths-ignore:
+    - 'docs/**'
+    - 'charts/**'
+    - 'scripts/**'
+    - '*.md'
+
+jobs:
+  golangci:
+    name: golangci-lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - name: Setup Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ env.SETUP_GO_VERSION }}
+
+      - name: Generate Golang
+        run: |
+          export PATH=$PATH:/home/runner/go/bin/
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3.1.0
+        with:
+          # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
+          version: v1.45
+
+          args: --timeout=10m --config=.golangci-full.json
+
+          # Optional: show only new issues if it's a pull request. The default value is `false`.
+          # The condition sets this to true for PR events.
+          only-new-issues: "${{ github.event_name == 'pull_request'}}"

--- a/.golangci-full.json
+++ b/.golangci-full.json
@@ -1,0 +1,50 @@
+{
+  "run": {
+    "deadline": "20s",
+    "skip-files": [
+      "/zz_generated_"
+    ]
+  },
+  "linters-settings": {
+    "revive": {
+      "rules": [
+        {
+          "name": "blank-imports",
+          "severity": "warning"
+        },
+        {
+          "name": "unexported-return",
+          "severity": "warning"
+        }
+      ]
+    },
+    "funlen": {
+      "lines": 270,
+      "statements": 110
+    }
+  },
+  "linters": {
+    "disable-all": true,
+    "enable": [
+      "misspell",
+      "structcheck",
+      "govet",
+      "staticcheck",
+      "deadcode",
+      "errcheck",
+      "varcheck",
+      "unparam",
+      "ineffassign",
+      "nakedret",
+      "gocyclo",
+      "dupl",
+      "goimports",
+      "revive",
+      "gosec",
+      "gosimple",
+      "typecheck",
+      "unused",
+      "funlen"
+    ]
+  }
+}

--- a/.golangci-full.json
+++ b/.golangci-full.json
@@ -46,5 +46,13 @@
       "unused",
       "funlen"
     ]
+  },
+  "issues": {
+    "exclude-rules": [
+      {
+        "path": "pkg/controllers/clusterregistration/controller.go",
+        "text": "G101: Potential hardcoded credentials"
+      }
+    ]
   }
 }

--- a/.golangci-full.json
+++ b/.golangci-full.json
@@ -52,6 +52,14 @@
       {
         "path": "pkg/controllers/clusterregistration/controller.go",
         "text": "G101: Potential hardcoded credentials"
+      },
+      {
+        "path": "cmd/fleetcontroller/main.go",
+        "text": "G108: Profiling endpoint is automatically exposed on /debug/pprof"
+      },
+      {
+        "path": "cmd/fleetagent/main.go",
+        "text": "G108: Profiling endpoint is automatically exposed on /debug/pprof"
       }
     ]
   }

--- a/.golangci-full.json
+++ b/.golangci-full.json
@@ -60,6 +60,10 @@
       {
         "path": "cmd/fleetagent/main.go",
         "text": "G108: Profiling endpoint is automatically exposed on /debug/pprof"
+      },
+      {
+        "path": "modules/agent/pkg/register/register.go",
+        "text": "G107: Potential HTTP request made with variable url"
       }
     ]
   }

--- a/modules/agent/pkg/deployer/monitor.go
+++ b/modules/agent/pkg/deployer/monitor.go
@@ -249,7 +249,7 @@ func modified(plan apply.Plan) (result []fleet.ModifiedStatus) {
 		}
 	}
 
-	return
+	return result
 }
 
 func nonReady(plan apply.Plan) (result []fleet.NonReadyStatus) {

--- a/modules/agent/pkg/deployer/monitor.go
+++ b/modules/agent/pkg/deployer/monitor.go
@@ -33,10 +33,7 @@ func (m *Manager) plan(bd *fleet.BundleDeployment, ns string, objs ...runtime.Ob
 		ns = m.defaultNamespace
 	}
 
-	a, err := m.getApply(bd, ns)
-	if err != nil {
-		return apply.Plan{}, err
-	}
+	a := m.getApply(bd, ns)
 	plan, err := a.DryRun(objs...)
 	if err != nil {
 		return plan, err
@@ -141,12 +138,12 @@ func (m *Manager) normalizers(live objectset.ObjectByGVK, bd *fleet.BundleDeploy
 	return norm, nil
 }
 
-func (m *Manager) getApply(bd *fleet.BundleDeployment, ns string) (apply.Apply, error) {
+func (m *Manager) getApply(bd *fleet.BundleDeployment, ns string) apply.Apply {
 	apply := m.apply
 	return apply.
 		WithIgnorePreviousApplied().
 		WithSetID(GetSetID(bd.Name, m.labelPrefix, m.labelSuffix)).
-		WithDefaultNamespace(ns), nil
+		WithDefaultNamespace(ns)
 }
 
 func (m *Manager) MonitorBundle(bd *fleet.BundleDeployment) (DeploymentStatus, error) {

--- a/modules/agent/pkg/deployer/normalizers/mutatingwebhook.go
+++ b/modules/agent/pkg/deployer/normalizers/mutatingwebhook.go
@@ -83,7 +83,7 @@ func setMutatingWebhookV1CacertNil(un *unstructured.Unstructured, index int) err
 	err := runtime.DefaultUnstructuredConverter.FromUnstructured(un.Object, &webhook)
 	if err != nil {
 		logrus.Errorf("Failed to convert unstructured to webhook, err: %v", err)
-		return nil
+		return err
 	}
 
 	if index >= len(webhook.Webhooks) {
@@ -93,12 +93,12 @@ func setMutatingWebhookV1CacertNil(un *unstructured.Unstructured, index int) err
 	newObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&webhook)
 	if err != nil {
 		logrus.Errorf("Failed to convert unstructured to webhook, err: %v", err)
-		return nil
+		return err
 	}
 	if webhook.Webhooks != nil {
 		if err = unstructured.SetNestedField(un.Object, newObj["webhooks"], "webhooks"); err != nil {
 			logrus.Errorf("MutatingWebhook normalization error: %v", err)
-			return nil
+			return err
 		}
 	}
 	return nil
@@ -109,7 +109,7 @@ func setMutatingWebhookV1beta1CacertNil(un *unstructured.Unstructured, index int
 	err := runtime.DefaultUnstructuredConverter.FromUnstructured(un.Object, &webhook)
 	if err != nil {
 		logrus.Error("Failed to convert unstructured to webhook")
-		return nil
+		return err
 	}
 
 	if index >= len(webhook.Webhooks) {
@@ -119,12 +119,12 @@ func setMutatingWebhookV1beta1CacertNil(un *unstructured.Unstructured, index int
 	newObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&webhook)
 	if err != nil {
 		logrus.Errorf("Failed to convert unstructured to webhook, err: %v", err)
-		return nil
+		return err
 	}
 	if webhook.Webhooks != nil {
 		if err = unstructured.SetNestedField(un.Object, newObj["webhooks"], "webhooks"); err != nil {
 			logrus.Errorf("MutatingWebhook normalization error: %v", err)
-			return nil
+			return err
 		}
 	}
 	return nil

--- a/modules/agent/pkg/deployer/normalizers/norm.go
+++ b/modules/agent/pkg/deployer/normalizers/norm.go
@@ -31,8 +31,7 @@ func New(lives objectset.ObjectByGVK, additions ...diff.Normalizer) Norm {
 		},
 	}
 
-	for _, a := range additions {
-		n.normalizers = append(n.normalizers, a)
-	}
+	n.normalizers = append(n.normalizers, additions...)
+
 	return n
 }

--- a/modules/agent/pkg/deployer/normalizers/validatingwebhook.go
+++ b/modules/agent/pkg/deployer/normalizers/validatingwebhook.go
@@ -82,7 +82,7 @@ func setValidatingWebhookV1CacertNil(un *unstructured.Unstructured, index int) e
 	err := runtime.DefaultUnstructuredConverter.FromUnstructured(un.Object, &webhook)
 	if err != nil {
 		logrus.Errorf("Failed to convert unstructured to webhook, err: %v", err)
-		return nil
+		return err
 	}
 
 	if index >= len(webhook.Webhooks) {
@@ -92,12 +92,12 @@ func setValidatingWebhookV1CacertNil(un *unstructured.Unstructured, index int) e
 	newObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&webhook)
 	if err != nil {
 		logrus.Errorf("Failed to convert unstructured to webhook, err: %v", err)
-		return nil
+		return err
 	}
 	if webhook.Webhooks != nil {
 		if err = unstructured.SetNestedField(un.Object, newObj["webhooks"], "webhooks"); err != nil {
 			logrus.Errorf("ValidatingWebhook normalization error: %v", err)
-			return nil
+			return err
 		}
 	}
 	return nil
@@ -108,7 +108,7 @@ func setValidatingWebhookV1beta1CacertNil(un *unstructured.Unstructured, index i
 	err := runtime.DefaultUnstructuredConverter.FromUnstructured(un.Object, &webhook)
 	if err != nil {
 		logrus.Error("Failed to convert unstructured to webhook")
-		return nil
+		return err
 	}
 
 	if index >= len(webhook.Webhooks) {
@@ -118,12 +118,12 @@ func setValidatingWebhookV1beta1CacertNil(un *unstructured.Unstructured, index i
 	newObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&webhook)
 	if err != nil {
 		logrus.Errorf("Failed to convert unstructured to webhook, err: %v", err)
-		return nil
+		return err
 	}
 	if webhook.Webhooks != nil {
 		if err = unstructured.SetNestedField(un.Object, newObj["webhooks"], "webhooks"); err != nil {
 			logrus.Errorf("ValidatingWebhook normalization error: %v", err)
-			return nil
+			return err
 		}
 	}
 	return nil

--- a/modules/agent/pkg/register/register.go
+++ b/modules/agent/pkg/register/register.go
@@ -83,7 +83,7 @@ func tryRegister(ctx context.Context, namespace, clusterID string, config *rest.
 		}
 	} else if err != nil {
 		return nil, err
-	} else if err := testClientConfig(ctx, secret.Data[Kubeconfig]); err != nil {
+	} else if err := testClientConfig(secret.Data[Kubeconfig]); err != nil {
 		logrus.Errorf("Current credential failed, failing back to reregistering: %v", err)
 		secret, err = runRegistration(ctx, k8s.Core().V1(), namespace, clusterID)
 		if err != nil {
@@ -193,7 +193,7 @@ func createClusterSecret(ctx context.Context, clusterID string, k8s corecontroll
 			return nil, err
 		}
 
-		if err := testClientConfig(ctx, newKubeconfig); err != nil {
+		if err := testClientConfig(newKubeconfig); err != nil {
 			return nil, err
 		}
 
@@ -277,7 +277,7 @@ func createClientConfigFromSecret(secret *corev1.Secret) clientcmd.ClientConfig 
 	return clientcmd.NewDefaultClientConfig(cfg, &clientcmd.ConfigOverrides{})
 }
 
-func testClientConfig(ctx context.Context, cfg []byte) error {
+func testClientConfig(cfg []byte) error {
 	cc, err := clientcmd.NewClientConfigFromBytes(cfg)
 	if err != nil {
 		return err

--- a/modules/cli/cmds/root.go
+++ b/modules/cli/cmds/root.go
@@ -31,7 +31,7 @@ func App() *cobra.Command {
 
 type Fleet struct {
 	SystemNamespace string `usage:"System namespace of the controller" default:"fleet-system"`
-	Namespace       string `usage:"namespace" env:"NAMESPACE" default:"fleet-local" short:"n" env:"NAMESPACE"`
+	Namespace       string `usage:"namespace" env:"NAMESPACE" default:"fleet-local" short:"n"`
 	Kubeconfig      string `usage:"kubeconfig for authentication" short:"k"`
 	Context         string `usage:"kubeconfig context for authentication"`
 }

--- a/modules/cli/controllermanifest/server.go
+++ b/modules/cli/controllermanifest/server.go
@@ -54,7 +54,7 @@ func marshalConfig(opts *Options) (string, error) {
 	if err := enc.Encode(config); err != nil {
 		return "", err
 	}
-	return string(buf.Bytes()), nil
+	return buf.String(), nil
 }
 
 func assignDefaults(opts *Options) {

--- a/pkg/bundle/read.go
+++ b/pkg/bundle/read.go
@@ -259,12 +259,8 @@ func appendTargets(def *fleet.Bundle, targetsFile string) (*fleet.Bundle, error)
 		return nil, err
 	}
 
-	for _, target := range spec.Targets {
-		def.Spec.Targets = append(def.Spec.Targets, target)
-	}
-	for _, targetRestriction := range spec.TargetRestrictions {
-		def.Spec.TargetRestrictions = append(def.Spec.TargetRestrictions, targetRestriction)
-	}
+	def.Spec.Targets = append(def.Spec.Targets, spec.Targets...)
+	def.Spec.TargetRestrictions = append(def.Spec.TargetRestrictions, spec.TargetRestrictions...)
 
 	return def, nil
 }

--- a/pkg/bundle/resources.go
+++ b/pkg/bundle/resources.go
@@ -360,6 +360,10 @@ func readContent(ctx context.Context, progress *progress.Progress, base, name st
 	}
 
 	err = filepath.Walk(temp, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
 		if info.IsDir() {
 			if strings.HasPrefix(filepath.Base(path), ".") {
 				return filepath.SkipDir

--- a/pkg/bundle/resources.go
+++ b/pkg/bundle/resources.go
@@ -338,7 +338,7 @@ func readContent(ctx context.Context, progress *progress.Progress, base, name st
 		httpGetter.Client.Transport = transport
 	}
 	if auth.SSHPrivateKey != nil {
-		if strings.IndexAny(c.Src, "?") == -1 {
+		if !strings.ContainsAny(c.Src, "?") {
 			c.Src += "?"
 		} else {
 			c.Src += "&"

--- a/pkg/bundle/resources.go
+++ b/pkg/bundle/resources.go
@@ -238,7 +238,7 @@ func readDirectories(ctx context.Context, compress bool, directories ...director
 		dir := dir
 		eg.Go(func() error {
 			defer sem.Release(1)
-			resources, err := readDirectory(ctx, p, compress, dir.prefix, dir.base, dir.path, dir.auth)
+			resources, err := readDirectory(ctx, compress, dir.prefix, dir.base, dir.path, dir.auth)
 			if err != nil {
 				return err
 			}
@@ -258,10 +258,10 @@ func readDirectories(ctx context.Context, compress bool, directories ...director
 	return result, eg.Wait()
 }
 
-func readDirectory(ctx context.Context, progress *progress.Progress, compress bool, prefix, base, name string, auth Auth) ([]fleet.BundleResource, error) {
+func readDirectory(ctx context.Context, compress bool, prefix, base, name string, auth Auth) ([]fleet.BundleResource, error) {
 	var resources []fleet.BundleResource
 
-	files, err := readContent(ctx, progress, base, name, auth)
+	files, err := readContent(ctx, base, name, auth)
 	if err != nil {
 		return nil, err
 	}
@@ -292,7 +292,7 @@ func readDirectory(ctx context.Context, progress *progress.Progress, compress bo
 	return resources, nil
 }
 
-func readContent(ctx context.Context, progress *progress.Progress, base, name string, auth Auth) (map[string][]byte, error) {
+func readContent(ctx context.Context, base, name string, auth Auth) (map[string][]byte, error) {
 	temp, err := ioutil.TempDir("", "fleet")
 	if err != nil {
 		return nil, err

--- a/pkg/bundle/resources.go
+++ b/pkg/bundle/resources.go
@@ -120,7 +120,8 @@ func chartURL(location *fleet.HelmOptions, auth Auth) (string, error) {
 		pool.AppendCertsFromPEM(auth.CABundle)
 		transport := http.DefaultTransport.(*http.Transport).Clone()
 		transport.TLSClientConfig = &tls.Config{
-			RootCAs: pool,
+			RootCAs:    pool,
+			MinVersion: tls.VersionTLS12,
 		}
 		client.Transport = transport
 	}
@@ -333,7 +334,8 @@ func readContent(ctx context.Context, progress *progress.Progress, base, name st
 		pool.AppendCertsFromPEM(auth.CABundle)
 		transport := http.DefaultTransport.(*http.Transport).Clone()
 		transport.TLSClientConfig = &tls.Config{
-			RootCAs: pool,
+			RootCAs:    pool,
+			MinVersion: tls.VersionTLS12,
 		}
 		httpGetter.Client.Transport = transport
 	}

--- a/pkg/bundleyaml/bundleyaml_test.go
+++ b/pkg/bundleyaml/bundleyaml_test.go
@@ -1,3 +1,6 @@
+//go:build !windows
+// +build !windows
+
 package bundleyaml
 
 import (

--- a/pkg/bundleyaml/bundleyaml_test.go
+++ b/pkg/bundleyaml/bundleyaml_test.go
@@ -1,5 +1,3 @@
-// +build !windows
-
 package bundleyaml
 
 import (

--- a/pkg/controllers/bootstrap/bootstrap.go
+++ b/pkg/controllers/bootstrap/bootstrap.go
@@ -26,7 +26,7 @@ const (
 )
 
 var (
-	splitter = regexp.MustCompile("\\s*,\\s*")
+	splitter = regexp.MustCompile(`\s*,\s*`)
 )
 
 type handler struct {

--- a/pkg/controllers/bundle/controller.go
+++ b/pkg/controllers/bundle/controller.go
@@ -101,7 +101,10 @@ func (h *handler) OnClusterChange(_ string, cluster *fleet.Cluster) (*fleet.Clus
 		}
 		for _, bundleDeployment := range bundleDeployments {
 			logrus.Debugf("cleaning up bundleDeployment %v in namespace %v not matching the cluster: %v", bundleDeployment.Name, bundleDeployment.Namespace, cluster.Name)
-			h.bundleDeployments.Delete(bundleDeployment.Namespace, bundleDeployment.Name, nil)
+			err := h.bundleDeployments.Delete(bundleDeployment.Namespace, bundleDeployment.Name, nil)
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
 

--- a/pkg/controllers/bundle/controller.go
+++ b/pkg/controllers/bundle/controller.go
@@ -186,8 +186,8 @@ func setResourceKey(status *fleet.BundleStatus, bundle *fleet.Bundle, isNSed fun
 		return err
 	}
 
-	for _, target := range bundle.Spec.Targets {
-		opts := options.Calculate(&bundle.Spec, &target)
+	for i := range bundle.Spec.Targets {
+		opts := options.Calculate(&bundle.Spec, &bundle.Spec.Targets[i])
 		objs, err := helmdeployer.Template(bundle.Name, m, opts)
 		if err != nil {
 			return err

--- a/pkg/controllers/bundle/controller.go
+++ b/pkg/controllers/bundle/controller.go
@@ -103,7 +103,7 @@ func (h *handler) OnClusterChange(_ string, cluster *fleet.Cluster) (*fleet.Clus
 			logrus.Debugf("cleaning up bundleDeployment %v in namespace %v not matching the cluster: %v", bundleDeployment.Name, bundleDeployment.Namespace, cluster.Name)
 			err := h.bundleDeployments.Delete(bundleDeployment.Namespace, bundleDeployment.Name, nil)
 			if err != nil {
-				return nil, err
+				logrus.Debugf("deleting bundleDeployment returned an error: %v", err)
 			}
 		}
 	}

--- a/pkg/controllers/cluster/import.go
+++ b/pkg/controllers/cluster/import.go
@@ -33,7 +33,6 @@ import (
 var (
 	ImportTokenPrefix = "import-token-"
 	ImportTokenTTL    = 12 * time.Hour
-	t                 = true
 )
 
 type importHandler struct {

--- a/pkg/controllers/clusterregistration/controller.go
+++ b/pkg/controllers/clusterregistration/controller.go
@@ -169,7 +169,7 @@ func (h *handler) OnSecretChange(key string, secret *v1.Secret) (*v1.Secret, err
 		return secret, nil
 	}
 
-	if time.Now().Sub(secret.CreationTimestamp.Time) > deleteSecretAfter {
+	if time.Since(secret.CreationTimestamp.Time) > deleteSecretAfter {
 		logrus.Infof("Deleting expired registration secret %s/%s", secret.Namespace, secret.Name)
 		return secret, h.secrets.Delete(secret.Namespace, secret.Name, nil)
 	}

--- a/pkg/controllers/clusterregistrationtoken/handler.go
+++ b/pkg/controllers/clusterregistrationtoken/handler.go
@@ -195,6 +195,6 @@ func (h *handler) deleteExpired(token *fleet.ClusterRegistrationToken) (bool, er
 		return true, h.clusterRegistrationTokens.Delete(token.Namespace, token.Name, nil)
 	}
 
-	h.clusterRegistrationTokens.EnqueueAfter(token.Namespace, token.Name, expire.Sub(time.Now()))
+	h.clusterRegistrationTokens.EnqueueAfter(token.Namespace, token.Name, time.Until(time.Now()))
 	return false, nil
 }

--- a/pkg/controllers/content/controller.go
+++ b/pkg/controllers/content/controller.go
@@ -21,7 +21,6 @@ type handler struct {
 }
 
 type contentRef struct {
-	deleteCandidate bool
 	safeToDelete    bool
 	markForDeletion bool
 	bundleCount     int

--- a/pkg/controllers/git/git.go
+++ b/pkg/controllers/git/git.go
@@ -108,13 +108,7 @@ func (h *handler) getConfig(repo *fleet.GitRepo) (*corev1.ConfigMap, error) {
 			ClusterGroup:         target.ClusterGroup,
 			ClusterGroupSelector: target.ClusterGroupSelector,
 		})
-		spec.TargetRestrictions = append(spec.TargetRestrictions, fleet.BundleTargetRestriction{
-			Name:                 target.Name,
-			ClusterName:          target.ClusterName,
-			ClusterSelector:      target.ClusterSelector,
-			ClusterGroup:         target.ClusterGroup,
-			ClusterGroupSelector: target.ClusterGroupSelector,
-		})
+		spec.TargetRestrictions = append(spec.TargetRestrictions, fleet.BundleTargetRestriction(target))
 	}
 	data, err := json.Marshal(spec)
 	if err != nil {

--- a/pkg/controllers/git/git.go
+++ b/pkg/controllers/git/git.go
@@ -16,7 +16,6 @@ import (
 	"github.com/rancher/fleet/pkg/summary"
 	gitjob "github.com/rancher/gitjob/pkg/apis/gitjob.cattle.io/v1"
 	v1 "github.com/rancher/gitjob/pkg/generated/controllers/gitjob.cattle.io/v1"
-	"github.com/rancher/lasso/pkg/client"
 	"github.com/rancher/wrangler/pkg/apply"
 	corev1controller "github.com/rancher/wrangler/pkg/generated/controllers/core/v1"
 	"github.com/rancher/wrangler/pkg/genericcondition"
@@ -77,7 +76,6 @@ func resolveGitRepo(namespace, name string, obj runtime.Object) ([]relatedresour
 }
 
 type handler struct {
-	shareClientFactory  client.SharedClientFactory
 	gitjobCache         v1.GitJobCache
 	secrets             corev1controller.SecretCache
 	bundleCache         fleetcontrollers.BundleCache

--- a/pkg/controllers/image/image.go
+++ b/pkg/controllers/image/image.go
@@ -272,7 +272,7 @@ func shouldSync(gitrepo *v1alpha1.GitRepo) bool {
 		}
 	}
 
-	if time.Now().Sub(gitrepo.Status.LastSyncedImageScanTime.Time) < interval.Duration {
+	if time.Since(gitrepo.Status.LastSyncedImageScanTime.Time) < interval.Duration {
 		return false
 	}
 	return true
@@ -381,7 +381,7 @@ func shouldScan(image *v1alpha1.ImageScan) bool {
 		return true
 	}
 
-	if time.Now().Sub(image.Status.LastScanTime.Time) < interval.Duration {
+	if time.Since(image.Status.LastScanTime.Time) < interval.Duration {
 		return false
 	}
 	return true

--- a/pkg/update/filter.go
+++ b/pkg/update/filter.go
@@ -104,10 +104,10 @@ func accept(v visitor, object *yaml.RNode, p string, settersSchema *spec.Schema)
 }
 
 // set applies the value from ext to field
-func (s *SetAllCallback) set(field *yaml.RNode, ext *setters2.CliExtension, sch *spec.Schema) (bool, error) {
+func (s *SetAllCallback) set(field *yaml.RNode, ext *setters2.CliExtension, sch *spec.Schema) error {
 	// check full setter
 	if ext.Setter == nil {
-		return false, nil
+		return nil
 	}
 
 	// this has a full setter, set its value
@@ -120,7 +120,7 @@ func (s *SetAllCallback) set(field *yaml.RNode, ext *setters2.CliExtension, sch 
 	if len(sch.Type) > 0 {
 		yaml.FormatNonStringStyle(field.YNode(), *sch)
 	}
-	return true, nil
+	return nil
 }
 
 // visitScalar
@@ -138,6 +138,6 @@ func (s *SetAllCallback) visitScalar(object *yaml.RNode, p string, fieldSchema *
 	}
 
 	// perform a direct set of the field if it matches
-	_, err = s.set(object, ext, fieldSchema.Schema)
+	err = s.set(object, ext, fieldSchema.Schema)
 	return err
 }

--- a/pkg/update/setters.go
+++ b/pkg/update/setters.go
@@ -93,7 +93,7 @@ func WithSetters(inpath, outpath string, scans []*v1alpha1.ImageScan) error {
 			}
 			result.Files[file] = fileres
 		}
-		objres, _ := fileres.Objects[oid]
+		objres := fileres.Objects[oid]
 		for _, n := range objres {
 			if n == ref {
 				return


### PR DESCRIPTION
Follow up of #757, which should be merged before. It fixes the mentioned issues or ignores them if they are not valid for us.

Regarding [enforcing TLS 1.2](https://github.com/rancher/fleet/commit/5638998e520a9343d25403df7b4bf55537f75044), it was introduced 2008, it is also the Minimum in modern browsers like Firefox without know issues, so it should not be a problem.
Nevertheless we should document it in the next release notes though if some customer has a very old https setup.

The [debug endpoint](https://github.com/rancher/fleet/commit/d7bb9c4673a420198d837eb71178e8464d7c9995) should not be a security issue because it only listens on localhost but it should in my opinion still not be enabled by default. I have not changed the code by now to not change expected behavior/use cases but we should discuss to only activate it in a debug mode for example.

The last two commits ([1](https://github.com/rancher/fleet/commit/09acbdcea410b545f9f4dd37eb917260958281f8), [2](https://github.com/rancher/fleet/commit/7cccb746038469473e82f63e3148470cf91acf09)) change the error handling in a few places. By not ignoring them anymore it might be possible that unexpected issues appear for some users, which did not happen before for the same setup.
We should still handle errors properly so I would treat these potential issues as bugs or a use case which should have not worked before because of missing files for example.