### PR TITLE
Support cluster repo change

### DIFF
--- a/charts/fleet-crd/templates/crds.yaml
+++ b/charts/fleet-crd/templates/crds.yaml
@@ -1822,6 +1822,9 @@ spec:
                 type: boolean
               agentNamespaceMigrated:
                 type: boolean
+              agentPrivateRepoURL:
+                nullable: true
+                type: string
               cattleNamespaceMigrated:
                 type: boolean
               conditions:

--- a/pkg/apis/fleet.cattle.io/v1alpha1/target.go
+++ b/pkg/apis/fleet.cattle.io/v1alpha1/target.go
@@ -67,7 +67,7 @@ type ClusterSpec struct {
 	RedeployAgentGeneration int64       `json:"redeployAgentGeneration,omitempty"`
 	AgentEnvVars            []v1.EnvVar `json:"agentEnvVars,omitempty"`
 	AgentNamespace          string      `json:"agentNamespace,omitempty"`
-       PrivateRepoURL          string      `json:"privateRepoURL,omitempty"`
+	PrivateRepoURL          string      `json:"privateRepoURL,omitempty"`
 }
 
 type ClusterStatus struct {
@@ -79,6 +79,7 @@ type ClusterStatus struct {
 	DesiredReadyGitRepos int                                 `json:"desiredReadyGitRepos"`
 
 	AgentEnvVarsHash        string `json:"agentEnvVarsHash,omitempty"`
+	AgentPrivateRepoURL     string `json:"agentPrivateRepoURL,omitempty"`
 	AgentDeployedGeneration *int64 `json:"agentDeployedGeneration,omitempty"`
 	AgentMigrated           bool   `json:"agentMigrated,omitempty"`
 	AgentNamespaceMigrated  bool   `json:"agentNamespaceMigrated,omitempty"`

--- a/pkg/secret/util.go
+++ b/pkg/secret/util.go
@@ -14,6 +14,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// GetServiceAccountTokenSecret gets or creates a secret for the service
+// account. It waits 2 seconds for the data to be populated with a token.
 func GetServiceAccountTokenSecret(sa *corev1.ServiceAccount, secretsController corecontrollers.SecretController) (*corev1.Secret, error) {
 	name := sa.Name + "-token"
 	secret, err := secretsController.Get(sa.Namespace, name, metav1.GetOptions{})


### PR DESCRIPTION
Refers to #948

More information in the commit messages


Tested this manually with manual and managed downstream agents. Changing the cluster resource, updates the agent with the configured repo.

Refers to https://github.com/rancher/rancher/pull/38950
