### PR TITLE
Allow resources to be kept when deleting a GitRepo or a Bundle

### DIFF
--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -98,6 +98,11 @@ jobs:
           FLEET_E2E_NS: fleet-local
         run: |
           ginkgo e2e/single-cluster
+      - name: E2E Tests for keep-resources
+        env:
+          FLEET_E2E_NS: fleet-local
+        run: |
+          ginkgo e2e/keep-resources
       -
         name: Fleet Tests Requiring Github Secrets
         # These tests can't run for PRs, because PRs don't have access to the secrets

--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -97,12 +97,7 @@ jobs:
         env:
           FLEET_E2E_NS: fleet-local
         run: |
-          ginkgo e2e/single-cluster
-      - name: E2E Tests for keep-resources
-        env:
-          FLEET_E2E_NS: fleet-local
-        run: |
-          ginkgo e2e/keep-resources
+          ginkgo e2e/single-cluster e2e/keep-resources
       -
         name: Fleet Tests Requiring Github Secrets
         # These tests can't run for PRs, because PRs don't have access to the secrets

--- a/charts/fleet-crd/templates/crds.yaml
+++ b/charts/fleet-crd/templates/crds.yaml
@@ -183,6 +183,8 @@ spec:
                   waitForJobs:
                     type: boolean
                 type: object
+              keepResources:
+                type: boolean
               kustomize:
                 nullable: true
                 properties:
@@ -556,6 +558,8 @@ spec:
                         waitForJobs:
                           type: boolean
                       type: object
+                    keepResources:
+                      type: boolean
                     kustomize:
                       nullable: true
                       properties:
@@ -1071,6 +1075,8 @@ spec:
                       waitForJobs:
                         type: boolean
                     type: object
+                  keepResources:
+                    type: boolean
                   kustomize:
                     nullable: true
                     properties:
@@ -1220,6 +1226,8 @@ spec:
                       waitForJobs:
                         type: boolean
                     type: object
+                  keepResources:
+                    type: boolean
                   kustomize:
                     nullable: true
                     properties:
@@ -2154,6 +2162,8 @@ spec:
                 nullable: true
                 type: string
               insecureSkipTLSVerify:
+                type: boolean
+              keepResources:
                 type: boolean
               paths:
                 items:

--- a/e2e/assets/keep-resources/do-not-keep/gitrepo.yaml
+++ b/e2e/assets/keep-resources/do-not-keep/gitrepo.yaml
@@ -1,0 +1,17 @@
+kind: GitRepo
+apiVersion: fleet.cattle.io/v1alpha1
+metadata:
+  name: dont-keep
+spec:
+  repo: https://github.com/rancher/fleet-examples
+  branch: master
+  paths:
+  - simple
+  targetNamespace: do-not-keep-resources
+  targets:
+    - clusterSelector:
+        matchExpressions:
+          - key: provider.cattle.io
+            operator: NotIn
+            values:
+              - harvester

--- a/e2e/assets/keep-resources/keep/gitrepo.yaml
+++ b/e2e/assets/keep-resources/keep/gitrepo.yaml
@@ -1,0 +1,18 @@
+kind: GitRepo
+apiVersion: fleet.cattle.io/v1alpha1
+metadata:
+  name: keep
+spec:
+  repo: https://github.com/rancher/fleet-examples
+  branch: master
+  paths:
+  - simple
+  targetNamespace: keep-resources
+  keepResources: true
+  targets:
+    - clusterSelector:
+        matchExpressions:
+          - key: provider.cattle.io
+            operator: NotIn
+            values:
+              - harvester

--- a/e2e/keep-resources/keep_resources_test.go
+++ b/e2e/keep-resources/keep_resources_test.go
@@ -1,0 +1,72 @@
+package examples_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/rancher/fleet/e2e/testenv"
+	"github.com/rancher/fleet/e2e/testenv/kubectl"
+)
+
+var _ = Describe("Keep resources", func() {
+	var (
+		asset     string
+		k         kubectl.Command
+		namespace string
+	)
+
+	BeforeEach(func() {
+		k = env.Kubectl.Namespace(env.Namespace)
+	})
+
+	JustBeforeEach(func() {
+		out, err := k.Apply("-f", testenv.AssetPath(asset))
+		Expect(err).ToNot(HaveOccurred(), out)
+		Eventually(func() string {
+			out, _ := k.Namespace(namespace).Get("pods")
+			return out
+		}).Should(ContainSubstring("frontend-"))
+	})
+
+	When("GitRepo does not contain keepResources", func() {
+		BeforeEach(func() {
+			asset = "keep-resources/do-not-keep"
+			namespace = "do-not-keep-resources"
+		})
+
+		It("resources are deleted when GitRepo is deleted", func() {
+			out, err := k.Delete("-f", testenv.AssetPath(asset))
+			Expect(err).ToNot(HaveOccurred(), out)
+
+			Eventually(func() string {
+				out, _ := k.Namespace(namespace).Get("deployments", "frontend")
+				return out
+			}).Should(ContainSubstring("Error from server (NotFound)"))
+		})
+	})
+
+	When("GitRepo has keepResources set to true", func() {
+		BeforeEach(func() {
+			asset = "keep-resources/keep"
+			namespace = "keep-resources"
+		})
+
+		It("resources are not deleted when GitRepo is deleted", func() {
+			out, err := k.Delete("-f", testenv.AssetPath(asset))
+			Expect(err).ToNot(HaveOccurred(), out)
+
+			By("checking helm secrets are deleted")
+			Eventually(func() string {
+				out, _ := k.Namespace(namespace).Get("secrets", "-l", "owner=helm")
+				return out
+			}).Should(ContainSubstring("No resources found"))
+
+			By("checking resources are not deleted")
+			Eventually(func() string {
+				out, _ := k.Namespace(namespace).Get("deployments", "frontend", "-o", "yaml")
+				return out
+			}).Should(SatisfyAll(
+				Not(ContainSubstring("Error from server (NotFound)")),
+			))
+		})
+	})
+})

