### PR TITLE
Ensure ClusterRegistrationToken name is below 63 characters

### DIFF
--- a/dev/delve-debug
+++ b/dev/delve-debug
@@ -24,4 +24,4 @@ trap "kill $!" EXIT
 echo `tput bold`
 echo 'Please wait for the line "debug layer=debugger continuing" to appear...'
 echo `tput sgr0`
-kubectl --namespace "$ns" debug -it "pod/$pod" --image=ghcr.io/moio/delve-debugger:latest --target="$app" --env="[EXECUTABLE=$procname]"
+kubectl --namespace "$ns" debug -it "pod/$pod" --image=ghcr.io/rancherlabs/delve-debugger:latest --target="$app" --env="[EXECUTABLE=$procname]"

--- a/pkg/controllers/manageagent/manageagent.go
+++ b/pkg/controllers/manageagent/manageagent.go
@@ -153,9 +153,10 @@ func (h *handler) OnNamespace(key string, namespace *corev1.Namespace) (*corev1.
 	var objs []runtime.Object
 
 	for _, cluster := range clusters {
-		logrus.Infof("Updated agent for cluster %s/%s", cluster.Namespace, cluster.Name)
+		logrus.Infof("Update agent bundle for cluster %s/%s", cluster.Namespace, cluster.Name)
 		bundle, err := h.newAgentBundle(namespace.Name, cluster)
 		if err != nil {
+			logrus.Errorf("Failed to update agent bundle for cluster %s/%s", cluster.Namespace, cluster.Name)
 			return nil, err
 		}
 		objs = append(objs, bundle)

--- a/pkg/name/name.go
+++ b/pkg/name/name.go
@@ -76,7 +76,7 @@ func HelmReleaseName(str string) string {
 
 	// shorten name to 53 characters, the limit for helm release names
 	if helmReleaseName.MatchString(str) && dnsLabelSafe.MatchString(str) {
-		logrus.Debugf("shorten bundle name %v to %v\n", str, Limit(str, v1alpha1.MaxHelmReleaseNameLen))
+		logrus.Debugf("shorten bundle name %v to %v", str, Limit(str, v1alpha1.MaxHelmReleaseNameLen))
 		return Limit(str, v1alpha1.MaxHelmReleaseNameLen)
 	}
 


### PR DESCRIPTION
Adding the token prefix to the cluster name could exceed 63 characters and the ClusterRegistrationToken would not have been created. The error was silently dropped.


Refers to https://github.com/rancher/rancher/issues/40710