### PR TITLE
Add Google credentials to Fleet gke workflow

### DIFF
--- a/.github/workflows/gke.yml
+++ b/.github/workflows/gke.yml
@@ -1,8 +1,8 @@
 name: CI GKE
 
 on:
-  # schedule:
-  #   - cron:  '0 1 * * *'
+  schedule:
+    - cron:  '0 1 * * *'
   workflow_dispatch:
     inputs:
       ref:
@@ -11,10 +11,6 @@ on:
         default: "master"
       keep_cluster:
         description: "Keep the cluster afterwards? (empty/yes)"
-        required: false
-        default: ""
-      fleetci_gcp_credentials:
-        description: "FLEETCI_GCP_CREDENTIALS"
         required: false
         default: ""
       fleetci_gke_project:
@@ -54,7 +50,7 @@ jobs:
         name: Authenticate to GCP
         uses: 'google-github-actions/auth@v0'
         with:
-          credentials_json: '${{ github.events.inputs.fleetci_gcp_credentials || secrets.FLEETCI_GCP_CREDENTIALS }}'
+          credentials_json: '${{ secrets.CI_GOOGLE_CREDENTIALS }}'
       -
         name: Setup gcloud
         uses: google-github-actions/setup-gcloud@v0

--- a/.github/workflows/gke.yml
+++ b/.github/workflows/gke.yml
@@ -13,11 +13,6 @@ on:
         description: "Keep the cluster afterwards? (empty/yes)"
         required: false
         default: ""
-      fleetci_gke_project:
-        description: "FLEETCI_GKE_PROJECT"
-        required: false
-        default: ""
-
 env:
   GOARCH: amd64
   CGO_ENABLED: 0
@@ -75,7 +70,7 @@ jobs:
         name: Get kubeconfig file from GKE
         run: |
           id="${{ steps.create-cluster.outputs.ID }}"
-          gcloud container clusters get-credentials fleetci$id --zone ${{ env.GKE_ZONE }} --project ${{ github.events.inputs.fleetci_gke_project || secrets.FLEETCI_GKE_PROJECT }}
+          gcloud container clusters get-credentials fleetci$id --zone ${{ env.GKE_ZONE }} --project ${{ secrets.CI_GOOGLE_PROJECT }}
       -
         name: Build fleet binaries
         run: |


### PR DESCRIPTION
I created the google credentials using `CI_GOOGLE_CREDENTIALS`
It's a mix of using the same credential mentioned in the GA doc https://github.com/google-github-actions/auth
and prefixing CI like all the other credentials