### PR TITLE
Add nightly builds

### DIFF
--- a/.github/workflows/aks.yml
+++ b/.github/workflows/aks.yml
@@ -26,6 +26,8 @@ env:
 jobs:
   aks-fleet-examples:
     runs-on: ubuntu-latest
+    if: >
+      github.repository == 'rancher/fleet'
 
     steps:
       -

--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -94,7 +94,9 @@ jobs:
       -
         name: Fleet Tests Requiring Github Secrets
         # These tests can't run for PRs, because PRs don't have access to the secrets
-        if: github.event_name != 'pull_request'
+        if: >
+          github.event_name != 'pull_request' &&
+          github.repository == 'rancher/fleet'
         env:
           FLEET_E2E_NS: fleet-local
           GIT_REPO_URL: "git@github.com:fleetrepoci/test.git"

--- a/.github/workflows/eks.yml
+++ b/.github/workflows/eks.yml
@@ -34,6 +34,8 @@ env:
 jobs:
   eks-fleet-examples:
     runs-on: ubuntu-latest
+    if: >
+      github.repository == 'rancher/fleet'
 
     steps:
       -

--- a/.github/workflows/gke.yml
+++ b/.github/workflows/gke.yml
@@ -25,6 +25,8 @@ env:
 jobs:
   gke-fleet-examples:
     runs-on: ubuntu-latest
+    if: >
+      github.repository == 'rancher/fleet'
 
     steps:
       -

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,152 @@
+name: Nightly Images Build
+
+on:
+  schedule:
+    # doing builds Tue-Sat, so we have changes from Fri
+    # available already on Sat
+    - cron:  '0 0 * * 2-6'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  SETUP_GO_VERSION: '^1.18'
+
+jobs:
+  nightly-release:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      -
+        name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ env.SETUP_GO_VERSION }}
+      -
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      -
+        name: Login to GitHub Docker Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      -
+        name: Set Nightly Version
+        run: |
+          tag_commit=$(git rev-list --abbrev-commit --tags --max-count=1)
+          tag=$(git describe --abbrev=0 --tags "$tag_commit")
+          version=$(git describe --long --tags --always --match 'v[0-9]\.*')-nightly
+          ts=$(date +%s)
+          version=$(echo $version | sed "s/$tag/$tag.$ts/")
+          # example: v0.6.0-alpha1.1667814448-8-gcd772be-nightly
+          echo "VERSION=$version" >> $GITHUB_ENV
+          echo "### $version :rocket:" >> $GITHUB_STEP_SUMMARY
+      -
+        name: Build
+        env:
+          GOOS: linux
+        run: |
+          export GOARCH=amd64
+          go build -gcflags='all=-N -l' -o bin/fleetcontroller-linux-amd64 ./cmd/fleetcontroller
+          go build -gcflags='all=-N -l' -o bin/fleet-linux-amd64
+          go build -gcflags='all=-N -l' -o bin/fleetagent-linux-amd64 ./cmd/fleetagent
+          export GOARCH=arm64
+          go build -gcflags='all=-N -l' -o bin/fleetcontroller-linux-arm64 ./cmd/fleetcontroller
+          go build -gcflags='all=-N -l' -o bin/fleet-linux-arm64
+          go build -gcflags='all=-N -l' -o bin/fleetagent-linux-arm64 ./cmd/fleetagent
+      -
+        id: meta-fleet
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            ghcr.io/rancher/fleet
+          tags: ${{ env.VERSION }}
+      -
+        name: Build and push controller
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: package/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          build-args: |
+            BUILD_ENV=buildx
+          tags: ${{ steps.meta-fleet.outputs.tags }}
+          labels: ${{ steps.meta-fleet.outputs.labels }}
+      -
+        id: meta-fleet-agent
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            ghcr.io/rancher/fleet-agent
+          tags: ${{ env.VERSION }}
+      -
+        name: Build and push agent
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: package/Dockerfile.agent
+          platforms: linux/amd64,linux/arm64
+          push: true
+          build-args: |
+            BUILD_ENV=buildx
+          tags: ${{ steps.meta-fleet-agent.outputs.tags }}
+          labels: ${{ steps.meta-fleet-agent.outputs.labels }}
+      -
+        name: Build Helm Chart
+        run: |
+          repo="ghcr.io/rancher/fleet"
+          sed -i \
+              -e "s@repository:.*@repository: $repo@" \
+              -e "s/tag:.*/tag: ${VERSION}/" \
+              charts/fleet/values.yaml
+
+          sed -i \
+              -e "s@repository:.*@repository: $repo@" \
+              -e "s/tag: dev/tag: ${VERSION}/" \
+              charts/fleet-agent/values.yaml
+
+          helm package --version="$VERSION" --app-version="$VERSION" -d ./dist ./charts/fleet
+          helm package --version="$VERSION" --app-version="$VERSION" -d ./dist ./charts/fleet-crd
+          helm package --version="$VERSION" --app-version="$VERSION" -d ./dist ./charts/fleet-agent
+      -
+        name: Upload Controller Chart
+        uses: actions/upload-artifact@v3
+        with:
+          name: fleet-${{ env.VERSION }}.tgz
+          path: ./dist/fleet-${{ env.VERSION }}.tgz
+          retention-days: 3
+      -
+        name: Upload CRD Chart
+        uses: actions/upload-artifact@v3
+        with:
+          name: fleet-crd-${{ env.VERSION }}.tgz
+          path: ./dist/fleet-crd-${{ env.VERSION }}.tgz
+          retention-days: 3
+      -
+        name: Upload Agent Chart
+        uses: actions/upload-artifact@v3
+        with:
+          name: fleet-agent-${{ env.VERSION }}.tgz
+          path: ./dist/fleet-agent-${{ env.VERSION }}.tgz
+          retention-days: 3

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,6 +1,15 @@
-FROM registry.suse.com/bci/bci-base:15.4.27.14.8
-ARG ARCH
-ENV ARCH=$ARCH
-COPY bin/fleetcontroller-linux-${ARCH} /usr/bin/fleetcontroller
+ARG BUILD_ENV=dapper
+
+FROM registry.suse.com/bci/bci-base:15.4.27.14.8 AS base
 USER 1000
