### PR TITLE
Consistenly use cattle-fleet-system as namespace

### DIFF
--- a/.github/scripts/deploy-fleet.sh
+++ b/.github/scripts/deploy-fleet.sh
@@ -15,15 +15,15 @@ else
   agentTag="dev"
 fi
 
-helm -n fleet-system install --create-namespace --wait fleet-crd charts/fleet-crd
+helm -n cattle-fleet-system install --create-namespace --wait fleet-crd charts/fleet-crd
 helm upgrade --install fleet charts/fleet \
-  -n fleet-system --create-namespace --wait \
+  -n cattle-fleet-system --create-namespace --wait \
   --set image.repository="$fleetRepo" \
   --set image.tag="$fleetTag" \
   --set agentImage.repository="$agentRepo" \
   --set agentImage.tag="$agentTag" \
   --set agentImage.imagePullPolicy=IfNotPresent
 
-kubectl -n fleet-system rollout status deploy/fleet-controller
-{ grep -q -m 1 "fleet-agent"; kill $!; } < <(kubectl get deployment -n fleet-system -w)
-kubectl -n fleet-system rollout status deploy/fleet-agent
+kubectl -n cattle-fleet-system rollout status deploy/fleet-controller
+{ grep -q -m 1 "fleet-agent"; kill $!; } < <(kubectl get deployment -n cattle-fleet-system -w)
+kubectl -n cattle-fleet-system rollout status deploy/fleet-agent

--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -121,8 +121,8 @@ jobs:
           kubectl get -A gitrepos,clusters,clustergroups,bundles,bundledeployments -o json > tmp/fleet.json
           kubectl get -A events > tmp/events.log
           helm list -A > tmp/helm.log
-          kubectl logs -n fleet-system -l app=fleet-controller > tmp/fleetcontroller.log
-          kubectl logs -n fleet-system -l app=fleet-agent > tmp/fleetagent.log
+          kubectl logs -n cattle-fleet-system -l app=fleet-controller > tmp/fleetcontroller.log
+          kubectl logs -n cattle-fleet-system -l app=fleet-agent > tmp/fleetagent.log
 
           docker logs k3d-k3s-default-server-0 &> tmp/k3s.log
           docker exec k3d-k3s-default-server-0 sh -c 'cd /var/log/containers; grep -r "." .' > tmp/containers.log

--- a/.github/workflows/e2e-multicluster-ci.yml
+++ b/.github/workflows/e2e-multicluster-ci.yml
@@ -116,7 +116,7 @@ jobs:
           ca=$(kubectl get -n default secret "$name" -o go-template='{{index .data "ca.crt" | base64decode}}')
 
           kubectl config use-context k3d-downstream
-          helm -n fleet-system upgrade --install --create-namespace --wait fleet-agent charts/fleet-agent \
+          helm -n cattle-fleet-system upgrade --install --create-namespace --wait fleet-agent charts/fleet-agent \
             --set-string labels.env=dev \
             --set apiServerCA="$ca" \
             --set apiServerURL="https://172.18.0.1.omg.howdoi.website:6443" \
@@ -149,14 +149,14 @@ jobs:
           kubectl get -A gitrepos,clusters,clustergroups,bundles,bundledeployments -o json > tmp/fleet.json
           kubectl get -A events > tmp/events.log
           helm list -A > tmp/helm.log
-          kubectl logs -n fleet-system -l app=fleet-controller > tmp/fleetcontroller.log
-          kubectl logs -n fleet-system -l app=fleet-agent > tmp/fleetagent.log
+          kubectl logs -n cattle-fleet-system -l app=fleet-controller > tmp/fleetcontroller.log
+          kubectl logs -n cattle-fleet-system -l app=fleet-agent > tmp/fleetagent.log
 
           kubectl config use-context k3d-downstream
           kubectl get -A pod,secret,service,ingress -o json > tmp/cluster-downstream.json
           kubectl get -A events > tmp/events-downstream.log
           helm list -A > tmp/helm-downstream.log
-          kubectl logs -n fleet-system -l app=fleet-agent > tmp/fleetagent-downstream.log
+          kubectl logs -n cattle-fleet-system -l app=fleet-agent > tmp/fleetagent-downstream.log
 
           docker logs k3d-upstream-server-0 &> tmp/k3s.log
           docker exec k3d-upstream-server-0 sh -c 'cd /var/log/containers; grep -r "." .' > tmp/containers.log

