### PR TITLE
Fix rancher integration disk pressure

### DIFF
--- a/.github/workflows/rancher-integration.yml
+++ b/.github/workflows/rancher-integration.yml
@@ -126,7 +126,9 @@ jobs:
             -p "80:80@agent:0:direct"
             -p "443:443@agent:0:direct"
             --api-port 6443
-            --agents 3
+            --agents 1
+            --k3s-arg '--kubelet-arg=eviction-hard=imagefs.available<1%,nodefs.available<1%@agent:*'
+            --k3s-arg '--kubelet-arg=eviction-minimum-reclaim=imagefs.available=1%,nodefs.available=1%@agent:*'
             --network "nw01"
       -
         name: Set up k3d downstream cluster
@@ -138,6 +140,8 @@ jobs:
             -p "444:443@agent:0:direct"
             --api-port 6644
             --agents 1
+            --k3s-arg '--kubelet-arg=eviction-hard=imagefs.available<1%,nodefs.available<1%@agent:*'
+            --k3s-arg '--kubelet-arg=eviction-minimum-reclaim=imagefs.available=1%,nodefs.available=1%@agent:*'
             --network "nw01"
       -
         name: Set up tmate debug session

--- a/e2e/gitrepo/gitrepo_test.go
+++ b/e2e/gitrepo/gitrepo_test.go
@@ -80,7 +80,7 @@ var _ = Describe("Git Repo", func() {
 			Eventually(func() string {
 				out, _ := k.Namespace("default").Get("pods")
 				return out
-			}, testenv.Timeout).Should(ContainSubstring("sleeper-"))
+			}).Should(ContainSubstring("sleeper-"))
 
 			By("updating the git repository")
 			replace(path.Join(repodir, "examples", "Chart.yaml"), "0.1.0", "0.2.0")
@@ -93,13 +93,13 @@ var _ = Describe("Git Repo", func() {
 			Eventually(func() string {
 				out, _ := k.Get("gitrepo", "testing", "-o", "yaml")
 				return out
-			}, testenv.Timeout).Should(ContainSubstring("commit: " + commit))
+			}).Should(ContainSubstring("commit: " + commit))
 
 			By("checking the deployment's new name")
 			Eventually(func() string {
 				out, _ := k.Namespace("default").Get("deployments")
 				return out
-			}, testenv.Timeout).Should(ContainSubstring("newsleep"))
+			}).Should(ContainSubstring("newsleep"))
 
 		})
 	})

--- a/e2e/gitrepo/suite_test.go
+++ b/e2e/gitrepo/suite_test.go
@@ -19,6 +19,7 @@ var (
 )
 
 var _ = BeforeSuite(func() {
+	SetDefaultEventuallyTimeout(testenv.Timeout)
 	testenv.SetRoot("../..")
 
 	env = testenv.New()

--- a/e2e/multi-cluster/multi_cluster_test.go
+++ b/e2e/multi-cluster/multi_cluster_test.go
@@ -44,7 +44,7 @@ var _ = Describe("multiCluster", func() {
 				Eventually(func() string {
 					out, _ := kd.Namespace("fleet-mc-helm-example").Get("pods")
 					return out
-				}, testenv.Timeout).Should(SatisfyAll(ContainSubstring("frontend-"), ContainSubstring("redis-")))
+				}).Should(SatisfyAll(ContainSubstring("frontend-"), ContainSubstring("redis-")))
 			})
 		})
 
@@ -57,7 +57,7 @@ var _ = Describe("multiCluster", func() {
 				Eventually(func() string {
 					out, _ := kd.Namespace("fleet-mc-manifest-example").Get("pods")
 					return out
-				}, testenv.Timeout).Should(SatisfyAll(ContainSubstring("frontend-"), ContainSubstring("redis-")))
+				}).Should(SatisfyAll(ContainSubstring("frontend-"), ContainSubstring("redis-")))
 
 				out, err := kd.Namespace("fleet-mc-manifest-example").Get("deployment", "-o", "json", "frontend")
 				Expect(err).ToNot(HaveOccurred())
@@ -78,7 +78,7 @@ var _ = Describe("multiCluster", func() {
 				Eventually(func() string {
 					out, _ := kd.Namespace("fleet-mc-kustomize-example").Get("pods")
 					return out
-				}, testenv.Timeout).Should(ContainSubstring("frontend-"))
+				}).Should(ContainSubstring("frontend-"))
 			})
 		})
 
@@ -91,7 +91,7 @@ var _ = Describe("multiCluster", func() {
 				Eventually(func() string {
 					out, _ := kd.Namespace("fleet-mc-helm-kustomize-example").Get("pods")
 					return out
-				}, testenv.Timeout).Should(ContainSubstring("frontend-"))
+				}).Should(ContainSubstring("frontend-"))
 			})
 		})
 
@@ -104,7 +104,7 @@ var _ = Describe("multiCluster", func() {
 				Eventually(func() string {
 					out, _ := kd.Namespace("fleet-mc-helm-external-example").Get("pods")
 					return out
-				}, testenv.Timeout).Should(ContainSubstring("frontend-"))
+				}).Should(ContainSubstring("frontend-"))
 			})
 		})
 

