### PR TITLE
Bump wrangler version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -49,7 +49,7 @@ require (
 	github.com/rancher/fleet/pkg/apis v0.0.0
 	github.com/rancher/gitjob v0.1.30
 	github.com/rancher/lasso v0.0.0-20220519004610-700f167d8324
-	github.com/rancher/wrangler v1.0.1-0.20220623232707-cc833dd0d546
+	github.com/rancher/wrangler v1.0.1-0.20221128225625-672366f64635
 	github.com/rancher/wrangler-cli v0.0.0-20220624114648-479c5692ba22
 	github.com/sirupsen/logrus v1.9.0
 	github.com/spf13/cobra v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -913,8 +913,8 @@ github.com/rancher/helm/v3 v3.9.0-rancher1 h1:lqDYFI2AmkDn6Jwzu9A3YKr8EJ34ZmdahR
 github.com/rancher/helm/v3 v3.9.0-rancher1/go.mod h1:fzZfyslcPAWwSdkXrXlpKexFeE2Dei8N27FFQWt+PN0=
 github.com/rancher/lasso v0.0.0-20220519004610-700f167d8324 h1:yi3gGq+tBqkMppIY2gLDidDMtxr6ajcoWxJ6HaLI0TA=
 github.com/rancher/lasso v0.0.0-20220519004610-700f167d8324/go.mod h1:T6WoUopOHBWTGjnphruTJAgoZ+dpm6llvn6GDYaa7Kw=
-github.com/rancher/wrangler v1.0.1-0.20220623232707-cc833dd0d546 h1:OCC9GH8IkXHG4JzujwjdDXRgTQ4TFfDG7i1NHj0nwi4=
-github.com/rancher/wrangler v1.0.1-0.20220623232707-cc833dd0d546/go.mod h1:Blhan9LdaIJjC9w+xGteSrHHEiIFIdPEHEMrtx82dPk=
+github.com/rancher/wrangler v1.0.1-0.20221128225625-672366f64635 h1:MG6oL7YhCf1w6RCYiBnPF8sexeyPMJQmoKUWqrA8bAk=
+github.com/rancher/wrangler v1.0.1-0.20221128225625-672366f64635/go.mod h1:Blhan9LdaIJjC9w+xGteSrHHEiIFIdPEHEMrtx82dPk=
 github.com/rancher/wrangler-cli v0.0.0-20220624114648-479c5692ba22 h1:ADMwgJyVwmLXJBSm/nNobB1XGSmFCTA+TY/otxgIPu4=
 github.com/rancher/wrangler-cli v0.0.0-20220624114648-479c5692ba22/go.mod h1:vyO9SU60oplNFa5ZqoEAFWmYKgj2F6remdy8p6H0SgI=
 github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446/go.mod h1:uYEyJGbgTkfkS4+E/PavXkNJcbFIpEtjt2B0KDQ5+9M=


### PR DESCRIPTION
Main motivation is to get https://github.com/rancher/wrangler/pull/232, which I had tested locally extensively over the past several weeks.

Additional unrelated changes brought in are:
- https://github.com/rancher/wrangler/pull/212 (documentation only)
- https://github.com/rancher/wrangler/pull/207 (dependabot)
- https://github.com/rancher/wrangler/pull/220 (documentation only)
- https://github.com/rancher/wrangler/pull/226 (formerly private fields/methods now made public)
- https://github.com/rancher/wrangler/pull/240 (improve behavior on SIGTERM, helps with https://github.com/rancher/fleet/issues/1096)

Therefore my understanding is that the bump should be a relatively safe one.