### PR TITLE
Do not fail on missing labels

### DIFF
--- a/pkg/target/target.go
+++ b/pkg/target/target.go
@@ -576,7 +576,7 @@ func processLabelValues(valuesMap map[string]interface{}, clusterLabels map[stri
 				valuesMap[key] = labelVal
 			} else {
 				valuesMap[key] = ""
-				logrus.Infof("invalid_label_reference %s in key %s", valStr, key)
+				logrus.Infof("Cluster label '%s' for key '%s' is missing from some clusters, setting value to empty string for these clusters.", valStr, key)
 			}
 		}
 

--- a/pkg/target/target.go
+++ b/pkg/target/target.go
@@ -575,7 +575,8 @@ func processLabelValues(valuesMap map[string]interface{}, clusterLabels map[stri
 			if labelPresent {
 				valuesMap[key] = labelVal
 			} else {
-				return fmt.Errorf("invalid_label_reference %s in key %s", valStr, key)
+				valuesMap[key] = ""
+				logrus.Infof("invalid_label_reference %s in key %s", valStr, key)
 			}
 		}
 


### PR DESCRIPTION
because if only one cluster misses the label the whole bundle deployments fails.

Fix #689

## Additional Information

### Tradeoff

Deployments on some clusters might fail if the label is not available.