### PR TITLE
Updating FOSSA CLI

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -24,7 +24,7 @@ steps:
       from_secret: FOSSA_API_KEY
   commands:
     - zypper -n install curl unzip
-    - "curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/spectrometer/master/install.sh | sh"
+    - "curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install-latest.sh | bash"
     - fossa analyze
     - fossa test
   when:


### PR DESCRIPTION
The previous install location was archived and it redirected to using the new location. This updates the FOSSA install to not use an archived repo.

This location also updates to a new version of the FOSSA CLI that more gracefully handles FOSSA API flakes which are known to happen.

