### PR TITLE
[v0.5] Do not fail on missing labels

### DIFF
--- a/pkg/target/target.go
+++ b/pkg/target/target.go
@@ -545,7 +545,7 @@ func processLabelValues(valuesMap map[string]interface{}, clusterLabels map[stri
 				valuesMap[key] = labelVal
 			} else {
 				valuesMap[key] = ""
-				logrus.Infof("invalid_label_reference %s in key %s", valStr, key)
+				logrus.Infof("Cluster label '%s' for key '%s' is missing from some clusters, setting value to empty string for these clusters.", valStr, key)
 			}
 		}
 


### PR DESCRIPTION
Back port fix to not fail on missing labels.

References rancher/fleet#689 and rancher/fleet#1114 