+
+FROM base AS copy_dapper
+ONBUILD ARG ARCH
+ONBUILD COPY bin/fleetcontroller-linux-${ARCH} /usr/bin/fleetcontroller
+
+FROM base AS copy_buildx
+ONBUILD ARG TARGETARCH
+ONBUILD COPY bin/fleetcontroller-linux-${TARGETARCH} /usr/bin/fleetcontroller
+
+FROM copy_${BUILD_ENV}
 CMD ["fleetcontroller"]

--- a/package/Dockerfile.agent
+++ b/package/Dockerfile.agent
@@ -1,8 +1,18 @@
-FROM registry.suse.com/bci/bci-base:15.4.27.14.8
-ARG ARCH
-ENV ARCH=$ARCH
+ARG BUILD_ENV=dapper
+
+FROM registry.suse.com/bci/bci-base:15.4.27.14.8 AS base
 RUN zypper in --no-recommends -y git bash openssh && groupadd -g 1000 fleet-apply && useradd -u 1000 -g 1000 -m fleet-apply; rm -fr /var/cache/* /var/log/*log
-COPY bin/fleetagent-linux-$ARCH /usr/bin/fleetagent
-COPY bin/fleet-linux-$ARCH /usr/bin/fleet
 COPY package/log.sh /usr/bin/
+
+FROM base AS copy_dapper
+ONBUILD ARG ARCH
+ONBUILD COPY bin/fleetagent-linux-$ARCH /usr/bin/fleetagent
+ONBUILD COPY bin/fleet-linux-$ARCH /usr/bin/fleet
+
+FROM base AS copy_buildx
+ONBUILD ARG TARGETARCH
+ONBUILD COPY bin/fleetagent-linux-$TARGETARCH /usr/bin/fleetagent
+ONBUILD COPY bin/fleet-linux-$TARGETARCH /usr/bin/fleet
+
+FROM copy_${BUILD_ENV}
 CMD ["fleetagent"]


### PR DESCRIPTION
fixes #1072

Images are pushed to ghcr.io, helm charts are attached to the Github Actions run.
It was not possible to use goreleaser, since "nightly" builds are a "pro" feature.