### PR TITLE
Limit recursion depth for cluster label replacement in values

### DIFF
--- a/pkg/options/calculate.go
+++ b/pkg/options/calculate.go
@@ -26,85 +26,85 @@ func DeploymentID(manifest *manifest.Manifest, opts fleet.BundleDeploymentOption
 	return digest + ":" + hex.EncodeToString(h.Sum(nil)), nil
 }
 
-// Merge overrides the 'base' options with the 'next' options, if 'next' is present (pure function)
-func Merge(base, next fleet.BundleDeploymentOptions) fleet.BundleDeploymentOptions { // nolint: gocyclo // business logic
+// Merge overrides the 'base' options with the 'target customization' options, if 'custom' is present (pure function)
+func Merge(base, custom fleet.BundleDeploymentOptions) fleet.BundleDeploymentOptions { // nolint: gocyclo // business logic
 	result := *base.DeepCopy()
-	if next.DefaultNamespace != "" {
-		result.DefaultNamespace = next.DefaultNamespace
-	} else if next.DefaultNamespace == "-" {
+	if custom.DefaultNamespace != "" {
+		result.DefaultNamespace = custom.DefaultNamespace
+	} else if custom.DefaultNamespace == "-" {
 		result.DefaultNamespace = ""
 	}
-	if next.TargetNamespace != "" {
-		result.TargetNamespace = next.TargetNamespace
-	} else if next.TargetNamespace == "-" {
+	if custom.TargetNamespace != "" {
+		result.TargetNamespace = custom.TargetNamespace
+	} else if custom.TargetNamespace == "-" {
 		result.TargetNamespace = ""
 	}
-	if next.ServiceAccount != "" {
-		result.ServiceAccount = next.ServiceAccount
-	} else if next.ServiceAccount == "-" {
+	if custom.ServiceAccount != "" {
+		result.ServiceAccount = custom.ServiceAccount
+	} else if custom.ServiceAccount == "-" {
 		result.ServiceAccount = ""
 	}
-	if next.ServiceAccount != "" {
-		result.ServiceAccount = next.ServiceAccount
-	} else if next.ServiceAccount == "-" {
+	if custom.ServiceAccount != "" {
+		result.ServiceAccount = custom.ServiceAccount
+	} else if custom.ServiceAccount == "-" {
 		result.ServiceAccount = ""
 	}
-	if next.Helm != nil {
+	if custom.Helm != nil {
 		if result.Helm == nil {
 			result.Helm = &fleet.HelmOptions{}
 		}
-		if next.Helm.TimeoutSeconds > 0 {
-			result.Helm.TimeoutSeconds = next.Helm.TimeoutSeconds
-		} else if next.Helm.TimeoutSeconds < 0 {
+		if custom.Helm.TimeoutSeconds > 0 {
+			result.Helm.TimeoutSeconds = custom.Helm.TimeoutSeconds
+		} else if custom.Helm.TimeoutSeconds < 0 {
 			result.Helm.TimeoutSeconds = 0
 		}
 		if result.Helm.Values == nil {
-			result.Helm.Values = next.Helm.Values
-		} else if next.Helm.Values != nil {
-			result.Helm.Values.Data = data.MergeMaps(result.Helm.Values.Data, next.Helm.Values.Data)
+			result.Helm.Values = custom.Helm.Values
+		} else if custom.Helm.Values != nil {
+			result.Helm.Values.Data = data.MergeMaps(result.Helm.Values.Data, custom.Helm.Values.Data)
 		}
-		if next.Helm.ValuesFrom != nil {
-			result.Helm.ValuesFrom = append(result.Helm.ValuesFrom, next.Helm.ValuesFrom...)
+		if custom.Helm.ValuesFrom != nil {
+			result.Helm.ValuesFrom = append(result.Helm.ValuesFrom, custom.Helm.ValuesFrom...)
 		}
-		if next.Helm.Repo != "" {
-			result.Helm.Repo = next.Helm.Repo
+		if custom.Helm.Repo != "" {
+			result.Helm.Repo = custom.Helm.Repo
 		}
-		if next.Helm.Chart != "" {
-			result.Helm.Chart = next.Helm.Chart
+		if custom.Helm.Chart != "" {
+			result.Helm.Chart = custom.Helm.Chart
 		}
-		if next.Helm.Version != "" {
-			result.Helm.Version = next.Helm.Version
+		if custom.Helm.Version != "" {
+			result.Helm.Version = custom.Helm.Version
 		}
-		if next.Helm.ReleaseName != "" {
-			result.Helm.ReleaseName = next.Helm.ReleaseName
+		if custom.Helm.ReleaseName != "" {
+			result.Helm.ReleaseName = custom.Helm.ReleaseName
 		}
-		result.Helm.Force = result.Helm.Force || next.Helm.Force
-		result.Helm.Atomic = result.Helm.Atomic || next.Helm.Atomic
-		result.Helm.TakeOwnership = result.Helm.TakeOwnership || next.Helm.TakeOwnership
-		result.Helm.DisablePreProcess = result.Helm.DisablePreProcess || next.Helm.DisablePreProcess
+		result.Helm.Force = result.Helm.Force || custom.Helm.Force
+		result.Helm.Atomic = result.Helm.Atomic || custom.Helm.Atomic
+		result.Helm.TakeOwnership = result.Helm.TakeOwnership || custom.Helm.TakeOwnership
+		result.Helm.DisablePreProcess = result.Helm.DisablePreProcess || custom.Helm.DisablePreProcess
 	}
-	if next.Kustomize != nil {
+	if custom.Kustomize != nil {
 		if result.Kustomize == nil {
 			result.Kustomize = &fleet.KustomizeOptions{}
 		}
-		if next.Kustomize.Dir != "" {
-			result.Kustomize.Dir = next.Kustomize.Dir
+		if custom.Kustomize.Dir != "" {
+			result.Kustomize.Dir = custom.Kustomize.Dir
 		}
 	}
-	if next.Diff != nil {
+	if custom.Diff != nil {
 		if result.Diff == nil {
 			result.Diff = &fleet.DiffOptions{}
 		}
-		result.Diff.ComparePatches = append(result.Diff.ComparePatches, next.Diff.ComparePatches...)
+		result.Diff.ComparePatches = append(result.Diff.ComparePatches, custom.Diff.ComparePatches...)
 	}
-	if next.YAML != nil {
+	if custom.YAML != nil {
 		if result.YAML == nil {
 			result.YAML = &fleet.YAMLOptions{}
 		}
-		result.YAML.Overlays = append(result.YAML.Overlays, next.YAML.Overlays...)
+		result.YAML.Overlays = append(result.YAML.Overlays, custom.YAML.Overlays...)
 	}
-	if next.ForceSyncGeneration > 0 {
-		result.ForceSyncGeneration = next.ForceSyncGeneration
+	if custom.ForceSyncGeneration > 0 {
+		result.ForceSyncGeneration = custom.ForceSyncGeneration
 	}
 	return result
 }

--- a/pkg/target/target_test.go
+++ b/pkg/target/target_test.go
@@ -46,7 +46,7 @@ func TestProcessLabelValues(t *testing.T) {
 		t.Fatalf("error during yaml parsing %v", err)
 	}
 
-	err = processLabelValues(bundle.Helm.Values.Data, clusterLabels)
+	err = processLabelValues(bundle.Helm.Values.Data, clusterLabels, 0)
 	if err != nil {
 		t.Fatalf("error during label processing %v", err)
 	}


### PR DESCRIPTION
Let's merge this after https://github.com/rancher/fleet/pull/671 is in.

* adds recursion depth check to cluster label replacement
* rename "next" to "custom", because it is the value from  the current "targetCustomization"
* extract cluster label replacement string "global.fleet.clusterLabels." into a constant to make it more visible