### PR TITLE
Switch CA extraction for k8s 1.24 in E2E CI

### DIFF
--- a/.github/workflows/e2e-multicluster-ci.yml
+++ b/.github/workflows/e2e-multicluster-ci.yml
@@ -114,8 +114,7 @@ jobs:
           { grep -q -m 1 "second-token"; kill $!; } < <(kubectl get secrets -n fleet-local -l "fleet.cattle.io/managed=true" -w)
 
           token=$(kubectl get secret -n fleet-local second-token -o go-template='{{index .data "values" | base64decode}}' | yq eval .token -)
-          name=$(kubectl get -n default sa default -o=jsonpath='{.secrets[0].name}')
-          ca=$(kubectl get -n default secret "$name" -o go-template='{{index .data "ca.crt" | base64decode}}')
+          ca=$(kubectl get secret -n cattle-fleet-system fleet-controller-bootstrap-token -o go-template='{{index .data "ca.crt" | base64decode}}')
 
           kubectl config use-context k3d-downstream
           helm -n cattle-fleet-system upgrade --install --create-namespace --wait fleet-agent charts/fleet-agent \


### PR DESCRIPTION
The workflow uses k3d to install k8s. k3d switched the default to 1.24.
We already had the workaround in `dev/`.


* 1.24: https://github.com/rancher/fleet/actions/runs/3724129779/jobs/6316086704
* 1.22:  https://github.com/rancher/fleet/actions/runs/3719356514/jobs/6308167849