### PR TITLE
Fix gitrepos with multiple paths

### DIFF
--- a/docs/gitrepo-add.md
+++ b/docs/gitrepo-add.md
@@ -75,12 +75,13 @@ spec:
   # insecureSkipTLSVerify: true
   #
   # A git repo can read multiple paths in a repo at once.
-  # The below field is expected to be an array of paths and will include subdirs.
+  # The below field is expected to be an array of paths and
+  # supports path globbing (ex: some/*/path)
   #
   # Example:
   # paths:
   # - single-path
-  # - multiple-paths
+  # - multiple-paths/*
   paths:
   - simple
 

--- a/e2e/assets/single-cluster/multiple-paths.yaml
+++ b/e2e/assets/single-cluster/multiple-paths.yaml
@@ -1,0 +1,9 @@
+kind: GitRepo
+apiVersion: fleet.cattle.io/v1alpha1
+metadata:
+  name: multiple-paths
+spec:
+  repo: https://github.com/rancher/fleet-examples
+  paths:
+  - single-cluster/manifests
+  - single-cluster/helm


### PR DESCRIPTION
Fixes https://github.com/rancher/rancher/issues/38672

Fleet 0.3.10 introduced bundle pruning. After debugging this for a while, it seems like the pruning code was too aggressive. When constructing multiple bundles from the same git repo, the loop would prune previously created bundles.

```
% cd fleet-examples
% fleet-0.3.10 apply --debug  --debug-level 9 multiple-paths single-cluster/manifests single-cluster/helm
INFO[0000] updated: fleet-local/multiple-paths-single-cluster-manifests
DEBU[0000] Bundle to be deleted since it is not found in gitrepo multiple-paths anymore fleet-local multiple-paths-single-cluster-helm
INFO[0000] created: fleet-local/multiple-paths-single-cluster-helm
DEBU[0000] Bundle to be deleted since it is not found in gitrepo multiple-paths anymore fleet-local multiple-paths-single-cluster-manifests
```
Afterwards one bundle would remain, but it doesn't have the 'fleet.cattle.io/repo-name' label anymore.


This PR moves pruning out of the loop, towards the end, after all bundles have been detected in all paths.

This also fixes https://github.com/rancher/fleet/issues/920, as the labels now remain intact.