### PR TITLE
[v0.6] Bump upgrade tests to rc.3

### DIFF
--- a/.github/workflows/fleet-upgrade-in-rancher.yml
+++ b/.github/workflows/fleet-upgrade-in-rancher.yml
@@ -42,7 +42,7 @@ jobs:
           - v2.6.9  # k3s: 1.20 - 1.24
           - v2.7.0  # k3s: 1.23 - 1.24
         fleet_version:
-          - "0.6.0-rc.1"
+          - "0.6.0-rc.3"
         exclude:
           - k3s_version: v1.20.15-k3s1
             rancher_version: v2.7.0


### PR DESCRIPTION
The upgrade tests for the `release/v0.6` branch failed because rc.1 is not available anymore.