### PR TITLE
Add CI for "gitrepo updates" and AKS/EKS/GKE

### DIFF
--- a/.github/scripts/deploy-fleet.sh
+++ b/.github/scripts/deploy-fleet.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+# usage: ./deploy-fleet.sh ghcr.io/rancher/fleet:sha-49f6f81 ghcr.io/rancher/fleet-agent:1h
+if [ $# -ge 2 ] && [ -n "$1" ] && [ -n "$2" ]; then
+  fleetRepo="${1%:*}"
+  fleetTag="${1#*:}"
+  agentRepo="${2%:*}"
+  agentTag="${2#*:}"
+else
+  fleetRepo="rancher/fleet"
+  fleetTag="dev"
+  agentRepo="rancher/fleet-agent"
+  agentTag="dev"
+fi
+
+helm -n fleet-system install --create-namespace --wait fleet-crd charts/fleet-crd
+helm upgrade --install fleet charts/fleet \
+  -n fleet-system --create-namespace --wait \
+  --set image.repository="$fleetRepo" \
+  --set image.tag="$fleetTag" \
+  --set agentImage.repository="$agentRepo" \
+  --set agentImage.tag="$agentTag" \
+  --set agentImage.imagePullPolicy=IfNotPresent
+
+kubectl -n fleet-system rollout status deploy/fleet-controller
+{ grep -q -m 1 "fleet-agent"; kill $!; } < <(kubectl get deployment -n fleet-system -w)
+kubectl -n fleet-system rollout status deploy/fleet-agent

--- a/.github/workflows/aks.yml
+++ b/.github/workflows/aks.yml
@@ -1,0 +1,166 @@
+name: CI AKS
+
+on:
+  # schedule:
+  #   - cron:  '0 0 * * *'
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "checkout git branch/tag"
+        required: true
+        default: "master"
+      keep_cluster:
+        description: "Keep the cluster afterwards? (empty/yes)"
+        required: false
+        default: ""
+      azure_credentials:
+        description: "AZURE_CREDENTIALS"
+        required: false
+        default: ""
+
+env:
+  GOARCH: amd64
+  CGO_ENABLED: 0
+  SETUP_GO_VERSION: '^1.18'
+  GINKGO_NODES: 1
+  FLAKE_ATTEMPTS: 1
+  AWS_REGION: 'us-east-2'
+  AKS_MACHINE_TYPE: 'Standard_D3_v2'
+
+jobs:
+  aks-fleet-examples:
+    runs-on: ubuntu-latest
+
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+          fetch-depth: 0
+      -
+        name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ env.SETUP_GO_VERSION }}
+      -
+        name: Setup Ginkgo Test Framework
+        run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.1.1
+
+      # Follow https://github.com/marketplace/actions/azure-login#configure-deployment-credentials
+      # az group create --name fleetCI --location eastus2
+      # az ad sp create-for-rbac --name "fleetCI" --sdk-auth --role contributor \
+      #   --scopes /subscriptions/{id}/resourceGroups/fleetCI
+      -
+        name: Login to Azure
+        uses: azure/login@v1
+        with:
+          creds: ${{ github.events.inputs.azure_credentials || secrets.AZURE_CREDENTIALS }}
+      -
+        name: Create AKS cluster
+        id: create-cluster
+        # We need to specify bash as a shell when a job is running on windows runner
+        shell: bash
+        run: |
+          id=$RANDOM
+          echo '::set-output name=ID::'$id
+          az aks create --resource-group fleetCI \
+          --node-vm-size ${{ env.AKS_MACHINE_TYPE }} \
+          --name fleetCI$id \
+          --node-count 2 \
+          --generate-ssh-keys
+
+          az aks get-credentials --resource-group fleetCI \
+          --name fleetCI$id \
+          --file kubeconfig-fleet-ci
+
+          # List existing clusters
+          az aks list | jq '.[] | .name + " " + (.powerState|tostring)'
+      -
+        name: Build fleet binaries
+        run: |
+          go build -o bin/fleetcontroller-linux-$GOARCH ./cmd/fleetcontroller
+
+          go build -o "bin/fleet-linux-$GOARCH"
+          go build -o "bin/fleetagent-linux-$GOARCH" ./cmd/fleetagent
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      -
+        name: Get UUID
+        id: uuid
+        run: echo "::set-output name=uuid::$(uuidgen)"
+      -
+        id: meta-fleet
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            ttl.sh/rancher/fleet-${{ steps.uuid.outputs.uuid }}
+          tags: type=raw,value=1h
+      -
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: package/Dockerfile
+          build-args: |
+            ARCH=${{ env.GOARCH }}
+          push: true
+          tags: ${{ steps.meta-fleet.outputs.tags }}
+          labels: ${{ steps.meta-fleet.outputs.labels }}
+      -
+        id: meta-fleet-agent
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            ttl.sh/rancher/fleet-agent-${{ steps.uuid.outputs.uuid }}
+          tags: type=raw,value=1h
+      -
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: package/Dockerfile.agent
+          build-args: |
+            ARCH=${{ env.GOARCH }}
+          push: true
+          tags: ${{ steps.meta-fleet-agent.outputs.tags }}
+          labels: ${{ steps.meta-fleet-agent.outputs.labels }}
+      -
+        name: Deploy Fleet
+        run: |
+          export KUBECONFIG="$GITHUB_WORKSPACE/kubeconfig-fleet-ci"
+          echo "${{ steps.meta-fleet.outputs.tags }} ${{ steps.meta-fleet-agent.outputs.tags }}"
+          ./.github/scripts/deploy-fleet.sh ${{ steps.meta-fleet.outputs.tags }} ${{ steps.meta-fleet-agent.outputs.tags }}
+      -
+        name: Fleet Examples Tests
+        env:
+          FLEET_E2E_NS: fleet-local
+        run: |
+          export KUBECONFIG="$GITHUB_WORKSPACE/kubeconfig-fleet-ci"
+          ginkgo e2e/single-cluster
+      -
+        name: Fleet Gitrepo Tests
+        env:
+          FLEET_E2E_NS: fleet-local
+          GIT_REPO_URL: "git@github.com:fleetrepoci/testaks.git"
+          GIT_REPO_HOST: "github.com"
+          GIT_REPO_USER: "git"
+        run: |
+          export KUBECONFIG="$GITHUB_WORKSPACE/kubeconfig-fleet-ci"
+          export GIT_SSH_KEY="$GITHUB_WORKSPACE/id_ecdsa"
+          export GIT_SSH_PUBKEY="$GITHUB_WORKSPACE/id_ecdsa.pub"
+          echo "${{ secrets.CI_AKS_SSH_KEY }}" > "$GIT_SSH_KEY"
+          echo "${{ secrets.CI_AKS_SSH_PUBKEY }}" > "$GIT_SSH_PUBKEY"
+
+          ginkgo e2e/gitrepo
+      -
+        name: Delete AKS cluster
+        # We always tear down the cluster, to avoid costs. Except when running
+        # manually and keep_cluster was set to "yes"
+        if: ${{ always() && github.event.inputs.keep_cluster != 'yes' }}
+        shell: bash
+        run: |
+          id="${{ steps.create-cluster.outputs.ID }}"
+          az aks delete --resource-group fleetCI --name fleetCI$id --yes

