### PR TITLE
Fix BundleNamespaceMapping ignoring bundle selector

### DIFF
--- a/pkg/target/target.go
+++ b/pkg/target/target.go
@@ -223,12 +223,14 @@ func (m *Manager) getNamespacesForBundle(bundle *fleet.Bundle) ([]string, error)
 			logrus.Errorf("invalid BundleNamespaceMapping %s/%s skipping: %v", mapping.Namespace, mapping.Name, err)
 			continue
 		}
-		namespaces, err := matcher.Namespaces()
-		if err != nil {
-			return nil, err
-		}
-		for _, namespace := range namespaces {
-			nses.Insert(namespace.Name)
+		if matcher.Matches(bundle) {
+			namespaces, err := matcher.Namespaces()
+			if err != nil {
+				return nil, err
+			}
+			for _, namespace := range namespaces {
+				nses.Insert(namespace.Name)
+			}
 		}
 	}
 


### PR DESCRIPTION
We noticed that the custom resource ignores the configured bundle selector. If you create a BundleNamespaceMapping all bundles in this namespace will be mapped to the downstream clusters. 

We already tested this change with our custom build which you can reach here: johnjcool/fleet:0.6.0-rc.5.7

