### PR TITLE
Helm Target Customization Repo/Version Override

### DIFF
--- a/e2e/assets/multi-cluster/helm-target-customizations.yaml
+++ b/e2e/assets/multi-cluster/helm-target-customizations.yaml
@@ -1,0 +1,14 @@
+kind: GitRepo
+apiVersion: fleet.cattle.io/v1alpha1
+metadata:
+  name: helm-target-customizations
+spec:
+  repo: https://github.com/rancher/fleet-examples
+  branch: add_target_customizations_test
+  paths:
+  - multi-cluster/helm-target-customizations/
+  targets:
+  - name: test
+    clusterSelector:
+      matchLabels:
+        env: test

--- a/pkg/bundle/read.go
+++ b/pkg/bundle/read.go
@@ -186,6 +186,8 @@ func read(ctx context.Context, name, baseDir string, bundleSpecReader io.Reader,
 
 	setTargetNames(&bundle.BundleSpec)
 
+	propagateHelmChartProperties(&bundle.BundleSpec)
+
 	resources, err := readResources(ctx, &bundle.BundleSpec, opts.Compress, baseDir, opts.Auth)
 	if err != nil {
 		return nil, err
@@ -245,6 +247,29 @@ func read(ctx context.Context, name, baseDir string, bundleSpecReader io.Reader,
 	}
 
 	return New(def, scans...)
+}
+
+// propagateHelmChartProperties propagates root Helm chart properties to the child targets.
+func propagateHelmChartProperties(spec *fleet.BundleSpec) {
+	// Check if there is anything to propagate
+	if spec.Helm == nil {
+		return
+	}
+	for _, target := range spec.Targets {
+		if target.Helm == nil {
+			// This target has nothing to propagate to
+			continue
+		}
+		if target.Helm.Repo == "" {
+			target.Helm.Repo = spec.Helm.Repo
+		}
+		if target.Helm.Chart == "" {
+			target.Helm.Chart = spec.Helm.Chart
+		}
+		if target.Helm.Version == "" {
+			target.Helm.Version = spec.Helm.Version
+		}
+	}
 }
 
 func appendTargets(def *fleet.Bundle, targetsFile string) (*fleet.Bundle, error) {

--- a/pkg/options/calculate.go
+++ b/pkg/options/calculate.go
@@ -67,8 +67,14 @@ func merge(base, next fleet.BundleDeploymentOptions) fleet.BundleDeploymentOptio
 		if next.Helm.ValuesFrom != nil {
 			result.Helm.ValuesFrom = append(result.Helm.ValuesFrom, next.Helm.ValuesFrom...)
 		}
+		if next.Helm.Repo != "" {
+			result.Helm.Repo = next.Helm.Repo
+		}
 		if next.Helm.Chart != "" {
 			result.Helm.Chart = next.Helm.Chart
+		}
+		if next.Helm.Version != "" {
+			result.Helm.Version = next.Helm.Version
 		}
 		if next.Helm.ReleaseName != "" {
 			result.Helm.ReleaseName = next.Helm.ReleaseName


### PR DESCRIPTION


<!-- Specify the issue ID that this pullrequest is solving -->
Fix #699
Fix #899

<!-- Describe the changes introduced by this pull request -->
This commit fixes an issue stopping versions and repos in Helm specs from being overridden in target customizations. It applies root repos and versions to customizations where appropriate to allow targets to  properly resolve the correct target.

## Test

To test this pull request, I used the following configurations:
[https://raw.githubusercontent.com/romejoe/fleet-test/main/multi-chart-test/fleet.yaml](https://raw.githubusercontent.com/romejoe/fleet-test/main/multi-chart-test/fleet.yaml)
[https://raw.githubusercontent.com/romejoe/fleet-test/main/version-test/fleet-config/fleet.yaml](https://raw.githubusercontent.com/romejoe/fleet-test/main/version-test/fleet-config/fleet.yaml)

The first test verifies that if the entire helm reference(repo, chart and version) are specified in a target customization, the proper chart is deployed to those targets.

The second test verifies that if only a version is specified, the updated version will be used. It also verifies that if the chart is overridden, the appropriate chart is still used.

## Additional Information

### Tradeoff
The only potential trade off is that if the user specifies a repo, chart and version in the root helm spec and then only overrides the chart property in a customization, the target customization will treat the chart as a relative path. The only time this could raise an issue is if the user changes the chart in the customization with the intent of selecting a different chart within the same repo.  This is probably out of scope though. The user is still able to do that, they just have to supply at least a repo or version as well in the customization.

