### PR TITLE
[v0.5] Fix Rancher upgrade

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -20,7 +20,10 @@ const (
 	AgentConfigName          = "fleet-agent"
 	AgentBootstrapConfigName = "fleet-agent-bootstrap"
 	Key                      = "config"
-	DefaultNamespace         = "cattle-fleet-system"
+	// DefaultNamespace is the default for the system namespace, which
+	// contains the manager and agent
+	DefaultNamespace       = "cattle-fleet-system"
+	LegacyDefaultNamespace = "fleet-system"
 )
 
 var (

--- a/pkg/controllers/cluster/import.go
+++ b/pkg/controllers/cluster/import.go
@@ -166,6 +166,10 @@ func (i *importHandler) deleteOldAgent(cluster *fleet.Cluster, kc kubernetes.Int
 }
 
 func (i *importHandler) importCluster(cluster *fleet.Cluster, status fleet.ClusterStatus) (_ fleet.ClusterStatus, err error) {
+	if cluster.Status.Agent.Namespace == config.LegacyDefaultNamespace {
+		cluster.Status.CattleNamespaceMigrated = false
+	}
+
 	if cluster.Spec.KubeConfigSecret == "" ||
 		agentDeployed(cluster) ||
 		cluster.Spec.ClientID == "" {
@@ -275,7 +279,7 @@ func (i *importHandler) importCluster(cluster *fleet.Cluster, status fleet.Clust
 		return status, err
 	}
 
-	if cluster.Spec.AgentNamespace != "" && (cluster.Status.Agent.Namespace != agentNamespace || !cluster.Status.AgentNamespaceMigrated) {
+	if cluster.Status.Agent.Namespace != agentNamespace || !cluster.Status.AgentNamespaceMigrated {
 		// delete old agent if moving namespaces for agent
 		if err := i.deleteOldAgentBundle(cluster); err != nil {
 			return status, err


### PR DESCRIPTION
CattleNamespaceMigrated Cluster status field is true in Rancher v2.5.16 even though it is still using the old namespace fleet-system. That's a problem when migrating to the new namespace cattle-fleet-system as downstream clusters thinks migration already happened, and registration was already done. That is not true, and it's missing the fleet-agent secret that contains the kubeconfig in the downstream cluster. Therefore, new downstream fleet-agents can't connect to the upstream cluster.

Old agent is not removed in downstream clusters because cluster.Spec.AgentNamespace is always empty. cluster.Spec.AgentNamespace just changes for the local fleet agent as it is passed as a bootstrap config when installing it in Rancher.

Set CattleNamespaceMigrated to false if the agent status namespace is fleet-system, so the new fleet-agent is registered. Remove cluster.Spec.AgentNamespace should be empty condition to delete old agents


Fix https://github.com/rancher/fleet/issues/1274

See https://github.com/rancher/fleet/issues/1269 for original QA template.
