### PR TITLE
[EXPERIMENTAL] Bundle controller optimization

### DIFF
--- a/pkg/controllers/bundle/controller.go
+++ b/pkg/controllers/bundle/controller.go
@@ -402,5 +402,5 @@ func resetDeployment(target *target.Target, status *fleet.BundleStatus) {
 	}
 
 	status.NewlyCreated++
-	target.AssignNewDeployment()
+	target.ResetDeployment()
 }

--- a/pkg/controllers/bundle/controller.go
+++ b/pkg/controllers/bundle/controller.go
@@ -354,7 +354,7 @@ func (h *handler) updateStatusAndTargets(status *fleet.BundleStatus, allTargets 
 			updateTarget(currentTarget, status, &partition.Status)
 		}
 
-		if target.IsPartitionUnavailable(&partition.Status, partition.Targets) {
+		if target.UpdateStatusUnavailable(&partition.Status, partition.Targets) {
 			status.UnavailablePartitions++
 		}
 

--- a/pkg/controllers/bundle/controller.go
+++ b/pkg/controllers/bundle/controller.go
@@ -340,7 +340,7 @@ func (h *handler) updateStatusAndTargets(status *fleet.BundleStatus, allTargets 
 	for _, partition := range partitions {
 		for _, target := range partition.Targets {
 			if target.Deployment == nil {
-				newTarget(target, status)
+				resetDeployment(target, status)
 			}
 			if target.Deployment != nil {
 				// NOTE merged options from targets.Targets() are set to be staged
@@ -395,8 +395,8 @@ func updateTarget(t *target.Target, status *fleet.BundleStatus, partitionStatus 
 	}
 }
 
-// newTarget resets target's Deployment with a new one and updates status accordingly
-func newTarget(target *target.Target, status *fleet.BundleStatus) {
+// resetDeployment resets target's Deployment with a new one and updates status accordingly
+func resetDeployment(target *target.Target, status *fleet.BundleStatus) {
 	if status.NewlyCreated >= status.MaxNew {
 		return
 	}

--- a/pkg/controllers/bundle/controller.go
+++ b/pkg/controllers/bundle/controller.go
@@ -190,8 +190,7 @@ func (h *handler) OnBundleChange(bundle *fleet.Bundle, status fleet.BundleStatus
 		return nil, status, err
 	}
 
-	// NOTE this mutates allTargets and adds new deployments
-	if err := h.calculateChanges(&status, matchedTargets); err != nil {
+	if err := h.updateStatusAndTargets(&status, matchedTargets); err != nil {
 		return nil, status, err
 	}
 
@@ -310,10 +309,10 @@ func bundleDeployments(targets []*target.Target, bundle *fleet.Bundle) (result [
 	return
 }
 
-// calculateChanges recomputes status, including partitions, from data in allTargets
+// updateStatusAndTargets recomputes status, including partitions, from data in allTargets
 // it creates Deployments in allTargets if they are missing
 // it updates Deployments in allTargets if they are out of sync (DeploymentID != StagedDeploymentID)
-func (h *handler) calculateChanges(status *fleet.BundleStatus, allTargets []*target.Target) (err error) {
+func (h *handler) updateStatusAndTargets(status *fleet.BundleStatus, allTargets []*target.Target) (err error) {
 	// reset
 	status.MaxNew = maxNew
 	status.Summary = fleet.BundleSummary{}

--- a/pkg/options/calculate.go
+++ b/pkg/options/calculate.go
@@ -26,7 +26,7 @@ func DeploymentID(manifest *manifest.Manifest, opts fleet.BundleDeploymentOption
 	return digest + ":" + hex.EncodeToString(h.Sum(nil)), nil
 }
 
-// Merge overrides the 'base' options with the 'next' options, if 'next' is present.
+// Merge overrides the 'base' options with the 'next' options, if 'next' is present (pure function)
 func Merge(base, next fleet.BundleDeploymentOptions) fleet.BundleDeploymentOptions { // nolint: gocyclo // business logic
 	result := *base.DeepCopy()
 	if next.DefaultNamespace != "" {

--- a/pkg/summary/summary.go
+++ b/pkg/summary/summary.go
@@ -82,6 +82,7 @@ func GetSummaryState(summary fleet.BundleSummary) fleet.BundleState {
 	return state
 }
 
+// GetDeploymentState calculates a fleet.BundleState from bundleDeployment (pure function)
 func GetDeploymentState(bundleDeployment *fleet.BundleDeployment) fleet.BundleState {
 	switch {
 	case bundleDeployment.Status.AppliedDeploymentID != bundleDeployment.Spec.DeploymentID:
@@ -100,6 +101,8 @@ func GetDeploymentState(bundleDeployment *fleet.BundleDeployment) fleet.BundleSt
 	}
 }
 
+// SetReadyConditions expects a status object as obj and updates its ready conditions according to summary
+// as per ReadyMessage
 func SetReadyConditions(obj interface{}, referencedKind string, summary fleet.BundleSummary) {
 	if reflect.ValueOf(obj).Kind() != reflect.Ptr {
 		panic("obj passed must be a pointer")
@@ -119,6 +122,7 @@ func MessageFromCondition(conditionType string, conds []genericcondition.Generic
 	return ""
 }
 
+// MessageFromDeployment returns a relevant message from the deployment conditions (pure function)
 func MessageFromDeployment(deployment *fleet.BundleDeployment) string {
 	if deployment == nil {
 		return ""

--- a/pkg/target/partition.go
+++ b/pkg/target/partition.go
@@ -13,7 +13,7 @@ type Partition struct {
 	Targets []*Target
 }
 
-// Partitions distributes targets into partitions based on the rollout strategy
+// Partitions distributes targets into partitions based on the rollout strategy (pure function)
 func Partitions(targets []*Target) ([]Partition, error) {
 	rollout := getRollout(targets)
 	if len(rollout.Partitions) == 0 {
@@ -23,6 +23,7 @@ func Partitions(targets []*Target) ([]Partition, error) {
 	return manualPartition(rollout, targets)
 }
 
+// manualPartition computes a slice of Partition given some targets and rollout strategy that already has partitions (pure function)
 func manualPartition(rollout *fleet.RolloutStrategy, targets []*Target) ([]Partition, error) {
 	var (
 		partitions []Partition
@@ -54,6 +55,7 @@ func manualPartition(rollout *fleet.RolloutStrategy, targets []*Target) ([]Parti
 	return partitions, nil
 }
 
+// appendPartition appends a new partition to partitions with partitionTargets as targets (does not mutate partitionTargets)
 func appendPartition(partitions []Partition, name string, partitionTargets []*Target, maxUnavailable ...*intstr.IntOrString) ([]Partition, error) {
 	maxUnavailableValue, err := limit(len(partitionTargets), maxUnavailable...)
 	if err != nil {
@@ -71,6 +73,7 @@ func appendPartition(partitions []Partition, name string, partitionTargets []*Ta
 	}), nil
 }
 
+// autoPartition computes a slice of Partition given some targets and rollout strategy (pure function)
 func autoPartition(rollout *fleet.RolloutStrategy, targets []*Target) ([]Partition, error) {
 	// if auto is disabled
 	if rollout.AutoPartitionSize != nil && rollout.AutoPartitionSize.Type == intstr.Int &&

--- a/pkg/target/target.go
+++ b/pkg/target/target.go
@@ -388,8 +388,8 @@ func (t *Target) IsPaused() bool {
 		t.Bundle.Spec.Paused
 }
 
-// AssignNewDeployment builds a new BundleDeployment for the target.
-func (t *Target) AssignNewDeployment() {
+// ResetDeployment replaces the BundleDeployment for the target with a new one
+func (t *Target) ResetDeployment() {
 	labels := map[string]string{}
 	for k, v := range deploymentLabelsForNewBundle(t.Bundle) {
 		labels[k] = v

--- a/pkg/target/target.go
+++ b/pkg/target/target.go
@@ -476,7 +476,9 @@ func MaxUnavailablePartitions(partitions []Partition, targets []*Target) (int, e
 	return limit(len(partitions), rollout.MaxUnavailablePartitions, &defMaxUnavailablePartitions)
 }
 
-func IsPartitionUnavailable(status *fleet.PartitionStatus, targets []*Target) bool {
+// UpdateStatusUnavailable recomputes and sets the status.Unavailable counter and returns true iff the partition
+// is unavailable, eg. there are more unavailable targets than the maximum set (does not mutate targets)
+func UpdateStatusUnavailable(status *fleet.PartitionStatus, targets []*Target) bool {
 	// Unavailable for a partition is stricter than unavailable for a target.
 	// For a partition a target must be available and update to date.
 	status.Unavailable = 0

--- a/pkg/target/target.go
+++ b/pkg/target/target.go
@@ -344,7 +344,7 @@ func (m *Manager) foldInDeployments(bundle *fleet.Bundle, targets []*Target) err
 
 	byNamespace := map[string]*fleet.BundleDeployment{}
 	for _, bd := range bundleDeployments {
-		byNamespace[bd.Namespace] = bd.DeepCopy()
+		byNamespace[bd.Namespace] = bd
 	}
 
 	for _, target := range targets {

--- a/pkg/target/target.go
+++ b/pkg/target/target.go
@@ -404,6 +404,7 @@ func (t *Target) AssignNewDeployment() {
 	}
 }
 
+// getRollout returns the rollout strategy for the specified targets (pure function)
 func getRollout(targets []*Target) *fleet.RolloutStrategy {
 	var rollout *fleet.RolloutStrategy
 	if len(targets) > 0 {
@@ -463,11 +464,13 @@ func limit(count int, val ...*intstr.IntOrString) (int, error) {
 	return i, nil
 }
 
+// MaxUnavailable returns the maximum number of unavailable deployments given the targets rollout strategy (pure function)
 func MaxUnavailable(targets []*Target) (int, error) {
 	rollout := getRollout(targets)
 	return limit(len(targets), rollout.MaxUnavailable)
 }
 
+// MaxUnavailablePartitions returns the maximum number of unavailable partitions given the targets and partitions (pure function)
 func MaxUnavailablePartitions(partitions []Partition, targets []*Target) (int, error) {
 	rollout := getRollout(targets)
 	return limit(len(partitions), rollout.MaxUnavailablePartitions, &defMaxUnavailablePartitions)
@@ -486,6 +489,7 @@ func IsPartitionUnavailable(status *fleet.PartitionStatus, targets []*Target) bo
 	return status.Unavailable > status.MaxUnavailable
 }
 
+// upToDate returns true if the target is up to date (pure function)
 func upToDate(target *Target) bool {
 	if target.Deployment == nil ||
 		target.Deployment.Spec.StagedDeploymentID != target.DeploymentID ||
@@ -497,6 +501,7 @@ func upToDate(target *Target) bool {
 	return true
 }
 
+// Unavailable counts the number of targets that are not available (pure function)
 func Unavailable(targets []*Target) (count int) {
 	for _, target := range targets {
 		if target.Deployment == nil {
@@ -509,6 +514,7 @@ func Unavailable(targets []*Target) (count int) {
 	return
 }
 
+// IsUnavailable checks if target is not available (pure function)
 func IsUnavailable(target *fleet.BundleDeployment) bool {
 	if target == nil {
 		return false
@@ -531,6 +537,7 @@ func (t *Target) nonReady() []fleet.NonReadyStatus {
 	return t.Deployment.Status.NonReadyStatus
 }
 
+// state calculates a fleet.BundleState from t (pure function)
 func (t *Target) state() fleet.BundleState {
 	switch {
 	case t.Deployment == nil:
@@ -540,10 +547,12 @@ func (t *Target) state() fleet.BundleState {
 	}
 }
 
+// message returns a relevant message from the target (pure function)
 func (t *Target) message() string {
 	return summary.MessageFromDeployment(t.Deployment)
 }
 
+// Summary calculates a fleet.BundleSummary from targets (pure function)
 func Summary(targets []*Target) fleet.BundleSummary {
 	var bundleSummary fleet.BundleSummary
 	for _, currentTarget := range targets {


### PR DESCRIPTION
Potentially fixes or helps with:
- #606
- #721
- https://jira.suse.com/browse/SURE-4967
- https://jira.suse.com/browse/SURE-3613
- https://jira.suse.com/browse/SURE-3597


Premise: wrangler's apply mechanism uses a `kubectl apply`-inspired three way patch mechanism to update custom resources. Such mechanism requires any applied resource to be serialized/deserialized to JSON, gzipped/ungzipped and base64 encoded/decoded every time. In some circumstances apply may be applied for many objects very frequently, bringing to a CPU bottleneck.

This patch aims at minimizing objects returned by the `OnBundleChange` handler, in hope of reducing CPU load in a high-scale scenario.

Please do not merge until the [EXPERIMENTAL] title tag is removed!