### PR TITLE
Add authentication support for OCI based Helm charts

### DIFF
--- a/.github/workflows/aks.yml
+++ b/.github/workflows/aks.yml
@@ -133,6 +133,8 @@ jobs:
         name: Fleet Examples Tests
         env:
           FLEET_E2E_NS: fleet-local
+          CI_OCI_USERNAME:  ${{ secrets.CI_OCI_USERNAME }}
+          CI_OCI_PASSWORD:  ${{ secrets.CI_OCI_PASSWORD }}
         run: |
           export KUBECONFIG="$GITHUB_WORKSPACE/kubeconfig-fleet-ci"
           ginkgo e2e/single-cluster

--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -93,6 +93,8 @@ jobs:
         name: E2E Tests for Examples
         env:
           FLEET_E2E_NS: fleet-local
+          CI_OCI_USERNAME:  ${{ secrets.CI_OCI_USERNAME }}
+          CI_OCI_PASSWORD:  ${{ secrets.CI_OCI_PASSWORD }}
         run: |
           ginkgo e2e/single-cluster
       -

--- a/.github/workflows/eks.yml
+++ b/.github/workflows/eks.yml
@@ -146,6 +146,8 @@ jobs:
         name: Fleet Examples Tests
         env:
           FLEET_E2E_NS: fleet-local
+          CI_OCI_USERNAME:  ${{ secrets.CI_OCI_USERNAME }}
+          CI_OCI_PASSWORD:  ${{ secrets.CI_OCI_PASSWORD }}
         run: |
           export KUBECONFIG="$GITHUB_WORKSPACE/kubeconfig-fleet-ci"
           ginkgo e2e/single-cluster

--- a/.github/workflows/gke.yml
+++ b/.github/workflows/gke.yml
@@ -132,6 +132,8 @@ jobs:
         name: Fleet Examples Tests
         env:
           FLEET_E2E_NS: fleet-local
+          CI_OCI_USERNAME:  ${{ secrets.CI_OCI_USERNAME }}
+          CI_OCI_PASSWORD:  ${{ secrets.CI_OCI_PASSWORD }}
         run: |
           ginkgo e2e/single-cluster
       -

--- a/e2e/assets/single-cluster/helm-oci-with-auth.yaml
+++ b/e2e/assets/single-cluster/helm-oci-with-auth.yaml
@@ -1,0 +1,17 @@
+kind: GitRepo
+apiVersion: fleet.cattle.io/v1alpha1
+metadata:
+  name: helm
+spec:
+  repo: https://github.com/rancher/fleet-examples
+  branch: add-helm-oci-with-auth-example
+  helmSecretName: helm-oci-secret
+  paths:
+  - single-cluster/helm-oci-with-auth
+  targets:
+  - clusterSelector:
+      matchExpressions:
+      - key: provider.cattle.io
+        operator: NotIn
+        values:
+        - harvester

--- a/e2e/single-cluster/single_cluster_test.go
+++ b/e2e/single-cluster/single_cluster_test.go
@@ -73,6 +73,15 @@ var _ = Describe("Single Cluster Examples", func() {
 				Expect(err).ToNot(HaveOccurred(), out)
 			})
 
+			AfterEach(func() {
+				k = env.Kubectl.Namespace(env.Namespace)
+
+				out, err := k.Delete(
+					"secret", "helm-oci-secret",
+				)
+				Expect(err).ToNot(HaveOccurred(), out)
+			})
+
 			It("deploys the helm chart", func() {
 				Eventually(func() string {
 					out, _ := k.Namespace("fleet-helm-oci-with-auth-example").Get("pods")

--- a/e2e/single-cluster/single_cluster_test.go
+++ b/e2e/single-cluster/single_cluster_test.go
@@ -56,7 +56,7 @@ var _ = Describe("Single Cluster Examples", func() {
 				Eventually(func() string {
 					out, _ := k.Namespace("fleet-helm-oci-example").Get("pods")
 					return out
-				}, testenv.Timeout).Should(ContainSubstring("frontend-"))
+				}).Should(ContainSubstring("frontend-"))
 			})
 		})
 
@@ -77,7 +77,7 @@ var _ = Describe("Single Cluster Examples", func() {
 				Eventually(func() string {
 					out, _ := k.Namespace("fleet-helm-oci-with-auth-example").Get("pods")
 					return out
-				}, testenv.Timeout).Should(ContainSubstring("frontend-"))
+				}).Should(ContainSubstring("frontend-"))
 			})
 		})
 
@@ -197,7 +197,7 @@ var _ = Describe("Single Cluster Examples", func() {
 				Eventually(func() string {
 					out, _ := k.Namespace("fleet-local").Get("bundles")
 					return out
-				}, testenv.Timeout).Should(SatisfyAll(
+				}).Should(SatisfyAll(
 					ContainSubstring("multiple-paths-single-cluster-manifests"),
 					ContainSubstring("multiple-paths-single-cluster-helm"),
 				))
@@ -210,7 +210,7 @@ var _ = Describe("Single Cluster Examples", func() {
 				Eventually(func() string {
 					out, _ := k.Get("bundledeployments", "-A")
 					return out
-				}, testenv.Timeout).Should(SatisfyAll(
+				}).Should(SatisfyAll(
 					ContainSubstring("multiple-paths-single-cluster-manifests"),
 					ContainSubstring("multiple-paths-single-cluster-helm"),
 				))
@@ -218,12 +218,12 @@ var _ = Describe("Single Cluster Examples", func() {
 				Eventually(func() string {
 					out, _ := k.Namespace("fleet-manifest-example").Get("deployments")
 					return out
-				}, testenv.Timeout).Should(SatisfyAll(ContainSubstring("frontend"), ContainSubstring("redis-")))
+				}).Should(SatisfyAll(ContainSubstring("frontend"), ContainSubstring("redis-")))
 
 				Eventually(func() string {
 					out, _ := k.Namespace("fleet-helm-example").Get("deployments")
 					return out
-				}, testenv.Timeout).Should(SatisfyAll(ContainSubstring("frontend"), ContainSubstring("redis-")))
+				}).Should(SatisfyAll(ContainSubstring("frontend"), ContainSubstring("redis-")))
 			})
 		})
 	})

--- a/pkg/controllers/git/git.go
+++ b/pkg/controllers/git/git.go
@@ -604,7 +604,6 @@ func argsAndEnvs(gitrepo *fleet.GitRepo) ([]string, []corev1.EnvVar) {
 		fmt.Sprintf("--sync-generation=%d", gitrepo.Spec.ForceSyncGeneration),
 		fmt.Sprintf("--paused=%v", gitrepo.Spec.Paused),
 		"--target-namespace", gitrepo.Spec.TargetNamespace,
-		"--",
 	)
 
 	var env []corev1.EnvVar
@@ -638,5 +637,5 @@ func argsAndEnvs(gitrepo *fleet.GitRepo) ([]string, []corev1.EnvVar) {
 			})
 	}
 
-	return append(args, gitrepo.Name), env
+	return append(args, "--", gitrepo.Name), env
 }


### PR DESCRIPTION
The credentials are provided via a Kubernetes secret specified by `gitRepo.spec.helmSecretName`.
Creating the secret is documented under `Private Helm Repo` in https://fleet.rancher.io/gitrepo-structure/.

Refers to #191