### PR TITLE
chore: complete container security context

### DIFF
--- a/charts/fleet-agent/templates/deployment.yaml
+++ b/charts/fleet-agent/templates/deployment.yaml
@@ -29,6 +29,10 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+          privileged: false
+          capabilities:
+            drop:
+            - ALL
         {{- end }}
       serviceAccountName: fleet-agent
       nodeSelector: {{ include "linux-node-selector" . | nindent 8 }}

--- a/charts/fleet/templates/deployment.yaml
+++ b/charts/fleet/templates/deployment.yaml
@@ -55,6 +55,10 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+          privileged: false
+          capabilities:
+            drop:
+            - ALL
         {{- end }}
         volumeMounts:
           - mountPath: /tmp


### PR DESCRIPTION
Fix #1292

## Test

To test this pull request, you can deploy the the controller and the agent and see whether the fulfill their roles.

## Additional Information

### Potential improvement

A supplemental group could also be added to the pod's security context, if needed.
 
### Problem

As described in issue #1292, the security context isn't complete, an unnecessary security omission.
  
### Solution
Added the security context.
 

### Engineering Testing
#### Manual Testing

I'm currently running this security context for the last couple of hours in a rancher 2.6.9 Cluster with Fleet 0.4.0. No problems so far.
