### PR TITLE
Add allowedTargetNamespaces to GitRepoRestriction

### DIFF
--- a/charts/fleet-crd/templates/crds.yaml
+++ b/charts/fleet-crd/templates/crds.yaml
@@ -2545,6 +2545,12 @@ spec:
               type: string
             nullable: true
             type: array
+          allowedTargetNamespaces:
+            items:
+              nullable: true
+              type: string
+            nullable: true
+            type: array
           defaultClientSecretName:
             nullable: true
             type: string

--- a/pkg/apis/fleet.cattle.io/v1alpha1/git.go
+++ b/pkg/apis/fleet.cattle.io/v1alpha1/git.go
@@ -132,6 +132,8 @@ type GitRepoRestriction struct {
 
 	DefaultClientSecretName  string   `json:"defaultClientSecretName,omitempty"`
 	AllowedClientSecretNames []string `json:"allowedClientSecretNames,omitempty"`
+
+	AllowedTargetNamespaces []string `json:"allowedTargetNamespaces,omitempty"`
 }
 
 type GitRepoResource struct {

--- a/pkg/apis/fleet.cattle.io/v1alpha1/zz_generated_deepcopy.go
+++ b/pkg/apis/fleet.cattle.io/v1alpha1/zz_generated_deepcopy.go
@@ -1342,6 +1342,11 @@ func (in *GitRepoRestriction) DeepCopyInto(out *GitRepoRestriction) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.AllowedTargetNamespaces != nil {
+		in, out := &in.AllowedTargetNamespaces, &out.AllowedTargetNamespaces
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/controllers/git/git.go
+++ b/pkg/controllers/git/git.go
@@ -147,6 +147,14 @@ func (h *handler) authorizeAndAssignDefaults(gitrepo *fleet.GitRepo) (*fleet.Git
 	restriction := aggregate(restrictions)
 	gitrepo = gitrepo.DeepCopy()
 
+	gitrepo.Spec.TargetNamespace, err = isAllowed(gitrepo.Spec.TargetNamespace,
+		"",
+		restriction.AllowedTargetNamespaces,
+		false)
+	if err != nil {
+		return nil, fmt.Errorf("disallowed targetNamespace %s: %w", gitrepo.Spec.TargetNamespace, err)
+	}
+
 	gitrepo.Spec.ServiceAccount, err = isAllowed(gitrepo.Spec.ServiceAccount,
 		restriction.DefaultServiceAccount,
 		restriction.AllowedServiceAccounts,
@@ -213,6 +221,7 @@ func aggregate(restrictions []*fleet.GitRepoRestriction) (result fleet.GitRepoRe
 		result.AllowedServiceAccounts = append(result.AllowedServiceAccounts, restriction.AllowedServiceAccounts...)
 		result.AllowedClientSecretNames = append(result.AllowedClientSecretNames, restriction.AllowedClientSecretNames...)
 		result.AllowedRepoPatterns = append(result.AllowedRepoPatterns, restriction.AllowedRepoPatterns...)
+		result.AllowedTargetNamespaces = append(result.AllowedTargetNamespaces, restriction.AllowedTargetNamespaces...)
 	}
 	return
 }


### PR DESCRIPTION
Add another field to GitRepoRestrictions, to limit GitRepo deployments to specific targetNamespaces.
When a GitRepoRestrictions has `allowedTargetNamespaces`, all created Gitrepos in the same namespace will be evaluated against the list of allowed namespaces. The deployment will fail if cluster-wide resources are included, or the GitRepo uses a disallowed targetNamespace.

Refers to #385 
