### PR TITLE
Change version number for nightly releases

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -53,12 +53,9 @@ jobs:
       -
         name: Set Nightly Version
         run: |
-          tag_commit=$(git rev-list --abbrev-commit --tags --max-count=1)
-          tag=$(git describe --abbrev=0 --tags "$tag_commit")
-          version=$(git describe --long --tags --always --match 'v[0-9]\.*')-nightly
+          commit=$(git rev-parse --short HEAD)
           ts=$(date +%s)
-          version=$(echo $version | sed "s/$tag/$tag.$ts/")
-          # example: v0.6.0-alpha1.1667814448-8-gcd772be-nightly
+          version="v999.0.0-$ts.$commit.nightly"
           echo "VERSION=$version" >> $GITHUB_ENV
           echo "### $version :rocket:" >> $GITHUB_STEP_SUMMARY
       -


### PR DESCRIPTION
With special tags for customer builds and release branches, it's hard to find the "latest official (pre-)release".