--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -88,11 +88,7 @@ jobs:
       -
         name: Deploy Fleet
         run: |
-          helm -n fleet-system install --create-namespace --wait fleet-crd charts/fleet-crd
-          helm -n fleet-system upgrade --install --create-namespace --wait fleet charts/fleet
-          kubectl -n fleet-system rollout status deploy/fleet-controller
-          { grep -q -m 1 "fleet-agent"; kill $!; } < <(kubectl get deployment -n fleet-system -w)
-          kubectl -n fleet-system rollout status deploy/fleet-agent
+          ./.github/scripts/deploy-fleet.sh
       -
         name: E2E Tests for Examples
         env:
@@ -101,6 +97,8 @@ jobs:
           ginkgo e2e/single-cluster
       -
         name: Fleet Gitrepo Tests
+        # git repo tests can't run for PRs, because PRs don't have access to the secrets
+        if: github.event_name != 'pull_request'
         env:
           FLEET_E2E_NS: fleet-local
           GIT_REPO_URL: "git@github.com:fleetrepoci/test.git"

--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -100,6 +100,21 @@ jobs:
         run: |
           ginkgo e2e/single-cluster
       -
+        name: Fleet Gitrepo Tests
+        env:
+          FLEET_E2E_NS: fleet-local
+          GIT_REPO_URL: "git@github.com:fleetrepoci/test.git"
+          GIT_REPO_HOST: "github.com"
+          GIT_REPO_USER: "git"
+          GIT_REPO_BRANCH: ${{ matrix.k3s_version }}
+        run: |
+          export GIT_SSH_KEY="$GITHUB_WORKSPACE/id_ecdsa"
+          export GIT_SSH_PUBKEY="$GITHUB_WORKSPACE/id_ecdsa.pub"
+          echo "${{ secrets.CI_SSH_KEY }}" > "$GIT_SSH_KEY"
+          echo "${{ secrets.CI_SSH_PUBKEY }}" > "$GIT_SSH_PUBKEY"
+
+          ginkgo e2e/gitrepo
+      -
         name: Dump Failed Environment
         if: failure()
         run: |