--- a/e2e/keep-resources/suite_test.go
+++ b/e2e/keep-resources/suite_test.go
@@ -1,0 +1,25 @@
+package examples_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/rancher/fleet/e2e/testenv"
+)
+
+func TestE2E(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "E2E Suite for Single-Cluster Examples")
+}
+
+var (
+	env *testenv.Env
+)
+
+var _ = BeforeSuite(func() {
+	SetDefaultEventuallyTimeout(testenv.Timeout)
+	testenv.SetRoot("../..")
+
+	env = testenv.New()
+})

--- a/integrationtests/cli/apply/apply_test.go
+++ b/integrationtests/cli/apply/apply_test.go
@@ -14,7 +14,7 @@ var _ = Describe("Fleet apply", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("then a Bundle is created with all the resources", func() {
+		It("then a Bundle is created with all the resources and keepResources is false", func() {
 			Eventually(func() bool {
 				bundle, err := cli.GetBundleFromOutput(buf)
 				Expect(err).NotTo(HaveOccurred())
@@ -24,7 +24,7 @@ var _ = Describe("Fleet apply", Ordered, func() {
 				isDeploymentPresent, err := cli.IsResourcePresentInBundle(cli.AssetsPath+"simple/deployment.yaml", bundle.Spec.Resources)
 				Expect(err).NotTo(HaveOccurred())
 
-				return isSvcPresent && isDeploymentPresent
+				return isSvcPresent && isDeploymentPresent && !bundle.Spec.KeepResources
 			}).Should(BeTrue())
 		})
 	})
@@ -143,6 +143,20 @@ var _ = Describe("Fleet apply", Ordered, func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				return isFleetAPresent && isDeploymentAPresent && isFleetCPresent && isRootDeploymentAPresent && isRootFleetAPresent && isRootSvcBPresent && isRootFleetCPresent && isRootDeploymentDPresent
+			}).Should(BeTrue())
+		})
+	})
+	When("containing keepResources in the fleet.yaml", func() {
+		It("fleet apply is called", func() {
+			err := fleetApply("keepResources", []string{cli.AssetsPath + "keep_resources"}, &apply.Options{})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("then a Bundle is created with keepResources", func() {
+			Eventually(func() bool {
+				bundle, err := cli.GetBundleFromOutput(buf)
+				Expect(err).NotTo(HaveOccurred())
+				return bundle.Spec.KeepResources
 			}).Should(BeTrue())
 		})
 	})

--- a/integrationtests/cli/assets/keep_resources/fleet.yaml
+++ b/integrationtests/cli/assets/keep_resources/fleet.yaml
@@ -1,0 +1,1 @@
+keepResources: true

--- a/integrationtests/cli/assets/keep_resources/svc.yaml
+++ b/integrationtests/cli/assets/keep_resources/svc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx-service
+spec:
+  selector:
+    app: nginx
+  ports:
+  - name: name-of-service-port
+    protocol: TCP
+    port: 80
+    targetPort: http-web-svc

--- a/modules/cli/apply/apply.go
+++ b/modules/cli/apply/apply.go
@@ -44,6 +44,7 @@ type Options struct {
 	SyncGeneration   int64
 	Auth             bundlereader.Auth
 	HelmRepoURLRegex string
+	KeepResources    bool
 }
 
 func globDirs(baseDir string) (result []string, err error) {
@@ -170,6 +171,7 @@ func readBundle(ctx context.Context, name, baseDir string, opts *Options) (*flee
 		SyncGeneration:   opts.SyncGeneration,
 		Auth:             opts.Auth,
 		HelmRepoURLRegex: opts.HelmRepoURLRegex,
+		KeepResources:    opts.KeepResources,
 	})
 }
 

--- a/modules/cli/cmds/apply.go
+++ b/modules/cli/cmds/apply.go
@@ -39,6 +39,7 @@ type Apply struct {
 	CACertsFile       string            `usage:"Path of custom cacerts for helm repo" name:"cacerts-file"`
 	SSHPrivateKeyFile string            `usage:"Path of ssh-private-key for helm repo" name:"ssh-privatekey-file"`
 	HelmRepoURLRegex  string            `usage:"Helm credentials will be used if the helm repo matches this regex. Credentials will always be used if this is empty or not provided" name:"helm-repo-url-regex"`
+	KeepResources     bool              `usage:"Keep resources created after the GitRepo or Bundle is deleted" name:"keep-resources"`
 }
 
 func (a *Apply) Run(cmd *cobra.Command, args []string) error {
@@ -65,6 +66,7 @@ func (a *Apply) Run(cmd *cobra.Command, args []string) error {
 		Paused:           a.Paused,
 		SyncGeneration:   int64(a.SyncGeneration),
 		HelmRepoURLRegex: a.HelmRepoURLRegex,
+		KeepResources:    a.KeepResources,
 	}
 
 	if a.Username != "" && a.PasswordFile != "" {

--- a/pkg/apis/fleet.cattle.io/v1alpha1/bundle.go
+++ b/pkg/apis/fleet.cattle.io/v1alpha1/bundle.go
@@ -197,6 +197,7 @@ type BundleDeploymentOptions struct {
 	ForceSyncGeneration int64             `json:"forceSyncGeneration,omitempty"`
 	YAML                *YAMLOptions      `json:"yaml,omitempty"`
 	Diff                *DiffOptions      `json:"diff,omitempty"`
+	KeepResources       bool              `json:"keepResources,omitempty"`
 }
 
 type DiffOptions struct {

--- a/pkg/apis/fleet.cattle.io/v1alpha1/git.go
+++ b/pkg/apis/fleet.cattle.io/v1alpha1/git.go
@@ -80,6 +80,9 @@ type GitRepoSpec struct {
 	// Commit specifies how to commit to the git repo when new image is scanned and write back to git repo
 	// +required
 	ImageScanCommit CommitSpec `json:"imageScanCommit,omitempty"`
+
+	// KeepResources specifies if the resources created must be kept after deleting the GitRepo
+	KeepResources bool `json:"keepResources,omitempty"`
 }
 
 type GitTarget struct {

--- a/pkg/bundlereader/read.go
+++ b/pkg/bundlereader/read.go
@@ -32,6 +32,7 @@ type Options struct {
 	SyncGeneration   int64
 	Auth             Auth
 	HelmRepoURLRegex string
+	KeepResources    bool
 }
 
 // Open reads the fleet.yaml, from stdin, or basedir, or a file in basedir.
@@ -249,6 +250,10 @@ func read(ctx context.Context, name, baseDir string, bundleSpecReader io.Reader,
 
 	if opts.Paused {
 		bundle.Spec.Paused = true
+	}
+
+	if opts.KeepResources {
+		bundle.Spec.KeepResources = opts.KeepResources
 	}
 
 	return bundle, scans, nil

--- a/pkg/controllers/git/git.go
+++ b/pkg/controllers/git/git.go
@@ -641,6 +641,10 @@ func argsAndEnvs(gitrepo *fleet.GitRepo) ([]string, []corev1.EnvVar) {
 		"--target-namespace", gitrepo.Spec.TargetNamespace,
 	)
 
+	if gitrepo.Spec.KeepResources {
+		args = append(args, "--keep-resources")
+	}
+
 	var env []corev1.EnvVar
 	if gitrepo.Spec.HelmSecretName != "" {
 		helmArgs := []string{

--- a/pkg/options/calculate.go
+++ b/pkg/options/calculate.go
@@ -107,5 +107,7 @@ func Merge(base, custom fleet.BundleDeploymentOptions) fleet.BundleDeploymentOpt
 	if custom.ForceSyncGeneration > 0 {
 		result.ForceSyncGeneration = custom.ForceSyncGeneration
 	}
+	result.KeepResources = result.KeepResources || custom.KeepResources
+
 	return result
 }


### PR DESCRIPTION
This PR adds a new field `keepResources` to the `GitRepo` and `Bundle` CRDs. It also adds the `keep-resources` flag to the fleet cli.  `keepResources`  can also be specified in the `fleet.yaml`

When a `GitRepo` has the `keepResources` field set to true it sets the `keep-resources` flag to true when executing fleet apply in the job. Then `keepResources` is true in the generated `Bundles` and `BundleDeployments`.

The chart annotation `fleet.cattle.io/keep-resources` is set to true if `keepResources` is true when installing the helm chart. This is done because when a `BundleDeployment` is deleted it is nil in the [cleanup](https://github.com/rancher/fleet/blob/master/modules/agent/pkg/controllers/bundledeployment/controller.go#L87), so we can use this annotation to know if resources should be kept.

Resources will not be deleted if `keepResources` is true. Helm release secrets will be removed instead, like it is done for the [fleet-agent](https://github.com/rancher/fleet/blob/master/pkg/helmdeployer/deployer.go#L632-L635)

e2e test added

Fix https://github.com/rancher/fleet/issues/680
Supersedes https://github.com/rancher/fleet/pull/1345
