### PR TITLE
Add Fleet issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.yml
@@ -1,0 +1,84 @@
+name: 'Bug report'
+labels: ['bug', 'triage']
+description: Create a report to help Fleet to improve
+body:
+- type: checkboxes
+  attributes:
+    label: Is there an existing issue for this?
+    description: Please search to see if an issue already exists for the bug you encountered.
+    options:
+    - label: I have searched the existing issues
+      required: true
+- type: textarea
+  attributes:
+    label: Current Behavior
+    description: A concise description of what you're experiencing.
+  validations:
+    required: false
+- type: textarea
+  attributes:
+    label: Expected Behavior
+    description: A concise description of what you expected to happen.
+  validations:
+    required: false
+- type: textarea
+  attributes:
+    label: Steps To Reproduce
+    description: Steps to reproduce the behavior.
+    placeholder: |
+      1. Install Fleet to '...'
+      4. See error
+  validations:
+    required: false
+- type: textarea
+  attributes:
+    label: Environment
+    description: |
+      examples:
+        - **Architecture**: arm64
+        - **Fleet Version**: 0.3.9
+        - **Cluster (please complete the following information):**
+          - Provider: [e.g. K3D, minikube, KinD, AKS, EKS, GKE, RKE, ...]
+          - Options: [e.g. number of nodes, storageclasses, loadbalancer if customised]
+          - Kubernetes Version: [e.g. 1.20]
+
+    value: |
+        - Architecture:
+        - Fleet Version:
+        - Cluster:
+          - Provider:
+          - Options:
+          - Kubernetes Version:
+    render: markdown
+  validations:
+    required: false
+- type: textarea
+  attributes:
+    label: Logs
+    description: |
+      If applicable, add logs to help explain your problem.
+      You can use attachments to add a screenshot of your clusters state, e.g. from k9s.
+
+      If you paste long logs, you could also add them into a collapsed block:
+
+      &lt;details&gt;
+        &lt;summary&gt;Click to expand&lt;summary&gt;
+
+        \```
+        pasted log
+        \```
+      &lt;details&gt;
+
+    render: markdown
+  validations:
+    required: false
+
+- type: textarea
+  attributes:
+    label: Anything else?
+    description: |
+      Links? References? Screenshots? Anything that will give us more context about the issue you are encountering!
+
+      Tip: You can attach images or log files by clicking this area to highlight it and then dragging files in.
+  validations:
+    required: false

--- a/.github/ISSUE_TEMPLATE/1-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.yml
@@ -1,5 +1,5 @@
 name: 'Bug report'
-labels: ['kind/bug', '[zube]: To Triage' ]
+labels: ['kind/bug', '[zube]: To Triage','area/fleet']
 description: Create a report to help Fleet to improve
 body:
 - type: checkboxes

--- a/.github/ISSUE_TEMPLATE/1-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.yml
@@ -1,5 +1,5 @@
 name: 'Bug report'
-labels: ['bug', 'triage']
+labels: ['kind/bug', '[zube]: To Triage' ]
 description: Create a report to help Fleet to improve
 body:
 - type: checkboxes

--- a/.github/ISSUE_TEMPLATE/2-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/2-feature-request.yml
@@ -1,5 +1,5 @@
 name: 'Feature Request'
-labels: ['[zube]: To Triage','kind/enhancement']
+labels: ['[zube]: To Triage','kind/enhancement','area/fleet']
 description: Create a feature request to help Fleet to improve
 title: 'Feature Request: '
 body:

--- a/.github/ISSUE_TEMPLATE/2-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/2-feature-request.yml
@@ -1,5 +1,5 @@
 name: 'Feature Request'
-labels: ['triage']
+labels: ['[zube]: To Triage','kind/enhancement']
 description: Create a feature request to help Fleet to improve
 title: 'Feature Request: '
 body:

--- a/.github/ISSUE_TEMPLATE/2-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/2-feature-request.yml
@@ -1,0 +1,32 @@
+name: 'Feature Request'
+labels: ['triage']
+description: Create a feature request to help Fleet to improve
+title: 'Feature Request: '
+body:
+- type: textarea
+  attributes:
+    label: Is your feature request related to a problem?
+    description: A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+  validations:
+    required: false
+- type: textarea
+  attributes:
+    label: Solution you'd like
+    description: A clear and concise description of what you want to happen
+  validations:
+    required: false
+- type: textarea
+  attributes:
+    label: Alternatives you've considered
+    description: A clear and concise description of any alternative solutions or features you've considered
+  validations:
+    required: false
+- type: textarea
+  attributes:
+    label: Anything else?
+    description: |
+      Links? References? Screenshots? Anything that will give us more context about the issue you are encountering!
+
+      Tip: You can attach images or log files by clicking this area to highlight it and then dragging files in.
+  validations:
+    required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true


### PR DESCRIPTION
I propose to add issue templates to encourage contributors to provide information that are useful to debug.

Feel free to look on this [epinio/docs](https://github.com/epinio/docs/issues/new/choose) to see what it would look like

Signed-off-by: Olivier Vernin <olivier.vernin@suse.com>