### PR TITLE
Fix Rancher upgrade

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -21,6 +21,7 @@ const (
 	AgentBootstrapConfigName = "fleet-agent-bootstrap"
 	Key                      = "config"
 	DefaultNamespace         = "cattle-fleet-system"
+	LegacyDefaultNamespace   = "fleet-system"
 )
 
 var (

--- a/pkg/controllers/cluster/import.go
+++ b/pkg/controllers/cluster/import.go
@@ -166,6 +166,10 @@ func (i *importHandler) deleteOldAgent(cluster *fleet.Cluster, kc kubernetes.Int
 }
 
 func (i *importHandler) importCluster(cluster *fleet.Cluster, status fleet.ClusterStatus) (_ fleet.ClusterStatus, err error) {
+	if cluster.Status.Agent.Namespace == config.LegacyDefaultNamespace {
+		cluster.Status.CattleNamespaceMigrated = false
+	}
+
 	if cluster.Spec.KubeConfigSecret == "" ||
 		agentDeployed(cluster) ||
 		cluster.Spec.ClientID == "" {
@@ -275,7 +279,7 @@ func (i *importHandler) importCluster(cluster *fleet.Cluster, status fleet.Clust
 		return status, err
 	}
 
-	if cluster.Spec.AgentNamespace != "" && (cluster.Status.Agent.Namespace != agentNamespace || !cluster.Status.AgentNamespaceMigrated) {
+	if cluster.Status.Agent.Namespace != agentNamespace || !cluster.Status.AgentNamespaceMigrated {
 		// delete old agent if moving namespaces for agent
 		if err := i.deleteOldAgentBundle(cluster); err != nil {
 			return status, err


### PR DESCRIPTION
`CattleNamespaceMigrated` `Cluster` status field is true in Rancher v2.5.16 and fleet 3.9 even though it is still using the old namespace `fleet-system`. That's a problem when migrating to the new namespace `cattle-fleet-system` as downstream clusters thinks migration already happened, and registration was already done because [agentDeployed](https://github.com/rancher/fleet/blob/v0.5.1/pkg/controllers/cluster/import.go#L170) returns true. Because of that, it's missing the `fleet-agent` secret that contains the `kubeconfig` in the `cattle-fleet-system` namespace in the downstream cluster. Therefore, new downstream `fleet-agents` can't connect to the upstream cluster.

Old agent is not removed in downstream clusters because `cluster.Spec.AgentNamespace` is always empty [here](https://github.com/rancher/fleet/blob/v0.5.1/pkg/controllers/cluster/import.go#L278) for downstream clusters. `cluster.Spec.AgentNamespace` is not empty for the local fleet agent as it is set by Rancher.

This PR sets `CattleNamespaceMigrated` to false if the agent status namespace is `fleet-system`, so the new `fleet-agent` is registered with the upstream cluster. It also removes the `cluster.Spec.AgentNamespace` should be empty condition, so old fleet-agents are deleted. 

<!-- Specify the issue ID that this pullrequest is solving -->
Fix https://github.com/rancher/rancher/issues/40127