--- a/.github/workflows/e2e-multicluster-ci.yml
+++ b/.github/workflows/e2e-multicluster-ci.yml
@@ -96,11 +96,7 @@ jobs:
         name: Deploy Fleet
         run: |
           kubectl config use-context k3d-upstream
-          helm -n fleet-system install --create-namespace --wait fleet-crd charts/fleet-crd
-          helm -n fleet-system upgrade --install --create-namespace --wait fleet charts/fleet
-          kubectl -n fleet-system rollout status deploy/fleet-controller
-          { grep -q -m 1 "fleet-agent"; kill $!; } < <(kubectl get deployment -n fleet-system -w)
-          kubectl -n fleet-system rollout status deploy/fleet-agent
+          ./.github/scripts/deploy-fleet.sh
       -
         name: Deploy and Register Downstream Fleet
         run: |

--- a/.github/workflows/eks.yml
+++ b/.github/workflows/eks.yml
@@ -1,0 +1,176 @@
+name: CI EKS
+
+on:
+  # schedule:
+  #   - cron:  '0 4 * * *'
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "checkout git branch/tag"
+        required: true
+        default: "master"
+      keep_cluster:
+        description: "Keep the cluster afterwards? (empty/yes)"
+        required: false
+        default: ""
+      aws_id:
+        description: "AWS_ACCESS_KEY_ID"
+        required: false
+        default: ""
+      aws_key:
+        description: "AWS_SECRET_ACCESS_KEY"
+        required: false
+        default: ""
+
+env:
+  GOARCH: amd64
+  CGO_ENABLED: 0
+  SETUP_GO_VERSION: '^1.18'
+  GINKGO_NODES: 1
+  FLAKE_ATTEMPTS: 1
+  AWS_REGION: 'us-east-2'
+  AWS_MACHINE_TYPE: 't3.xlarge'
+
+jobs:
+  eks-fleet-examples:
+    runs-on: ubuntu-latest
+
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+          fetch-depth: 0
+      -
+        name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ env.SETUP_GO_VERSION }}
+      -
+        name: Setup Ginkgo Test Framework
+        run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.1.1
+      -
+        name: Install Dependencies
+        run: |
+          brew install kubernetes-cli coreutils
+      -
+        name: Install EKSCTL
+        run: |
+          # Better to always use the latest eksctl binary to avoid API version issue
+          EKSCTL_GH=https://github.com/weaveworks/eksctl/releases/latest/download
+          curl --location ${EKSCTL_GH}/eksctl_$(uname -s)_amd64.tar.gz | tar xz -C .
+          chmod +x eksctl
+          sudo mv eksctl /usr/local/bin
+      -
+        name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ github.event.inputs.aws_id || secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ github.event.inputs.aws_key || secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+      -
+        name: Create EKS cluster
+        id: create-cluster
+        run: |
+          id=$RANDOM
+          echo '::set-output name=ID::'$id
+          eksctl create cluster --name=fleet-ci$id \
+          --region=${{ env.AWS_REGION }} \
+          --nodes=2 \
+          --node-type=${{ env.AWS_MACHINE_TYPE }} \
+          --node-volume-size=40 \
+          --managed \
+          --kubeconfig=kubeconfig-fleet-ci
+          # Workaround for https://github.com/aws/aws-cli/issues/6920
+          # https://stackoverflow.com/questions/71318743/kubectl-versions-error-exec-plugin-is-configured-to-use-api-version-client-auth
+          sed -i.bak -e 's/v1alpha1/v1beta1/' kubeconfig-fleet-ci
+      -
+        name: Build fleet binaries
+        run: |
+          go build -o bin/fleetcontroller-linux-$GOARCH ./cmd/fleetcontroller
+
+          go build -o "bin/fleet-linux-$GOARCH"
+          go build -o "bin/fleetagent-linux-$GOARCH" ./cmd/fleetagent
+      -
+        name: Get UUID
+        id: uuid
+        run: echo "::set-output name=uuid::$(uuidgen)"
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      -
+        id: meta-fleet
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            ttl.sh/rancher/fleet-${{ steps.uuid.outputs.uuid }}
+          tags: type=raw,value=1h
+      -
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: package/Dockerfile
+          build-args: |
+            ARCH=${{ env.GOARCH }}
+          push: true
+          tags: ${{ steps.meta-fleet.outputs.tags }}
+          labels: ${{ steps.meta-fleet.outputs.labels }}
+      -
+        id: meta-fleet-agent
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            ttl.sh/rancher/fleet-agent-${{ steps.uuid.outputs.uuid }}
+          tags: type=raw,value=1h
+      -
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: package/Dockerfile.agent
+          build-args: |
+            ARCH=${{ env.GOARCH }}
+          push: true
+          tags: ${{ steps.meta-fleet-agent.outputs.tags }}
+          labels: ${{ steps.meta-fleet-agent.outputs.labels }}
+      -
+        name: Deploy Fleet
+        run: |
+          export KUBECONFIG="$GITHUB_WORKSPACE/kubeconfig-fleet-ci"
+          echo "${{ steps.meta-fleet.outputs.tags }} ${{ steps.meta-fleet-agent.outputs.tags }}"
+          ./.github/scripts/deploy-fleet.sh ${{ steps.meta-fleet.outputs.tags }} ${{ steps.meta-fleet-agent.outputs.tags }}
+      -
+        name: Fleet Examples Tests
+        env:
+          FLEET_E2E_NS: fleet-local
+        run: |
+          export KUBECONFIG="$GITHUB_WORKSPACE/kubeconfig-fleet-ci"
+          ginkgo e2e/single-cluster
+      -
+        name: Fleet Gitrepo Tests
+        env:
+          FLEET_E2E_NS: fleet-local
+          GIT_REPO_URL: "git@github.com:fleetrepoci/testeks.git"
+          GIT_REPO_HOST: "github.com"
+          GIT_REPO_USER: "git"
+        run: |
+          export KUBECONFIG="$GITHUB_WORKSPACE/kubeconfig-fleet-ci"
+          export GIT_SSH_KEY="$GITHUB_WORKSPACE/id_ecdsa"
+          export GIT_SSH_PUBKEY="$GITHUB_WORKSPACE/id_ecdsa.pub"
+          echo "${{ secrets.CI_EKS_SSH_KEY }}" > "$GIT_SSH_KEY"
+          echo "${{ secrets.CI_EKS_SSH_PUBKEY }}" > "$GIT_SSH_PUBKEY"
+
+          ginkgo e2e/gitrepo
+      -
+        name: Delete EKS cluster
+        # We always tear down the cluster, to avoid costs. Except when running
+        # manually and keep_cluster was set to "yes"
+        if: ${{ always() && github.event.inputs.keep_cluster != 'yes' }}
+        env:
+          KUBECONFIG: kubeconfig-fleet-ci
+        run: |
+          id="${{ steps.create-cluster.outputs.ID }}"
+          eksctl delete cluster --region=${{ env.AWS_REGION }} --name=fleet-ci$id

