### PR TITLE
Managed fleet-agent uses same securityContext as helm chart

### DIFF
--- a/pkg/agent/manifest.go
+++ b/pkg/agent/manifest.go
@@ -225,6 +225,8 @@ func agentDeployment(namespace, name, image, imagePullPolicy, serviceAccount str
 			container.SecurityContext = &corev1.SecurityContext{
 				AllowPrivilegeEscalation: &[]bool{false}[0],
 				ReadOnlyRootFilesystem:   &[]bool{true}[0],
+				Privileged:               &[]bool{false}[0],
+				Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
 			}
 		}
 		deployment.Spec.Template.Spec.SecurityContext = &corev1.PodSecurityContext{


### PR DESCRIPTION
Use the same `securityContext` options for auto generated Fleet chart as in the helm charts.

Followup to rancher/fleet#1293 and rancher/fleet#1292