### PR TITLE
Fix gke e2e tests

### DIFF
--- a/.github/workflows/gke.yml
+++ b/.github/workflows/gke.yml
@@ -51,6 +51,9 @@ jobs:
       -
         name: Setup gcloud
         uses: google-github-actions/setup-gcloud@v1
+        with:
+          install_components: 'gke-gcloud-auth-plugin'
+
       -
         name: Install gcloud kubectl version
         run: gcloud components install kubectl


### PR DESCRIPTION
[e2e are failing](https://github.com/rancher/fleet/actions/runs/3736842647/jobs/6341532628) because of a warning returned by the gke github action. This is because we  are generating credentials via gcloud container clusters get-credentials. Install `gke-gcloud-auth-plugin` to fix this.

More info https://github.com/google-github-actions/setup-gcloud/issues/561#issuecomment-1137363453