--- a/.github/workflows/gke.yml
+++ b/.github/workflows/gke.yml
@@ -1,0 +1,164 @@
+name: CI GKE
+
+on:
+  # schedule:
+  #   - cron:  '0 1 * * *'
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "checkout git branch/tag"
+        required: true
+        default: "master"
+      keep_cluster:
+        description: "Keep the cluster afterwards? (empty/yes)"
+        required: false
+        default: ""
+      fleetci_gcp_credentials:
+        description: "FLEETCI_GCP_CREDENTIALS"
+        required: false
+        default: ""
+      fleetci_gke_project:
+        description: "FLEETCI_GKE_PROJECT"
+        required: false
+        default: ""
+
+env:
+  GOARCH: amd64
+  CGO_ENABLED: 0
+  SETUP_GO_VERSION: '^1.18'
+  GINKGO_NODES: 1
+  FLAKE_ATTEMPTS: 1
+  GKE_ZONE: 'europe-west1-b'
+  GKE_MACHINE_TYPE: 'n2-standard-4'
+
+jobs:
+  gke-fleet-examples:
+    runs-on: ubuntu-latest
+
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+          fetch-depth: 0
+      -
+        name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ env.SETUP_GO_VERSION }}
+      -
+        name: Setup Ginkgo Test Framework
+        run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.1.1
+      -
+        name: Authenticate to GCP
+        uses: 'google-github-actions/auth@v0'
+        with:
+          credentials_json: '${{ github.events.inputs.fleetci_gcp_credentials || secrets.FLEETCI_GCP_CREDENTIALS }}'
+      -
+        name: Setup gcloud
+        uses: google-github-actions/setup-gcloud@v0
+      -
+        name: Install gcloud kubectl version
+        run: gcloud components install kubectl
+      -
+        # needs a project and a network
+        name: Create GKE cluster
+        id: create-cluster
+        run: |
+          id=$RANDOM
+          echo '::set-output name=ID::'$id
+          gcloud container clusters create fleetci$id \
+          --disk-size 100 \
+          --num-nodes=1 \
+          --machine-type ${{ env.GKE_MACHINE_TYPE }} \
+          --no-enable-cloud-logging \
+          --no-enable-cloud-monitoring  \
+          --zone ${{ env.GKE_ZONE }}
+      -
+        name: Get kubeconfig file from GKE
+        run: |
+          id="${{ steps.create-cluster.outputs.ID }}"
+          gcloud container clusters get-credentials fleetci$id --zone ${{ env.GKE_ZONE }} --project ${{ github.events.inputs.fleetci_gke_project || secrets.FLEETCI_GKE_PROJECT }}
+      -
+        name: Build fleet binaries
+        run: |
+          go build -o bin/fleetcontroller-linux-$GOARCH ./cmd/fleetcontroller
+
+          go build -o "bin/fleet-linux-$GOARCH"
+          go build -o "bin/fleetagent-linux-$GOARCH" ./cmd/fleetagent
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      -
+        name: Get UUID
+        id: uuid
+        run: echo "::set-output name=uuid::$(uuidgen)"
+      -
+        id: meta-fleet
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            ttl.sh/rancher/fleet-${{ steps.uuid.outputs.uuid }}
+          tags: type=raw,value=1h
+      -
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: package/Dockerfile
+          build-args: |
+            ARCH=${{ env.GOARCH }}
+          push: true
+          tags: ${{ steps.meta-fleet.outputs.tags }}
+          labels: ${{ steps.meta-fleet.outputs.labels }}
+      -
+        id: meta-fleet-agent
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            ttl.sh/rancher/fleet-agent-${{ steps.uuid.outputs.uuid }}
+          tags: type=raw,value=1h
+      -
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: package/Dockerfile.agent
+          build-args: |
+            ARCH=${{ env.GOARCH }}
+          push: true
+          tags: ${{ steps.meta-fleet-agent.outputs.tags }}
+          labels: ${{ steps.meta-fleet-agent.outputs.labels }}
+      -
+        name: Deploy Fleet
+        run: |
+          echo "${{ steps.meta-fleet.outputs.tags }} ${{ steps.meta-fleet-agent.outputs.tags }}"
+          ./.github/scripts/deploy-fleet.sh ${{ steps.meta-fleet.outputs.tags }} ${{ steps.meta-fleet-agent.outputs.tags }}
+      -
+        name: Fleet Examples Tests
+        env:
+          FLEET_E2E_NS: fleet-local
+        run: |
+          ginkgo e2e/single-cluster
+      -
+        name: Fleet Gitrepo Tests
+        env:
+          FLEET_E2E_NS: fleet-local
+          GIT_REPO_URL: "git@github.com:fleetrepoci/testgke.git"
+          GIT_REPO_HOST: "github.com"
+          GIT_REPO_USER: "git"
+        run: |
+          export GIT_SSH_KEY="$GITHUB_WORKSPACE/id_ecdsa"
+          export GIT_SSH_PUBKEY="$GITHUB_WORKSPACE/id_ecdsa.pub"
+          echo "${{ secrets.CI_GKE_SSH_KEY }}" > "$GIT_SSH_KEY"
+          echo "${{ secrets.CI_GKE_SSH_PUBKEY }}" > "$GIT_SSH_PUBKEY"
+
+          ginkgo e2e/gitrepo
+      -
+        name: Delete GKE cluster
+        if: ${{ always() && github.event.inputs.keep_cluster != 'yes' }}
+        run: |
+          id="${{ steps.create-cluster.outputs.ID }}"
+          gcloud container clusters delete fleetci$id --zone ${{ env.GKE_ZONE }} --quiet

