### PR TITLE
Fix waiting on agent in CI setup

### DIFF
--- a/.github/scripts/deploy-fleet-latest-release.sh
+++ b/.github/scripts/deploy-fleet-latest-release.sh
@@ -8,7 +8,7 @@ controller_url=$(echo "$assets" | jq -r '.[] | select(.name | test("fleet-\\d.*.
 helm -n cattle-fleet-system upgrade --install --create-namespace --wait fleet-crd "$crd_url"
 helm -n cattle-fleet-system upgrade --install --create-namespace --wait fleet "$controller_url"
 
-# wait
+# wait for controller and agent rollout
 kubectl -n cattle-fleet-system rollout status deploy/fleet-controller
-{ grep -q -m 1 "fleet-agent"; kill $!; } < <(kubectl get deployment -n cattle-fleet-system -w)
+{ grep -E -q -m 1 "fleet-agent-local.*1/1"; kill $!; } < <(kubectl get bundles -n fleet-local -w)
 kubectl -n cattle-fleet-system rollout status deploy/fleet-agent

--- a/.github/scripts/deploy-fleet.sh
+++ b/.github/scripts/deploy-fleet.sh
@@ -24,7 +24,7 @@ helm upgrade --install fleet charts/fleet \
   --set agentImage.tag="$agentTag" \
   --set agentImage.imagePullPolicy=IfNotPresent
 
-# wait
+# wait for controller and agent rollout
 kubectl -n cattle-fleet-system rollout status deploy/fleet-controller
-{ grep -q -m 1 "fleet-agent"; kill $!; } < <(kubectl get deployment -n cattle-fleet-system -w)
+{ grep -E -q -m 1 "fleet-agent-local.*1/1"; kill $!; } < <(kubectl get bundles -n fleet-local -w)
 kubectl -n cattle-fleet-system rollout status deploy/fleet-agent

--- a/.github/scripts/setup-latest-rancher.sh
+++ b/.github/scripts/setup-latest-rancher.sh
@@ -21,8 +21,10 @@ helm upgrade rancher rancher-latest/rancher \
   --set "extraEnv[0].value=https://$url" \
   --set "extraEnv[1].name=CATTLE_BOOTSTRAP_PASSWORD" \
   --set "extraEnv[1].value=rancherpassword"
+
 # wait for deployment of rancher
 kubectl -n cattle-system rollout status deploy/rancher
+
 # wait for rancher to create fleet namespace, deployment and controller
 { grep -q -m 1 "fleet"; kill $!; } < <(kubectl get deployments -n cattle-fleet-system -w)
 kubectl -n cattle-fleet-system rollout status deploy/fleet-controller

--- a/.github/scripts/upgrade-rancher-fleet-to-dev-fleet.sh
+++ b/.github/scripts/upgrade-rancher-fleet-to-dev-fleet.sh
@@ -38,19 +38,11 @@ helm upgrade fleet charts/fleet \
 kubectl -n cattle-fleet-system rollout status deploy/fleet-controller
 helm list -A
 
-kubectl config use-context k3d-downstream
+# wait for fleet agent bundle for downstream cluster
+sleep 5
+{ grep -E -q -m 1 "fleet-agent-cluster.*1/1"; kill $!; } < <(kubectl get bundles -n fleet-local -w)
 
-# wait for fleet to be up on downstream cluster
-sleep 30
-{ grep -q -m 1 "cattle-fleet-system"; kill $!; } < <(kubectl get namespace -w)
-{ grep -q -m 1 "fleet-agent"; kill $!; } < <(kubectl get deployment -n cattle-fleet-system -w)
-# FLAKE: rollout fails: object has been deleted
-# https://github.com/manno/fleet/issues/4
+kubectl config use-context k3d-downstream
 kubectl -n cattle-fleet-system rollout status deploy/fleet-agent
-# FLAKE: infinite loop
-until helm list -A | grep -q "fleet-agent.*cattle-fleet-system.*deployed"; do
-  echo waiting for fleet agent helm chart
-  helm list -A
-  sleep 3
-done
+
 helm list -A

--- a/dev/setup-fleet
+++ b/dev/setup-fleet
@@ -14,5 +14,5 @@ helm -n cattle-fleet-system upgrade --install --create-namespace --wait --reset-
 
 # wait for it
 kubectl -n cattle-fleet-system rollout status deploy/fleet-controller
-{ grep -q -m 1 "fleet-agent"; kill $!; } < <(kubectl get deployment -n cattle-fleet-system -w)
+{ grep -E -q -m 1 "fleet-agent-local.*1/1"; kill $!; } < <(kubectl get bundles -n fleet-local -w)
 kubectl -n cattle-fleet-system rollout status deploy/fleet-agent


### PR DESCRIPTION
The local agent is rolled out twice, previously our CI would sometimes flake if it tried to wait for the rollout.

```
Waiting for deployment "fleet-agent" rollout to finish: 0 out of 1 new replicas have been updated...
Waiting for deployment "fleet-agent" rollout to finish: 0 of 1 updated replicas are available...
error: object has been deleted
```

Fleet re-deployed the deployment. This might be an issue in fleet in general, but most likely this is due to fleet's registration for the local cluster. It will create the deployment (import cluster) and then later the bundle for that deployment (manageagent), thus "adopting" the deployment.

We can wait for the bundle to be ready, instead of waiting for namespaces, deployments and helm charts.

```
% kubectl get bundles -Aw
fleet-local   fleet-agent-local
fleet-local   fleet-agent-local                             Pending(1) [Cluster fleet-local/local]
fleet-local   fleet-agent-local   0/1                       Pending(1) [Cluster fleet-local/local]
fleet-local   fleet-agent-local   0/1                       WaitApplied(1) [Cluster fleet-local/local]
fleet-local   fleet-agent-local   0/1                       WaitApplied(1) [Cluster fleet-local/local]
fleet-local   fleet-agent-local   0/1                       NotReady(1) [Cluster fleet-local/local]
fleet-local   fleet-agent-local   0/1                       NotReady(1) [Cluster fleet-local/local]
fleet-local   fleet-agent-local   0/1                       NotReady(1) [Cluster fleet-local/local]; deployment.apps cattle-fleet-system/fleet-agent [progressing] Pending termination: 1
fleet-local   fleet-agent-local   0/1
fleet-local   fleet-agent-local   1/1
```
