### PR TITLE
Add CLI to generate reference docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@
 *.DS_Store
 /fleet
 /.vscode
+docs/fleet-agent/
+docs/fleet-cli/
+docs/fleet-controller/

--- a/cmd/docs/generate-cli-docs.go
+++ b/cmd/docs/generate-cli-docs.go
@@ -1,0 +1,148 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/pkg/errors"
+
+	fleetagent "github.com/rancher/fleet/modules/agent/cmds"
+	fleetcli "github.com/rancher/fleet/modules/cli/cmds"
+	fleetcontroller "github.com/rancher/fleet/modules/controller/cmds"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/cobra/doc"
+)
+
+func main() {
+	docDir := filepath.Join("./", os.Args[1])
+
+	// fleet cli for gitjob
+	cmd := fleetcli.App()
+	cmd.DisableAutoGenTag = true
+
+	err := generateCmdDoc(cmd, filepath.Join(docDir, "fleet-cli"))
+	if err != nil {
+		panic(err)
+	}
+
+	// fleet agent controller
+	cmd = fleetagent.App()
+	cmd.DisableAutoGenTag = true
+
+	err = generateCmdDoc(cmd, filepath.Join(docDir, "fleet-agent"))
+	if err != nil {
+		panic(err)
+	}
+
+	// fleet controller
+	cmd = fleetcontroller.App()
+	cmd.DisableAutoGenTag = true
+
+	err = generateCmdDoc(cmd, filepath.Join(docDir, "fleet-controller"))
+	if err != nil {
+		panic(err)
+	}
+
+}
+
+// generateCmdDoc will generate the documentation for the given command, in the given directory
+func generateCmdDoc(cmd *cobra.Command, dir string) error {
+	if cmd.Hidden {
+		return nil
+	}
+
+	// create the directory if it doesn't exist
+	err := os.MkdirAll(dir, 0700)
+	if err != nil {
+		return errors.Wrapf(err, "error creating directory [%s]", dir)
+	}
+
+	// create the documentation for the given command
+	err = createMarkdownFile(cmd, dir)
+	if err != nil {
+		return errors.Wrapf(err, "error creating markdown file for command [%s]", cmd.Name())
+	}
+
+	// create the documentation for its subcommands
+	for _, subcmd := range cmd.Commands() {
+		// if the subcommand does not have other subcommands, just generate the doc and continue
+		if !subcmd.HasSubCommands() {
+			err = createMarkdownFile(subcmd, dir)
+			if err != nil {
+				return errors.Wrapf(err, "error creating markdown file for command [%s]", subcmd.Name())
+			}
+			continue
+		}
+
+		// if the subcommand has other subcommands, then recurse in its own directory
+		subdir := filepath.Join(dir, subcmd.Name())
+		err = generateCmdDoc(subcmd, subdir)
+		if err != nil {
+			return errors.Wrapf(err, "error generating doc for command [%s]", subcmd.Name())
+		}
+	}
+
+	return nil
+}
+
+// createMarkdownFile will create the markdown file for the given command in the given directory
+func createMarkdownFile(cmd *cobra.Command, dir string) error {
+	// skip 'help' command
+	if cmd.Name() == "help" {
+		return nil
+	}
+
+	basename := strings.Replace(cmd.CommandPath(), " ", "_", -1) + ".md"
+	filename := filepath.Join(dir, basename)
+
+	f, err := os.Create(filename)
+	if err != nil {
+		return errors.Wrap(err, "error creating file")
+	}
+	defer f.Close()
+
+	err = writeFileHeader(f, cmd.CommandPath())
+	if err != nil {
+		return errors.Wrapf(err, "error writing file header for command [%s]", cmd.Name())
+	}
+
+	err = doc.GenMarkdownCustom(cmd, f, linkHandler(cmd, dir))
+	return errors.Wrap(err, "error generating markdown custom")
+}
+
+// linkHandler will return a function that will handle the markdown link generation
+func linkHandler(cmd *cobra.Command, _ string) func(link string) string {
+	return func(link string) string {
+		link = strings.TrimSuffix(link, ".md")
+		cmdPathLink := strings.ReplaceAll(link, "_", " ")
+
+		// check if the link was referring to the parent command
+		// we also need to check if the current command has subcommands, because if it does not then the link needs to point to the same directory
+		if cmd.HasParent() && cmd.Parent().CommandPath() == cmdPathLink && cmd.HasSubCommands() {
+			return "../" + link
+		}
+
+		for _, subcmd := range cmd.Commands() {
+			// if the subcommand has other subcommands then it will have its own directory
+			if subcmd.CommandPath() == cmdPathLink && subcmd.HasSubCommands() {
+				return fmt.Sprintf("./%s/%s", subcmd.Name(), link)
+			}
+		}
+
+		return "./" + link
+	}
+}
+
+func writeFileHeader(w io.Writer, sidebarLabel string) error {
+	_, err := fmt.Fprintf(w, `---
+title: ""
+sidebar_label: "%s"
+---
+`, sidebarLabel)
+
+	return errors.Wrap(err, "error writing file header")
+}