--- a/.golangci.json
+++ b/.golangci.json
@@ -70,6 +70,14 @@
         "linters": [
           "revive"
         ]
+      },
+      {
+        "path": "_test.go",
+        "linters": [
+          "gocyclo",
+          "dupl",
+          "gosec"
+        ]
       }
     ]
   }

--- a/e2e/assets/gitrepo/sleeper-chart/.helmignore
+++ b/e2e/assets/gitrepo/sleeper-chart/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/e2e/assets/gitrepo/sleeper-chart/Chart.yaml
+++ b/e2e/assets/gitrepo/sleeper-chart/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: sleeper-chart
+description: A test chart
+type: application
+version: 0.1.0
+appVersion: "1.16.0"

--- a/e2e/assets/gitrepo/sleeper-chart/templates/deployment.yaml
+++ b/e2e/assets/gitrepo/sleeper-chart/templates/deployment.yaml
@@ -1,0 +1,47 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sleeper
+  labels:
+    fleet: testing
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: sleeper
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        app: sleeper
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          command:
+            - sleep
+            - 7d
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/e2e/assets/gitrepo/sleeper-chart/values.yaml
+++ b/e2e/assets/gitrepo/sleeper-chart/values.yaml
@@ -1,0 +1,17 @@
+replicaCount: 1
+
+image:
+  repository: rancher/mirrored-library-busybox
+  pullPolicy: IfNotPresent
+  tag: "1.34.1"
+
+imagePullSecrets: []
+
+podAnnotations: {}
+
+podSecurityContext: {}
+securityContext: {}
+
+nodeSelector: {}
+tolerations: []
+affinity: {}

