### PR TITLE
Adds priorityClassName to deployments.

### DIFF
--- a/charts/fleet/charts/gitjob/templates/deployment.yaml
+++ b/charts/fleet/charts/gitjob/templates/deployment.yaml
@@ -43,3 +43,6 @@ spec:
 {{- if .Values.tolerations }}
 {{ toYaml .Values.tolerations | indent 8 }}
 {{- end }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: "{{.Values.priorityClassName}}"
+      {{- end }}

--- a/charts/fleet/charts/gitjob/values.yaml
+++ b/charts/fleet/charts/gitjob/values.yaml
@@ -23,4 +23,7 @@ nodeSelector: {}
 ## List of node taints to tolerate (requires Kubernetes >= 1.6)
 tolerations: []
 
+## PriorityClassName assigned to deployment.
+priorityClassName: ""
+
 debug: false

--- a/charts/fleet/templates/deployment.yaml
+++ b/charts/fleet/templates/deployment.yaml
@@ -50,6 +50,10 @@ spec:
 {{- if .Values.tolerations }}
 {{ toYaml .Values.tolerations | indent 8 }}
 {{- end }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: "{{.Values.priorityClassName}}"
+      {{- end }}
+
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000

--- a/charts/fleet/values.yaml
+++ b/charts/fleet/values.yaml
@@ -53,6 +53,9 @@ nodeSelector: {}
 ## List of node taints to tolerate (requires Kubernetes >= 1.6)
 tolerations: []
 
+## PriorityClassName assigned to deployment.
+priorityClassName: ""
+
 gitops:
   enabled: true
 


### PR DESCRIPTION
<!-- Specify the issue ID that this pullrequest is solving -->
Related to https://github.com/rancher/rancher/issues/37927

<!-- Describe the changes introduced by this pull request -->
The purpose of this PR is to add the ability to set a priorityClassName for fleet pods in the rancher cluster.

### Test
- Create a new Kubernetes cluster.
- Helm install with the following options
 ` --set priorityClassName=system-cluster-critical --set gitjob.priorityClassName=system-cluster-critical`
 - Describe fleet and gitjob pods using `kubectl`
 - Verify that both pods have "system-cluster-critical" set as their priorityClassName in the pod spec
