### PR TITLE
Introduce parameter to debug controller but not agents

### DIFF
--- a/charts/fleet/templates/deployment.yaml
+++ b/charts/fleet/templates/deployment.yaml
@@ -17,6 +17,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: FLEET_PROPAGATE_DEBUG_SETTINGS_TO_AGENTS
+          value: {{ quote .Values.propagateDebugSettingsToAgents }}
         {{- if .Values.proxy }}
         - name: HTTP_PROXY
           value: {{ .Values.proxy }}

--- a/charts/fleet/values.yaml
+++ b/charts/fleet/values.yaml
@@ -61,6 +61,7 @@ gitops:
 
 debug: false
 debugLevel: 0
+propagateDebugSettingsToAgents: true
 
 ## Optional CPU pprof configuration. Profiles are collected continuously and saved every period
 ## Any valid volume configuration can be provided, the example below uses hostPath

--- a/pkg/agent/manifest.go
+++ b/pkg/agent/manifest.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"os"
 	"path"
 	"strconv"
 	"strings"
@@ -88,8 +89,9 @@ func Manifest(namespace string, agentScope string, opts ManifestOptions) []runti
 	// DefaultAgentImage = "rancher/fleet-agent" + ":" + version.Version
 	image := resolve(opts.SystemDefaultRegistry, opts.PrivateRepoURL, opts.AgentImage)
 
-	// if debug is enabled in controller, enable in agent too
-	debug := logrus.IsLevelEnabled(logrus.DebugLevel)
+	// if debug is enabled in controller, enable in agents too (unless otherwise specified)
+	propagateDebug, _ := strconv.ParseBool(os.Getenv("FLEET_PROPAGATE_DEBUG_SETTINGS_TO_AGENTS"))
+	debug := logrus.IsLevelEnabled(logrus.DebugLevel) && propagateDebug
 	dep := agentDeployment(namespace, DefaultName, image, opts.AgentImagePullPolicy, DefaultName, false, debug)
 	dep.Spec.Template.Spec.Containers[0].Env = append(dep.Spec.Template.Spec.Containers[0].Env,
 		corev1.EnvVar{


### PR DESCRIPTION
This adds a Helm configuration parameter to selectively debug the fleet controller (without fleet agents).

This contrasts with the current behavior which is to always set the same debug level on both.

Especially in large-scale scenarios, it is undesirable to have all agents restart when temporarily debugging the controller.

## Test

Install with the following Helm options:

```
--set debug=true --set propagateDebugSettingsToAgents=false
```

Or the equivalent `values.yaml` variables.

 - Check that debug logging is enabled on the fleet-controller deployment (there should be a `--debug` line)
 - Check that debug logging is *not* enabled on the fleet-agent deployment (there should *not* be a `--debug` line)


