### PR TITLE
Add support to continuous pprof CPU profiling

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -256,6 +256,41 @@ That being said, downstream `fleet-agent` deployments can perform Kubernetes API
 While network traffic is major point of consideration, we also have to consider whether our performance issues are **compute-based**, **memory-based**, or **network-based**.
 For example: you may encounter a pod with high compute usage, but that could be caused by heightened network traffic received from the _truly_ malfunctioning pod.
 
+### Using pprof
+
+[http pprof](https://pkg.go.dev/net/http/pprof) handlers are enabled by default with all [default profiles](https://pkg.go.dev/runtime/pprof#Profile) under the `/debug/pprof` prefix.
+
+Additionally, it is possible to enable continuous CPU profiling for `fleetcontroller` to observe how CPU usage changes over time.
+
+Add the following extra Helm values:
+```yaml
+cpuPprof:
+  period: "60s"
+  volumeConfiguration:
+    hostPath:
+      path: /tmp/pprof
+      type: DirectoryOrCreate
+```
+
+Notes:
+ - `period` is the pprof CPU period and can be changed with any other value
+ - `volumeConfiguration` can be any valid volume configuration (not necessarily `hostPath`)
+
+Alternatively, use the following Helm commandline arguments:
+```
+--set cpuPprof.period=60s \
+--set cpuPprof.volumeConfiguration.hostPath.path=/tmp/pprof \
+--set cpuPprof.volumeConfiguration.hostPath.type=DirectoryOrCreate \
+```
+
+If using `hostPath`, make sure that the target directory (`/tmp/pprof` in above examples) is writable.
+
+Profiles can be inspected with the [pprof tool](https://github.com/google/pprof), eg.:
+
+```sh
+pprof -http=localhost:5000 ./2022-11-04_19_47_18.pprof.fleetcontroller.samples.cpu.pb.gz
+```
+
 ### Tips and Tricks
 
 Since the Fleet components' controller framework of choice is [Wrangler](https://github.com/rancher/wrangler), we can share caches and avoid unnecessary API requests.

--- a/charts/fleet/templates/deployment.yaml
+++ b/charts/fleet/templates/deployment.yaml
@@ -25,6 +25,14 @@ spec:
         - name: NO_PROXY
           value: {{ .Values.noProxy }}
         {{- end }}
+        {{- if .Values.cpuPprof }}
+        - name: FLEET_CPU_PPROF_DIR
+          value: /tmp/pprof/
+        {{- end }}
+        {{- if .Values.cpuPprof }}
+        - name: FLEET_CPU_PPROF_PERIOD
+          value: {{ quote .Values.cpuPprof.period }}
+        {{- end }}
         image: '{{ template "system_default_registry" . }}{{ .Values.image.repository }}:{{ .Values.image.tag }}'
         name: fleet-controller
         imagePullPolicy: "{{ .Values.image.imagePullPolicy }}"
@@ -42,6 +50,16 @@ spec:
         {{- if not .Values.gitops.enabled }}
         - --disable-gitops
         {{- end }}
+        {{- if .Values.cpuPprof }}
+        volumeMounts:
+          - mountPath: /tmp/pprof
+            name: pprof
+        {{- end }}
+      {{- if .Values.cpuPprof }}
+      volumes:
+        - name: pprof {{ toYaml .Values.cpuPprof.volumeConfiguration | nindent 10 }}
+      {{- end }}
+
       serviceAccountName: fleet-controller
       nodeSelector: {{ include "linux-node-selector" . | nindent 8 }}
 {{- if .Values.nodeSelector }}

--- a/charts/fleet/values.yaml
+++ b/charts/fleet/values.yaml
@@ -61,3 +61,12 @@ gitops:
 
 debug: false
 debugLevel: 0
+
+## Optional CPU pprof configuration. Profiles are collected continuously and saved every period
+## Any valid volume configuration can be provided, the example below uses hostPath
+#cpuPprof:
+#  period: "60s"
+#  volumeConfiguration:
+#    hostPath:
+#      path: /tmp/pprof
+#      type: DirectoryOrCreate

--- a/cmd/fleetcontroller/main.go
+++ b/cmd/fleetcontroller/main.go
@@ -2,9 +2,17 @@
 package main
 
 import (
+	"context"
 	"log"
 	"net/http"
 	_ "net/http/pprof"
+	"os"
+	"path"
+	"runtime/pprof"
+	"time"
+
+	"github.com/rancher/fleet/pkg/durations"
+	"k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/spf13/cobra"
 
@@ -28,6 +36,7 @@ type FleetManager struct {
 }
 
 func (f *FleetManager) Run(cmd *cobra.Command, args []string) error {
+	setupCpuPprof(cmd.Context())
 	go func() {
 		log.Println(http.ListenAndServe("localhost:6060", nil)) // nolint:gosec // Debugging only
 	}()
@@ -42,6 +51,49 @@ func (f *FleetManager) Run(cmd *cobra.Command, args []string) error {
 
 	<-cmd.Context().Done()
 	return nil
+}
+
+// setupCpuPprof starts a goroutine that captures a cpu pprof profile
+// into FLEET_CPU_PPROF_DIR every FLEET_CPU_PPROF_PERIOD
+func setupCpuPprof(ctx context.Context) {
+	if dir, ok := os.LookupEnv("FLEET_CPU_PPROF_DIR"); ok {
+		go func() {
+			var pprofCpuFile *os.File
+
+			period := durations.DefaultCpuPprofPeriod
+			if customPeriod, err := time.ParseDuration(os.Getenv("FLEET_CPU_PPROF_PERIOD")); err == nil {
+				period = customPeriod
+			}
+			wait.UntilWithContext(ctx, func(ctx context.Context) {
+				stopCpuPprof(pprofCpuFile)
+				pprofCpuFile = startCpuPprof(dir)
+			}, period)
+		}()
+	}
+}
+
+// stopCpuPprof concludes a cpu pprof capture, if any is ongoing
+func stopCpuPprof(f *os.File) {
+	pprof.StopCPUProfile()
+	if f != nil {
+		err := f.Close()
+		if err != nil {
+			log.Println("could not close CPU profile file ", err)
+		}
+	}
+}
+
+// startCpuPprof starts a pprof cpu capture into a timestamp-prefixed file in dir
+func startCpuPprof(dir string) *os.File {
+	name := time.Now().UTC().Format("2006-01-02_15_04_05") + ".pprof.fleetcontroller.samples.cpu.pb.gz"
+	f, err := os.Create(path.Join(dir, name))
+	if err != nil {
+		log.Println("could not create CPU profile: ", err)
+	}
+	if err := pprof.StartCPUProfile(f); err != nil {
+		log.Println("could not start CPU profile: ", err)
+	}
+	return f
 }
 
 func main() {

--- a/pkg/durations/durations.go
+++ b/pkg/durations/durations.go
@@ -23,4 +23,5 @@ const (
 	ServiceTokenSleep              = time.Second * 2
 	TokenClusterEnqueueDelay       = time.Second * 2
 	TriggerSleep                   = time.Second * 2
+	DefaultCpuPprofPeriod          = time.Minute
 )


### PR DESCRIPTION
This PR adds Helm chart values to configure continuous [pprof](https://pkg.go.dev/runtime/pprof#hdr-Profiling_a_Go_program) CPU profiling on fleetcontroller.

Since CPU pprof profiling requires a writer to stream data to, this PR creates an optional volume and environment variables to configure it.

## Test

To test this pull request:

- install Fleet with the following extra Helm values:

```yaml
cpuPprof:
  period: "60s"
  volumeConfiguration:
    hostPath:
      path: /tmp/pprof
      type: DirectoryOrCreate
```

Alternatively, use the following Helm commandline arguments:

```
--set cpuPprof.period=60s \
--set cpuPprof.volumeConfiguration.hostPath.path=/tmp/pprof \
--set cpuPprof.volumeConfiguration.hostPath.type=DirectoryOrCreate \
```

- make sure that `/tmp/pprof` is writable
- start Fleet
- after some minutes, check contents of `/tmp/pprof`. It is expected a `2022-11-04_19_47_18.pprof.fleetcontroller.samples.cpu.pb.gz` file is created every minute
- profiles can be inspected with:

```sh
pprof -http=localhost:5000 ./2022-11-04_19_47_18.pprof.fleetcontroller.samples.cpu.pb.gz
```

Output can be formatted as flame graph, eg.:

![example flame graph](https://user-images.githubusercontent.com/250541/200064221-08fb4cfd-1032-441f-9770-4fb16052b850.png)


## Additional Information

### Tradeoff

The volume type could be hard-coded to simplify the values file, at the expense of flexibility.

### Potential improvement

Code could be migrated to wrangler and applied to all wrangler-based projects.
