### PR TITLE
Bump Gitjob to 0.1.34

### DIFF
--- a/charts/fleet/charts/gitjob/Chart.yaml
+++ b/charts/fleet/charts/gitjob/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 0.1.33
+appVersion: 0.1.34
 description: Controller that run jobs based on git events
 name: gitjob
-version: 0.1.33
+version: 0.1.34

--- a/charts/fleet/charts/gitjob/templates/deployment.yaml
+++ b/charts/fleet/charts/gitjob/templates/deployment.yaml
@@ -35,10 +35,6 @@ spec:
             - name: NO_PROXY
               value: {{ .Values.noProxy }}
           {{- end }}
-          {{- if .Values.debug }}
-            - name: CATTLE_DEV_MODE
-              value: "true"
-          {{- end }}
       {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}

--- a/charts/fleet/charts/gitjob/values.yaml
+++ b/charts/fleet/charts/gitjob/values.yaml
@@ -1,10 +1,10 @@
 gitjob:
   repository: rancher/gitjob
-  tag: v0.1.33
+  tag: v0.1.34
 
 tekton:
   repository: rancher/tekton-utils
-  tag: v0.1.8
+  tag: v0.1.9
 
 global:
   cattle:


### PR DESCRIPTION
Only a small bump to get the latest bci images: https://github.com/rancher/gitjob/releases/tag/v0.1.34

It might be worth backporting to the branch release/v0.6.