### PR TITLE
Remove Rancher Integration from PR

### DIFF
--- a/.github/workflows/rancher-integration.yml
+++ b/.github/workflows/rancher-integration.yml
@@ -15,6 +15,7 @@ on:
         required: false
         default: "false"
   push:
+    tags: [ 'v*' ]
     paths-ignore:
       - 'scripts/**'
       - '*.md'


### PR DESCRIPTION
The test is still too flaky: https://github.com/rancher/fleet/actions/workflows/rancher-integration.yml?query=event%3Aschedule

This will limit the test to pushes on release tags, so it won't show up in internal PRs anymore.
