### PR TITLE
Add test for building binaries/images on several platforms

### DIFF
--- a/.github/workflows/release-images-test.yml
+++ b/.github/workflows/release-images-test.yml
@@ -1,0 +1,49 @@
+name: Release Images Test
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: read
+
+env:
+  SETUP_GO_VERSION: '^1.18'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      -
+        name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ env.SETUP_GO_VERSION }}
+      -
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      -
+        name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          distribution: goreleaser
+          version: 1.11.5
+          args: release --rm-dist --skip-publish --snapshot

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,245 @@
+---
+project_name: fleet
+
+archives:
+  -
+    name_template: '{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
+    replacements:
+      amd64: x86_64
+    format: binary
+    format_overrides:
+      - goos: windows
+        format: zip
+
+before:
+  hooks:
+    - go mod download
+
+builds:
+  -
+    id: fleet-controller
+    main: ./cmd/fleetcontroller
+    binary: fleetcontroller
+    # gcflags:
+    #   - all="-N -l"
+    ldflags:
+      - -w -s
+      - -X github.com/rancher/fleet/pkg/version.GitCommit={{ .Commit }}
+      - -X github.com/rancher/fleet/pkg/version.Version={{ .Tag }}
+    goos:
+      - linux
+      - windows
+    goarch:
+      - amd64
+      - arm64
+      - s390x
+    goarm:
+      - "7"
+    targets:
+    - linux_amd64_v1
+    - linux_arm64
+    - linux_s390x
+    - windows_amd64
+  -
+    id: fleet-agent
+    main: ./cmd/fleetagent
+    binary: fleetagent
+    ldflags:
+      - -w -s
+      - -X github.com/rancher/fleet/pkg/version.GitCommit={{ .Commit }}
+      - -X github.com/rancher/fleet/pkg/version.Version={{ .Tag }}
+    goos:
+      - linux
+      - windows
+    goarch:
+      - amd64
+      - arm64
+      - s390x
+    goarm:
+      - "7"
+    targets:
+    - linux_amd64_v1
+    - linux_arm64
+    - linux_s390x
+    - windows_amd64
+  -
+    id: fleet-cli
+    binary: fleet
+    ldflags:
+      - -w -s
+      - -X github.com/rancher/fleet/pkg/version.GitCommit={{ .Commit }}
+      - -X github.com/rancher/fleet/pkg/version.Version={{ .Tag }}
+    goos:
+      - darwin
+      - linux
+      - windows
+    goarch:
+      - amd64
+      - arm64
+      - s390x
+    goarm:
+      - "7"
+    targets:
+    - linux_amd64_v1
+    - linux_arm64
+    - linux_s390x
+    - windows_amd64
+
+changelog:
+  ## Delegate Changelog to release-drafter
+  skip: true
+
+env:
+  - CGO_ENABLED=0
+
+snapshot:
+  name_template: "{{ .Tag }}-next"
+
+dockers:
+  # fleet-controller images
+  -
+    use: buildx
+
+    # GOOS of the built binaries/packages that should be used.
+    goos: linux
+
+    # GOARCH of the built binaries/packages that should be used.
+    goarch: amd64
+
+    # IDs to filter the binaries/packages.
+    ids:
+    - fleet-controller
+
+    # Templates of the Docker image names.
+    image_templates:
+    - "ghcr.io/rancher/fleet:{{ .Tag }}-amd64"
+
+    # Skips the docker push.
+    skip_push: "true"
+
+    # Path to the Dockerfile (from the project root).
+    dockerfile: package/Dockerfile
+
+    # Template of the docker build flags.
+    build_flag_templates:
+    - "--pull"
+    - "--label=org.opencontainers.image.created={{.Date}}"
+    - "--label=org.opencontainers.image.title={{.ProjectName}}"
+    - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+    - "--label=org.opencontainers.image.version={{.Version}}"
+    - "--label=org.opencontainers.image.source=https://github.com/rancher/fleet"
+    - "--build-arg=BUILD_ENV=goreleaser"
+    - "--platform=linux/amd64"
+  -
+    use: buildx
+    goos: linux
+    goarch: arm64
+    ids:
+    - fleet-controller
+    image_templates:
+    - "ghcr.io/rancher/fleet:{{ .Tag }}-arm64v8"
+    dockerfile: package/Dockerfile
+    build_flag_templates:
+    - "--pull"
+    - "--label=org.opencontainers.image.created={{.Date}}"
+    - "--label=org.opencontainers.image.title={{.ProjectName}}"
+    - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+    - "--label=org.opencontainers.image.version={{.Version}}"
+    - "--label=org.opencontainers.image.source=https://github.com/rancher/fleet"
+    - "--build-arg=BUILD_ENV=goreleaser"
+    - "--platform=linux/arm64/v8"
+  -
+    use: buildx
+    goos: linux
+    goarch: s390x
+    ids:
+    - fleet-controller
+    image_templates:
+    - "ghcr.io/rancher/fleet:{{ .Tag }}-s390x"
+    dockerfile: package/Dockerfile
+    build_flag_templates:
+    - "--pull"
+    - "--label=org.opencontainers.image.created={{.Date}}"
+    - "--label=org.opencontainers.image.title={{.ProjectName}}"
+    - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+    - "--label=org.opencontainers.image.version={{.Version}}"
+    - "--label=org.opencontainers.image.source=https://github.com/rancher/fleet"
+    - "--build-arg=BUILD_ENV=goreleaser"
+    - "--platform=linux/s390x"
+  # fleet-agent images
+  -
+    use: buildx
+    goos: linux
+    goarch: amd64
+    ids:
+    - fleet-agent
+    - fleet-cli
+    image_templates:
+    - "ghcr.io/rancher/fleet-agent:{{ .Tag }}-amd64"
+    skip_push: "true"
+    dockerfile: package/Dockerfile.agent
+    build_flag_templates:
+    - "--pull"
+    - "--label=org.opencontainers.image.created={{.Date}}"
+    - "--label=org.opencontainers.image.title={{.ProjectName}}"
+    - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+    - "--label=org.opencontainers.image.version={{.Version}}"
+    - "--label=org.opencontainers.image.source=https://github.com/rancher/fleet"
+    - "--build-arg=BUILD_ENV=goreleaser"
+    - "--platform=linux/amd64"
+    extra_files: [ "package/log.sh" ]
+  -
+    use: buildx
+    goos: linux
+    goarch: arm64
+    ids:
+    - fleet-agent
+    - fleet-cli
+    image_templates:
+    - "ghcr.io/rancher/fleet-agent:{{ .Tag }}-arm64v8"
+    dockerfile: package/Dockerfile.agent
+    build_flag_templates:
+    - "--pull"
+    - "--label=org.opencontainers.image.created={{.Date}}"
+    - "--label=org.opencontainers.image.title={{.ProjectName}}"
+    - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+    - "--label=org.opencontainers.image.version={{.Version}}"
+    - "--label=org.opencontainers.image.source=https://github.com/rancher/fleet"
+    - "--build-arg=BUILD_ENV=goreleaser"
+    - "--platform=linux/arm64/v8"
+    extra_files: [ "package/log.sh" ]
+  -
+    use: buildx
+    goos: linux
+    goarch: s390x
+    ids:
+    - fleet-agent
+    - fleet-cli
+    image_templates:
+    - "ghcr.io/rancher/fleet-agent:{{ .Tag }}-s390x"
+    dockerfile: package/Dockerfile.agent
+    build_flag_templates:
+    - "--pull"
+    - "--label=org.opencontainers.image.created={{.Date}}"
+    - "--label=org.opencontainers.image.title={{.ProjectName}}"
+    - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+    - "--label=org.opencontainers.image.version={{.Version}}"
+    - "--label=org.opencontainers.image.source=https://github.com/rancher/fleet"
+    - "--build-arg=BUILD_ENV=goreleaser"
+    - "--platform=linux/s390x"
+    extra_files: [ "package/log.sh" ]
+
+docker_manifests:
+  # https://goreleaser.com/customization/docker_manifest/
+  -
+    name_template: "ghcr.io/rancher/fleet:{{ .Tag }}"
+    image_templates:
+    - "ghcr.io/rancher/fleet:{{ .Tag }}-amd64"
+    - "ghcr.io/rancher/fleet:{{ .Tag }}-arm64v8"
+    - "ghcr.io/rancher/fleet:{{ .Tag }}-s390x"
+  -
+    name_template: "ghcr.io/rancher/fleet-agent:{{ .Tag }}"
+    image_templates:
+    - "ghcr.io/rancher/fleet-agent:{{ .Tag }}-amd64"
+    - "ghcr.io/rancher/fleet-agent:{{ .Tag }}-arm64v8"
+    - "ghcr.io/rancher/fleet-agent:{{ .Tag }}-s390x"

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,6 +1,15 @@
-FROM registry.suse.com/bci/bci-base:15.4.27.11.29
+ARG BUILD_ENV=bin
+
+FROM registry.suse.com/bci/bci-base:15.4.27.11.29 AS base
+USER 1000
+
+FROM base AS copy_bin
 ARG ARCH
 ENV ARCH=$ARCH
