### PR TITLE
Long release names, shorten only once

### DIFF
--- a/modules/agent/pkg/register/register.go
+++ b/modules/agent/pkg/register/register.go
@@ -30,7 +30,7 @@ import (
 )
 
 const (
-	CredName            = "fleet-agent"
+	CredName            = "fleet-agent" // same as AgentConfigName
 	Kubeconfig          = "kubeconfig"
 	Token               = "token"
 	Values              = "values"
@@ -211,6 +211,7 @@ func createClusterSecret(ctx context.Context, clusterID string, k8s corecontroll
 			return nil, err
 		}
 
+		// fleet-agent secret
 		updatedSecret := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      CredName,

--- a/modules/cli/apply/apply.go
+++ b/modules/cli/apply/apply.go
@@ -217,6 +217,7 @@ func createName(name, baseDir string) string {
 	// shorten name to 53 characters, the limit for helm release names
 	if helmReleaseName.MatchString(str) && dnsLabelSafe.MatchString(str) {
 		// name2.Limit will add another checksum if the name is too long
+		logrus.Debugf("shorten bundle name %v to %v\n", str, name2.Limit(str, 53))
 		return name2.Limit(str, 53)
 	}
 

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -110,6 +110,7 @@ func agentToken(ctx context.Context, agentNamespace, controllerNamespace string,
 				},
 			},
 		},
+		// fleet-agent-bootstrap
 		&v1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      config.AgentBootstrapConfigName,

--- a/pkg/controllers/manageagent/manageagent.go
+++ b/pkg/controllers/manageagent/manageagent.go
@@ -135,6 +135,12 @@ func (h *handler) OnNamespace(key string, namespace *corev1.Namespace) (*corev1.
 		return nil, nil
 	}
 
+	cfg := config.Get()
+	// managed agents are disabled, so we don't need to create the bundle
+	if cfg.ManageAgent != nil && !*cfg.ManageAgent {
+		return nil, nil
+	}
+
 	clusters, err := h.clusterCache.List(namespace.Name, labels.Everything())
 	if err != nil {
 		return nil, err
@@ -164,11 +170,6 @@ func (h *handler) OnNamespace(key string, namespace *corev1.Namespace) (*corev1.
 
 func (h *handler) newAgentBundle(ns string, cluster *fleet.Cluster) (runtime.Object, error) {
 	cfg := config.Get()
-	// managed agents are disabled, so we don't need to create the bundle
-	if cfg.ManageAgent != nil && !*cfg.ManageAgent {
-		return nil, nil
-	}
-
 	agentNamespace := h.systemNamespace
 	if cluster.Spec.AgentNamespace != "" {
 		agentNamespace = cluster.Spec.AgentNamespace

--- a/pkg/helmdeployer/deployer.go
+++ b/pkg/helmdeployer/deployer.go
@@ -245,23 +245,24 @@ func (h *Helm) getOpts(bundleID string, options fleet.BundleDeploymentOptions) (
 		timeout = time.Second * time.Duration(options.Helm.TimeoutSeconds)
 	}
 
+	ns := options.DefaultNamespace
 	if options.TargetNamespace != "" {
-		options.DefaultNamespace = options.TargetNamespace
+		ns = options.TargetNamespace
 	}
 
-	if options.DefaultNamespace == "" {
-		options.DefaultNamespace = h.defaultNamespace
+	if ns == "" {
+		ns = h.defaultNamespace
+	}
+
+	if options.Helm != nil && options.Helm.ReleaseName != "" {
+		// JSON schema validation makes sure that the option is valid
+		return timeout, ns, options.Helm.ReleaseName
 	}
 
 	// releaseName has a limit of 53 in helm https://github.com/helm/helm/blob/main/pkg/action/install.go#L58
-	// apply already makes sure that the bundle.Name is not longer than 53 characters
-	releaseName := name.Limit(bundleID, 53)
-	if options.Helm != nil && options.Helm.ReleaseName != "" {
-		// JSON schema validation makes sure that the option is valid
-		releaseName = options.Helm.ReleaseName
-	}
-
-	return timeout, options.DefaultNamespace, releaseName
+	// apply already makes sure that the bundle.Name/bundleID is not longer
+	// than 53 characters
+	return timeout, ns, bundleID
 }
 
 func (h *Helm) getCfg(namespace, serviceAccountName string) (action.Configuration, error) {


### PR DESCRIPTION
Fix #1272


Long release names are shortened and a md5 hash is appended. The
existing code would shorten a release name twice. Once when creating the
bundle name and again when creating the helm release name.
This happened because name.Limit(str, 53) shortens any string smaller
than 53 chars to 53 chars. It will modify a string of 53 chars, so it's
not stable when calling it multiple times.

When the release name is different from the bundle name, fleet will
clean up such a release as it no longer belongs to a bundle.