### PR TITLE
Update namespaces.md

### DIFF
--- a/docs/namespaces.md
+++ b/docs/namespaces.md
@@ -82,5 +82,5 @@ namespaceSelector:
 
 If the `BundleNamespaceMappings` `bundleSelector` field matches a `Bundles` labels then that `Bundle` target criteria will
 be evaluated against all clusters in all namespaces that match `namespaceSelector`. One can specify labels for the created
-bundles from git by putting labels in the `fleet.yaml` file or on the `metadata.labels` field on the `GitRepo`.
+bundles from git by putting labels in the `fleet.yaml` file.
 


### PR DESCRIPTION
I  tried to add labels to the GitRepo resource, but they only show up on the GitJob, not on the generated bundles. I looked into the code and the labels are not passed to the "fleet apply" CLI.

* [adding labels to the GitJob](https://github.com/rancher/fleet/blob/master/pkg/controllers/git/git.go#L389)
* [not using them at all for apply](https://github.com/rancher/fleet/blob/b2cff9c467a9658567820404f61ce628bd659b0a/pkg/controllers/git/git.go#L601)