### PR TITLE
Sync only changed objects

### DIFF
--- a/pkg/controllers/controllers.go
+++ b/pkg/controllers/controllers.go
@@ -243,8 +243,9 @@ func controllerFactory(rest *rest.Config) (controller.SharedControllerFactory, e
 
 	cacheFactory := cache.NewSharedCachedFactory(clientFactory, nil)
 	return controller.NewSharedControllerFactory(cacheFactory, &controller.SharedControllerFactoryOptions{
-		DefaultRateLimiter: rateLimit,
-		DefaultWorkers:     50,
+		DefaultRateLimiter:     rateLimit,
+		DefaultWorkers:         50,
+		SyncOnlyChangedObjects: true,
 	}), nil
 }
 


### PR DESCRIPTION
Skip controller handler calls from lasso when they refer to a resource which was not actually updated (in terms of changes to `resourceVersion`). That happens when the underlying Informer resyncs.

This change is expected to reduce load in some scenarios due to the reduced number of handler calls. Nevertheless it carries a risk of uncovering bugs in case handlers relied on this behavior as a "self-correction" mechanism - particularly in case of missed events. With this change in, the expectation is that controllers have alternative ways of "retrying" when necessary.

This corresponds to the `CATTLE_SYNC_ONLY_CHANGED_OBJECTS` environment variable in Rancher.

## Test

No special prescription is known at this time. Virtually all fleet behavior is influenced by this setting.

## Additional Information

### Tradeoff

Negative impacts described above are being studied.

### Potential improvement

A similar mechanism could be proposed to avoid multiple `Enqueue` operations on the same revision of the same resource in Wrangler - which is at least in some occasions not wanted.

@rancher/qa

## Additionnal QA
 
### Problem

Users with hundreds or thousands of clusters hit scalability limits (fleetcontroller uses all available CPUs). It is believed excessive firing of Handlers (particularly for the bundle controller) could be the culprit and this change is expected to help.
 
### Solution

Adopt a setting already proposed experimentally in Rancher for scaling issues.
 
### Testing

### Engineering Testing
#### Manual Testing

Count the number of calls to the bundle handler after killing an agent pod. Inspecting resourceVersion of the passed objects to see it is not called multiple times.

#### Automated Testing

No change to automated tests yet.

### QA Testing Considerations

Should equally affect new installs and upgrades, no need to test upgrade scenarios specifically.
 
#### Regressions Considerations

There is a chance of regressions in case of missed events - eg. when a pod is temporarily not available.