### PR TITLE
Simplify Go Container reference

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,4 +1,4 @@
-FROM registry.suse.com/bci/golang:1.19-20.13
+FROM registry.suse.com/bci/golang:1.19
 
 ARG DAPPER_HOST_ARCH
 ENV ARCH $DAPPER_HOST_ARCH


### PR DESCRIPTION
to just reference the Go version and not the specific container base so always the latest container for the specified go version is used which prevents usless go container bump prs.

For relevant BCI image updates we have to bump Fleet anyway so a new build/release process needs to be triggered in any case.