### PR TITLE
Bugfix: do not ignore agentCheckinInterval

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -92,7 +92,7 @@ func AgentWithConfig(ctx context.Context, agentNamespace, controllerNamespace, a
 	mo.AgentImage = cfg.AgentImage
 	mo.SystemDefaultRegistry = cfg.SystemDefaultRegistry
 	mo.AgentImagePullPolicy = cfg.AgentImagePullPolicy
-	mo.CheckinInterval = cfg.AgentCheckinInternal.Duration.String()
+	mo.CheckinInterval = cfg.AgentCheckinInterval.Duration.String()
 
 	objs = append(objs, Manifest(agentNamespace, agentScope, mo)...)
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -38,7 +38,7 @@ type Config struct {
 	AgentImage                      string            `json:"agentImage,omitempty"`
 	AgentImagePullPolicy            string            `json:"agentImagePullPolicy,omitempty"`
 	SystemDefaultRegistry           string            `json:"systemDefaultRegistry,omitempty"`
-	AgentCheckinInternal            metav1.Duration   `json:"agentCheckinInternal,omitempty"`
+	AgentCheckinInterval            metav1.Duration   `json:"agentCheckinInterval,omitempty"`
 	ManageAgent                     *bool             `json:"manageAgent,omitempty"`
 	Labels                          map[string]string `json:"labels,omitempty"`
 	ClientID                        string            `json:"clientID,omitempty"`

--- a/pkg/controllers/cluster/import.go
+++ b/pkg/controllers/cluster/import.go
@@ -264,7 +264,7 @@ func (i *importHandler) importCluster(cluster *fleet.Cluster, status fleet.Clust
 			},
 			ManifestOptions: agent.ManifestOptions{
 				AgentEnvVars:    cluster.Spec.AgentEnvVars,
-				CheckinInterval: cfg.AgentCheckinInternal.Duration.String(),
+				CheckinInterval: cfg.AgentCheckinInterval.Duration.String(),
 				Generation:      string(cluster.UID) + "-" + strconv.FormatInt(cluster.Generation, 10),
 				PrivateRepoURL:  cluster.Spec.PrivateRepoURL,
 			},

--- a/pkg/controllers/manageagent/manageagent.go
+++ b/pkg/controllers/manageagent/manageagent.go
@@ -181,7 +181,7 @@ func (h *handler) newAgentBundle(ns string, cluster *fleet.Cluster) (runtime.Obj
 			AgentEnvVars:          cluster.Spec.AgentEnvVars,
 			AgentImage:            cfg.AgentImage,
 			AgentImagePullPolicy:  cfg.AgentImagePullPolicy,
-			CheckinInterval:       cfg.AgentCheckinInternal.Duration.String(),
+			CheckinInterval:       cfg.AgentCheckinInterval.Duration.String(),
 			Generation:            "bundle",
 			PrivateRepoURL:        cluster.Spec.PrivateRepoURL,
 			SystemDefaultRegistry: cfg.SystemDefaultRegistry,


### PR DESCRIPTION
Fixes #1057 

A typo in a configuration parameter name prevented it from being correctly applied. rancher/rancher seems not to be affected (a grep search only surfaces the correct parameter name), so this might only affect standalone installations.

## Test

See reproduction steps in https://github.com/rancher/fleet/issues/1057

I tested this manually.

## Additional Information

### Tradeoff

Keeping the old name around and use it if defined. From my understanding nobody really used it so far.

### Potential improvement

None.