### PR TITLE
fix: keepResources not set properly if releaseName is empty

### DIFF
--- a/pkg/helmdeployer/deployer.go
+++ b/pkg/helmdeployer/deployer.go
@@ -589,17 +589,17 @@ func (h *Helm) ResourcesFromPreviousReleaseVersion(bundleID, resourcesID string)
 // release.
 func (h *Helm) Delete(bundleID, releaseName string) error {
 	keepResources := false
-	if releaseName == "" {
-		deployments, err := h.ListDeployments()
-		if err != nil {
-			return err
-		}
-		for _, deployment := range deployments {
-			if deployment.BundleID == bundleID {
+	deployments, err := h.ListDeployments()
+	if err != nil {
+		return err
+	}
+	for _, deployment := range deployments {
+		if deployment.BundleID == bundleID {
+			if releaseName == "" {
 				releaseName = deployment.ReleaseName
-				keepResources = deployment.KeepResources
-				break
 			}
+			keepResources = deployment.KeepResources
+			break
 		}
 	}
 	if releaseName == "" {


### PR DESCRIPTION
`keepResources` was not set if `releaseName` was empty. This was deleting resources when changing a cluster to a different workspace.
This PR always sets `keepResources` regardless of the `releaseName`  value

We call delete without `releaseName` [here](https://github.com/rancher/fleet/blob/master/modules/agent/pkg/deployer/manager.go#L96), which is called when a `BundleDeployment` is deleted [here](https://github.com/rancher/fleet/blob/master/modules/agent/pkg/controllers/bundledeployment/controller.go#L95). We don't have the release name because the `BundleDeployment` is nil, so we retreive it from the deployment list.
However, when the orphan Bundle[ is called](https://github.com/rancher/fleet/blob/master/modules/agent/pkg/deployer/manager.go#L72) we do have the releaseName, so we pass it. This is what it is happening when moving workload to a different workspaces

fixes https://github.com/rancher/fleet/issues/680