--- a/.github/workflows/e2e-multicluster-ci.yml
+++ b/.github/workflows/e2e-multicluster-ci.yml
@@ -121,7 +121,6 @@ jobs:
             --set apiServerCA="$ca" \
             --set apiServerURL="https://172.18.0.1.omg.howdoi.website:6443" \
             --set clusterNamespace="fleet-local" \
-            --set systemRegistrationNamespace="fleet-clusters-system" \
             --set token="$token"
       -
         name: Label Downstream Cluster

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -214,10 +214,10 @@ If you would like to test standalone Fleet, you can do the following: build and 
     go fmt ./...
     REPO=$AGENT_REPO make agent-dev
     docker push $AGENT_REPO/fleet-agent:dev
-    for i in fleet-system fleet-default fleet-local; do kubectl create namespace $i; done
-    helm install -n fleet-system fleet-crd ./charts/fleet-crd
-    helm install -n fleet-system fleet --set agentImage.repository=$AGENT_REPO/fleet-agent --set agentImage.imagePullPolicy=Always ./charts/fleet
-    kubectl delete deployment -n fleet-system fleet-controller
+    for i in cattle-fleet-system fleet-default fleet-local; do kubectl create namespace $i; done
+    helm install -n cattle-fleet-system fleet-crd ./charts/fleet-crd
+    helm install -n cattle-fleet-system fleet --set agentImage.repository=$AGENT_REPO/fleet-agent --set agentImage.imagePullPolicy=Always ./charts/fleet
+    kubectl delete deployment -n cattle-fleet-system fleet-controller
     go run cmd/fleetcontroller/main.go
 )
 ```
@@ -228,10 +228,10 @@ We'll use the latest Git tag for this, and _assume_ it is available on DockerHub
 ```sh
 (
     go fmt ./...
-    for i in fleet-system fleet-default fleet-local; do kubectl create namespace $i; done
-    helm install -n fleet-system fleet-crd ./charts/fleet-crd
-    helm install -n fleet-system fleet --set agentImage.tag=$(git tag --sort=taggerdate | tail -1) ./charts/fleet
-    kubectl delete deployment -n fleet-system fleet-controller
+    for i in cattle-fleet-system fleet-default fleet-local; do kubectl create namespace $i; done
+    helm install -n cattle-fleet-system fleet-crd ./charts/fleet-crd
+    helm install -n cattle-fleet-system fleet --set agentImage.tag=$(git tag --sort=taggerdate | tail -1) ./charts/fleet
+    kubectl delete deployment -n cattle-fleet-system fleet-controller
     go run cmd/fleetcontroller/main.go
 )
 ```

--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ Install the Fleet Helm charts (there's two because we separate out CRDs for ulti
 
 ```shell
 VERSION=0.3.9
-helm -n fleet-system install --create-namespace --wait \
+helm -n cattle-fleet-system install --create-namespace --wait \
     fleet-crd https://github.com/rancher/fleet/releases/download/v${VERSION}/fleet-crd-${VERSION}.tgz
