### PR TITLE
Use debugger-friendly compile settings if DEBUG is set

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -6,7 +6,7 @@ ENV ARCH $DAPPER_HOST_ARCH
 RUN zypper -n install git docker vim wget
 RUN curl -sL https://get.helm.sh/helm-v3.9.3-linux-${ARCH}.tar.gz | tar xvzf - -C /usr/local/bin --strip-components=1
 
-ENV DAPPER_ENV REPO TAG DRONE_TAG CROSS
+ENV DAPPER_ENV REPO TAG DRONE_TAG CROSS DEBUG
 ENV DAPPER_SOURCE /go/src/github.com/rancher/fleet/
 ENV DAPPER_OUTPUT ./bin ./dist
 ENV DAPPER_DOCKER_SOCKET true

--- a/charts/fleet-agent/templates/deployment.yaml
+++ b/charts/fleet-agent/templates/deployment.yaml
@@ -25,10 +25,11 @@ spec:
         - --debug
         - --debug-level
         - {{ quote .Values.debugLevel }}
-        {{- end }}
+        {{- else }}
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        {{- end }}
       serviceAccountName: fleet-agent
       nodeSelector: {{ include "linux-node-selector" . | nindent 8 }}
 {{- if .Values.fleetAgent.nodeSelector }}
@@ -38,7 +39,9 @@ spec:
 {{- if .Values.fleetAgent.tolerations }}
 {{ toYaml .Values.fleetAgent.tolerations | indent 8 }}
 {{- end }}
+{{- if not .Values.debug }}
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000
         runAsGroup: 1000
+{{- end }}

--- a/charts/fleet/templates/deployment.yaml
+++ b/charts/fleet/templates/deployment.yaml
@@ -34,13 +34,14 @@ spec:
         - --debug
         - --debug-level
         - {{ quote .Values.debugLevel }}
+        {{- else }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
         {{- end }}
         {{- if not .Values.gitops.enabled }}
         - --disable-gitops
         {{- end }}
-        securityContext:
-          allowPrivilegeEscalation: false
-          readOnlyRootFilesystem: true
       serviceAccountName: fleet-controller
       nodeSelector: {{ include "linux-node-selector" . | nindent 8 }}
 {{- if .Values.nodeSelector }}
@@ -54,7 +55,9 @@ spec:
       priorityClassName: "{{.Values.priorityClassName}}"
       {{- end }}
 
+{{- if not .Values.debug }}
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000
         runAsGroup: 1000
+{{- end }}

--- a/scripts/build
+++ b/scripts/build
@@ -7,9 +7,15 @@ cd $(dirname $0)/..
 
 mkdir -p bin
 
+if [ -n "${DEBUG}" ]; then
+  GCFLAGS="-N -l"
+fi
+
 LINKFLAGS="-X github.com/rancher/fleet/pkg/version.Version=$VERSION"
 LINKFLAGS="-X github.com/rancher/fleet/pkg/version.GitCommit=$COMMIT $LINKFLAGS"
-LINKFLAGS="-s -w $LINKFLAGS"
+if [ -z "${DEBUG}" ]; then
+  LINKFLAGS="-s -w $LINKFLAGS"
+fi
 OTHER_LINKFLAGS="-extldflags -static"
 
 function build-binaries() {
@@ -22,10 +28,10 @@ function build-binaries() {
     if [ $1 = "windows" ]; then
         TEMP_SUFFIX=".exe"
     fi
-    GOOS=${1} GOARCH=${2} CGO_ENABLED=0 go build -ldflags "$TEMP_LINKFLAGS" -o bin/fleet-${1}-${2}${TEMP_SUFFIX}
+    GOOS=${1} GOARCH=${2} CGO_ENABLED=0 go build -gcflags="all=${GCFLAGS}" -ldflags "$TEMP_LINKFLAGS" -o bin/fleet-${1}-${2}${TEMP_SUFFIX}
     if ! [ $1 = "darwin" ]; then
-        GOOS=${1} GOARCH=${2} CGO_ENABLED=0 go build -ldflags "$TEMP_LINKFLAGS" -o bin/fleetcontroller-${1}-${2}${TEMP_SUFFIX} ./cmd/fleetcontroller
-        GOOS=${1} GOARCH=${2} CGO_ENABLED=0 go build -ldflags "$TEMP_LINKFLAGS" -o bin/fleetagent-${1}-${2}${TEMP_SUFFIX} ./cmd/fleetagent
+        GOOS=${1} GOARCH=${2} CGO_ENABLED=0 go build -gcflags="all=${GCFLAGS}" -ldflags "$TEMP_LINKFLAGS" -o bin/fleetcontroller-${1}-${2}${TEMP_SUFFIX} ./cmd/fleetcontroller
+        GOOS=${1} GOARCH=${2} CGO_ENABLED=0 go build -gcflags="all=${GCFLAGS}" -ldflags "$TEMP_LINKFLAGS" -o bin/fleetagent-${1}-${2}${TEMP_SUFFIX} ./cmd/fleetagent
     fi
 }
 


### PR DESCRIPTION
In order to use a debugger such as [Delve](https://github.com/go-delve/delve), binaries have to be compiled with debugging symbols and disabling some optimizations.

This PR makes it possible to build binaries and container images in such a way.

## Test

```shell
make
```
is expected to continue working exactly as before, therefore stripped binaries should continue to be produced, so `file bin/fleet*` should produce something like:

```
bin/fleet-linux-arm64:           ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, Go BuildID=..., stripped
bin/fleetagent-linux-arm64:      ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, Go BuildID=..., stripped
bin/fleetcontroller-linux-arm64: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, Go BuildID=..., stripped
```

Instead:

```shell
DEBUG=true make
```
is expected to now produce non-stripped binaries, such as:

```
bin/fleet-linux-arm64:           ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, Go BuildID=..., not stripped
bin/fleetagent-linux-arm64:      ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, Go BuildID=..., not stripped
bin/fleetcontroller-linux-arm64: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, Go BuildID=..., not stripped
```

## Additional Information

One way to run Delve against a running container is: https://github.com/moio/delve-debugger

Procedure is:

1. rebuild images with `DEBUG=true make` (with the patch from this PR)
2. deploy the rebuilt images to the Kubernetes environment
3. find the namespace of the executable to debug (eg. `cattle-fleet-system`)
4. find the pod name (eg. `fleet-controller-XXX-YYY`)
5. find the container name (eg. `fleet-controller`)
6. find the executable name (eg. `fleetcontroller`)
7. from the above repo, run:

```
./delve-debugger.sh cattle-fleet-system fleet-controller-XXX-YYY fleet-controller fleetcontroller
```

That will open local port 4000 to attach GoLand (or another debugger).

### Tradeoffs

I noticed build scripts differ in subtle ways between this project, gitjob and rancher (eg. gitjob does not use the `-w` linker flag at all). I am not sure the differences are intentional and I did not proceed aligning them. That could be done in a follow-up PR.

### Potential improvements

If this PR is accepted:
- convenience scripts to automate the use of delve-debugger with fleet specifics will be contributed to this repo
- docs to explain the use of delve-debugger with fleet specifics will be contributed to this repo
- equivalent PRs will be opened against gitjob
- equivalent PRs will be opened against rancher
