### PR TITLE
Allow to run longer before killing leader during debugging

### DIFF
--- a/charts/fleet/templates/deployment.yaml
+++ b/charts/fleet/templates/deployment.yaml
@@ -33,6 +33,10 @@ spec:
         - name: FLEET_CPU_PPROF_PERIOD
           value: {{ quote .Values.cpuPprof.period }}
         {{- end }}
+        {{- if .Values.debug }}
+        - name: CATTLE_DEV_MODE
+          value: "true"
+        {{- end }}
         image: '{{ template "system_default_registry" . }}{{ .Values.image.repository }}:{{ .Values.image.tag }}'
         name: fleet-controller
         imagePullPolicy: "{{ .Values.image.imagePullPolicy }}"


### PR DESCRIPTION
This PR leverages [a recent wrangler change](https://github.com/rancher/wrangler/pull/240) to allow breakpoint-setting with debuggers such as Delve.

When stopping on a breakpoint, we want leader election to last longer and not kill the process, which was the previous behavior.

Requires: #1136 