-helm -n fleet-system install --create-namespace --wait \
+helm -n cattle-fleet-system install --create-namespace --wait \
     fleet https://github.com/rancher/fleet/releases/download/v${VERSION}/fleet-${VERSION}.tgz
 ```
 

--- a/charts/fleet-agent/values.yaml
+++ b/charts/fleet-agent/values.yaml
@@ -29,7 +29,7 @@ systemRegistrationNamespace: fleet-clusters-system
 
 # Please do not change the below setting unless you really know what you are doing
 internal:
-  systemNamespace: fleet-system
+  systemNamespace: cattle-fleet-system
   managedReleaseName: fleet-agent
 
 # The nodeSelector and tolerations for the agent deployment

--- a/charts/fleet-agent/values.yaml
+++ b/charts/fleet-agent/values.yaml
@@ -25,7 +25,7 @@ clientID: ""
 clusterNamespace: ""
 
 # The namespace containing the clusters registration secrets
-systemRegistrationNamespace: fleet-clusters-system
+systemRegistrationNamespace: cattle-fleet-clusters-system
 
 # Please do not change the below setting unless you really know what you are doing
 internal:

--- a/charts/fleet/values.yaml
+++ b/charts/fleet/values.yaml
@@ -32,7 +32,7 @@ bootstrap:
   # The namespace that will be autocreated and the local cluster will be registered in
   namespace: fleet-local
   # The namespace where the fleet agent for the local cluster will be ran, if empty
-  # this will default to fleet-system
+  # this will default to cattle-fleet-system
   agentNamespace: ""
   # A repo to add at install time that will deploy to the local cluster. This allows
   # one to fully bootstrap fleet, it's configuration and all it's downstream clusters

--- a/cmd/fleetcontroller/main.go
+++ b/cmd/fleetcontroller/main.go
@@ -20,7 +20,7 @@ var (
 
 type FleetManager struct {
 	Kubeconfig    string `usage:"Kubeconfig file"`
-	Namespace     string `usage:"namespace to watch" default:"fleet-system" env:"NAMESPACE"`
+	Namespace     string `usage:"namespace to watch" default:"cattle-fleet-system" env:"NAMESPACE"`
 	DisableGitops bool   `usage:"disable gitops components" name:"disable-gitops"`
 }
 

--- a/docs/agent-initiated.md
+++ b/docs/agent-initiated.md
@@ -46,7 +46,7 @@ under the `ca.crt` key.
 
 
 !!! hint "Use proper namespace and release name"
-    For the agent chart the namespace must be `fleet-system` and the release name `fleet-agent`
+    For the agent chart the namespace must be `cattle-fleet-system` and the release name `fleet-agent`
 
 !!! hint "Ensure you are installing to the right cluster"
     Helm will use the default context in `${HOME}/.kube/config` to deploy the agent. Use `--kubeconfig` and `--kube-context`
@@ -55,7 +55,7 @@ under the `ca.crt` key.
 Finally, install the agent using Helm.
 
 ```shell
-helm -n fleet-system install --create-namespace --wait \
+helm -n cattle-fleet-system install --create-namespace --wait \
     ${CLUSTER_LABELS} \
     --values values.yaml \
     --set apiServerCA=${API_SERVER_CA} \
@@ -67,8 +67,8 @@ The agent should now be deployed.  You can check that status of the fleet pods b
 
 ```shell
 # Ensure kubectl is pointing to the right cluster
-kubectl -n fleet-system logs -l app=fleet-agent
-kubectl -n fleet-system get pods -l app=fleet-agent
+kubectl -n cattle-fleet-system logs -l app=fleet-agent
+kubectl -n cattle-fleet-system get pods -l app=fleet-agent
 ```
 
 Additionally you should see a new cluster registered in the Fleet manager.  Below is an example of checking that a new cluster
@@ -119,7 +119,7 @@ CLUSTER_CLIENT_ID="really-random"
 ```
 
 !!! hint "Use proper namespace and release name"
-    For the agent chart the namespace must be `fleet-system` and the release name `fleet-agent`
+    For the agent chart the namespace must be `cattle-fleet-system` and the release name `fleet-agent`
 
 !!! hint "Ensure you are installing to the right cluster"
     Helm will use the default context in `${HOME}/.kube/config` to deploy the agent. Use `--kubeconfig` and `--kube-context`
@@ -128,7 +128,7 @@ CLUSTER_CLIENT_ID="really-random"
 Finally, install the agent using Helm.
 
 ```shell
-helm -n fleet-system install --create-namespace --wait \
+helm -n cattle-fleet-system install --create-namespace --wait \
     --set clientID="${CLUSTER_CLIENT_ID}" \
     --values values.yaml \
     fleet-agent https://github.com/rancher/fleet/releases/download/{{fleet.version}}/fleet-agent-{{fleet.version}}.tgz
@@ -138,8 +138,8 @@ The agent should now be deployed.  You can check that status of the fleet pods b
 
 ```shell
 # Ensure kubectl is pointing to the right cluster
-kubectl -n fleet-system logs -l app=fleet-agent
-kubectl -n fleet-system get pods -l app=fleet-agent
+kubectl -n cattle-fleet-system logs -l app=fleet-agent
+kubectl -n cattle-fleet-system get pods -l app=fleet-agent
 ```
 
 Additionally you should see a new cluster registered in the Fleet manager.  Below is an example of checking that a new cluster

--- a/docs/gitrepo-add.md
+++ b/docs/gitrepo-add.md
@@ -87,7 +87,7 @@ spec:
 
   # The service account that will be used to perform this deployment.
   # This is the name of the service account that exists in the
