### PR TITLE
Make syncing of unchanged objects optional

### DIFF
--- a/cmd/fleetcontroller/main.go
+++ b/cmd/fleetcontroller/main.go
@@ -22,9 +22,10 @@ var (
 )
 
 type FleetManager struct {
-	Kubeconfig    string `usage:"Kubeconfig file"`
-	Namespace     string `usage:"namespace to watch" default:"cattle-fleet-system" env:"NAMESPACE"`
-	DisableGitops bool   `usage:"disable gitops components" name:"disable-gitops"`
+	Kubeconfig           string `usage:"Kubeconfig file"`
+	Namespace            string `usage:"namespace to watch" default:"cattle-fleet-system" env:"NAMESPACE"`
+	DisableGitops        bool   `usage:"disable gitops components" name:"disable-gitops"`
+	SyncUnchangedObjects bool   `usage:"force syncing of unchanged objects periodically" name:"sync-unchanged-objects"`
 }
 
 func (f *FleetManager) Run(cmd *cobra.Command, args []string) error {
@@ -32,7 +33,7 @@ func (f *FleetManager) Run(cmd *cobra.Command, args []string) error {
 		log.Println(http.ListenAndServe("localhost:6060", nil))
 	}()
 	debugConfig.MustSetupDebug()
-	if err := fleetcontroller.Start(cmd.Context(), f.Namespace, f.Kubeconfig, f.DisableGitops); err != nil {
+	if err := fleetcontroller.Start(cmd.Context(), f.Namespace, f.Kubeconfig, f.DisableGitops, f.SyncUnchangedObjects); err != nil {
 		return err
 	}
 

--- a/pkg/fleetcontroller/app.go
+++ b/pkg/fleetcontroller/app.go
@@ -11,7 +11,7 @@ import (
 	"github.com/rancher/wrangler/pkg/ratelimit"
 )
 
-func Start(ctx context.Context, systemNamespace string, kubeconfigFile string, disableGitops bool) error {
+func Start(ctx context.Context, systemNamespace string, kubeconfigFile string, disableGitops bool, syncUnchangedObjects bool) error {
 	cfg := kubeconfig.GetNonInteractiveClientConfig(kubeconfigFile)
 	clientConfig, err := cfg.ClientConfig()
 	if err != nil {
@@ -24,5 +24,5 @@ func Start(ctx context.Context, systemNamespace string, kubeconfigFile string, d
 		return err
 	}
 
-	return controllers.Register(ctx, systemNamespace, cfg, disableGitops)
+	return controllers.Register(ctx, systemNamespace, cfg, disableGitops, syncUnchangedObjects)
 }


### PR DESCRIPTION
Extends #1041 a bit by making the parameter configurable (for test purposes only).

Plan is to have this tested by few users and revert this commit if results match expectations.

## Additional Information

### Tradeoff

Ideally this parameter should not be configurable, but it is necessary to test it in isolation on user premises before taking a final decision on all users.

### Testing

I tested this manually.