### PR TITLE
Remove armv7 from container image manifest

### DIFF
--- a/manifest.tmpl
+++ b/manifest.tmpl
@@ -6,11 +6,6 @@ manifests:
       architecture: amd64
       os: linux
   -
-    image: rancher/fleet:{{#if build.tag}}{{build.tag}}{{else}}{{replace "release/" "" build.branch }}-head{{/if}}-linux-arm
-    platform:
-      architecture: arm
-      os: linux
-  -
     image: rancher/fleet:{{#if build.tag}}{{build.tag}}{{else}}{{replace "release/" "" build.branch }}-head{{/if}}-linux-arm64
     platform:
       architecture: arm64


### PR DESCRIPTION
This is a left-over from removing ARMv7, so we can switch to BCI images.

Refers to https://github.com/rancher/rancher/issues/38248