-  # downstream cluster in the fleet-system namespace. It is assumed
+  # downstream cluster in the cattle-fleet-system namespace. It is assumed
   # this service account already exists so it should be create before
   # hand, most likely coming from another git repo registered with
   # the Fleet manager.

--- a/docs/multi-cluster-install.md
+++ b/docs/multi-cluster-install.md
@@ -135,12 +135,12 @@ Helm charts.
 
 First install the Fleet CustomResourcesDefintions.
 ```shell
-helm -n fleet-system install --create-namespace --wait fleet-crd https://github.com/rancher/fleet/releases/download/{{fleet.version}}/fleet-crd-{{fleet.helmversion}}.tgz
+helm -n cattle-fleet-system install --create-namespace --wait fleet-crd https://github.com/rancher/fleet/releases/download/{{fleet.version}}/fleet-crd-{{fleet.helmversion}}.tgz
 ```
 
 Second install the Fleet controllers.
 ```shell
-helm -n fleet-system install --create-namespace --wait \
+helm -n cattle-fleet-system install --create-namespace --wait \
     --set apiServerURL="${API_SERVER_URL}" \
     --set-file apiServerCA="${API_SERVER_CA}" \
     fleet https://github.com/rancher/fleet/releases/download/{{fleet.version}}/fleet-{{fleet.helmversion}}.tgz
@@ -149,8 +149,8 @@ helm -n fleet-system install --create-namespace --wait \
 Fleet should be ready to use. You can check the status of the Fleet controller pods by running the below commands.
 
 ```shell
-kubectl -n fleet-system logs -l app=fleet-controller
-kubectl -n fleet-system get pods -l app=fleet-controller
+kubectl -n cattle-fleet-system logs -l app=fleet-controller
+kubectl -n cattle-fleet-system get pods -l app=fleet-controller
 ```
 
 ```

--- a/docs/namespaces.md
+++ b/docs/namespaces.md
@@ -36,7 +36,7 @@ on.
 The Fleet controller and Fleet agent run in this namespace. All service accounts referenced by `GitRepos` are expected
 to live in this namespace in the downstream cluster.
 
-### fleet-clusters-system
+### cattle-fleet-clusters-system
 
 This namespace holds secrets for the cluster registration process. It should contain no other resources in it,
 especially secrets.

