### PR TITLE
fix agent not starting in fleet-system namespace

### DIFF
--- a/pkg/controllers/cluster/import.go
+++ b/pkg/controllers/cluster/import.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"os"
 	"strconv"
 
 	"github.com/sirupsen/logrus"
@@ -170,7 +171,7 @@ func (i *importHandler) deleteOldAgent(cluster *fleet.Cluster, kc kubernetes.Int
 
 // importCluster is triggered for manager initiated deployments and the local agent,
 func (i *importHandler) importCluster(cluster *fleet.Cluster, status fleet.ClusterStatus) (_ fleet.ClusterStatus, err error) {
-	if cluster.Status.Agent.Namespace == config.LegacyDefaultNamespace {
+	if shouldMigrateFromLegacyNamespace(cluster.Status.Agent.Namespace) {
 		cluster.Status.CattleNamespaceMigrated = false
 	}
 
@@ -333,6 +334,17 @@ func (i *importHandler) importCluster(cluster *fleet.Cluster, status fleet.Clust
 	}
 	status.AgentNamespaceMigrated = true
 	return status, nil
+}
+
+func shouldMigrateFromLegacyNamespace(agentStatusNs string) bool {
+	return !isLegacyAgentNamespaceSelectedByUser() && agentStatusNs == config.LegacyDefaultNamespace
+}
+
+func isLegacyAgentNamespaceSelectedByUser() bool {
+	cfg := config.Get()
+
+	return os.Getenv("NAMESPACE") == config.LegacyDefaultNamespace ||
+		cfg.Bootstrap.AgentNamespace == config.LegacyDefaultNamespace
 }
 
 // restConfigFromKubeConfig checks kubeconfig data and tries to connect to server. If server is behind public CA, remove CertificateAuthorityData in kubeconfig file.


### PR DESCRIPTION
Check if the user wants to use `fleet-system` as the namespace to install the `fleet-agent`. We do that by checking if :
- the NAMESPACE env var to check if the helm release is installed in the fleet-system namespace
- the bootstrap AgentNamespace is set to fleet-system

In that case case don't set the `CattleNamespaceMigrated` flag to false as it causes and endless loop of killing and starting the agent.

I tested upgrade from rancher 2.5.15 to rancher 2.6.9 with this fix

backport to v0.5.0 from https://github.com/rancher/fleet/pull/1269