### PR TITLE
Revert "Refactoring: avoid needless DeepCopy, the object is not mutated"

### DIFF
--- a/pkg/target/target.go
+++ b/pkg/target/target.go
@@ -344,7 +344,7 @@ func (m *Manager) foldInDeployments(bundle *fleet.Bundle, targets []*Target) err
 
 	byNamespace := map[string]*fleet.BundleDeployment{}
 	for _, bd := range bundleDeployments {
-		byNamespace[bd.Namespace] = bd
+		byNamespace[bd.Namespace] = bd.DeepCopy()
 	}
 
 	for _, target := range targets {


### PR DESCRIPTION
This change was preventing Fleet triggering on GitJob changes shown by our "updating a git repository" test.

This reverts commit 866a6159256064aca810c7f3e6fa3fd2e073c37a.