--- a/e2e/multi-cluster/suite_test.go
+++ b/e2e/multi-cluster/suite_test.go
@@ -19,6 +19,7 @@ var (
 )
 
 var _ = BeforeSuite(func() {
+	SetDefaultEventuallyTimeout(testenv.Timeout)
 	testenv.SetRoot("../..")
 
 	env = testenv.New()

--- a/e2e/single-cluster/single_cluster_test.go
+++ b/e2e/single-cluster/single_cluster_test.go
@@ -41,7 +41,7 @@ var _ = Describe("SingleCluster", func() {
 				Eventually(func() string {
 					out, _ := k.Namespace("fleet-helm-example").Get("pods")
 					return out
-				}, testenv.Timeout).Should(ContainSubstring("frontend-"))
+				}).Should(ContainSubstring("frontend-"))
 			})
 		})
 
@@ -54,7 +54,7 @@ var _ = Describe("SingleCluster", func() {
 				Eventually(func() string {
 					out, _ := k.Namespace("fleet-manifest-example").Get("pods")
 					return out
-				}, testenv.Timeout).Should(SatisfyAll(ContainSubstring("frontend-"), ContainSubstring("redis-")))
+				}).Should(SatisfyAll(ContainSubstring("frontend-"), ContainSubstring("redis-")))
 			})
 		})
 
@@ -67,7 +67,7 @@ var _ = Describe("SingleCluster", func() {
 				Eventually(func() string {
 					out, _ := k.Namespace("fleet-kustomize-example").Get("pods")
 					return out
-				}, testenv.Timeout).Should(ContainSubstring("frontend-"))
+				}).Should(ContainSubstring("frontend-"))
 			})
 		})
 
@@ -80,7 +80,7 @@ var _ = Describe("SingleCluster", func() {
 				Eventually(func() string {
 					out, _ := k.Namespace("fleet-helm-kustomize-example").Get("pods")
 					return out
-				}, testenv.Timeout).Should(ContainSubstring("frontend-"))
+				}).Should(ContainSubstring("frontend-"))
 			})
 		})
 
@@ -93,7 +93,7 @@ var _ = Describe("SingleCluster", func() {
 				Eventually(func() string {
 					out, _ := k.Namespace("fleet-local").Get("bundles")
 					return out
-				}, testenv.Timeout).Should(SatisfyAll(
+				}).Should(SatisfyAll(
 					ContainSubstring("helm-single-cluster-helm-multi-chart-guestbook"),
 					ContainSubstring("helm-single-cluster-helm-multi-chart-rancher-monitoring"),
 				))
@@ -101,7 +101,7 @@ var _ = Describe("SingleCluster", func() {
 				Eventually(func() string {
 					out, _ := k.Get("bundledeployments", "-A")
 					return out
-				}, testenv.Timeout).Should(SatisfyAll(
+				}).Should(SatisfyAll(
 					ContainSubstring("helm-single-cluster-helm-multi-chart-guestbook"),
 					ContainSubstring("helm-single-cluster-helm-multi-chart-rancher-monitoring"),
 				))
@@ -109,7 +109,46 @@ var _ = Describe("SingleCluster", func() {
 				Eventually(func() string {
 					out, _ := k.Namespace("fleet-multi-chart-helm-example").Get("deployments")
 					return out
-				}, testenv.Timeout).Should(SatisfyAll(ContainSubstring("frontend"), ContainSubstring("redis-")))
+				}).Should(SatisfyAll(ContainSubstring("frontend"), ContainSubstring("redis-")))
+			})
+		})
+
+		Context("containing multiple paths", func() {
+			BeforeEach(func() {
+				asset = "single-cluster/multiple-paths.yaml"
+			})
+
+			It("deploys bundles from all the paths", func() {
+				Eventually(func() string {
+					out, _ := k.Namespace("fleet-local").Get("bundles")
+					return out
+				}).Should(SatisfyAll(
+					ContainSubstring("multiple-paths-single-cluster-manifests"),
+					ContainSubstring("multiple-paths-single-cluster-helm"),
+				))
+
+				out, _ := k.Namespace("fleet-local").Get("bundles",
+					"-l", "fleet.cattle.io/repo-name=multiple-paths",
+					`-o=jsonpath={.items[*].metadata.name}`)
+				Expect(strings.Split(out, " ")).To(HaveLen(2))
+
+				Eventually(func() string {
+					out, _ := k.Get("bundledeployments", "-A")
+					return out
+				}).Should(SatisfyAll(
+					ContainSubstring("multiple-paths-single-cluster-manifests"),
+					ContainSubstring("multiple-paths-single-cluster-helm"),
+				))
+
+				Eventually(func() string {
+					out, _ := k.Namespace("fleet-manifest-example").Get("deployments")
+					return out
+				}).Should(SatisfyAll(ContainSubstring("frontend"), ContainSubstring("redis-")))
+
+				Eventually(func() string {
+					out, _ := k.Namespace("fleet-helm-example").Get("deployments")
+					return out
+				}).Should(SatisfyAll(ContainSubstring("frontend"), ContainSubstring("redis-")))
 			})
 		})
 

--- a/e2e/single-cluster/suite_test.go
+++ b/e2e/single-cluster/suite_test.go
@@ -19,6 +19,7 @@ var (
 )
 
 var _ = BeforeSuite(func() {
+	SetDefaultEventuallyTimeout(testenv.Timeout)
 	testenv.SetRoot("../..")
 
 	env = testenv.New()


### PR DESCRIPTION
Disk pressure error in Rancher integration test

The rancher integration tests are flaky. The event logs show disk pressure errors.

Reduce the number of agents and apply the fix from https://k3d.io/v5.0.1/faq/faq/#pods-evicted-due-to-lack-of-disk-space