### PR TITLE
fleet apply: allow debugging

### DIFF
--- a/modules/cli/cmds/apply.go
+++ b/modules/cli/cmds/apply.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -41,6 +42,14 @@ type Apply struct {
 }
 
 func (a *Apply) Run(cmd *cobra.Command, args []string) error {
+	if wfd := os.Getenv("WAIT_FOR_DEBUGGER"); wfd != "" {
+		// When connected with an interactive debugger, change the value of waitForDebugger to false
+		waitForDebugger := true
+		for waitForDebugger {
+			time.Sleep(1 * time.Second)
+		}
+	}
+
 	labels := a.Label
 	if a.Commit == "" {
 		a.Commit = currentCommit()


### PR DESCRIPTION
This adds mechanisms to attach a debugger (specifically Delve) to fleet apply.

That means:

1. disabling the security context if DEBUG is set
2. passing over one extra environment variable
3. sitting in a loop at the start of fleet apply to get a chance to attach the debugger

Point 3. is implemented in an admittedly hacky way, but I do not really know of better alternatives at this point.

@manno let me know if this patch is acceptable or not.