--- a/e2e/gitrepo/gitrepo_test.go
+++ b/e2e/gitrepo/gitrepo_test.go
@@ -1,0 +1,107 @@
+package gitrepo_test
+
+import (
+	"bytes"
+	"html/template"
+	"io/ioutil"
+	"os"
+	"path"
+	"strings"
+
+	"github.com/go-git/go-git/v5"
+	"github.com/rancher/fleet/e2e/testenv"
+	"github.com/rancher/fleet/e2e/testenv/githelper"
+	"github.com/rancher/fleet/e2e/testenv/kubectl"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Git Repo", func() {
+	var (
+		tmpdir  string
+		repodir string
+		k       kubectl.Command
+		gh      *githelper.Git
+		repo    *git.Repository
+	)
+
+	replace := func(path string, s string, r string) {
+		b, err := os.ReadFile(path)
+		Expect(err).ToNot(HaveOccurred())
+
+		b = bytes.ReplaceAll(b, []byte(s), []byte(r))
+
+		err = ioutil.WriteFile(path, b, 0644)
+		Expect(err).ToNot(HaveOccurred())
+	}
+
+	BeforeEach(func() {
+		k = env.Kubectl.Namespace(env.Namespace)
+		gh = githelper.New()
+		tmpdir, _ = os.MkdirTemp("", "fleet-")
+
+		out, err := k.Create(
+			"secret", "generic", "git-auth", "--type", "kubernetes.io/ssh-auth",
+			"--from-file=ssh-privatekey="+gh.SSHKey,
+			"--from-file=ssh-publickey="+gh.SSHPubKey,
+		)
+		Expect(err).ToNot(HaveOccurred(), out)
+
+		known := path.Join(tmpdir, "known_hosts")
+		os.Setenv("SSH_KNOWN_HOSTS", known)
+		out, err = gh.UpdateKnownHosts(known)
+		Expect(err).ToNot(HaveOccurred(), out)
+
+		repodir = path.Join(tmpdir, "repo")
+		repo, err = gh.Create(repodir, testenv.AssetPath("gitrepo/sleeper-chart"), "examples")
+		Expect(err).ToNot(HaveOccurred())
+
+		tmpl := template.Must(template.New("test").Parse(githelper.GitRepoTemplate))
+		var yaml strings.Builder
+		err = tmpl.Execute(&yaml, githelper.GitRepo{Repo: gh.URL, Branch: gh.Branch})
+		Expect(err).ToNot(HaveOccurred())
+		fleet := path.Join(tmpdir, "fleet.yaml")
+		err = os.WriteFile(fleet, []byte(yaml.String()), 0644)
+		Expect(err).ToNot(HaveOccurred())
+
+		out, err = k.Apply("-f", fleet)
+		Expect(err).ToNot(HaveOccurred(), out)
+	})
+
+	AfterEach(func() {
+		os.RemoveAll(tmpdir)
+		_, _ = k.Delete("secret", "git-auth")
+		_, _ = k.Delete("gitrepo", "testing")
+	})
+
+	When("updating a git repository", func() {
+		It("updates the deployment", func() {
+			By("checking the pod exists")
+			Eventually(func() string {
+				out, _ := k.Namespace("default").Get("pods")
+				return out
+			}, testenv.Timeout).Should(ContainSubstring("sleeper-"))
+
+			By("updating the git repository")
+			replace(path.Join(repodir, "examples", "Chart.yaml"), "0.1.0", "0.2.0")
+			replace(path.Join(repodir, "examples", "templates", "deployment.yaml"), "name: sleeper", "name: newsleep")
+
+			commit, err := gh.Update(repo)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("checking for the updated commit hash in gitrepo")
+			Eventually(func() string {
+				out, _ := k.Get("gitrepo", "testing", "-o", "yaml")
+				return out
+			}, testenv.Timeout).Should(ContainSubstring("commit: " + commit))
+
+			By("checking the deployment's new name")
+			Eventually(func() string {
+				out, _ := k.Namespace("default").Get("deployments")
+				return out
+			}, testenv.Timeout).Should(ContainSubstring("newsleep"))
+
+		})
+	})
+})

