### PR TITLE
Check chart with the helmRepoURLRegex

### DIFF
--- a/pkg/bundlereader/resources.go
+++ b/pkg/bundlereader/resources.go
@@ -155,7 +155,7 @@ func mergeGenericMap(first, second *fleet.GenericMap) *fleet.GenericMap {
 func addRemoteCharts(directories []directory, base string, charts []*fleet.HelmOptions, auth Auth, helmRepoURLRegex string) ([]directory, error) {
 	for _, chart := range charts {
 		if _, err := os.Stat(filepath.Join(base, chart.Chart)); os.IsNotExist(err) || chart.Repo != "" {
-			shouldAddAuthToRequest, err := shouldAddAuthToRequest(helmRepoURLRegex, chart.Repo)
+			shouldAddAuthToRequest, err := shouldAddAuthToRequest(helmRepoURLRegex, chart.Repo, chart.Chart)
 			if err != nil {
 				return nil, err
 			}
@@ -181,10 +181,14 @@ func addRemoteCharts(directories []directory, base string, charts []*fleet.HelmO
 	return directories, nil
 }
 
-func shouldAddAuthToRequest(helmRepoURLRegex, repo string) (bool, error) {
+func shouldAddAuthToRequest(helmRepoURLRegex, repo, chart string) (bool, error) {
 	if helmRepoURLRegex == "" {
 		return true, nil
 	}
+	if repo == "" {
+		return regexp.MatchString(helmRepoURLRegex, chart)
+	}
+
 	return regexp.MatchString(helmRepoURLRegex, repo)
 }
 


### PR DESCRIPTION
Helm OCI urls are provided in the `chart` parameter not in the `repo`. Also`https` helm repository could be provided with the `chart` parameter instead of the `repo`.
In this PR the `chart` parameter is checked if `repo` is not provided

Fix https://github.com/rancher/fleet/issues/978#issuecomment-1435142942
