### PR TITLE
[Experimental] Scaling: make ClusterEnqueueDelay configurable via environment variable

### DIFF
--- a/pkg/durations/durations.go
+++ b/pkg/durations/durations.go
@@ -5,7 +5,7 @@ import "time"
 const (
 	AgentRegistrationRetry         = time.Minute * 1
 	AgentSecretTimeout             = time.Minute * 1
-	ClusterEnqueueDelay            = time.Second * 15
+	DefaultClusterEnqueueDelay     = time.Second * 15
 	ClusterImportTokenTTL          = time.Hour * 12
 	ClusterRegisterDelay           = time.Second * 15
 	ClusterRegistrationDeleteDelay = time.Minute * 40


### PR DESCRIPTION
Potentially fixes or helps with:
- #606
- https://jira.suse.com/browse/SURE-4967
- https://jira.suse.com/browse/SURE-3613
- https://jira.suse.com/browse/SURE-3597

`fleetcontroller` recomputes the status of Clusters (eg. desired/ready BundleDeployment counts) every 15s until they reach a ready state.

This can be too frequent for large deployments, eg., in a 1500 cluster deployment the checks happens 100 times per second. In a particular user case this hogged the CPU close to 90% (30 out of 32 cores busy).

This PR makes the check time configurable.

## Test

To test this PR:

- install fleet (with debug logging) and register one cluster
- edit the `fleet-controller` deployment (eg. via `k9s`) adding the `FLEET_CLUSTER_ENQUEUE_DELAY` environment variable:

```yaml
spec:
  containers:
  - command:
    - fleetcontroller

[...]

    env:
    - name: FLEET_CLUSTER_ENQUEUE_DELAY
      value: 120s
```

- deploy the simple example:

gitrepo.yaml:
```yaml
kind: GitRepo
apiVersion: fleet.cattle.io/v1alpha1
metadata:
  name: my-repo
  namespace: fleet-local
spec:
  repo: https://github.com/rancher/fleet-examples
  paths:
    - simple
```

Then in a shell:
```shell
kubectl apply -f ./gitrepo.yaml
```

- once completely deployed, kill one of the `frontend` pods on the downstream cluster. This will result in the cluster being re-enqueued, which is visible from fleet-controller logs with a line similar to the following:

```
time="2022-11-03T12:37:30Z" level=debug msg="Cluster fleet-local/cluster-90581f3745e8 is not ready because not all gitrepos are ready: 5/6, enqueue cluster again"
```

(the log line may be repeated)

- after the configured amount of time (2 minutes in the example above) the cluster should be checked again, which is visible from fleet-controller logs with a line similar to the following:

```
time="2022-11-03T12:39:30Z" level=debug msg="OnClusterChanged for cluster status cluster-90581f3745e8, checking cluster registration, updating status from bundledeployments, gitrepos"                                            │
```

Most importantly, the message above **should not** be repeated every 15s (the default).


## Additional Information

### Tradeoff

It is probably possible to keep the default value and make refreshes faster instead. That is an option that can be evaluated later - 15s for each cluster in a multi-thousand cluster scenario does not make much sense anyway.

### Potential improvement

Ideally the time could be auto-tuned or rate-limited. Otherwise, this parameter could be surfaced in Helm charts and properly documented.


At the moment it is still being verified whether this patch helps in the particular user situation I am looking at.