--- a/e2e/gitrepo/suite_test.go
+++ b/e2e/gitrepo/suite_test.go
@@ -1,4 +1,4 @@
-package mc_examples_test
+package gitrepo_test
 
 import (
 	"testing"
@@ -11,7 +11,7 @@ import (
 
 func TestE2E(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "E2E Suite for Multi-Cluster Examples")
+	RunSpecs(t, "E2E Suite for Git Repo Tests")
 }
 
 var (

--- a/e2e/multi-cluster/multi_cluster_test.go
+++ b/e2e/multi-cluster/multi_cluster_test.go
@@ -1,4 +1,4 @@
-package examples_test
+package mc_examples_test
 
 import (
 	"encoding/json"

--- a/e2e/testenv/githelper/git.go
+++ b/e2e/testenv/githelper/git.go
@@ -1,0 +1,153 @@
+package githelper
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path"
+	"time"
+
+	"github.com/go-git/go-billy/v5/osfs"
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/config"
+	"github.com/go-git/go-git/v5/plumbing/cache"
+	"github.com/go-git/go-git/v5/plumbing/object"
+	"github.com/go-git/go-git/v5/plumbing/transport/ssh"
+	"github.com/go-git/go-git/v5/storage/filesystem"
+)
+
+type Git struct {
+	URL       string
+	User      string
+	SSHKey    string
+	SSHPubKey string
+	Host      string
+	Branch    string
+}
+
+func New() *Git {
+	g := &Git{
+		User:      os.Getenv("GIT_REPO_USER"),
+		SSHKey:    os.Getenv("GIT_SSH_KEY"),
+		SSHPubKey: os.Getenv("GIT_SSH_PUBKEY"),
+		URL:       os.Getenv("GIT_REPO_URL"),
+		Host:      os.Getenv("GIT_REPO_HOST"),
+		Branch:    os.Getenv("GIT_REPO_BRANCH"),
+	}
+	if g.Branch == "" {
+		g.Branch = "master"
+	}
+	g.check()
+
+	return g
+}
+
+func author() *object.Signature {
+	return &object.Signature{
+		Name:  "CI",
+		Email: "fleet@example.org",
+		When:  time.Now(),
+	}
+}
+
+func (g *Git) check() {
+	if g.User == "" || g.SSHKey == "" || g.URL == "" || g.Host == "" || g.SSHPubKey == "" {
+		panic("GIT_REPO_USER, GIT_SSH_KEY, GIT_SSH_PUBKEY, GIT_REPO_URL, GIT_REPO_HOST must be set")
+	}
+}
+
+// UpdateKnownHosts works around https://github.com/go-git/go-git/issues/411
+func (g *Git) UpdateKnownHosts(path string) (string, error) {
+	cmd := exec.Command("/bin/sh", "-c", "ssh-keyscan "+g.Host+" >> "+path) //nolint:gosec // test code should never receive user input
+
+	var b bytes.Buffer
+	cmd.Stdout = &b
+	cmd.Stderr = &b
+
+	err := cmd.Run()
+	return b.String(), err
+}
+
+func (g *Git) Create(repodir string, from string, subdir string) (*git.Repository, error) {
+	//fmt.Printf("Creating git repository in %s\n", repodir)
+	s := osfs.New(path.Join(repodir, ".git"))
+	repo, err := git.Init(filesystem.NewStorage(s, cache.NewObjectLRUDefault()), osfs.New(repodir))
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = repo.CreateRemote(&config.RemoteConfig{
+		Name: "origin",
+		URLs: []string{g.URL},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	//fmt.Printf("Copying %s to %s\n", from, to)
+	cmd := exec.Command("cp", "-a", from, path.Join(repodir, subdir)) //nolint:gosec // test code should never receive user input
+	err = cmd.Run()
+	if err != nil {
+		return nil, err
+	}
+
+	w, err := repo.Worktree()
+	if err != nil {
+		return nil, err
+	}
+
+	if _, err := w.Add("."); err != nil {
+		return nil, err
+	}
+
+	_, err = w.Commit("add chart", &git.CommitOptions{
+		Author: author(),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	//fmt.Printf("Pushing to remote: %s\n", g.SSHKey)
+	keys, err := ssh.NewPublicKeysFromFile(g.User, g.SSHKey, "")
+	if err != nil {
+		return nil, err
+	}
+
+	err = repo.Push(&git.PushOptions{
+		Auth:     keys,
+		Progress: os.Stdout,
+		// Force push, so our initial state is deterministic
+		RefSpecs: []config.RefSpec{config.RefSpec("+refs/heads/master:refs/heads/" + g.Branch)},
+	})
+
+	return repo, err
+}
+
+func (g *Git) Update(repo *git.Repository) (string, error) {
+	w, err := repo.Worktree()
+	if err != nil {
+		return "", err
+	}
+
+	if _, err := w.Add("."); err != nil {
+		return "", err
+	}
+
+	h, err := w.Commit("add chart", &git.CommitOptions{
+		Author: author(),
+	})
+	if err != nil {
+		return "", err
+	}
+
+	keys, err := ssh.NewPublicKeysFromFile(g.User, g.SSHKey, "")
+	if err != nil {
+		return "", err
+	}
+
+	return h.String(), repo.Push(&git.PushOptions{
+		Auth:     keys,
+		Progress: os.Stdout,
+		RefSpecs: []config.RefSpec{config.RefSpec("refs/heads/master:refs/heads/" + g.Branch)},
+	})
+}

--- a/e2e/testenv/githelper/gitrepo.go
+++ b/e2e/testenv/githelper/gitrepo.go
@@ -1,0 +1,20 @@
+package githelper
+
+// GitRepoTemplate can be used as fleet.yaml
+const GitRepoTemplate = `
+kind: GitRepo
+apiVersion: fleet.cattle.io/v1alpha1
+metadata:
+  name: testing
+spec:
+  repo: {{.Repo}}
+  clientSecretName: git-auth
+  branch: {{.Branch}}
+  paths:
+  - examples
+`
+
+type GitRepo struct {
+	Repo   string
+	Branch string
+}

--- a/e2e/testenv/kubectl/kubectl.go
+++ b/e2e/testenv/kubectl/kubectl.go
@@ -59,6 +59,10 @@ func (c Command) Delete(args ...string) (string, error) {
 	return c.Run(append([]string{"delete"}, args...)...)
 }
 
+func (c Command) Create(args ...string) (string, error) {
+	return c.Run(append([]string{"create"}, args...)...)
+}
+
 func (c Command) Run(args ...string) (string, error) {
 	if c.cnt != "" {
 		mu.Lock()


### PR DESCRIPTION
The new "gitrepo update" test needs a repo which it can control. These repos were created in a new account, which is orchestrated by the test. 
The workflows need deploy keys, one per repo as each workflow uses a separate repo to avoid conflicts.

The new AKS/EKS/GKE workflows require cloud credentials. They are triggered manually, we can activate a schedule once the secrets are set. The AKS/EKS workflows are tested: (https://github.com/manno/fleet/actions/runs/2669615696, https://github.com/manno/fleet/actions/runs/2669617653). The GKE workflow needs a service account with API keys first (like in Epinio).

Required secrets:

* ci (needed before this PR  is green)
  * CI_SSH_KEY
  * CI_SSH_PUBKEY
* eks (run manually only)
  * AWS_ACCESS_KEY_ID
  * AWS_SECRET_ACCESS_KEY
  * CI_EKS_SSH_KEY
  * CI_EKS_SSH_PUBKEY
* gke (run manually only)
  * EPCI_GCP_CREDENTIALS
  * EPCI_GKE_PROJECT
  * CI_GKE_SSH_KEY
  * CI_GKE_SSH_PUBKEY
* aks (run manually only)
  * AZURE_CREDENTIALS
  * CI_AKS_SSH_KEY
  * CI_AKS_SSH_PUBKEY


I could split both commits into separate PRs, but this is only CI and the PRs would depend on each other.