--- a/cmd/fleetagent/main.go
+++ b/cmd/fleetagent/main.go
@@ -2,67 +2,13 @@
 package main
 
 import (
-	"fmt"
-	"log"
-	"net/http"
 	_ "net/http/pprof"
-	"time"
 
-	"github.com/spf13/cobra"
-
-	"github.com/rancher/fleet/modules/agent/pkg/agent"
-	"github.com/rancher/fleet/modules/agent/pkg/simulator"
-	"github.com/rancher/fleet/pkg/version"
+	"github.com/rancher/fleet/modules/agent/cmds"
 
 	command "github.com/rancher/wrangler-cli"
 )
 
-var (
-	debugConfig command.DebugConfig
-)
-
-type FleetAgent struct {
-	Kubeconfig      string `usage:"kubeconfig file"`
-	Namespace       string `usage:"namespace to watch" env:"NAMESPACE"`
-	AgentScope      string `usage:"An identifier used to scope the agent bundleID names, typically the same as namespace" env:"AGENT_SCOPE"`
-	Simulators      int    `usage:"Numbers of simulators to run"`
-	CheckinInterval string `usage:"How often to post cluster status" env:"CHECKIN_INTERVAL"`
-}
-
-func (a *FleetAgent) Run(cmd *cobra.Command, args []string) error {
-	go func() {
-		log.Println(http.ListenAndServe("localhost:6060", nil)) // nolint:gosec // Debugging only
-	}()
-
-	debugConfig.MustSetupDebug()
-	var (
-		opts agent.Options
-		err  error
-	)
-
-	if a.CheckinInterval != "" {
-		opts.CheckinInterval, err = time.ParseDuration(a.CheckinInterval)
-		if err != nil {
-			return err
-		}
-	}
-	if a.Namespace == "" {
-		return fmt.Errorf("--namespace or env NAMESPACE is required to be set")
-	}
-	if a.Simulators > 0 {
-		return simulator.Simulate(cmd.Context(), a.Simulators, a.Kubeconfig, a.Namespace, "default", opts)
-	}
-	if err := agent.Start(cmd.Context(), a.Kubeconfig, a.Namespace, a.AgentScope, &opts); err != nil {
-		return err
-	}
-	<-cmd.Context().Done()
-	return nil
-}
-
 func main() {
-	cmd := command.Command(&FleetAgent{}, cobra.Command{
-		Version: version.FriendlyVersion(),
-	})
-	cmd = command.AddDebug(cmd, &debugConfig)
-	command.Main(cmd)
+	command.Main(cmds.App())
 }

