### PR TITLE
Fix external helm chart targetCustomization test

### DIFF
--- a/e2e/assets/multi-cluster/helm-target-customizations.yaml
+++ b/e2e/assets/multi-cluster/helm-target-customizations.yaml
@@ -4,7 +4,7 @@ metadata:
   name: helm-target-customizations
 spec:
   repo: https://github.com/rancher/fleet-examples
-  branch: add_target_customizations_test
+  branch: add_target_customizations_test2
   paths:
   - multi-cluster/helm-target-customizations/
   targets:

--- a/e2e/multi-cluster/multi_cluster_test.go
+++ b/e2e/multi-cluster/multi_cluster_test.go
@@ -133,7 +133,7 @@ var _ = Describe("Multi Cluster Examples", func() {
 			})
 
 			It("can replace the chart version and url", func() {
-				expectedVersion := "0.0.36"
+				expectedVersion := "6.5.0"
 
 				// Verify bundledeployment changes
 				Eventually(func() string {
@@ -144,13 +144,13 @@ var _ = Describe("Multi Cluster Examples", func() {
 				Eventually(func() string {
 					out, _ := helmRepo("helm-target-customizations")
 					return out
-				}).Should(ContainSubstring("https://charts.truecharts.org///"))
+				}).Should(ContainSubstring("https://oauth2-proxy.github.io/manifests///"))
 
 				// Verify actual deployment downstream
 				Eventually(func() string {
-					out, _ := kd.Get("deployments", "-A", "-l", "helm.sh/chart=radicale-"+expectedVersion)
+					out, _ := kd.Get("deployments", "-A", "-l", "helm.sh/chart=oauth2-proxy-"+expectedVersion)
 					return out
-				}).Should(ContainSubstring("radicale"))
+				}).Should(ContainSubstring("oauth2-proxy"))
 			})
 		})
 	})


### PR DESCRIPTION
this is a small app which seems not to delete old versions so hopefully it should be stable for the foreseeable future.

The alternative would be to create our own app versions on GitHub and use them but this would be almost the same as our OCI test.