### PR TITLE
[0.4] Backport Remove ignored fileds from status struct, to avoid loop

### DIFF
--- a/modules/agent/pkg/controllers/bundledeployment/controller.go
+++ b/modules/agent/pkg/controllers/bundledeployment/controller.go
@@ -280,6 +280,15 @@ func (h *handler) cleanupOldAgent(modifiedStatuses []fleet.ModifiedStatus) error
 	return merr.NewErrors(errs...)
 }
 
+// removePrivateFields removes fields from the status, which won't be marshalled to JSON.
+// They would however trigger a status update in apply
+func removePrivateFields(s1 *fleet.BundleDeploymentStatus) {
+	for id := range s1.NonReadyStatus {
+		s1.NonReadyStatus[id].Summary.Relationships = nil
+		s1.NonReadyStatus[id].Summary.Attributes = nil
+	}
+}
+
 func (h *handler) MonitorBundle(bd *fleet.BundleDeployment, status fleet.BundleDeploymentStatus) (fleet.BundleDeploymentStatus, error) {
 	if bd.Spec.DeploymentID != status.AppliedDeploymentID {
 		return status, nil
@@ -329,6 +338,8 @@ func (h *handler) MonitorBundle(bd *fleet.BundleDeployment, status fleet.BundleD
 	if readyError != nil {
 		logrus.Errorf("bundle %s: %v", bd.Name, readyError)
 	}
+
+	removePrivateFields(&status)
 	return status, nil
 }
 


### PR DESCRIPTION
The fields are ignored in the JSON struct, however it would still
trigger a status update, which would trigger another MonitorBundle call.
The reason behind that is, that the structs are different, even though
the marshalled JSON is not.

Fixes #1174 