### PR TITLE
Changes to Fleet to support K8s 1.24 

### DIFF
--- a/pkg/controllers/controllers.go
+++ b/pkg/controllers/controllers.go
@@ -143,7 +143,8 @@ func Register(ctx context.Context, systemNamespace string, cfg clientcmd.ClientC
 			appCtx.RBAC.RoleBinding()),
 		appCtx.ClusterRegistrationToken(),
 		appCtx.Core.ServiceAccount(),
-		appCtx.Core.Secret().Cache())
+		appCtx.Core.Secret().Cache(),
+		appCtx.Core.Secret())
 
 	cleanup.Register(ctx,
 		appCtx.Apply.WithCacheTypes(
@@ -203,6 +204,7 @@ func Register(ctx context.Context, systemNamespace string, cfg clientcmd.ClientC
 			appCtx.Core.Secret()),
 		appCtx.ClientConfig,
 		appCtx.Core.ServiceAccount().Cache(),
+		appCtx.Core.Secret(),
 		appCtx.Core.Secret().Cache())
 
 	display.Register(ctx,

--- a/pkg/controllers/data.go
+++ b/pkg/controllers/data.go
@@ -10,6 +10,7 @@ import (
 )
 
 func addData(systemNamespace, systemRegistrationNamespace string, appCtx *appContext) error {
+
 	return appCtx.Apply.
 		WithSetID("fleet-bootstrap-data").
 		WithDynamicLookup().

--- a/pkg/secret/util.go
+++ b/pkg/secret/util.go
@@ -1,0 +1,76 @@
+package secret
+
+import (
+	"fmt"
+	"time"
+
+	corecontrollers "github.com/rancher/wrangler/pkg/generated/controllers/core/v1"
+	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func GetServiceAccountTokenSecret(sa *v1.ServiceAccount, secretsController corecontrollers.SecretController) (*v1.Secret, error) {
+	name := sa.Name + "-token"
+	secret, err := secretsController.Get(sa.Namespace, name, metav1.GetOptions{})
+	if err != nil {
+		if !apierrors.IsNotFound(err) {
+			return nil, fmt.Errorf("error getting secret: %w", err)
+		}
+		return createServiceAccountTokenSecret(sa, secretsController)
+	}
+	return secret, nil
+}
+
+func createServiceAccountTokenSecret(sa *v1.ServiceAccount, secretsController corecontrollers.SecretController) (*v1.Secret, error) {
+	// create the secret for the serviceAccount
+	logrus.Debugf("creating ServiceAccountTokenSecret for sa %v", sa.Name)
+	name := sa.Name + "-token"
+	sc := corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: sa.Namespace,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: "v1",
+					Kind:       "ServiceAccount",
+					Name:       sa.Name,
+					UID:        sa.UID,
+				},
+			},
+			Annotations: map[string]string{
+				"kubernetes.io/service-account.name": sa.Name,
+			},
+		},
+		Type: corev1.SecretTypeServiceAccountToken,
+	}
+	secret, err := secretsController.Create(&sc)
+	if err != nil {
+		if !apierrors.IsAlreadyExists(err) {
+			return nil, fmt.Errorf("error creating secret: %w", err)
+		}
+		secret, err = secretsController.Get(sa.Namespace, name, metav1.GetOptions{})
+		if err != nil {
+			logrus.Debugf("secret %v already exists, error getting it", name)
+			return nil, fmt.Errorf("error getting secret: %w", err)
+		}
+	}
+	//Kubernetes auto populates the secret token after it is created, for which we should wait
+	logrus.Infof("waiting for service account token key to be populated for secret %s/%s", secret.Namespace, secret.Name)
+	if _, ok := secret.Data[v1.ServiceAccountTokenKey]; !ok {
+		for {
+			logrus.Debugf("wait for svc account secret to be populated with token %s", secret.Name)
+			time.Sleep(2 * time.Second)
+			secret, err = secretsController.Get(sa.Namespace, name, metav1.GetOptions{})
+			if err != nil {
+				return nil, err
+			}
+			if _, ok := secret.Data[v1.ServiceAccountTokenKey]; ok {
+				break
+			}
+		}
+	}
+	return secret, nil
+}


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/37885

Fleet does not work in k8s 1.24 cluster because there is no auto-generated secret-based service account token anymore in K8s 1.24. Prior to 1.24, every serviceAccount created was auto-backed by K8s by a Secret token. Now with 1.24, there will be no auto population of the Secret token for serviceaccounts.

Thus we need to create the ServiceAccount Secrets ourselves in the controllers when needed for all the serviceAccounts used in Fleet.

We need to fix this issue to support the goal of running rancher in k8s 1.24

Changes include:
- If a ServiceAccount does not have a Secret token, then Fleet will create a secret of type SecretTypeServiceAccountToken   and wait for K8s to populate it
- This change is needed for fleet-controller bootstrap and clusterRegistration usecases.