--- a/cmd/fleetcontroller/main.go
+++ b/cmd/fleetcontroller/main.go
@@ -2,104 +2,15 @@
 package main
 
 import (
-	"context"
-	"log"
-	"net/http"
 	_ "net/http/pprof"
-	"os"
-	"path"
-	"runtime/pprof"
-	"time"
 
-	"github.com/rancher/fleet/pkg/durations"
-	"k8s.io/apimachinery/pkg/util/wait"
-
-	"github.com/spf13/cobra"
-
-	"github.com/rancher/fleet/pkg/agent"
-	"github.com/rancher/fleet/pkg/fleetcontroller"
-	"github.com/rancher/fleet/pkg/version"
+	controller "github.com/rancher/fleet/modules/controller/cmds"
 
 	command "github.com/rancher/wrangler-cli"
 	_ "github.com/rancher/wrangler/pkg/generated/controllers/apiextensions.k8s.io"
 	_ "github.com/rancher/wrangler/pkg/generated/controllers/networking.k8s.io"
 )
 
-var (
-	debugConfig command.DebugConfig
-)
-
-type FleetManager struct {
-	Kubeconfig    string `usage:"Kubeconfig file"`
-	Namespace     string `usage:"namespace to watch" default:"cattle-fleet-system" env:"NAMESPACE"`
-	DisableGitops bool   `usage:"disable gitops components" name:"disable-gitops"`
-}
-
-func (f *FleetManager) Run(cmd *cobra.Command, args []string) error {
-	setupCpuPprof(cmd.Context())
-	go func() {
-		log.Println(http.ListenAndServe("localhost:6060", nil)) // nolint:gosec // Debugging only
-	}()
-	debugConfig.MustSetupDebug()
-	if err := fleetcontroller.Start(cmd.Context(), f.Namespace, f.Kubeconfig, f.DisableGitops); err != nil {
-		return err
-	}
-
-	if debugConfig.Debug {
-		agent.DebugLevel = debugConfig.DebugLevel
-	}
-
-	<-cmd.Context().Done()
-	return nil
-}
-
-// setupCpuPprof starts a goroutine that captures a cpu pprof profile
-// into FLEET_CPU_PPROF_DIR every FLEET_CPU_PPROF_PERIOD
-func setupCpuPprof(ctx context.Context) {
-	if dir, ok := os.LookupEnv("FLEET_CPU_PPROF_DIR"); ok {
-		go func() {
-			var pprofCpuFile *os.File
-
-			period := durations.DefaultCpuPprofPeriod
-			if customPeriod, err := time.ParseDuration(os.Getenv("FLEET_CPU_PPROF_PERIOD")); err == nil {
-				period = customPeriod
-			}
-			wait.UntilWithContext(ctx, func(ctx context.Context) {
-				stopCpuPprof(pprofCpuFile)
-				pprofCpuFile = startCpuPprof(dir)
-			}, period)
-		}()
-	}
-}
-
-// stopCpuPprof concludes a cpu pprof capture, if any is ongoing
-func stopCpuPprof(f *os.File) {
-	pprof.StopCPUProfile()
-	if f != nil {
-		err := f.Close()
-		if err != nil {
-			log.Println("could not close CPU profile file ", err)
-		}
-	}
-}
-
-// startCpuPprof starts a pprof cpu capture into a timestamp-prefixed file in dir
-func startCpuPprof(dir string) *os.File {
-	name := time.Now().UTC().Format("2006-01-02_15_04_05") + ".pprof.fleetcontroller.samples.cpu.pb.gz"
-	f, err := os.Create(path.Join(dir, name))
-	if err != nil {
-		log.Println("could not create CPU profile: ", err)
-	}
-	if err := pprof.StartCPUProfile(f); err != nil {
-		log.Println("could not start CPU profile: ", err)
-	}
-	return f
-}
-
 func main() {
-	cmd := command.Command(&FleetManager{}, cobra.Command{
-		Version: version.FriendlyVersion(),
-	})
-	cmd = command.AddDebug(cmd, &debugConfig)
-	command.Main(cmd)
+	command.Main(controller.App())
 }

