### PR TITLE
Fix orphan resources created by operators

### DIFF
--- a/pkg/helmdeployer/deployer.go
+++ b/pkg/helmdeployer/deployer.go
@@ -465,16 +465,12 @@ func (h *Helm) ListDeployments() ([]DeployedBundle, error) {
 	return result, nil
 }
 
-func (h *Helm) getRelease(bundleID, resourcesID string) (*release.Release, error) {
-
+func getReleaseNameVersionAndNamespace(bundleID, resourcesID string) (string, int, string, error) {
 	// When a bundle is installed a resourcesID is generated. If there is no
 	// resourcesID then there isn't anything to lookup.
 	if resourcesID == "" {
-		return nil, ErrNoResourceID
+		return "", 0, "", ErrNoResourceID
 	}
-
-	hist := action.NewHistory(&h.globalCfg)
-
 	namespace, name := kv.Split(resourcesID, "/")
 	releaseName, versionStr := kv.Split(name, ":")
 	version, _ := strconv.Atoi(versionStr)
@@ -482,6 +478,13 @@ func (h *Helm) getRelease(bundleID, resourcesID string) (*release.Release, error
 	if releaseName == "" {
 		releaseName = bundleID
 	}
+
+	return releaseName, version, namespace, nil
+}
+
+func (h *Helm) getRelease(releaseName, namespace string, version int) (*release.Release, error) {
+
+	hist := action.NewHistory(&h.globalCfg)
 
 	releases, err := hist.Run(releaseName)
 	if err == driver.ErrReleaseNotFound {
@@ -500,7 +503,12 @@ func (h *Helm) getRelease(bundleID, resourcesID string) (*release.Release, error
 }
 
 func (h *Helm) EnsureInstalled(bundleID, resourcesID string) (bool, error) {
-	if _, err := h.getRelease(bundleID, resourcesID); err == ErrNoRelease {
+	releaseName, version, namespace, err := getReleaseNameVersionAndNamespace(bundleID, resourcesID)
+	if err != nil {
+		return false, err
+	}
+
+	if _, err := h.getRelease(releaseName, namespace, version); err == ErrNoRelease {
 		return false, nil
 	} else if err != nil {
 		return false, err
@@ -509,7 +517,27 @@ func (h *Helm) EnsureInstalled(bundleID, resourcesID string) (bool, error) {
 }
 
 func (h *Helm) Resources(bundleID, resourcesID string) (*Resources, error) {
-	release, err := h.getRelease(bundleID, resourcesID)
+	releaseName, version, namespace, err := getReleaseNameVersionAndNamespace(bundleID, resourcesID)
+	if err != nil {
+		return &Resources{}, err
+	}
+
+	release, err := h.getRelease(releaseName, namespace, version)
+	if err == ErrNoRelease {
+		return &Resources{}, nil
+	} else if err != nil {
+		return nil, err
+	}
+	return releaseToResources(release)
+}
+
+func (h *Helm) ResourcesFromPreviousReleaseVersion(bundleID, resourcesID string) (*Resources, error) {
+	releaseName, version, namespace, err := getReleaseNameVersionAndNamespace(bundleID, resourcesID)
+	if err != nil {
+		return &Resources{}, err
+	}
+
+	release, err := h.getRelease(releaseName, namespace, version-1)
 	if err == ErrNoRelease {
 		return &Resources{}, nil
 	} else if err != nil {


### PR DESCRIPTION
It is possible that some operators copy the `objectset.rio.cattle.io/hash` label into a dynamically created objects. Wrangler plan will look for all resources with that label, and will think they all belong to the release. However they should not be considered part of the release. We need to skip these resources because they are not part of the release, and they would appear as orphaned.

For that, we look into the previous release to see if the resource we have to delete was already present. If it was not present it means it will not be deleted, and should not be part of the release so we just skip it.

This [test](https://github.com/rancher/fleet/commit/65961b344ef6d72e052eb28a3807b1964acd79a2#diff-5d4640ccdcecacd353830fb273e4be6e72f5c1a645e8bebc35f8117c87eb5fbcR143-R164) simulates the problem. It is failing without the fix in this PR

Fix https://github.com/rancher/fleet/issues/1141
