### PR TITLE
Reading contents&secrets uses specific service account

### DIFF
--- a/.github/scripts/deploy-fleet-latest-release.sh
+++ b/.github/scripts/deploy-fleet-latest-release.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+assets=$(curl -s https://api.github.com/repos/rancher/fleet/releases | jq -r "sort_by(.tag_name) | [ .[] | select(.draft | not) ] | .[-1].assets")
+crd_url=$(echo "$assets" | jq -r '.[] | select(.name | test("fleet-crd-.*.tgz")) | .browser_download_url')
+controller_url=$(echo "$assets" | jq -r '.[] | select(.name | test("fleet-\\d.*.tgz")) | .browser_download_url')
+helm -n cattle-fleet-system upgrade --install --create-namespace --wait fleet-crd "$crd_url"
+helm -n cattle-fleet-system upgrade --install --create-namespace --wait fleet "$controller_url"
+
+# wait
+kubectl -n cattle-fleet-system rollout status deploy/fleet-controller
+{ grep -q -m 1 "fleet-agent"; kill $!; } < <(kubectl get deployment -n cattle-fleet-system -w)
+kubectl -n cattle-fleet-system rollout status deploy/fleet-agent

--- a/.github/scripts/deploy-fleet.sh
+++ b/.github/scripts/deploy-fleet.sh
@@ -15,7 +15,7 @@ else
   agentTag="dev"
 fi
 
-helm -n cattle-fleet-system install --create-namespace --wait fleet-crd charts/fleet-crd
+helm -n cattle-fleet-system upgrade --install --create-namespace --wait fleet-crd charts/fleet-crd
 helm upgrade --install fleet charts/fleet \
   -n cattle-fleet-system --create-namespace --wait \
   --set image.repository="$fleetRepo" \
@@ -24,6 +24,7 @@ helm upgrade --install fleet charts/fleet \
   --set agentImage.tag="$agentTag" \
   --set agentImage.imagePullPolicy=IfNotPresent
 
+# wait
 kubectl -n cattle-fleet-system rollout status deploy/fleet-controller
 { grep -q -m 1 "fleet-agent"; kill $!; } < <(kubectl get deployment -n cattle-fleet-system -w)
 kubectl -n cattle-fleet-system rollout status deploy/fleet-agent

--- a/.github/scripts/dump-failed-k3ds.sh
+++ b/.github/scripts/dump-failed-k3ds.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+mkdir -p tmp
+
+kubectl config use-context k3d-upstream
+kubectl get -A pod,secret,service,ingress -o json > tmp/cluster.json
+kubectl get -A gitrepos,clusters,clustergroups,bundles,bundledeployments -o json > tmp/fleet.json
+kubectl get -A events > tmp/events.log
+helm list -A > tmp/helm.log
+kubectl logs -n cattle-fleet-system -l app=fleet-controller > tmp/fleetcontroller.log
+kubectl logs -n cattle-fleet-system -l app=fleet-agent > tmp/fleetagent.log
+
+docker logs k3d-upstream-server-0 &> tmp/k3s.log
+docker exec k3d-upstream-server-0 sh -c 'cd /var/log/containers; grep -r "." .' > tmp/containers.log
+
+if k3d cluster list -o json | jq '.[].name' | grep -q "downstream"; then
+  kubectl config use-context k3d-downstream
+  kubectl get -A pod,secret,service,ingress -o json > tmp/cluster-second.json
+  kubectl get -A events > tmp/events-downstream.log
+  helm list -A > tmp/helm-downstream.log
+  kubectl logs -n cattle-fleet-system -l app=fleet-agent > tmp/fleetagent-second.log
+
+  docker logs k3d-downstream-server-0 &> tmp/k3s-downstream.log
+  docker exec k3d-downstream-server-0 sh -c 'cd /var/log/containers; grep -r "." .' > tmp/containers-downstream.log
+fi

--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -115,15 +115,7 @@ jobs:
         if: failure()
         run: |
           mkdir -p tmp
-          kubectl get -A pod,secret,service,ingress -o json > tmp/cluster.json
-          kubectl get -A gitrepos,clusters,clustergroups,bundles,bundledeployments -o json > tmp/fleet.json
-          kubectl get -A events > tmp/events.log
-          helm list -A > tmp/helm.log
-          kubectl logs -n cattle-fleet-system -l app=fleet-controller > tmp/fleetcontroller.log
-          kubectl logs -n cattle-fleet-system -l app=fleet-agent > tmp/fleetagent.log
-
-          docker logs k3d-k3s-default-server-0 &> tmp/k3s.log
-          docker exec k3d-k3s-default-server-0 sh -c 'cd /var/log/containers; grep -r "." .' > tmp/containers.log
+          ./.github/scripts/dump-failed-k3ds.sh
       -
         name: Upload Logs
         uses: actions/upload-artifact@v3

--- a/.github/workflows/e2e-multicluster-ci.yml
+++ b/.github/workflows/e2e-multicluster-ci.yml
@@ -143,26 +143,7 @@ jobs:
         name: Dump Failed Environment
         if: failure()
         run: |
-          mkdir -p tmp
-          kubectl config use-context k3d-upstream
-          kubectl get -A pod,secret,service,ingress -o json > tmp/cluster.json
-          kubectl get -A gitrepos,clusters,clustergroups,bundles,bundledeployments -o json > tmp/fleet.json
-          kubectl get -A events > tmp/events.log
-          helm list -A > tmp/helm.log
-          kubectl logs -n cattle-fleet-system -l app=fleet-controller > tmp/fleetcontroller.log
-          kubectl logs -n cattle-fleet-system -l app=fleet-agent > tmp/fleetagent.log
-
-          kubectl config use-context k3d-downstream
-          kubectl get -A pod,secret,service,ingress -o json > tmp/cluster-downstream.json
-          kubectl get -A events > tmp/events-downstream.log
-          helm list -A > tmp/helm-downstream.log
-          kubectl logs -n cattle-fleet-system -l app=fleet-agent > tmp/fleetagent-downstream.log
-
-          docker logs k3d-upstream-server-0 &> tmp/k3s.log
-          docker exec k3d-upstream-server-0 sh -c 'cd /var/log/containers; grep -r "." .' > tmp/containers.log
-
-          docker logs k3d-downstream-server-0 &> tmp/k3s-downstream.log
-          docker exec k3d-downstream-server-0 sh -c 'cd /var/log/containers; grep -r "." .' > tmp/containers-downstream.log
+          ./.github/scripts/dump-failed-k3ds.sh
       -
         name: Upload Logs
         uses: actions/upload-artifact@v3

--- a/.github/workflows/fleet-upgrade.yml
+++ b/.github/workflows/fleet-upgrade.yml
@@ -1,0 +1,127 @@
+name: Upgrade Fleet
+
+on:
+  schedule:
+    - cron: '0 8 */2 * *'
+  workflow_dispatch:
+    inputs:
+      enable_tmate:
+        description: 'Enable debugging via tmate'
+        required: false
+        default: "false"
+  pull_request:
+
+env:
+  GOARCH: amd64
+  CGO_ENABLED: 0
+  SETUP_GO_VERSION: '^1.19'
+
+jobs:
+  fleet-upgrade-test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        k3s_version:
+          - v1.22.10-k3s1
+    steps:
+      -
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      -
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ env.SETUP_GO_VERSION }}
+      -
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      -
+        name: Install Ginkgo CLI
+        run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.1
+      -
+        name: Provision k3d Cluster
+        uses: AbsaOSS/k3d-action@v2
+        # k3d will automatically create a network named k3d-test-cluster-1 with the range 172.18.0.0/16
+        with:
+          cluster-name: "k3s-default"
+          args: >-
+            --agents 3
+            --network "nw01"
+            --image docker.io/rancher/k3s:${{matrix.k3s_version}}
+      -
+        name: Set Up Tmate Debug Session
+        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.enable_tmate == 'true' }}
+        uses: mxschmitt/action-tmate@v3
+        timeout-minutes: 15
+        with:
+          limit-access-to-actor: true
+      -
+        name: Deploy Latest Release
+        run: |
+          ./.github/scripts/deploy-fleet-latest-release.sh
+      -
+        name: Create example workload
+        run: |
+          kubectl apply -n fleet-local -f e2e/assets/bundle-diffs/gitrepo.yaml
+      -
+        name: Build Fleet Binaries
+        run: |
+          go build -o bin/fleetcontroller-linux-$GOARCH ./cmd/fleetcontroller
+
+          go build -o "bin/fleet-linux-$GOARCH"
+          go build -o "bin/fleetagent-linux-$GOARCH" ./cmd/fleetagent
+      -
+        name: Build Docker Images
+        run: |
+          docker build -f package/Dockerfile -t rancher/fleet:dev --build-arg="ARCH=$GOARCH" .
+          docker build -f package/Dockerfile.agent -t rancher/fleet-agent:dev --build-arg="ARCH=$GOARCH" .
+      -
+        name: Import Images Into k3d
+        run: |
+          k3d image import rancher/fleet:dev rancher/fleet-agent:dev
+      -
+        name: Verify Example Workload
+        run: |
+          # we waited long enough by importing the image first
+          kubectl get configmap -n bundle-diffs-example | grep -q -m 1 "app-config"
+      -
+        name: Upgrade to Dev Version
+        run: |
+          ./.github/scripts/deploy-fleet.sh
+      -
+        name: Verify Installation
+        env:
+          FLEET_E2E_NS: fleet-local
+        run: |
+          ginkgo e2e/installation
+      -
+        name: Dump Failed Environment
+        if: failure()
+        run: |
+          mkdir -p tmp
+          kubectl get -A pod,secret,service,ingress -o json > tmp/cluster.json
+          kubectl get -A gitrepos,clusters,clustergroups,bundles,bundledeployments -o json > tmp/fleet.json
+          kubectl get -A events > tmp/events.log
+          helm list -A > tmp/helm.log
+          kubectl logs -n cattle-fleet-system -l app=fleet-controller > tmp/fleetcontroller.log
+          kubectl logs -n cattle-fleet-system -l app=fleet-agent > tmp/fleetagent.log
+
+          docker logs k3d-k3s-default-server-0 &> tmp/k3s.log
+          docker exec k3d-k3s-default-server-0 sh -c 'cd /var/log/containers; grep -r "." .' > tmp/containers.log
+      -
+        name: Upload Logs
+        uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: gha-fleet-e2e-logs-${{ github.sha }}-${{ matrix.k3s_version }}-${{ github.run_id }}
+          path: |
+            tmp/*.json
+            tmp/*.log
+          retention-days: 2
+

--- a/.github/workflows/fleet-upgrade.yml
+++ b/.github/workflows/fleet-upgrade.yml
@@ -104,16 +104,7 @@ jobs:
         name: Dump Failed Environment
         if: failure()
         run: |
-          mkdir -p tmp
-          kubectl get -A pod,secret,service,ingress -o json > tmp/cluster.json
-          kubectl get -A gitrepos,clusters,clustergroups,bundles,bundledeployments -o json > tmp/fleet.json
-          kubectl get -A events > tmp/events.log
-          helm list -A > tmp/helm.log
-          kubectl logs -n cattle-fleet-system -l app=fleet-controller > tmp/fleetcontroller.log
-          kubectl logs -n cattle-fleet-system -l app=fleet-agent > tmp/fleetagent.log
-
-          docker logs k3d-k3s-default-server-0 &> tmp/k3s.log
-          docker exec k3d-k3s-default-server-0 sh -c 'cd /var/log/containers; grep -r "." .' > tmp/containers.log
+          ./.github/scripts/dump-failed-k3ds.sh
       -
         name: Upload Logs
         uses: actions/upload-artifact@v3

--- a/.github/workflows/rancher-integration.yml
+++ b/.github/workflows/rancher-integration.yml
@@ -192,26 +192,7 @@ jobs:
         name: Dump failed environment
         if: failure()
         run: |
-          mkdir -p tmp
-          kubectl config use-context k3d-upstream
-          kubectl get -A pod,secret,service,ingress -o json > tmp/cluster.json
-          kubectl get -A gitrepos,clusters,clustergroups,bundles,bundledeployments -o json > tmp/fleet.json
-          kubectl get -A events > tmp/events.log
-          helm list -A > tmp/helm.log
-          kubectl logs -n cattle-fleet-system -l app=fleet-controller > tmp/fleetcontroller.log
-          kubectl logs -n cattle-fleet-system -l app=fleet-agent > tmp/fleetagent.log
-
-          kubectl config use-context k3d-downstream
-          kubectl get -A pod,secret,service,ingress -o json > tmp/cluster-second.json
-          kubectl get -A events > tmp/events-downstream.log
-          helm list -A > tmp/helm-downstream.log
-          kubectl logs -n cattle-fleet-system -l app=fleet-agent > tmp/fleetagent-second.log
-
-          docker logs k3d-upstream-server-0 &> tmp/k3s.log
-          docker exec k3d-upstream-server-0 sh -c 'cd /var/log/containers; grep -r "." .' > tmp/containers.log
-
-          docker logs k3d-downstream-server-0 &> tmp/k3s-downstream.log
-          docker exec k3d-downstream-server-0 sh -c 'cd /var/log/containers; grep -r "." .' > tmp/containers-downstream.log
+          ./.github/scripts/dump-failed-k3ds.sh
       -
         name: Upload logs
         uses: actions/upload-artifact@v3

--- a/dev/remove-fleet
+++ b/dev/remove-fleet
@@ -16,6 +16,8 @@ kubectl delete ns cattle-fleet-clusters-system --now
 kubectl delete ns fleet-local --now
 kubectl delete ns -l "fleet.cattle.io/managed=true"
 
+kubectl delete clusterrolebinding fleet-agent-get-content cattle-fleet-system-fleet-agent-role-binding
+kubectl delete clusterrole cattle-fleet-system-fleet-agent-role fleet-bundle-deployment fleet-content
 
 kubectl config use-context "$downstream_ctx"
 helm uninstall -n cattle-fleet-system fleet-agent
@@ -23,3 +25,4 @@ helm uninstall -n cattle-fleet-system fleet-agent
 kubectl delete ns cattle-fleet-system --now
 
 kubectl config use-context "$ctx"
+

--- a/dev/setup-k3ds
+++ b/dev/setup-k3ds
@@ -18,7 +18,8 @@ EOF
   args="--registry-config $TMP_CONFIG"
 fi
 
-#args="$args -i docker.io/rancher/k3s:v1.22.15-rc1-k3s1"
+# k3d version list k3s
+#args="$args -i docker.io/rancher/k3s:v1.22.15-k3s1"
 
 k3d cluster create upstream --servers 3 --api-port 36443 -p '80:80@server:0' -p '443:443@server:0' $args
 k3d cluster create downstream --servers 1 --api-port 36444 -p '5080:80@server:0' -p '3444:443@server:0' $args

--- a/e2e/assets/simple/gitrepo.yaml
+++ b/e2e/assets/simple/gitrepo.yaml
@@ -1,0 +1,10 @@
+kind: GitRepo
+apiVersion: fleet.cattle.io/v1alpha1
+metadata:
+  name: {{.Name}}
+spec:
+  repo: https://github.com/rancher/fleet-examples
+  branch: master
+  paths:
+  - bundle-diffs
+  targetNamespace: {{.TargetNamespace}}

--- a/e2e/installation/suite_test.go
+++ b/e2e/installation/suite_test.go
@@ -1,0 +1,26 @@
+package installation_test
+
+import (
+	"testing"
+
+	"github.com/rancher/fleet/e2e/testenv"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestE2E(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Verify Fleet Installation")
+}
+
+var (
+	env *testenv.Env
+)
+
+var _ = BeforeSuite(func() {
+	SetDefaultEventuallyTimeout(testenv.Timeout)
+	testenv.SetRoot("../..")
+
+	env = testenv.New()
+})

--- a/e2e/installation/verify_test.go
+++ b/e2e/installation/verify_test.go
@@ -1,0 +1,68 @@
+package installation_test
+
+import (
+	"os"
+	"path"
+
+	"github.com/rancher/fleet/e2e/testenv"
+	"github.com/rancher/fleet/e2e/testenv/kubectl"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// This runs after an upgrade of fleet to verify workloads are still there and
+// new workload can be created
+var _ = Describe("Fleet Installation", func() {
+	var (
+		asset string
+		k     kubectl.Command
+	)
+
+	BeforeEach(func() {
+		k = env.Kubectl.Namespace(env.Namespace)
+	})
+
+	Context("sanity checks", func() {
+		It("finds the original workload", func() {
+			out, _ := k.Namespace("bundle-diffs-example").Get("services")
+			Expect(out).To(ContainSubstring("app-service"))
+		})
+
+	})
+
+	When("Deploying another bundle", func() {
+		var tmpdir string
+		BeforeEach(func() {
+			asset = "simple/gitrepo.yaml"
+		})
+
+		JustBeforeEach(func() {
+			tmpdir, _ = os.MkdirTemp("", "fleet-")
+			gitrepo := path.Join(tmpdir, "gitrepo.yaml")
+			err := testenv.Template(gitrepo, testenv.AssetPath(asset), struct {
+				Name            string
+				TargetNamespace string
+			}{
+				"testname",
+				"testexample",
+			})
+			Expect(err).ToNot(HaveOccurred())
+
+			out, err := k.Apply("-f", gitrepo)
+			Expect(err).ToNot(HaveOccurred(), out)
+		})
+
+		AfterEach(func() {
+			os.RemoveAll(tmpdir)
+		})
+
+		It("creates the new workload", func() {
+			Eventually(func() string {
+				out, _ := k.Namespace("testexample").Get("configmaps")
+				return out
+			}).Should(ContainSubstring("app-config"))
+		})
+
+	})
+})

--- a/e2e/testenv/kubectl/kubectl.go
+++ b/e2e/testenv/kubectl/kubectl.go
@@ -6,11 +6,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
-	"sync"
 )
-
-// use a mutex to workaround context being a global config
-var mu sync.Mutex
 
 type Command struct {
 	cnt    string
@@ -69,11 +65,7 @@ func (c Command) Patch(args ...string) (string, error) {
 
 func (c Command) Run(args ...string) (string, error) {
 	if c.cnt != "" {
-		mu.Lock()
-		defer mu.Unlock()
-		if out, err := c.exec("kubectl", "config", "use-context", c.cnt); err != nil {
-			return out, err
-		}
+		args = append([]string{"--context", c.cnt}, args...)
 	}
 
 	if c.ns != "" {

--- a/modules/agent/pkg/agent/app.go
+++ b/modules/agent/pkg/agent/app.go
@@ -30,6 +30,7 @@ type Options struct {
 	StartAfter       <-chan struct{}
 }
 
+// Register is only used by simulators to start an agent
 func Register(ctx context.Context, kubeConfig, namespace, clusterID string) error {
 	clientConfig := kubeconfig.GetNonInteractiveClientConfig(kubeConfig)
 	kc, err := clientConfig.ClientConfig()
@@ -42,6 +43,7 @@ func Register(ctx context.Context, kubeConfig, namespace, clusterID string) erro
 	return err
 }
 
+// Start the fleet agent
 func Start(ctx context.Context, kubeConfig, namespace, agentScope string, opts *Options) error {
 	if opts == nil {
 		opts = &Options{}

--- a/pkg/basic/objects.go
+++ b/pkg/basic/objects.go
@@ -2,13 +2,9 @@
 package basic
 
 import (
-	"github.com/rancher/wrangler/pkg/name"
-
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 )
 
 func ConfigMap(namespace, name string, kvs ...string) *corev1.ConfigMap {
@@ -123,61 +119,3 @@ func ServiceAccount(namespace, name string) *corev1.ServiceAccount {
 	}
 }
 
-func Role(serviceAccount *corev1.ServiceAccount, namespace string, rules ...rbacv1.PolicyRule) []runtime.Object {
-	return []runtime.Object{
-		&rbacv1.Role{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      name.SafeConcatName(serviceAccount.Namespace, serviceAccount.Name, "role"),
-				Namespace: namespace,
-			},
-			Rules: rules,
-		},
-		&rbacv1.RoleBinding{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      name.SafeConcatName(serviceAccount.Namespace, serviceAccount.Name, "role", "binding"),
-				Namespace: namespace,
-			},
-			Subjects: []rbacv1.Subject{
-				{
-					Kind:      "ServiceAccount",
-					APIGroup:  "",
-					Name:      serviceAccount.Name,
-					Namespace: serviceAccount.Namespace,
-				},
-			},
-			RoleRef: rbacv1.RoleRef{
-				APIGroup: rbacv1.GroupName,
-				Kind:     "Role",
-				Name:     name.SafeConcatName(serviceAccount.Namespace, serviceAccount.Name, "role"),
-			},
-		},
-	}
-}
-
-func ClusterRole(serviceAccount *corev1.ServiceAccount, rules ...rbacv1.PolicyRule) []runtime.Object {
-	return []runtime.Object{
-		&rbacv1.ClusterRole{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: name.SafeConcatName(serviceAccount.Namespace, serviceAccount.Name, "role"),
-			},
-			Rules: rules,
-		},
-		&rbacv1.ClusterRoleBinding{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: name.SafeConcatName(serviceAccount.Namespace, serviceAccount.Name, "role", "binding"),
-			},
-			Subjects: []rbacv1.Subject{
-				{
-					Kind:      "ServiceAccount",
-					Name:      serviceAccount.Name,
-					Namespace: serviceAccount.Namespace,
-				},
-			},
-			RoleRef: rbacv1.RoleRef{
-				APIGroup: rbacv1.GroupName,
-				Kind:     "ClusterRole",
-				Name:     name.SafeConcatName(serviceAccount.Namespace, serviceAccount.Name, "role"),
-			},
-		},
-	}
-}

--- a/pkg/controllers/bootstrap/bootstrap.go
+++ b/pkg/controllers/bootstrap/bootstrap.go
@@ -68,7 +68,7 @@ func (h *handler) OnConfig(config *config.Config) error {
 		return nil
 	}
 
-	secret, err := h.getSecret(config.Bootstrap.Namespace, h.cfg)
+	secret, err := h.buildSecret(config.Bootstrap.Namespace, h.cfg)
 	if err != nil {
 		return err
 	}
@@ -152,6 +152,7 @@ func (h *handler) getToken() (string, error) {
 		return "", err
 	}
 
+	// kubernetes 1.24 doesn't populate sa.Secrets
 	if len(sa.Secrets) == 0 {
 		logrus.Infof("waiting on secret for service account %s/%s", h.systemNamespace, FleetBootstrap)
 		secret, err := secretutil.GetServiceAccountTokenSecret(sa, h.secretsController)
@@ -169,7 +170,7 @@ func (h *handler) getToken() (string, error) {
 	return string(secret.Data[corev1.ServiceAccountTokenKey]), nil
 }
 
-func (h *handler) getSecret(bootstrapNamespace string, cfg clientcmd.ClientConfig) (*corev1.Secret, error) {
+func (h *handler) buildSecret(bootstrapNamespace string, cfg clientcmd.ClientConfig) (*corev1.Secret, error) {
 	rawConfig, err := cfg.RawConfig()
 	if err != nil {
 		return nil, err

--- a/pkg/controllers/cluster/import.go
+++ b/pkg/controllers/cluster/import.go
@@ -178,7 +178,7 @@ func (i *importHandler) importCluster(cluster *fleet.Cluster, status fleet.Clust
 		return status, err
 	}
 
-	logrus.Debugf("ClusterStatusHandler cluster '%s/%s' changed, setting up agent", cluster.Namespace, cluster.Name)
+	logrus.Debugf("ClusterStatusHandler cluster '%s/%s' changed, setting up agent with kubeconfig from %s", cluster.Namespace, cluster.Name, cluster.Spec.KubeConfigSecret)
 	var (
 		cfg          = config.Get()
 		apiServerURL = string(secret.Data["apiServerURL"])

--- a/pkg/controllers/clusterregistration/controller.go
+++ b/pkg/controllers/clusterregistration/controller.go
@@ -225,6 +225,7 @@ func (h *handler) OnChange(request *fleet.ClusterRegistration, status fleet.Clus
 		request.Namespace, request.Name, cluster.Namespace, cluster.Name, status.Granted)
 
 	status.ClusterName = cluster.Name
+	// e.g. request- in cluster-registration-namespace
 	return append(objects,
 		&v1.ServiceAccount{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/controllers/clusterregistration/controller.go
+++ b/pkg/controllers/clusterregistration/controller.go
@@ -297,7 +297,28 @@ func (h *handler) OnChange(request *fleet.ClusterRegistration, status fleet.Clus
 				Kind:     "Role",
 				Name:     request.Name,
 			},
-		}), status, nil
+		},
+		&rbacv1.ClusterRoleBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: name.SafeConcatName(request.Name, "content"),
+				Labels: map[string]string{
+					fleet.ManagedLabel: "true",
+				},
+			},
+			Subjects: []rbacv1.Subject{
+				{
+					Kind:      "ServiceAccount",
+					Name:      saName,
+					Namespace: cluster.Status.Namespace,
+				},
+			},
+			RoleRef: rbacv1.RoleRef{
+				APIGroup: rbacv1.GroupName,
+				Kind:     "ClusterRole",
+				Name:     "fleet-content",
+			},
+		},
+	), status, nil
 }
 
 func KeyHash(s string) string {

--- a/pkg/controllers/clusterregistrationtoken/handler.go
+++ b/pkg/controllers/clusterregistrationtoken/handler.go
@@ -126,6 +126,7 @@ func (h *handler) OnChange(token *fleet.ClusterRegistrationToken, status fleet.C
 		status.Expires = &metav1.Time{Time: token.CreationTimestamp.Add(token.Spec.TTL.Duration)}
 	}
 
+	// e.g.: import-token-local in system-registration-namespace
 	return append([]runtime.Object{
 		&corev1.ServiceAccount{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/controllers/clusterregistrationtoken/handler.go
+++ b/pkg/controllers/clusterregistrationtoken/handler.go
@@ -174,6 +174,37 @@ func (h *handler) OnChange(token *fleet.ClusterRegistrationToken, status fleet.C
 				Name:     name.SafeConcatName(saName, "role"),
 			},
 		},
+		&rbacv1.Role{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name.SafeConcatName(saName, "creds"),
+				Namespace: h.systemRegistrationNamespace,
+			},
+			Rules: []rbacv1.PolicyRule{
+				{
+					Verbs:     []string{"get"},
+					APIGroups: []string{""},
+					Resources: []string{"secrets"},
+				},
+			},
+		},
+		&rbacv1.RoleBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name.SafeConcatName(saName, "creds"),
+				Namespace: h.systemRegistrationNamespace,
+			},
+			Subjects: []rbacv1.Subject{
+				{
+					Kind:      "ServiceAccount",
+					Name:      saName,
+					Namespace: token.Namespace,
+				},
+			},
+			RoleRef: rbacv1.RoleRef{
+				APIGroup: rbacv1.GroupName,
+				Kind:     "Role",
+				Name:     name.SafeConcatName(saName, "creds"),
+			},
+		},
 	}, secrets...), status, nil
 }
 

--- a/pkg/controllers/controllers.go
+++ b/pkg/controllers/controllers.go
@@ -92,7 +92,10 @@ func Register(ctx context.Context, systemNamespace string, cfg clientcmd.ClientC
 	}
 
 	clusterregistration.Register(ctx,
-		appCtx.Apply,
+		appCtx.Apply.WithCacheTypes(
+			appCtx.RBAC.ClusterRole(),
+			appCtx.RBAC.ClusterRoleBinding(),
+		),
 		systemNamespace,
 		systemRegistrationNamespace,
 		appCtx.Core.ServiceAccount(),

--- a/pkg/controllers/data.go
+++ b/pkg/controllers/data.go
@@ -57,53 +57,5 @@ func addData(systemNamespace, systemRegistrationNamespace string, appCtx *appCon
 					Name: systemRegistrationNamespace,
 				},
 			},
-			&rbacv1.Role{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "fleet-agent-get-cred",
-					Namespace: systemRegistrationNamespace,
-				},
-				Rules: []rbacv1.PolicyRule{
-					{
-						Verbs:     []string{"get"},
-						APIGroups: []string{""},
-						Resources: []string{"secrets"},
-					},
-				},
-			},
-			&rbacv1.RoleBinding{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "fleet-agent-get-cred",
-					Namespace: systemRegistrationNamespace,
-				},
-				Subjects: []rbacv1.Subject{
-					{
-						Kind:     "Group",
-						APIGroup: "rbac.authorization.k8s.io",
-						Name:     "system:serviceaccounts",
-					},
-				},
-				RoleRef: rbacv1.RoleRef{
-					APIGroup: "rbac.authorization.k8s.io",
-					Kind:     "Role",
-					Name:     "fleet-agent-get-cred",
-				},
-			},
-			&rbacv1.ClusterRoleBinding{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "fleet-agent-get-content",
-				},
-				Subjects: []rbacv1.Subject{
-					{
-						Kind:     "Group",
-						APIGroup: "rbac.authorization.k8s.io",
-						Name:     "system:serviceaccounts",
-					},
-				},
-				RoleRef: rbacv1.RoleRef{
-					APIGroup: "rbac.authorization.k8s.io",
-					Kind:     "ClusterRole",
-					Name:     "fleet-content",
-				},
-			},
 		)
 }

--- a/pkg/controllers/data.go
+++ b/pkg/controllers/data.go
@@ -16,6 +16,7 @@ func addData(systemNamespace, systemRegistrationNamespace string, appCtx *appCon
 		WithDynamicLookup().
 		WithNoDeleteGVK(fleetns.GVK()).
 		ApplyObjects(
+			// used by request-* service accounts from agents
 			&rbacv1.ClusterRole{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "fleet-bundle-deployment",
@@ -33,6 +34,7 @@ func addData(systemNamespace, systemRegistrationNamespace string, appCtx *appCon
 					},
 				},
 			},
+			// used by request-* service accounts from agents
 			&rbacv1.ClusterRole{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "fleet-content",


### PR DESCRIPTION
Fixes an issue, by moving the two roles onto specific service accounts.


RBAC previously allowed any user to get contents and any secrets in
the system registration namespace.
However, their names are random and listing was not allowed.

The agents on downstream clusters already use the`request-` account to
retrieve bundledeployments from the upstream cluster and report back the
status. We extend that account to be able to retrieve 'contents', too.

The agents use a `import-` account for reqstration, e.g. to create a
ClusterRegistration. That one is extended, so it can read the secrets in
the agent's cluster registration namespace.


I previously observed issues when updating the agent, but can no longer reproduce these, e.g. the agent log would show
`level=error msg="Failed to register agent: looking up secret cattle-fleet-system/fleet-agent-bootstrap: looking up secret cattle-fleet-system/fleet-agent-bootstrap: secrets \"fleet-agent-bootstrap\" not found".`

Since an upgrade wouldn't modify the dynamically created roles, the old permissions should still be in place. Only new fleet installations benefit from the stricter role bindings.