### PR TITLE
Fix gitrepo e2e tests

### DIFF
--- a/e2e/require-secrets/gitrepo_test.go
+++ b/e2e/require-secrets/gitrepo_test.go
@@ -37,7 +37,6 @@ var _ = Describe("Git Repo", func() {
 	BeforeEach(func() {
 		k = env.Kubectl.Namespace(env.Namespace)
 		gh = githelper.New()
-		tmpdir, _ = os.MkdirTemp("", "fleet-")
 
 		out, err := k.Create(
 			"secret", "generic", "git-auth", "--type", "kubernetes.io/ssh-auth",
@@ -46,11 +45,7 @@ var _ = Describe("Git Repo", func() {
 		)
 		Expect(err).ToNot(HaveOccurred(), out)
 
-		known := path.Join(tmpdir, "known_hosts")
-		os.Setenv("SSH_KNOWN_HOSTS", known)
-		out, err = gh.UpdateKnownHosts(known)
-		Expect(err).ToNot(HaveOccurred(), out)
-
+		tmpdir, _ = os.MkdirTemp("", "fleet-")
 		repodir = path.Join(tmpdir, "repo")
 		repo, err = gh.Create(repodir, testenv.AssetPath("gitrepo/sleeper-chart"), "examples")
 		Expect(err).ToNot(HaveOccurred())

--- a/e2e/require-secrets/imagescan_test.go
+++ b/e2e/require-secrets/imagescan_test.go
@@ -23,6 +23,7 @@ var _ = Describe("Image Scan", func() {
 	BeforeEach(func() {
 		k = env.Kubectl.Namespace(env.Namespace)
 		gh = githelper.New()
+		gh.Branch = "imagescan"
 
 		out, err := k.Create(
 			"secret", "generic", "git-auth", "--type", "kubernetes.io/ssh-auth",
@@ -31,8 +32,6 @@ var _ = Describe("Image Scan", func() {
 			"--from-file=known_hosts="+knownHostsPath,
 		)
 		Expect(err).ToNot(HaveOccurred(), out)
-
-		os.Setenv("GIT_REPO_BRANCH", "imagescan")
 
 		tmpdir, _ = os.MkdirTemp("", "fleet-")
 		repodir = path.Join(tmpdir, "repo")

--- a/e2e/require-secrets/imagescan_test.go
+++ b/e2e/require-secrets/imagescan_test.go
@@ -23,23 +23,18 @@ var _ = Describe("Image Scan", func() {
 	BeforeEach(func() {
 		k = env.Kubectl.Namespace(env.Namespace)
 		gh = githelper.New()
-		tmpdir, _ = os.MkdirTemp("", "fleet-")
 
-		known := path.Join(tmpdir, "known_hosts")
-		os.Setenv("SSH_KNOWN_HOSTS", known)
-		out, err := gh.UpdateKnownHosts(known)
-		Expect(err).ToNot(HaveOccurred(), out)
-
-		out, err = k.Create(
+		out, err := k.Create(
 			"secret", "generic", "git-auth", "--type", "kubernetes.io/ssh-auth",
 			"--from-file=ssh-privatekey="+gh.SSHKey,
 			"--from-file=ssh-publickey="+gh.SSHPubKey,
-			"--from-file=known_hosts="+known,
+			"--from-file=known_hosts="+knownHostsPath,
 		)
 		Expect(err).ToNot(HaveOccurred(), out)
 
 		os.Setenv("GIT_REPO_BRANCH", "imagescan")
 
+		tmpdir, _ = os.MkdirTemp("", "fleet-")
 		repodir = path.Join(tmpdir, "repo")
 		_, err = gh.Create(repodir, testenv.AssetPath("imagescan/repo"), "examples")
 		Expect(err).ToNot(HaveOccurred())

--- a/e2e/require-secrets/suite_test.go
+++ b/e2e/require-secrets/suite_test.go
@@ -1,9 +1,12 @@
 package require_secrets
 
 import (
+	"os"
+	"path"
 	"testing"
 
 	"github.com/rancher/fleet/e2e/testenv"
+	"github.com/rancher/fleet/e2e/testenv/githelper"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -15,7 +18,9 @@ func TestE2E(t *testing.T) {
 }
 
 var (
-	env *testenv.Env
+	env            *testenv.Env
+	khDir          string
+	knownHostsPath string
 )
 
 var _ = BeforeSuite(func() {
@@ -23,4 +28,17 @@ var _ = BeforeSuite(func() {
 	testenv.SetRoot("../..")
 
 	env = testenv.New()
+
+	// setup SSH known_hosts for all tests, since environment variables are
+	// shared between parallel test runs
+	khDir, _ = os.MkdirTemp("", "fleet-")
+
+	knownHostsPath := path.Join(khDir, "known_hosts")
+	os.Setenv("SSH_KNOWN_HOSTS", knownHostsPath)
+	out, err := githelper.CreateKnownHosts(knownHostsPath, os.Getenv("GIT_REPO_HOST"))
+	Expect(err).ToNot(HaveOccurred(), out)
+})
+
+var _ = AfterSuite(func() {
+	os.RemoveAll(khDir)
 })

--- a/e2e/testenv/githelper/git.go
+++ b/e2e/testenv/githelper/git.go
@@ -21,7 +21,6 @@ type Git struct {
 	User      string
 	SSHKey    string
 	SSHPubKey string
-	Host      string
 	Branch    string
 }
 
@@ -31,7 +30,6 @@ func New() *Git {
 		SSHKey:    os.Getenv("GIT_SSH_KEY"),
 		SSHPubKey: os.Getenv("GIT_SSH_PUBKEY"),
 		URL:       os.Getenv("GIT_REPO_URL"),
-		Host:      os.Getenv("GIT_REPO_HOST"),
 		Branch:    os.Getenv("GIT_REPO_BRANCH"),
 	}
 	if g.Branch == "" {
@@ -51,14 +49,14 @@ func author() *object.Signature {
 }
 
 func (g *Git) check() {
-	if g.User == "" || g.SSHKey == "" || g.URL == "" || g.Host == "" || g.SSHPubKey == "" {
+	if g.User == "" || g.SSHKey == "" || g.URL == "" || g.SSHPubKey == "" {
 		panic("GIT_REPO_USER, GIT_SSH_KEY, GIT_SSH_PUBKEY, GIT_REPO_URL, GIT_REPO_HOST must be set")
 	}
 }
 
-// UpdateKnownHosts works around https://github.com/go-git/go-git/issues/411
-func (g *Git) UpdateKnownHosts(path string) (string, error) {
-	cmd := exec.Command("/bin/sh", "-c", "ssh-keyscan "+g.Host+" >> "+path) //nolint:gosec // test code should never receive user input
+// CreateKnownHosts works around https://github.com/go-git/go-git/issues/411
+func CreateKnownHosts(path string, host string) (string, error) {
+	cmd := exec.Command("/bin/sh", "-c", "ssh-keyscan "+host+" >> "+path) //nolint:gosec // test code should never receive user input
 
 	var b bytes.Buffer
 	cmd.Stdout = &b


### PR DESCRIPTION
E2E tests were flaky, because tests were modifying env vars.

E.g. the gitrepo test suddenly tried to push to the imagescan branch:

https://github.com/rancher/fleet/actions/runs/3755744686/jobs/6381089656