--- a/go.mod
+++ b/go.mod
@@ -109,6 +109,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/chai2010/gettext-go v0.0.0-20170215093142-bf70f2a70fb1 // indirect
 	github.com/containerd/containerd v1.6.6 // indirect
+	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect
 	github.com/cyphar/filepath-securejoin v0.2.3 // indirect
 	github.com/dimchansky/utfbom v1.1.1 // indirect
 	github.com/docker/cli v20.10.20+incompatible // indirect
@@ -216,6 +217,7 @@ require (
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/rubenv/sql-migrate v1.1.2 // indirect
 	github.com/russross/blackfriday v1.6.0 // indirect
+	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/ryanuber/go-glob v1.0.0 // indirect
 	github.com/sergi/go-diff v1.2.0 // indirect
 	github.com/shopspring/decimal v1.3.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -262,6 +262,7 @@ github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfc
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.1/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
+github.com/cpuguy83/go-md2man/v2 v2.0.2 h1:p1EgwI/C7NhT0JmVkwCD2ZBK8j4aeHQX2pMHHBfMQ6w=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.11 h1:07n33Z8lZxZ2qwegKbObQohDhXDQxiMMz1NOUGYlesw=
@@ -933,6 +934,7 @@ github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR
 github.com/russross/blackfriday v1.6.0 h1:KqfZb0pUVN2lYqZUYRddxF4OR8ZMURnJIG5Y3VRLtww=
 github.com/russross/blackfriday v1.6.0/go.mod h1:ti0ldHuxg49ri4ksnFxlkCfN+hvslNlmVHqNRXXJNAY=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/ryanuber/columnize v2.1.0+incompatible/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=

--- a/modules/agent/cmds/root.go
+++ b/modules/agent/cmds/root.go
@@ -1,0 +1,65 @@
+package cmds
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/rancher/fleet/modules/agent/pkg/agent"
+	"github.com/rancher/fleet/modules/agent/pkg/simulator"
+	"github.com/rancher/fleet/pkg/version"
+
+	command "github.com/rancher/wrangler-cli"
+)
+
+var (
+	debugConfig command.DebugConfig
+)
+
+type FleetAgent struct {
+	Kubeconfig      string `usage:"kubeconfig file"`
+	Namespace       string `usage:"namespace to watch" env:"NAMESPACE"`
+	AgentScope      string `usage:"An identifier used to scope the agent bundleID names, typically the same as namespace" env:"AGENT_SCOPE"`
+	Simulators      int    `usage:"Numbers of simulators to run"`
+	CheckinInterval string `usage:"How often to post cluster status" env:"CHECKIN_INTERVAL"`
+}
+
+func (a *FleetAgent) Run(cmd *cobra.Command, args []string) error {
+	go func() {
+		log.Println(http.ListenAndServe("localhost:6060", nil)) // nolint:gosec // Debugging only
+	}()
+
+	debugConfig.MustSetupDebug()
+	var (
+		opts agent.Options
+		err  error
+	)
+
+	if a.CheckinInterval != "" {
+		opts.CheckinInterval, err = time.ParseDuration(a.CheckinInterval)
+		if err != nil {
+			return err
+		}
+	}
+	if a.Namespace == "" {
+		return fmt.Errorf("--namespace or env NAMESPACE is required to be set")
+	}
+	if a.Simulators > 0 {
+		return simulator.Simulate(cmd.Context(), a.Simulators, a.Kubeconfig, a.Namespace, "default", opts)
+	}
+	if err := agent.Start(cmd.Context(), a.Kubeconfig, a.Namespace, a.AgentScope, &opts); err != nil {
+		return err
+	}
+	<-cmd.Context().Done()
+	return nil
+}
+
+func App() *cobra.Command {
+	cmd := command.Command(&FleetAgent{}, cobra.Command{
+		Version: version.FriendlyVersion(),
+	})
+	return command.AddDebug(cmd, &debugConfig)
+}

