### PR TITLE
Removing ignored paths for CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,11 +4,6 @@ on:
   schedule:
     - cron:  '0 5 * * *'
   pull_request:
-    paths-ignore:
-    - 'docs/**'
-    - 'charts/**'
-    - 'scripts/**'
-    - '*.md'
 
 env:
   GOARCH: amd64


### PR DESCRIPTION
The CI test is a required job for merging pull requests. If there is a change that does not trigger this CI job the PR can't be merged as it does not meet branch protection rules. There are cases where this can happen.

While it is extra computing work to run these jobs when there are no changes to the code there is additional process overhead to deal with PRs that don't meet branch protection rules and who has access to merge those.