### PR TITLE
Fix Windows 1809 builds on Drone

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -309,6 +309,10 @@ platform:
   os: windows
   arch: amd64
   version: 1809
+# Currently have to define "depth" as otherwise clone fails at
+# https://github.com/drone/drone-git/blob/39d233b3d9eccc68e66508a06a725a2567f33143/windows/clone-tag.ps1#L12
+clone:
+  depth: 20
 steps:
 - name: docker-publish-agent
   image: plugins/docker


### PR DESCRIPTION
because otherwise it is unable to checkout tags. It seems the image for 1809 was rebuilt and something got updated. Empty args where ignored before but not anymore.

It fails at https://github.com/drone/drone-git/blob/39d233b3d9eccc68e66508a06a725a2567f33143/windows/clone-tag.ps1#L12