### PR TITLE
Add an empty json tag to nested API structures

### DIFF
--- a/pkg/apis/fleet.cattle.io/v1alpha1/bundle.go
+++ b/pkg/apis/fleet.cattle.io/v1alpha1/bundle.go
@@ -56,7 +56,7 @@ type BundleNamespaceMapping struct {
 }
 
 type BundleSpec struct {
-	BundleDeploymentOptions
+	BundleDeploymentOptions `json:""` //nolint
 
 	Paused             bool                      `json:"paused,omitempty"`
 	RolloutStrategy    *RolloutStrategy          `json:"rolloutStrategy,omitempty"`
@@ -102,12 +102,12 @@ type BundleTargetRestriction struct {
 }
 
 type BundleTarget struct {
-	BundleDeploymentOptions
-	Name                 string                `json:"name,omitempty"`
-	ClusterName          string                `json:"clusterName,omitempty"`
-	ClusterSelector      *metav1.LabelSelector `json:"clusterSelector,omitempty"`
-	ClusterGroup         string                `json:"clusterGroup,omitempty"`
-	ClusterGroupSelector *metav1.LabelSelector `json:"clusterGroupSelector,omitempty"`
+	BundleDeploymentOptions `json:""`             //nolint
+	Name                    string                `json:"name,omitempty"`
+	ClusterName             string                `json:"clusterName,omitempty"`
+	ClusterSelector         *metav1.LabelSelector `json:"clusterSelector,omitempty"`
+	ClusterGroup            string                `json:"clusterGroup,omitempty"`
+	ClusterGroupSelector    *metav1.LabelSelector `json:"clusterGroupSelector,omitempty"`
 }
 
 type BundleSummary struct {


### PR DESCRIPTION
We are using fleet API structures in [elemental operator](https://github.com/rancher/elemental-operator/) and I'm trying to set up CRD generation using the controller runtime tool https://book.kubebuilder.io/reference/controller-gen.html. The generation fails because the tool doesn't know how to handle nested structures without json tag so an empty tag should work.