### PR TITLE
Stop re-queuing on failed deployments

### DIFF
--- a/modules/agent/pkg/controllers/bundledeployment/controller.go
+++ b/modules/agent/pkg/controllers/bundledeployment/controller.go
@@ -16,6 +16,7 @@ import (
 	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
 	"github.com/rancher/fleet/pkg/durations"
 	fleetcontrollers "github.com/rancher/fleet/pkg/generated/controllers/fleet.cattle.io/v1alpha1"
+	"github.com/rancher/fleet/pkg/helmdeployer"
 
 	"github.com/rancher/wrangler/pkg/condition"
 	"github.com/rancher/wrangler/pkg/merr"
@@ -101,11 +102,81 @@ func (h *handler) DeployBundle(bd *fleet.BundleDeployment, status fleet.BundleDe
 
 	release, err := h.deployManager.Deploy(bd)
 	if err != nil {
+		// When an error from DeployBundle is returned it causes DeployBundle
+		// to requeue and keep trying to deploy on a loop. If there is something
+		// wrong with the deployed manifests this will be a loop that re-deploying
+		// cannot fix. Here we catch those errors and update the status to note
+		// the problem while skipping the constant requeuing.
+		if do, newStatus := deployErrToStatus(err, status); do {
+			// Setting the release to an empty string remove the previous
+			// release name. When a deployment fails the release name is not
+			// returned. Keeping the old release name can lead to other functions
+			// looking up old data in the history and presenting the wrong status.
+			// For example, the h.deployManager.Deploy function will find the old
+			// release and not return an error. It will set everything as if the
+			// current one is running properly.
+			newStatus.Release = ""
+			newStatus.AppliedDeploymentID = bd.Spec.DeploymentID
+			return newStatus, nil
+		}
 		return status, err
 	}
 	status.Release = release
 	status.AppliedDeploymentID = bd.Spec.DeploymentID
+
+	// Setting the error to nil clears any existing error
+	condition.Cond(fleet.BundleDeploymentConditionInstalled).SetError(&status, "", nil)
 	return status, nil
+}
+
+// deployErrToStatus converts an error into a status update
+func deployErrToStatus(err error, status fleet.BundleDeploymentStatus) (bool, fleet.BundleDeploymentStatus) {
+	if err == nil {
+		return false, status
+	}
+
+	msg := err.Error()
+
+	// The following error conditions are turned into a status
+	// * when a Helm wait occurs and it times out
+	// * manifests fail to pass validation
+	// * atomic is set and a rollback occurs
+	// Note: these error strings are returned by the Helm SDK and its dependencies
+	if strings.Contains(msg, "timed out waiting for the condition") ||
+		strings.Contains(msg, "error validating data") ||
+		strings.Contains(msg, "failed, and has been rolled back due to atomic being set") {
+
+		status.Ready = false
+		status.NonModified = true
+
+		// The ready status is displayed throughout the UI. Setting this as well
+		// as installed enables the status to be displayed when looking at the
+		// CRD or a UI build on that.
+		readyError := fmt.Errorf("not ready: %s", msg)
+		condition.Cond(fleet.BundleDeploymentConditionReady).SetError(&status, "", readyError)
+
+		// Deployed and Monitored conditions are automated. They are true if their
+		// handlers return no error and false if an error is returned. When an
+		// error is returned they are requeued. To capture the state of an error
+		// that is not returned a new condition is being captured. Ready is the
+		// condition that displays for status in general and it is used for
+		// the readiness of resources. Only when we cannot capture the status of
+		// resources, like here, can use use it for a message like the above.
+		// The Installed condition lets us have a condition to capture the error
+		// that can be bubbled up for Bundles and Gitrepos to consume.
+		installError := fmt.Errorf("not installed: %s", msg)
+		condition.Cond(fleet.BundleDeploymentConditionInstalled).SetError(&status, "", installError)
+
+		return true, status
+	}
+
+	// The case that the bundle is already in an error state. A previous
+	// condition with the error should already be applied.
+	if err == helmdeployer.ErrNoResourceID {
+		return true, status
+	}
+
+	return false, status
 }
 
 func (h *handler) checkDependency(bd *fleet.BundleDeployment) error {
@@ -231,8 +302,23 @@ func (h *handler) MonitorBundle(bd *fleet.BundleDeployment, status fleet.BundleD
 		return status, nil
 	}
 
+	// If the bundle failed to install the status should not be updated. Updating
+	// here would remove the condition message that was previously set on it.
+	if condition.Cond(fleet.BundleDeploymentConditionInstalled).IsFalse(bd) {
+		return status, nil
+	}
+
 	deploymentStatus, err := h.deployManager.MonitorBundle(bd)
 	if err != nil {
+
+		// Returning an error will cause MonitorBundle to requeue in a loop.
+		// When there is no resourceID the error should be on the status. Without
+		// the ID we do not have the information to lookup the resources to
+		// compute the plan and discover the state of resources.
+		if err == helmdeployer.ErrNoResourceID {
+			return status, nil
+		}
+
 		return status, err
 	}
 

--- a/pkg/apis/fleet.cattle.io/v1alpha1/bundle.go
+++ b/pkg/apis/fleet.cattle.io/v1alpha1/bundle.go
@@ -131,9 +131,10 @@ type NonReadyResource struct {
 }
 
 var (
-	BundleConditionReady              = "Ready"
-	BundleDeploymentConditionReady    = "Ready"
-	BundleDeploymentConditionDeployed = "Deployed"
+	BundleConditionReady               = "Ready"
+	BundleDeploymentConditionReady     = "Ready"
+	BundleDeploymentConditionInstalled = "Installed"
+	BundleDeploymentConditionDeployed  = "Deployed"
 )
 
 type BundleStatus struct {

--- a/pkg/helmdeployer/deployer.go
+++ b/pkg/helmdeployer/deployer.go
@@ -41,8 +41,9 @@ const (
 )
 
 var (
-	ErrNoRelease = errors.New("failed to find release")
-	DefaultKey   = "values.yaml"
+	ErrNoRelease    = errors.New("failed to find release")
+	ErrNoResourceID = errors.New("no resource ID available")
+	DefaultKey      = "values.yaml"
 )
 
 type postRender struct {
@@ -465,6 +466,13 @@ func (h *Helm) ListDeployments() ([]DeployedBundle, error) {
 }
 
 func (h *Helm) getRelease(bundleID, resourcesID string) (*release.Release, error) {
+
+	// When a bundle is installed a resourcesID is generated. If there is no
+	// resourcesID then there isn't anything to lookup.
+	if resourcesID == "" {
+		return nil, ErrNoResourceID
+	}
+
 	hist := action.NewHistory(&h.globalCfg)
 
 	namespace, name := kv.Split(resourcesID, "/")

--- a/pkg/summary/summary.go
+++ b/pkg/summary/summary.go
@@ -125,6 +125,9 @@ func MessageFromDeployment(deployment *fleet.BundleDeployment) string {
 	}
 	message := MessageFromCondition("Deployed", deployment.Status.Conditions)
 	if message == "" {
+		message = MessageFromCondition("Installed", deployment.Status.Conditions)
+	}
+	if message == "" {
 		message = MessageFromCondition("Monitored", deployment.Status.Conditions)
 	}
 	return message


### PR DESCRIPTION
This change fixes an issue where failed bundle deployments constantly requeued. This caused some problems including:

1. The constant requeuing put considerable load on the k8s API as it constantly looks up the Helm history
2. In some situations each retry would increment the Helm release

This change captures certain errors and turns them into status updates instead of returning errors. This avoids constant requeuing.

A new condition was added to achieve this. Deployed and Monitored are automated by generated code. When DeployBundle() returns an error Deployed is set to False. Otherwise it's true. MonitorBundle() works the same for Monitored. An Installed Condition was added that is manually managed. It contains the error that is propogated from BundleDeployment to Bundle and Gitrepo. Status is also updated to work with the display of the message.

Note, every time there is an install or upgrade it is "installed" twice. Each time the Helm release is incremented. There is a future optimization that can happen around this.

Relates to #499 (Fixes it)
<!-- Specify the issue ID that this pullrequest is solving -->
Fix #499

<!-- Describe the changes introduced by this pull request -->


## Test

This describes manual tests:

1. Install both the controller and agent change. If you're testing inside of Rancher you can upgrade the fleet used there. 
2. Fork the fleet examples repo. Forking it is important so that you can commit changes to it to test situations. It's at https://github.com/rancher/fleet-examples/
3. Add a gitrepo to your fork and point it at the simple example
4. Stream the logs for the agent
5. Once it's online, make a change for it to fail validation, timeout, and do an atomic change that would fail. Each of these can be tested alone. Push that change and watch out Fleet handles it.
6. Once it is has propagates undo the change and what the system reconcile.

## Additional Information

### Tradeoff

The change was made to make the impact as minimal as possible so that it works with Rancher and the Rancher Dashboard. Errors it and the dashboard know how to display were kept in mind.                                                                                                                                                                                                                                                                                                            

### Potential improvement

@rancher/qa

## Additionnal QA
### Issue: #499 
 
### Problem
The fleet agent controller goes in to a requeuing loop. For example, take an existing known good fleet setup for Helm. In the template yaml have something that goes off schema (e.g., insert `foo: bar`). Helm, when installing, checks that something follows the Kubernetes schemas. Go to install that while watching the agent logs. You will see constant requeuing of the workload even though it's bad and will never be installable. This puts a load on the API server with constant history lookups (querying for secrets)
 
### Solution
When something cannot be installed it is detected and the status is updated. This includes an installed condition that is set to False with the error message. Ready is also updated as the ready message is what is presented through the current user interfaces.
 
### Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

### Engineering Testing
#### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->
The specific tests described in this PR was all manually done by engineering as fleet standalone and installed in Rancher.

#### Automated Testing
<!-- If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->
N/A at this time

### QA Testing Considerations
Fresh install and upgrades should be tested. The normal set of fleet tests should be tested. The following tests would be good to test as an upgrade and fresh install:

- setting the atomic flag for a helm deployment
- invalid kubernetes YAML
- a timeout. For example, set a timeout for 30s and have an image in the yaml that does not exist so it cannot pull it. You can do this by providing an invalid tag.
 
#### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->

Running the full fleet test suite would be useful to check for regressions as the install/upgrade loop was modified.
