### PR TITLE
Enforce presence of targetNamespace if gitreporestriction is present.

### DIFF
--- a/e2e/assets/gitrepo/gitrepo.yaml
+++ b/e2e/assets/gitrepo/gitrepo.yaml
@@ -1,7 +1,3 @@
-package githelper
-
-// GitRepoTemplate can be used as fleet.yaml
-const GitRepoTemplate = `
 kind: GitRepo
 apiVersion: fleet.cattle.io/v1alpha1
 metadata:
@@ -12,9 +8,3 @@ spec:
   branch: {{.Branch}}
   paths:
   - examples
-`
-
-type GitRepo struct {
-	Repo   string
-	Branch string
-}

--- a/e2e/assets/multi-cluster/bundle-namespace-mapping.yaml
+++ b/e2e/assets/multi-cluster/bundle-namespace-mapping.yaml
@@ -41,7 +41,7 @@ spec:
   paths:
   - bundle-diffs
 
-  targetNamespace: {{.TargetNamespace}}
+  {{.TargetNamespace}}
 
   targets:
   - name: test

--- a/e2e/assets/multi-cluster/bundle-namespace-mapping.yaml
+++ b/e2e/assets/multi-cluster/bundle-namespace-mapping.yaml
@@ -1,0 +1,50 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{.Namespace}}
+---
+kind: GitRepoRestriction
+apiVersion: fleet.cattle.io/v1alpha1
+metadata:
+  name: restriction
+  namespace: {{.Namespace}}
+
+allowedTargetNamespaces:
+  - project1simpleapp
+---
+kind: BundleNamespaceMapping
+apiVersion: fleet.cattle.io/v1alpha1
+metadata:
+  name: mapping
+  namespace: {{.Namespace}}
+
+bundleSelector:
+  matchLabels:
+    team: one
+
+namespaceSelector:
+  matchLabels:
+    kubernetes.io/metadata.name: fleet-local
+---
+kind: GitRepo
+apiVersion: fleet.cattle.io/v1alpha1
+metadata:
+  name: simpleapp
+  namespace: {{.Namespace}}
+  labels:
+    team: one
+
+spec:
+  repo: https://github.com/rancher/fleet-examples
+  branch: master
+  paths:
+  - bundle-diffs
+
+  targetNamespace: {{.TargetNamespace}}
+
+  targets:
+  - name: test
+    clusterSelector:
+      matchLabels:
+        env: test

--- a/e2e/multi-cluster/bundle_namespace_mapping_test.go
+++ b/e2e/multi-cluster/bundle_namespace_mapping_test.go
@@ -1,0 +1,89 @@
+package mc_examples_test
+
+import (
+	"os"
+	"path"
+
+	"github.com/rancher/fleet/e2e/testenv"
+	"github.com/rancher/fleet/e2e/testenv/kubectl"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Bundle Namespace Mapping", func() {
+	var (
+		k  kubectl.Command
+		kd kubectl.Command
+
+		asset     string
+		namespace string
+		data      any
+		tmpdir    string
+	)
+
+	BeforeEach(func() {
+		k = env.Kubectl.Context(env.Fleet)
+		kd = env.Kubectl.Context(env.Downstream)
+	})
+
+	JustBeforeEach(func() {
+		tmpdir, _ = os.MkdirTemp("", "fleet-")
+		output := path.Join(tmpdir, testenv.RandomFilename("manifests.yaml"))
+		err := testenv.Template(output, testenv.AssetPath(asset), data)
+		Expect(err).ToNot(HaveOccurred())
+
+		out, err := k.Namespace(namespace).Apply("-f", output)
+		Expect(err).ToNot(HaveOccurred(), out)
+	})
+
+	AfterEach(func() {
+		out, err := k.Delete("ns", namespace)
+		Expect(err).ToNot(HaveOccurred(), out)
+		os.RemoveAll(tmpdir)
+	})
+
+	When("creating gitrepo resource in another namespace", func() {
+		Context("downstream namespace is allowed", func() {
+			BeforeEach(func() {
+				namespace = "project1"
+				asset = "multi-cluster/bundle-namespace-mapping.yaml"
+				data = struct {
+					Namespace       string
+					TargetNamespace string
+				}{namespace, "project1simpleapp"}
+			})
+
+			It("deploys to the the downstream cluster", func() {
+				Eventually(func() string {
+					out, _ := k.Get("bundledeployments", "-A")
+					return out
+				}).Should(ContainSubstring("simpleapp-bundle-diffs"))
+				Eventually(func() string {
+					out, _ := kd.Namespace("project1simpleapp").Get("configmaps")
+					return out
+				}).Should(ContainSubstring("app-config"))
+			})
+		})
+
+		Context("downstream namespace is denied by gitreporestriction", func() {
+			BeforeEach(func() {
+				namespace = "project2"
+				asset = "multi-cluster/bundle-namespace-mapping.yaml"
+				data = struct {
+					Namespace       string
+					TargetNamespace string
+				}{namespace, "denythisnamespace"}
+			})
+
+			It("denies deployment to downstream cluster", func() {
+				Eventually(func() string {
+					out, _ := k.Namespace(namespace).Get("gitrepo", "simpleapp",
+						"-o=jsonpath={.status.conditions[*].message}",
+					)
+					return out
+				}).Should(ContainSubstring("disallowed targetNamespace denythisnamespace"))
+			})
+		})
+	})
+})

