### PR TITLE
Scaling: avoid needlessly looking up agent bundle deployments

### DIFF
--- a/pkg/target/mapping.go
+++ b/pkg/target/mapping.go
@@ -110,9 +110,13 @@ func (b *bundleSet) insert(bundles []*fleet.Bundle, err error) error {
 		return err
 	}
 	for _, bundle := range bundles {
-		key := bundle.Namespace + "/" + bundle.Name
-		b.bundleMap[key] = bundle
-		b.bundleKeys.Insert(key)
+		b.insertSingle(bundle)
 	}
 	return nil
+}
+
+func (b *bundleSet) insertSingle(bundle *fleet.Bundle) {
+	key := bundle.Namespace + "/" + bundle.Name
+	b.bundleMap[key] = bundle
+	b.bundleKeys.Insert(key)
 }

--- a/pkg/target/target.go
+++ b/pkg/target/target.go
@@ -105,8 +105,20 @@ func (m *Manager) clusterGroupsForCluster(cluster *fleet.Cluster) (result []*fle
 func (m *Manager) getBundlesInScopeForCluster(cluster *fleet.Cluster) ([]*fleet.Bundle, error) {
 	bundleSet := newBundleSet()
 
-	if err := bundleSet.insert(m.bundleCache.List(cluster.Namespace, labels.Everything())); err != nil {
+	// all bundles in the cluster namespace are in scope
+	// except for agent bundles of other clusters
+	bundles, err := m.bundleCache.List(cluster.Namespace, labels.Everything())
+	if err != nil {
 		return nil, err
+	}
+	for _, b := range bundles {
+		if b.Annotations["objectset.rio.cattle.io/id"] == "fleet-manage-agent" {
+			if b.Name == "fleet-agent-"+cluster.Name {
+				bundleSet.insertSingle(b)
+			}
+		} else {
+			bundleSet.insertSingle(b)
+		}
 	}
 
 	mappings, err := m.bundleNamespaceMappingCache.List("", labels.Everything())


### PR DESCRIPTION
Potentially fixes or helps with:
- #606
- https://jira.suse.com/browse/SURE-4967
- https://jira.suse.com/browse/SURE-3613
- https://jira.suse.com/browse/SURE-3597

## TL;DR

Fix for a handler triggered every 15' resulted and taking `O(n²)` CPU time, where `n` is the number of clusters.

In my test setup with 2000 clusters it results in a **~16x speedup** (22 seconds down from 6 minutes).

## Performance analysis

A user experienced constant CPU load on fleetcontroller, and shared the CPU pprof profile. Flame graph looked like the following:

![Screen Shot 2022-10-27 at 12 28 40](https://user-images.githubusercontent.com/250541/198283892-528b0ef0-b8c6-4014-bd3e-2ba17d4b414e.png)


Observations:
 - the first small flame is GC work
 - the second big flame has two smaller flames:
    - one is about [bundle controller's OnBundleChange](https://github.com/rancher/fleet/blob/e2e4b564690287708870084781177dfcd91a78dc/pkg/controllers/bundle/controller.go#L171) (this can deduced because it's registered via `RegisterBundleGeneratingHandler`, which adds the specific `FromBundleHandlerToHandler`/`sync`/`Handler` wrappers and results in a Wrangler `Apply` operation)
    - one is about [bundle controller's OnClusterChange](https://github.com/rancher/fleet/blob/e2e4b564690287708870084781177dfcd91a78dc/pkg/controllers/bundle/controller.go#L97)

I am focusing on the last one to start, as it takes the majority of CPU time (>55%).

Further observations:
 - `OnClusterChange` spends most of its time in `GetBundleDeploymentsForBundleInCluster`
 - `GetBundleDeploymentsForBundleInCluster` is called for all cluster/bundle combinations*:

https://github.com/rancher/fleet/blob/e2e4b564690287708870084781177dfcd91a78dc/pkg/controllers/bundle/controller.go#L104-L109

*to be more precise, only bundles which are classified as "to clean up" by `BundlesForCluster` are considered. But actually `BundlesForCluster` selects the vast majority of bundles, so that is a safe approximation according to my tests.

Further observations:
 - there is always at least one bundle per cluster (the cluster agent's)
 - thus we have **an ~n² number of calls to `GetBundleDeploymentsForBundleInCluster`** where n is the cluster count

Theoretical bottom line: even if `GetBundleDeploymentsForBundleInCluster` were quite fast (eg. 100 microseconds), with 2000 clusters we can expect 2000x2000 = 4 million calls so it will still take long (eg. several minutes at 100% CPU). This is compatible with reported symptoms.

## Proposed Fix

Avoid `BundlesForCluster` to return other clusters' agent bundles as "bundles to clean up". IOW, every time `OnClusterChange` fires, [which is by default at least every 15 minutes for each cluster](https://github.com/rancher/fleet/blob/e2e4b564690287708870084781177dfcd91a78dc/charts/fleet/values.yaml#L19-L20)), only clean up that cluster's agent bundle, and any applicable user-defined bundle.

## Results

In my setup, with 2000 fake clusters this patch yields a **~16x speedup** (6 minutes unpatched, 22 seconds patched). Details about the setup follow.

I am waiting on results from the affected user and will update this once I have them.

According to my tests fleetcontroller's ability to update fleet-agents on downstream clusters on version changes remains intact.

## Test

1. install fleet, register one downstream cluster
2. generate 2000 fake cluster resources:
```bash
NAMESPACE=fleet-local

FIRST_CLUSTER_NAME=$(kubectl get --namespace=$NAMESPACE cluster --output=custom-columns=":metadata.name" | grep cluster- | head -1)
kubectl get --namespace=$NAMESPACE cluster $FIRST_CLUSTER_NAME --output=yaml > cluster.yaml

for i in {1..2000}
do
    CLUSTER_ID=`echo $i | md5sum | head --bytes 12`
    cat cluster.yaml | sed "s/$FIRST_CLUSTER_NAME/cluster-$CLUSTER_ID/g" | kubectl apply --filename=-
done
```

3. stop fleetcontroller:
```sh
kubectl scale --namespace=fleet-system deployments/fleet-controller --replicas=0
```

4. "touch" all clusters:
```sh
kubectl get --all-namespaces cluster --output yaml | kubectl apply --filename=- --server-side
```

5. bring fleetcontroller up again, CPU is expected to go 100% for some time:
```sh
kubectl scale --namespace=fleet-system deployments/fleet-controller --replicas=1
vmstat --unit=M --wide --one-header 1 | nl --starting-line-number=-2
```

6. measure how long it takes before it returns back to normal, by paying attention to the CPU `us` column. The first column (output of `nl`) indicates the number of seconds since the start
7. apply the patch, replacing fleetcontroller, then repeat steps 3.-6. and calculate the speedup

To clean up:
```sh
for i in {1..2000}
do
    CLUSTER_ID=`echo $i | md5sum | head --bytes 12`
    kubectl delete --namespace=$NAMESPACE cluster cluster-$CLUSTER_ID --cascade=foreground
    kubectl delete --namespace=$NAMESPACE bundle fleet-agent-cluster-$CLUSTER_ID --cascade=foreground
done
```

### Tradeoff

Bundle selection could be made more precise by adding specific labels to agent bundles instead of relying on bundle names.

Even better, potentially, use one bundle for all agents - and many BundleDeployments (one per cluster). There might be good reasons why the setup is of one Bundle per Cluster, I just do know them.

### Potential improvement

Similar work could be done for the second flame in the flame graph above.

pprof cpu profiling should become a standard fleet option.


