### PR TITLE
Upsert bootstrap cluster

### DIFF
--- a/pkg/controllers/config/controller.go
+++ b/pkg/controllers/config/controller.go
@@ -1,4 +1,4 @@
-// Package config reads the initial global configuration. (fleetcontroller)
+// Package config reads and monitors the fleet-controller configuration. (fleetcontroller)
 package config
 
 import (

--- a/pkg/controllers/controllers.go
+++ b/pkg/controllers/controllers.go
@@ -212,7 +212,8 @@ func Register(ctx context.Context, systemNamespace string, cfg clientcmd.ClientC
 		appCtx.ClientConfig,
 		appCtx.Core.ServiceAccount().Cache(),
 		appCtx.Core.Secret(),
-		appCtx.Core.Secret().Cache())
+		appCtx.Core.Secret().Cache(),
+		appCtx.Cluster().Cache())
 
 	display.Register(ctx,
 		appCtx.Cluster(),


### PR DESCRIPTION
When the bootstrap config changes, the local cluster resource might be overwritten.

### Notes

I upgraded Rancher 2.6.9 to 2.7.0 and `kubectl get cm -w -n cattle-fleet-system fleet-controller` indicated a change.
The cluster resource is rewritten and the labels change, however the manually created label stays.
Rancher's cluster sync eventually copies the management.cattle.io labels back. The name=local label appears, but is removed during the sync.
The `objectset.rio.cattle.io/id:` changes from `fleet-cluster` to `fleet-bootstrap` and back.

E.g. after editing the agentInterval in the fleet-controller configmap:

```
---
apiVersion: fleet.cattle.io/v1alpha1
kind: Cluster
metadata:
  annotations:
    objectset.rio.cattle.io/id: fleet-cluster
    objectset.rio.cattle.io/owner-gvk: provisioning.cattle.io/v1, Kind=Cluster
    objectset.rio.cattle.io/owner-name: local
    objectset.rio.cattle.io/owner-namespace: fleet-local
  creationTimestamp: "2022-12-07T13:06:09Z"
  generation: 2
  labels:
    test: label
    management.cattle.io/cluster-display-name: local
    management.cattle.io/cluster-name: local
    objectset.rio.cattle.io/hash: f2a8a9999a85e11ff83654e61cec3a781479fbf7
    provider.cattle.io: k3s
  name: local
  namespace: fleet-local
  resourceVersion: "9707"
status:
  agent:
    lastSeen: "2022-12-07T13:12:26Z"
    namespace: cattle-fleet-local-system
    nonReadyNodeNames: null
    nonReadyNodes: 0
    readyNodeNames:
    - k3d-upstream-server-0
    - k3d-upstream-server-1
    - k3d-upstream-server-2
    readyNodes: 3
  agentDeployedGeneration: 0
  agentMigrated: true
  agentNamespaceMigrated: true
  cattleNamespaceMigrated: true
  conditions:
  - lastUpdateTime: "2022-12-07T13:12:18Z"
    status: "True"
    type: Ready
  - lastUpdateTime: "2022-12-07T13:12:26Z"
    status: "True"
    type: Processed
---
apiVersion: fleet.cattle.io/v1alpha1
kind: Cluster
metadata:
  annotations:
    objectset.rio.cattle.io/id: fleet-bootstrap
  creationTimestamp: "2022-12-07T13:06:09Z"
  generation: 2
  labels:
    test: label
    name: local
    objectset.rio.cattle.io/hash: 67f475f626e5473772f6084a291170a9de5942d1
  name: local
  namespace: fleet-local
  resourceVersion: "14358"
---
apiVersion: fleet.cattle.io/v1alpha1
kind: Cluster
metadata:
  annotations:
    objectset.rio.cattle.io/id: fleet-bootstrap
  creationTimestamp: "2022-12-07T13:06:09Z"
  generation: 2
  labels:
    test: label
    name: local
    objectset.rio.cattle.io/hash: 67f475f626e5473772f6084a291170a9de5942d1
  name: local
  namespace: fleet-local
  resourceVersion: "14364"
status:
  conditions:
  - lastUpdateTime: "2022-12-07T13:22:29Z"
    message: WaitApplied(1) [Bundle fleet-agent-local]
    status: "False"
    type: Ready
  - lastUpdateTime: "2022-12-07T13:22:29Z"
    status: "True"
    type: Processed
---
apiVersion: fleet.cattle.io/v1alpha1
kind: Cluster
metadata:
  annotations:
    objectset.rio.cattle.io/id: fleet-bootstrap
  creationTimestamp: "2022-12-07T13:06:09Z"
  generation: 2
  labels:
    test: label
    name: local
    objectset.rio.cattle.io/hash: 67f475f626e5473772f6084a291170a9de5942d1
  name: local
  namespace: fleet-local
  resourceVersion: "14365"
status:
  conditions:
  - lastUpdateTime: "2022-12-07T13:22:29Z"
    message: WaitApplied(1) [Bundle fleet-agent-local]
    status: "False"
    type: Ready
---
apiVersion: fleet.cattle.io/v1alpha1
kind: Cluster
metadata:
  annotations:
    objectset.rio.cattle.io/id: fleet-bootstrap
  creationTimestamp: "2022-12-07T13:06:09Z"
  generation: 2
  labels:
    test: label
    name: local
    objectset.rio.cattle.io/hash: 67f475f626e5473772f6084a291170a9de5942d1
  name: local
  namespace: fleet-local
  resourceVersion: "14395"
status:
  conditions:
  - lastUpdateTime: "2022-12-07T13:22:29Z"
    status: "True"
    type: Ready
---
apiVersion: fleet.cattle.io/v1alpha1
kind: Cluster
metadata:
  annotations:
    objectset.rio.cattle.io/id: fleet-bootstrap
  creationTimestamp: "2022-12-07T13:06:09Z"
  generation: 2
  labels:
    test: label
    name: local
    objectset.rio.cattle.io/hash: 67f475f626e5473772f6084a291170a9de5942d1
  name: local
  namespace: fleet-local
  resourceVersion: "14397"
---
apiVersion: fleet.cattle.io/v1alpha1
kind: Cluster
metadata:
  annotations:
    objectset.rio.cattle.io/id: fleet-cluster
    objectset.rio.cattle.io/owner-gvk: provisioning.cattle.io/v1, Kind=Cluster
    objectset.rio.cattle.io/owner-name: local
    objectset.rio.cattle.io/owner-namespace: fleet-local
  creationTimestamp: "2022-12-07T13:06:09Z"
  generation: 2
  labels:
    test: label
    management.cattle.io/cluster-display-name: local
    management.cattle.io/cluster-name: local
    objectset.rio.cattle.io/hash: f2a8a9999a85e11ff83654e61cec3a781479fbf7
    provider.cattle.io: k3s
  name: local
  namespace: fleet-local
  resourceVersion: "14491"

```


Refers to #1079