### PR TITLE
readme: YML files are deployed as well

### DIFF
--- a/docs/gitrepo-structure.md
+++ b/docs/gitrepo-structure.md
@@ -19,7 +19,7 @@ The following files are looked for to determine the how the resources will be de
 | **Chart.yaml**:| / relative to `path` or custom path from `fleet.yaml` | The resources will be deployed as a Helm chart. Refer to the `fleet.yaml` for more options. |
 | **kustomization.yaml**:| / relative to `path` or custom path from `fleet.yaml` | The resources will be deployed using Kustomize. Refer to the `fleet.yaml` for more options. |
 | **fleet.yaml** | Any subpath | If any fleet.yaml is found a new [bundle](./concepts.md) will be defined. This allows mixing charts, kustomize, and raw YAML in the same repo |
-| ** *.yaml ** | Any subpath | If a `Chart.yaml` or `kustomization.yaml` is not found then any `.yaml` file will be assumed to be a Kubernetes resource and will be deployed. |
+| ** *.yaml ** | Any subpath | If a `Chart.yaml` or `kustomization.yaml` is not found then any `.yaml` or `.yml` file will be assumed to be a Kubernetes resource and will be deployed. |
 | **overlays/{name}** | / relative to `path` | When deploying using raw YAML (not Kustomize or Helm) `overlays` is a special directory for customizations. |
 
 ## `fleet.yaml`


### PR DESCRIPTION
## Issue

I was surprised to see that yml files are also being deployed. I was trying to have some configuration files and gator tests for Gatekeeper in YAML format in my repository, and after reading the documentation I though changing the file extention to `.yml` would ignore the files. 

## Changes

As files with the yml extension get deployed as well (as fleet explicitly searches for both extensions), so it would make sence to make mention of it in the documentation, as you're refering to the extension itself and not the markup language, which of course is used with *both* extensions.

## Potential improvement

Clearer understanding of the way fleet works.
