### PR TITLE
[EXPERIMENTAL] Avoid wrangler 3-way merge in bundle/controller

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.18
 
 replace (
 	github.com/rancher/fleet/pkg/apis => ./pkg/apis
+	github.com/rancher/wrangler => github.com/moio/wrangler v0.0.0-20221108212643-8df82c78249b
 	helm.sh/helm/v3 => github.com/rancher/helm/v3 v3.9.0-rancher1
 	k8s.io/api => k8s.io/api v0.24.5
 	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.24.5

--- a/go.sum
+++ b/go.sum
@@ -800,6 +800,8 @@ github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3Rllmb
 github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/mohae/deepcopy v0.0.0-20170603005431-491d3605edfb/go.mod h1:TaXosZuwdSHYgviHp1DAtfrULt5eUgsSMsZf+YrPgl8=
+github.com/moio/wrangler v0.0.0-20221108212643-8df82c78249b h1:0Uqajap3opBkdt1xipEe1z7YwyNnaGygfkD80k606wM=
+github.com/moio/wrangler v0.0.0-20221108212643-8df82c78249b/go.mod h1:Blhan9LdaIJjC9w+xGteSrHHEiIFIdPEHEMrtx82dPk=
 github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 h1:n6/2gBQ3RWajuToeY6ZtZTIKv2v7ThUy5KKusIT0yc0=
 github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00/go.mod h1:Pm3mSP3c5uWn86xMLZ5Sa7JB9GsEZySvHYXCTK4E9q4=
 github.com/morikuni/aec v1.0.0 h1:nP9CBfwrvYnBRgY6qfDQkygYDmYwOilePFkwzv4dU8A=
@@ -913,8 +915,6 @@ github.com/rancher/helm/v3 v3.9.0-rancher1 h1:lqDYFI2AmkDn6Jwzu9A3YKr8EJ34ZmdahR
 github.com/rancher/helm/v3 v3.9.0-rancher1/go.mod h1:fzZfyslcPAWwSdkXrXlpKexFeE2Dei8N27FFQWt+PN0=
 github.com/rancher/lasso v0.0.0-20220519004610-700f167d8324 h1:yi3gGq+tBqkMppIY2gLDidDMtxr6ajcoWxJ6HaLI0TA=
 github.com/rancher/lasso v0.0.0-20220519004610-700f167d8324/go.mod h1:T6WoUopOHBWTGjnphruTJAgoZ+dpm6llvn6GDYaa7Kw=
-github.com/rancher/wrangler v1.0.1-0.20220623232707-cc833dd0d546 h1:OCC9GH8IkXHG4JzujwjdDXRgTQ4TFfDG7i1NHj0nwi4=
-github.com/rancher/wrangler v1.0.1-0.20220623232707-cc833dd0d546/go.mod h1:Blhan9LdaIJjC9w+xGteSrHHEiIFIdPEHEMrtx82dPk=
 github.com/rancher/wrangler-cli v0.0.0-20220624114648-479c5692ba22 h1:ADMwgJyVwmLXJBSm/nNobB1XGSmFCTA+TY/otxgIPu4=
 github.com/rancher/wrangler-cli v0.0.0-20220624114648-479c5692ba22/go.mod h1:vyO9SU60oplNFa5ZqoEAFWmYKgj2F6remdy8p6H0SgI=
 github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446/go.mod h1:uYEyJGbgTkfkS4+E/PavXkNJcbFIpEtjt2B0KDQ5+9M=

--- a/pkg/controllers/bundle/controller.go
+++ b/pkg/controllers/bundle/controller.go
@@ -64,7 +64,7 @@ func Register(ctx context.Context,
 	// This handler is triggered for bundles.OnChange
 	fleetcontrollers.RegisterBundleGeneratingHandler(ctx,
 		bundles,
-		apply.WithCacheTypes(bundleDeployments),
+		apply.WithCacheTypes(bundleDeployments).WithIgnorePreviousApplied(),
 		"Processed",
 		"bundle",
 		h.OnBundleChange,


### PR DESCRIPTION
Potentially fixes or helps with:
- #606
- #721
- https://jira.suse.com/browse/SURE-4967
- https://jira.suse.com/browse/SURE-3613
- https://jira.suse.com/browse/SURE-3597


Premise: wrangler's apply mechanism uses a three way patch calculated from the original object (latest version that was ever applied), the current object (as it is currently in the cluster) and the new object (passed as argument to apply). The original object is serialized and stored in a special annotation (LabelApplied) every time an apply occurs - to be available for the next apply. A similar mechanism is implemented in kubectl apply, which inspired wrangler apply.

The above mechanism means any object processed by wrangler's apply will be serialized to JSON, gzipped and base64 encoded into an annotation (and vice versa) every time Apply is called. This can be CPU intensive if it happens very frequently, and for some handlers might be unnecessary.

This patch aims at disabling the mechanism for the bundle/controller OnBundleChange handler.

Please do not merge until the [EXPERIMENTAL] title tag is removed!