--- a/docs/namespaces.md
+++ b/docs/namespaces.md
@@ -31,7 +31,7 @@ on.
 
 **Note:** If you would like to migrate your cluster from `fleet-local` to `default`, please see this [documentation](./troubleshooting.md#migrate-the-local-cluster-to-the-fleet-default-cluster).
 
-### fleet-system
+### cattle-fleet-system
 
 The Fleet controller and Fleet agent run in this namespace. All service accounts referenced by `GitRepos` are expected
 to live in this namespace in the downstream cluster.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -14,9 +14,9 @@ brew install helm
 Install the Fleet Helm charts (there's two because we separate out CRDs for ultimate flexibility.)
 
 ```shell
-helm -n fleet-system install --create-namespace --wait \
+helm -n cattle-fleet-system install --create-namespace --wait \
     fleet-crd https://github.com/rancher/fleet/releases/download/{{fleet.version}}/fleet-crd-{{fleet.version}}.tgz
-helm -n fleet-system install --create-namespace --wait \
+helm -n cattle-fleet-system install --create-namespace --wait \
     fleet https://github.com/rancher/fleet/releases/download/{{fleet.version}}/fleet-{{fleet.version}}.tgz
 ```
 

--- a/docs/single-cluster-install.md
+++ b/docs/single-cluster-install.md
@@ -36,13 +36,13 @@ Install the following two Helm charts.
 
 First install the Fleet CustomResourcesDefintions.
 ```shell
-helm -n fleet-system install --create-namespace --wait \
+helm -n cattle-fleet-system install --create-namespace --wait \
     fleet-crd https://github.com/rancher/fleet/releases/download/{{fleet.version}}/fleet-crd-{{fleet.helmversion}}.tgz
 ```
 
 Second install the Fleet controllers.
 ```shell
-helm -n fleet-system install --create-namespace --wait \
+helm -n cattle-fleet-system install --create-namespace --wait \
     fleet https://github.com/rancher/fleet/releases/download/{{fleet.version}}/fleet-{{fleet.helmversion}}.tgz
 ```
 
@@ -50,8 +50,8 @@ Fleet should be ready to use now for single cluster. You can check the status of
 running the below commands.
 
 ```shell
-kubectl -n fleet-system logs -l app=fleet-controller
-kubectl -n fleet-system get pods -l app=fleet-controller
+kubectl -n cattle-fleet-system logs -l app=fleet-controller
+kubectl -n cattle-fleet-system get pods -l app=fleet-controller
 ```
 
 ```

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -58,8 +58,8 @@ $ kubectl logs -f $gitRepoName-pod-name -n namespace
 You can check the status of the `fleet-controller` pods by running the commands below:
 
 ```bash
-kubectl -n fleet-system logs -l app=fleet-controller
-kubectl -n fleet-system get pods -l app=fleet-controller
+kubectl -n cattle-fleet-system logs -l app=fleet-controller
+kubectl -n cattle-fleet-system get pods -l app=fleet-controller
 ```
 
 ```bash

--- a/docs/uninstall.md
+++ b/docs/uninstall.md
@@ -5,6 +5,6 @@ uninstalling the appropriate Helm charts. To uninstall Fleet run the following
 two commands:
 
 ```shell
-helm -n fleet-system uninstall fleet
-helm -n fleet-system uninstall fleet-crd
+helm -n cattle-fleet-system uninstall fleet
+helm -n cattle-fleet-system uninstall fleet-crd
 ```

--- a/docs/webhook.md
+++ b/docs/webhook.md
@@ -10,7 +10,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: webhook-ingress
-  namespace: fleet-system
+  namespace: cattle-fleet-system
 spec:
   rules:
   - host: your.domain.com
@@ -42,7 +42,7 @@ secret, follow step 3.
 !!! note
     If you configured the webhook the polling interval will be automatically adjusted to 1 hour.
     
-### 3. (Optional) Configure webhook secret. The secret is for validating webhook payload. Make sure to put it in a k8s secret called `gitjob-webhook` in `fleet-system`.
+### 3. (Optional) Configure webhook secret. The secret is for validating webhook payload. Make sure to put it in a k8s secret called `gitjob-webhook` in `cattle-fleet-system`.
 
 | Provider        | K8s Secret Key                   |
 |-----------------| ---------------------------------|
@@ -55,7 +55,7 @@ secret, follow step 3.
 For example, to create a secret containing a GitHub secret to validate the webhook payload, run:
 
 ```shell
-kubectl create secret generic gitjob-webhook -n fleet-system --from-literal=github=webhooksecretvalue
+kubectl create secret generic gitjob-webhook -n cattle-fleet-system --from-literal=github=webhooksecretvalue
 ```
 
 ### 4. Go to your git provider and test the connection. You should get a HTTP response code.

--- a/modules/cli/cmds/root.go
+++ b/modules/cli/cmds/root.go
@@ -30,7 +30,7 @@ func App() *cobra.Command {
 }
 
 type Fleet struct {
-	SystemNamespace string `usage:"System namespace of the controller" default:"fleet-system"`
+	SystemNamespace string `usage:"System namespace of the controller" default:"cattle-fleet-system"`
 	Namespace       string `usage:"namespace" env:"NAMESPACE" default:"fleet-local" short:"n"`
 	Kubeconfig      string `usage:"kubeconfig for authentication" short:"k"`
 	Context         string `usage:"kubeconfig context for authentication"`

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -18,7 +18,7 @@ const (
 	AgentConfigName          = "fleet-agent"
 	AgentBootstrapConfigName = "fleet-agent-bootstrap"
 	Key                      = "config"
-	DefaultNamespace         = "fleet-system"
+	DefaultNamespace         = "cattle-fleet-system"
 )
 
 var (


### PR DESCRIPTION
throughout the documentation.

To be consistent and prevent issues we also need to change the fleet-agent chart, because https://github.com/rancher/fleet/blob/master/pkg/namespace/util.go#L18-L24 generates `systemRegistrationNamespace` by search and replace.

So if someone updates their fleet standalone installation, which uses the old name fleet-system, it is necessary to pass systemNamespace and systemRegistrationNamespace with the old names:

```
helm -n fleet-system upgrade --install ...
  --set systemRegistrationNamespace="fleet-clusters-system" \
  ...
```

Fixes #754