--- a/e2e/require-secrets/gitrepo_test.go
+++ b/e2e/require-secrets/gitrepo_test.go
@@ -2,10 +2,8 @@ package require_secrets
 
 import (
 	"bytes"
-	"html/template"
 	"os"
 	"path"
-	"strings"
 
 	"github.com/go-git/go-git/v5"
 
@@ -57,12 +55,14 @@ var _ = Describe("Git Repo", func() {
 		repo, err = gh.Create(repodir, testenv.AssetPath("gitrepo/sleeper-chart"), "examples")
 		Expect(err).ToNot(HaveOccurred())
 
-		tmpl := template.Must(template.New("test").Parse(githelper.GitRepoTemplate))
-		var yaml strings.Builder
-		err = tmpl.Execute(&yaml, githelper.GitRepo{Repo: gh.URL, Branch: gh.Branch})
-		Expect(err).ToNot(HaveOccurred())
 		gitrepo := path.Join(tmpdir, "gitrepo.yaml")
-		err = os.WriteFile(gitrepo, []byte(yaml.String()), 0644)
+		err = testenv.Template(gitrepo, testenv.AssetPath("gitrepo/gitrepo.yaml"), struct {
+			Repo   string
+			Branch string
+		}{
+			gh.URL,
+			gh.Branch,
+		})
 		Expect(err).ToNot(HaveOccurred())
 
 		out, err = k.Apply("-f", gitrepo)

--- a/e2e/testenv/template.go
+++ b/e2e/testenv/template.go
@@ -1,0 +1,38 @@
+package testenv
+
+import (
+	"html/template"
+	"math/rand"
+	"os"
+	"path"
+	"strconv"
+	"strings"
+)
+
+// Template loads a gotemplate from a file and writes templated output to
+// another file, preferably in a temp dir
+func Template(output string, tmplPath string, data any) error {
+	b, err := os.ReadFile(tmplPath)
+	if err != nil {
+		return err
+	}
+
+	tmpl := template.Must(template.New("test").Parse(string(b)))
+	var sb strings.Builder
+	err = tmpl.Execute(&sb, data)
+	if err != nil {
+		return err
+	}
+	err = os.WriteFile(output, []byte(sb.String()), 0644) // nolint:gosec // test code
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// RandomName returns a slightly random name, so temporary assets don't conflict
+func RandomFilename(filename string) string {
+	ext := path.Ext(filename)
+	r := strconv.Itoa(rand.Intn(99999)) // nolint:gosec // Non-crypto use
+	return strings.TrimSuffix(filename, ext) + r + ext
+}

--- a/pkg/controllers/cluster/controller.go
+++ b/pkg/controllers/cluster/controller.go
@@ -176,6 +176,8 @@ func (h *handler) OnClusterChanged(cluster *fleet.Cluster, status fleet.ClusterS
 	}
 
 	if allReady && status.ResourceCounts.Ready != status.ResourceCounts.DesiredReady {
+		logrus.Debugf("Cluster %s/%s is not ready because not all gitrepos are ready: %d/%d", cluster.Namespace, cluster.Name, status.ResourceCounts.Ready, status.ResourceCounts.DesiredReady)
+
 		// Counts from gitrepo are out of sync with bundleDeployment state
 		// just retry in 15 seconds as there no great way to trigger an event that
 		// doesn't cause a loop

--- a/pkg/controllers/git/git.go
+++ b/pkg/controllers/git/git.go
@@ -280,7 +280,18 @@ func mergeConditions(existing, next []genericcondition.GenericCondition) []gener
 	return result
 }
 
+func accpetedLastUpdate(conds []genericcondition.GenericCondition) string {
+	for _, cond := range conds {
+		if cond.Type == "Accepted" {
+			return cond.LastUpdateTime
+		}
+	}
+
+	return ""
+}
+
 func (h *handler) OnChange(gitrepo *fleet.GitRepo, status fleet.GitRepoStatus) ([]runtime.Object, fleet.GitRepoStatus, error) {
+	logrus.Debugf("OnChange GitRepo %s/%s for commit %s last accepted at %s", gitrepo.Namespace, gitrepo.Name, gitrepo.Status.Commit, accpetedLastUpdate(gitrepo.Status.Conditions))
 	status.ObservedGeneration = gitrepo.Generation
 
 	if gitrepo.Spec.Repo == "" {

--- a/pkg/controllers/git/git.go
+++ b/pkg/controllers/git/git.go
@@ -147,6 +147,10 @@ func (h *handler) authorizeAndAssignDefaults(gitrepo *fleet.GitRepo) (*fleet.Git
 	restriction := aggregate(restrictions)
 	gitrepo = gitrepo.DeepCopy()
 
+	if len(restriction.AllowedTargetNamespaces) > 0 && gitrepo.Spec.TargetNamespace == "" {
+		return nil, fmt.Errorf("empty targetNamespace denied, because allowedTargetNamespaces restriction is present")
+	}
+
 	gitrepo.Spec.TargetNamespace, err = isAllowed(gitrepo.Spec.TargetNamespace,
 		"",
 		restriction.AllowedTargetNamespaces,


### PR DESCRIPTION


This completes checking the gitrepo's targetNamespace against an allow
list from the gitreporestriction resource.
If a restriction is present a targetNamespace must be given, so the
restriction can not be circumvented by using a namespace in the
manifests.




The tests make use of "bundle labels", `allowedTargetNamespaces`
gitreporestrictions and bundlenamespacemappings.

The PR also extracts templating of test assets into testenv package, so we can use templated yaml files in tests.


This also adds two debug messages. The message in git.go should give some context to the "DesiredState - No change" log messages, which are emitted for gitrepos every 15s.

Refers to https://github.com/rancher/fleet/issues/385
