### PR TITLE
Setup a managed cluster for dev

### DIFF
--- a/dev/setup-fleet
+++ b/dev/setup-fleet
@@ -9,8 +9,14 @@ if [ ! -d ./charts/fleet ]; then
 fi
 
 # single cluster
+host=$( docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' k3d-upstream-server-0 )
+ca=$( kubectl config view --flatten -o jsonpath='{.clusters[?(@.name == "k3d-upstream")].cluster.certificate-authority-data}' | base64 -d )
+server="https://$host:6443"
 helm -n cattle-fleet-system upgrade --install --create-namespace --wait fleet-crd charts/fleet-crd
-helm -n cattle-fleet-system upgrade --install --create-namespace --wait --reset-values --set debug=true --set debugLevel=99 fleet charts/fleet
+helm -n cattle-fleet-system upgrade --install --create-namespace --wait --reset-values \
+  --set apiServerCA="$ca" \
+  --set apiServerURL="$server" \
+  --set debug=true --set debugLevel=99 fleet charts/fleet
 
 # wait for controller and agent rollout
 kubectl -n cattle-fleet-system rollout status deploy/fleet-controller

--- a/dev/setup-fleet-managed-downstream
+++ b/dev/setup-fleet-managed-downstream
@@ -1,0 +1,58 @@
+#!/bin/bash
+# Description: setup managed fleet agent in the downstream cluster
+
+set -euxo pipefail
+
+if [ ! -d ./charts/fleet ]; then
+  echo "please change the current directory to the fleet repo checkout"
+  exit 1
+fi
+
+# fetching from local kubeconfig
+host=$( docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' k3d-downstream-server-0 )
+ca=$( kubectl config view --flatten -o jsonpath='{.clusters[?(@.name == "k3d-downstream")].cluster.certificate-authority-data}' )
+client_cert=$( kubectl config view --flatten -o jsonpath='{.users[?(@.name == "admin@k3d-downstream")].user.client-certificate-data}' )
+token=$( kubectl config view --flatten -o jsonpath='{.users[?(@.name == "admin@k3d-downstream")].user.client-key-data}' )
+server="https://$host:6443"
+
+value=$(cat <<EOF
+apiVersion: v1
+kind: Config
+current-context: default
+clusters:
+- cluster:
+    certificate-authority-data: $ca
+    server: $server
+  name: cluster
+contexts:
+- context:
+    cluster: cluster
+    user: user
+  name: default
+preferences: {}
+users:
+- name: user
+  user:
+    client-certificate-data: $client_cert
+    client-key-data: $token
+EOF
+)
+
+kubectl create ns fleet-default || true
+kubectl delete secret -n fleet-default kbcfg-second || true
+# Rancher sets a token value in the secret, but our docs don't mention it
+# * https://github.com/rancher/rancher/blob/c24fb8b0869a0b445f55b3307c6ed4582e147747/pkg/provisioningv2/kubeconfig/manager.go#L362
+# * https://fleet.rancher.io/0.5/manager-initiated#kubeconfig-secret-1
+kubectl create secret generic -n fleet-default kbcfg-second --from-literal=token="$token" --from-literal=value="$value"
+
+kubectl apply -n fleet-default -f - <<EOF
+apiVersion: "fleet.cattle.io/v1alpha1"
+kind: Cluster
+metadata:
+  name: second
+  namespace: fleet-default
+  labels:
+    name: second
+spec:
+  kubeConfigSecret: kbcfg-second
+EOF

--- a/dev/setup-k3ds
+++ b/dev/setup-k3ds
@@ -2,7 +2,7 @@
 
 set -euxo pipefail
 
-args=${k3d_args-}
+args=${k3d_args---network fleet}
 docker_mirror=${docker_mirror-}
 
 if [ -n "$docker_mirror" ]; then


### PR DESCRIPTION
Add scripts to test the [manager initiated registration style](https://fleet.rancher.io/manager-initiated) in development.

Possible breaking changes for devs:
* moves k3d clusters into "fleet" docker network
* `setup-fleet` tries to determine `apiServerURL` and `apiServerCA`  (should only matter if using the new `dev/setup-fleet-managed-downstream` script, though)