### PR TITLE
Apply gitrepo labels to bundles

### DIFF
--- a/e2e/assets/single-cluster/helm.yaml
+++ b/e2e/assets/single-cluster/helm.yaml
@@ -2,6 +2,8 @@ kind: GitRepo
 apiVersion: fleet.cattle.io/v1alpha1
 metadata:
   name: helm
+  labels:
+    test: me
 spec:
   repo: https://github.com/rancher/fleet-examples
   paths:

--- a/e2e/single-cluster/bundle_diffs_test.go
+++ b/e2e/single-cluster/bundle_diffs_test.go
@@ -2,7 +2,6 @@ package examples_test
 
 import (
 	"encoding/json"
-	"fmt"
 	"time"
 
 	"github.com/rancher/fleet/e2e/testenv"
@@ -58,7 +57,6 @@ var _ = Describe("BundleDiffs", func() {
 			// make sure resources are cleaned up
 			Eventually(func() bool {
 				_, err := bundleDeploymentStatus("bundle-diffs-test")
-				fmt.Printf("bundleDeploymentStatus: %v\n", err)
 				if err != nil && apierrors.IsNotFound(err) {
 					return true
 				}

--- a/e2e/single-cluster/single_cluster_test.go
+++ b/e2e/single-cluster/single_cluster_test.go
@@ -1,6 +1,7 @@
 package examples_test
 
 import (
+	"encoding/json"
 	"strings"
 
 	"github.com/rancher/fleet/e2e/testenv"
@@ -43,6 +44,17 @@ var _ = Describe("Single Cluster Examples", func() {
 					out, _ := k.Namespace("fleet-helm-example").Get("pods")
 					return out
 				}).Should(ContainSubstring("frontend-"))
+
+				By("Checking that labels from gitrepo are present on the bundle", func() {
+					out, err := k.Namespace("fleet-local").Get("bundle", "helm-single-cluster-helm",
+						`-o=jsonpath={.metadata.labels}`)
+					Expect(err).ToNot(HaveOccurred())
+
+					labels := &map[string]string{}
+					err = json.Unmarshal([]byte(out), labels)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(*labels).To(HaveKeyWithValue("test", "me"))
+				})
 			})
 		})
 

--- a/pkg/controllers/git/git.go
+++ b/pkg/controllers/git/git.go
@@ -596,9 +596,13 @@ func argsAndEnvs(gitrepo *fleet.GitRepo) ([]string, []corev1.EnvVar) {
 		args = append(args, "--debug", "--debug-level", "9")
 	}
 
+	bundleLabels := labels.Merge(gitrepo.Labels, map[string]string{
+		fleet.RepoLabel: gitrepo.Name,
+	})
+
 	args = append(args,
 		"--targets-file=/run/config/targets.yaml",
-		"--label="+fleet.RepoLabel+"="+gitrepo.Name,
+		"--label="+bundleLabels.String(),
 		"--namespace", gitrepo.Namespace,
 		"--service-account", gitrepo.Spec.ServiceAccount,
 		fmt.Sprintf("--sync-generation=%d", gitrepo.Spec.ForceSyncGeneration),


### PR DESCRIPTION
According to the docs labels from GitRepo resources are applied to generated bundles.

This re-uses an existing test for the expectation, so we keep resource usage low.


fixes #1006 

refers to #385 