--- a/modules/controller/cmds/root.go
+++ b/modules/controller/cmds/root.go
@@ -1,0 +1,100 @@
+package controller
+
+import (
+	"context"
+	"log"
+	"net/http"
+	"os"
+	"path"
+	"runtime/pprof"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	"github.com/rancher/fleet/pkg/agent"
+	"github.com/rancher/fleet/pkg/durations"
+	"github.com/rancher/fleet/pkg/fleetcontroller"
+	"github.com/rancher/fleet/pkg/version"
+
+	command "github.com/rancher/wrangler-cli"
+)
+
+var (
+	debugConfig command.DebugConfig
+)
+
+type FleetManager struct {
+	Kubeconfig    string `usage:"Kubeconfig file"`
+	Namespace     string `usage:"namespace to watch" default:"cattle-fleet-system" env:"NAMESPACE"`
+	DisableGitops bool   `usage:"disable gitops components" name:"disable-gitops"`
+}
+
+func (f *FleetManager) Run(cmd *cobra.Command, args []string) error {
+	setupCpuPprof(cmd.Context())
+	go func() {
+		log.Println(http.ListenAndServe("localhost:6060", nil)) // nolint:gosec // Debugging only
+	}()
+	debugConfig.MustSetupDebug()
+	if err := fleetcontroller.Start(cmd.Context(), f.Namespace, f.Kubeconfig, f.DisableGitops); err != nil {
+		return err
+	}
+
+	if debugConfig.Debug {
+		agent.DebugLevel = debugConfig.DebugLevel
+	}
+
+	<-cmd.Context().Done()
+	return nil
+}
+
+func App() *cobra.Command {
+	cmd := command.Command(&FleetManager{}, cobra.Command{
+		Version: version.FriendlyVersion(),
+	})
+	return command.AddDebug(cmd, &debugConfig)
+}
+
+// setupCpuPprof starts a goroutine that captures a cpu pprof profile
+// into FLEET_CPU_PPROF_DIR every FLEET_CPU_PPROF_PERIOD
+func setupCpuPprof(ctx context.Context) {
+	if dir, ok := os.LookupEnv("FLEET_CPU_PPROF_DIR"); ok {
+		go func() {
+			var pprofCpuFile *os.File
+
+			period := durations.DefaultCpuPprofPeriod
+			if customPeriod, err := time.ParseDuration(os.Getenv("FLEET_CPU_PPROF_PERIOD")); err == nil {
+				period = customPeriod
+			}
+			wait.UntilWithContext(ctx, func(ctx context.Context) {
+				stopCpuPprof(pprofCpuFile)
+				pprofCpuFile = startCpuPprof(dir)
+			}, period)
+		}()
+	}
+}
+
+// stopCpuPprof concludes a cpu pprof capture, if any is ongoing
+func stopCpuPprof(f *os.File) {
+	pprof.StopCPUProfile()
+	if f != nil {
+		err := f.Close()
+		if err != nil {
+			log.Println("could not close CPU profile file ", err)
+		}
+	}
+}
+
+// startCpuPprof starts a pprof cpu capture into a timestamp-prefixed file in dir
+func startCpuPprof(dir string) *os.File {
+	name := time.Now().UTC().Format("2006-01-02_15_04_05") + ".pprof.fleetcontroller.samples.cpu.pb.gz"
+	f, err := os.Create(path.Join(dir, name))
+	if err != nil {
+		log.Println("could not create CPU profile: ", err)
+	}
+	if err := pprof.StartCPUProfile(f); err != nil {
+		log.Println("could not start CPU profile: ", err)
+	}
+	return f
+}


### PR DESCRIPTION
Copied from Epinio.
Importing 'main' as a package is not possible, so extracting the cobra command generation into separate packages, like 'fleet cli' already did.

refers to #1102 