-COPY bin/fleetcontroller-linux-${ARCH} /usr/bin/fleetcontroller
-USER 1000
+ONBUILD COPY bin/fleetcontroller-linux-${ARCH} /usr/bin/fleetcontroller
+
+FROM base AS copy_goreleaser
+ONBUILD COPY fleetcontroller /usr/bin/fleetcontroller
+
+FROM copy_${BUILD_ENV}
 CMD ["fleetcontroller"]

--- a/package/Dockerfile.agent
+++ b/package/Dockerfile.agent
@@ -1,8 +1,18 @@
-FROM registry.suse.com/bci/bci-base:15.4.27.11.29
+ARG BUILD_ENV=bin
+
+FROM registry.suse.com/bci/bci-base:15.4.27.11.29 AS base
+RUN zypper in --no-recommends -y git bash openssh && groupadd -g 1000 fleet-apply && useradd -u 1000 -g 1000 -m fleet-apply; rm -fr /var/cache/* /var/log/*log
+COPY package/log.sh /usr/bin/
+
+FROM base AS copy_bin
 ARG ARCH
 ENV ARCH=$ARCH
-RUN zypper in --no-recommends -y git bash openssh && groupadd -g 1000 fleet-apply && useradd -u 1000 -g 1000 -m fleet-apply; rm -fr /var/cache/* /var/log/*log
-COPY bin/fleetagent-linux-$ARCH /usr/bin/fleetagent
-COPY bin/fleet-linux-$ARCH /usr/bin/fleet
-COPY package/log.sh /usr/bin/
+ONBUILD COPY bin/fleetagent-linux-$ARCH /usr/bin/fleetagent
+ONBUILD COPY bin/fleet-linux-$ARCH /usr/bin/fleet
+
+FROM base AS copy_goreleaser
+ONBUILD COPY fleetagent /usr/bin/fleetagent
+ONBUILD COPY fleet /usr/bin/fleet
+
+FROM copy_${BUILD_ENV}
 CMD ["fleetagent"]


### PR DESCRIPTION
This uses goreleaser just to build images and binaries. Nothing is actually released by the workflow. It replicates
the settings from scripts/build and scripts/package. Windows builds are not included in the workflow.

The changes to the Dockerfiles are necessary, because goreleaser automatically provides the right archtitecture binary to in it's build dir. However that is incompatible with the existing Drone release pipeline and `scripts/build`. By using a variable we can support both at the cost of readability.
