### PR TITLE
Add waitForJobs as a helm option

### DIFF
--- a/charts/fleet-crd/templates/crds.yaml
+++ b/charts/fleet-crd/templates/crds.yaml
@@ -180,6 +180,8 @@ spec:
                   version:
                     nullable: true
                     type: string
+                  waitForJobs:
+                    type: boolean
                 type: object
               kustomize:
                 nullable: true
@@ -551,6 +553,8 @@ spec:
                         version:
                           nullable: true
                           type: string
+                        waitForJobs:
+                          type: boolean
                       type: object
                     kustomize:
                       nullable: true
@@ -1064,6 +1068,8 @@ spec:
                       version:
                         nullable: true
                         type: string
+                      waitForJobs:
+                        type: boolean
                     type: object
                   kustomize:
                     nullable: true
@@ -1211,6 +1217,8 @@ spec:
                       version:
                         nullable: true
                         type: string
+                      waitForJobs:
+                        type: boolean
                     type: object
                   kustomize:
                     nullable: true

--- a/pkg/apis/fleet.cattle.io/v1alpha1/bundle.go
+++ b/pkg/apis/fleet.cattle.io/v1alpha1/bundle.go
@@ -234,6 +234,7 @@ type HelmOptions struct {
 	TakeOwnership  bool         `json:"takeOwnership,omitempty"`
 	MaxHistory     int          `json:"maxHistory,omitempty"`
 	ValuesFiles    []string     `json:"valuesFiles,omitempty"`
+	WaitForJobs    bool         `json:"waitForJobs,omitempty"`
 
 	// Atomic sets the --atomic flag when Helm is performing an upgrade
 	Atomic bool `json:"atomic,omitempty"`

--- a/pkg/helmdeployer/deployer.go
+++ b/pkg/helmdeployer/deployer.go
@@ -357,6 +357,7 @@ func (h *Helm) install(bundleID string, manifest *manifest.Manifest, chart *char
 		u.Timeout = timeout
 		u.DryRun = dryRun
 		u.PostRenderer = pr
+		u.WaitForJobs = options.Helm.WaitForJobs
 		if u.Timeout > 0 {
 			u.Wait = true
 		}
@@ -379,6 +380,7 @@ func (h *Helm) install(bundleID string, manifest *manifest.Manifest, chart *char
 	u.DryRun = dryRun
 	u.DisableOpenAPIValidation = h.template || dryRun
 	u.PostRenderer = pr
+	u.WaitForJobs = options.Helm.WaitForJobs
 	if u.Timeout > 0 {
 		u.Wait = true
 	}

--- a/pkg/options/calculate.go
+++ b/pkg/options/calculate.go
@@ -82,6 +82,7 @@ func Merge(base, custom fleet.BundleDeploymentOptions) fleet.BundleDeploymentOpt
 		result.Helm.Atomic = result.Helm.Atomic || custom.Helm.Atomic
 		result.Helm.TakeOwnership = result.Helm.TakeOwnership || custom.Helm.TakeOwnership
 		result.Helm.DisablePreProcess = result.Helm.DisablePreProcess || custom.Helm.DisablePreProcess
+		result.Helm.WaitForJobs = result.Helm.WaitForJobs || custom.Helm.WaitForJobs
 	}
 	if custom.Kustomize != nil {
 		if result.Kustomize == nil {


### PR DESCRIPTION
Look in the `fleet.yaml` for the boolean `waitForJobs` inside the helm section. Then add it to the `HelmOptions` of the `Bundle`. It will be passed to the helm deployer [here](https://github.com/raulcabello/fleet/blob/71639d5af01be8fd392b1fe26309104a29d7d8c9/pkg/helmdeployer/deployer.go#L360). 

helm `waitForJobs` just works if the flag`--wait` is also passed to the helm installer. Currently we just add `--wait` if the [timeout is provided](https://github.com/raulcabello/fleet/blob/71639d5af01be8fd392b1fe26309104a29d7d8c9/pkg/helmdeployer/deployer.go#L361), therefore timeout needs to be provided in order for `waitForJobs` to work

That will make the `GitRepo` and `Bundle` to be in a `WaitApplied` state until the jobs have finished or the timeout finishes.

<!-- Specify the issue ID that this pullrequest is solving -->
Fix https://github.com/rancher/fleet/issues/364


