### PR TITLE
Scaling: fold bundle display controller handler into main bundle controller

### DIFF
--- a/pkg/controllers/bundle/controller.go
+++ b/pkg/controllers/bundle/controller.go
@@ -3,6 +3,7 @@ package bundle
 
 import (
 	"context"
+	"fmt"
 	"sort"
 	"time"
 
@@ -191,6 +192,12 @@ func (h *handler) OnBundleChange(bundle *fleet.Bundle, status fleet.BundleStatus
 	objs := toRuntimeObjects(targets, bundle)
 
 	elapsed := time.Since(start)
+
+	status.Display.ReadyClusters = fmt.Sprintf("%d/%d",
+		status.Summary.Ready,
+		status.Summary.DesiredReady)
+	status.Display.State = string(summary.GetSummaryState(status.Summary))
+
 	logrus.Debugf("OnBundleChange for bundle '%s' took %s", bundle.Name, elapsed)
 
 	return objs, status, nil

--- a/pkg/controllers/display/displaycontrollers.go
+++ b/pkg/controllers/display/displaycontrollers.go
@@ -29,17 +29,6 @@ func Register(ctx context.Context,
 	fleetcontrollers.RegisterClusterGroupStatusHandler(ctx, clustergroups, "", "clustergroup-display", h.OnClusterGroupChange)
 	fleetcontrollers.RegisterGitRepoStatusHandler(ctx, gitrepos, "", "gitrepo-display", h.OnRepoChange)
 	fleetcontrollers.RegisterBundleDeploymentStatusHandler(ctx, bundledeployments, "", "bundledeployment-display", h.OnBundleDeploymentChange)
-	fleetcontrollers.RegisterBundleStatusHandler(ctx, bundles, "", "bundle-display", h.OnBundleChange)
-}
-
-func (h *handler) OnBundleChange(bundle *fleet.Bundle, status fleet.BundleStatus) (fleet.BundleStatus, error) {
-	logrus.Debugf("OnBundleChange: bundle %s changed, updating its status.Display", bundle.Name)
-	status.Display.ReadyClusters = fmt.Sprintf("%d/%d",
-		status.Summary.Ready,
-		status.Summary.DesiredReady)
-	status.Display.State = string(summary.GetSummaryState(status.Summary))
-
-	return status, nil
 }
 
 func (h *handler) OnClusterChange(cluster *fleet.Cluster, status fleet.ClusterStatus) (fleet.ClusterStatus, error) {


### PR DESCRIPTION
Potentially fixes or helps with:
- #606
- #721
- https://jira.suse.com/browse/SURE-4967
- https://jira.suse.com/browse/SURE-3613
- https://jira.suse.com/browse/SURE-3597

Every time a bundle changes:
- the `bundle/controller.go`'s `OnBundleChange` handler fires
- the handler code changes the bundle's `Status`
- that, in turn, fires `displaycontrollers.go`'s `OnBundleChange` handler

Both of those handler return objects that are applied via wrangler's `apply` facility, which can be heavy on the CPU.

In a user's large setup case, `apply` is fired ~24 times/s and takes up the majority of CPU time (in purple below):

![flame graph](https://user-images.githubusercontent.com/250541/200337687-e7731521-5e9b-49b5-8ffd-68f98e0ed664.png)

This PR folds the two handlers together, thereby reducing the number of `apply` calls by 50%.

## Test

This PR should be seen as an internal-only refactoring, no user-visible behavior should change.

