### PR TITLE
Add troubleshooting instructions to issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.yml
@@ -57,7 +57,12 @@ body:
     label: Logs
     description: |
       If applicable, add logs to help explain your problem.
-      You can use attachments to add a screenshot of your clusters state, e.g. from k9s.
+      You can use attachments to add a screenshot of your clusters state, e.g. from [k9s](https://k9scli.io/).
+
+      There is more information on getting logs in the [troubleshooting docs](https://fleet.rancher.io/troubleshooting/#how-do-i).
+
+      Often status fields are valuable information, for example if you have failed git resources, include the output of `kubectl get gitrepo -A -o jsonpath='{.items[*].status}'`.
+
 
       If you paste long logs, you could also add them into a collapsed block:
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -10,7 +10,7 @@ This section contains commands and tips to troubleshoot Fleet.
 In the local management cluster where the `fleet-controller` is deployed, run the following command with your specific `fleet-controller` pod name filled in:
 
 ```
-$ kubectl logs -f $fleet-controller-pod-name -n cattle-fleet-system
+$ kubectl logs -l app=fleet-controller -n cattle-fleet-system
 ```
 
 ### Fetch the log from the `fleet-agent`?
@@ -19,9 +19,9 @@ Go to each downstream cluster and run the following command for the local cluste
 
 ```
 # Downstream cluster
-$ kubectl logs -f $fleet-agent-pod-name -n cattle-fleet-system
+$ kubectl logs -l app=fleet-agent -n cattle-fleet-system
 # Local cluster
-$ kubectl logs -f $fleet-agent-pod-name -n cattle-local-fleet-system
+$ kubectl logs -l app=fleet-agent -n cattle-local-fleet-system
 ```
 
 ### Fetch detailed error logs from `GitRepos` and `Bundles`?


### PR DESCRIPTION
Add troubleshooting instructions to issue template from https://github.com/rancher/fleet/pull/858

Also use labels in troubleshooting docs, so it's no longer necessary to copy paste the pod name.