### PR TITLE
Fix CRD download url

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Install the Fleet Helm charts (there's two because we separate out CRDs for ulti
 
 ```shell
 helm -n cattle-fleet-system install --create-namespace --wait \
-    fleet-crd https://github.com/rancher/fleet/releases/download/v0.5.0/fleet-0.5.0.tgz
+    fleet-crd https://github.com/rancher/fleet/releases/download/v0.5.0/fleet-crd-0.5.0.tgz
 helm -n cattle-fleet-system install --create-namespace --wait \
     fleet https://github.com/rancher/fleet/releases/download/v0.5.0/fleet-0.5.0.tgz
 ```


### PR DESCRIPTION
It appears that automation introduced in https://github.com/rancher/fleet/pull/1182 broken the CRD url