### PR TITLE
Adding atomic flag support for Helm charts

### DIFF
--- a/charts/fleet-crd/templates/crds.yaml
+++ b/charts/fleet-crd/templates/crds.yaml
@@ -112,6 +112,8 @@ spec:
               helm:
                 nullable: true
                 properties:
+                  atomic:
+                    type: boolean
                   chart:
                     nullable: true
                     type: string
@@ -479,6 +481,8 @@ spec:
                     helm:
                       nullable: true
                       properties:
+                        atomic:
+                          type: boolean
                         chart:
                           nullable: true
                           type: string
@@ -986,6 +990,8 @@ spec:
                   helm:
                     nullable: true
                     properties:
+                      atomic:
+                        type: boolean
                       chart:
                         nullable: true
                         type: string
@@ -1129,6 +1135,8 @@ spec:
                   helm:
                     nullable: true
                     properties:
+                      atomic:
+                        type: boolean
                       chart:
                         nullable: true
                         type: string

--- a/docs/gitrepo-structure.md
+++ b/docs/gitrepo-structure.md
@@ -98,6 +98,8 @@ helm:
       key: values.yaml
   # Override immutable resources. This could be dangerous.
   force: false
+  # Set the Helm --atomic flag when upgrading
+  atomic: false
 
 # A paused bundle will not update downstream clusters but instead mark the bundle
 # as OutOfSync. One can then manually confirm that a bundle should be deployed to

--- a/pkg/apis/fleet.cattle.io/v1alpha1/bundle.go
+++ b/pkg/apis/fleet.cattle.io/v1alpha1/bundle.go
@@ -233,6 +233,9 @@ type HelmOptions struct {
 	TakeOwnership  bool         `json:"takeOwnership,omitempty"`
 	MaxHistory     int          `json:"maxHistory,omitempty"`
 	ValuesFiles    []string     `json:"valuesFiles,omitempty"`
+
+	// Atomic sets the --atomic flag when Helm is performing an upgrade
+	Atomic bool `json:"atomic,omitempty"`
 }
 
 // Define helm values that can come from configmap, secret or external. Credit: https://github.com/fluxcd/helm-operator/blob/0cfea875b5d44bea995abe7324819432070dfbdc/pkg/apis/helm.fluxcd.io/v1/types_helmrelease.go#L439

--- a/pkg/helmdeployer/deployer.go
+++ b/pkg/helmdeployer/deployer.go
@@ -340,6 +340,7 @@ func (h *helm) install(bundleID string, manifest *manifest.Manifest, chart *char
 	u := action.NewUpgrade(&cfg)
 	u.Adopt = true
 	u.Force = options.Helm.Force
+	u.Atomic = options.Helm.Atomic
 	u.MaxHistory = options.Helm.MaxHistory
 	if u.MaxHistory == 0 {
 		u.MaxHistory = 10


### PR DESCRIPTION
This feature is a pass through from fleet configuration to the
Helm SDK.

Closes: #928