### PR TITLE
catatonit init process

### DIFF
--- a/charts/fleet/charts/gitjob/templates/deployment.yaml
+++ b/charts/fleet/charts/gitjob/templates/deployment.yaml
@@ -15,8 +15,7 @@ spec:
       containers:
         - image: "{{ template "system_default_registry" . }}{{ .Values.gitjob.repository }}:{{ .Values.gitjob.tag }}"
           name: gitjob
-          command:
-          - gitjob
+          args:
           {{- if .Values.debug }}
           - --debug
           {{- end }}


### PR DESCRIPTION
catatonit was added to the entrypoint in gitjob in https://github.com/rancher/gitjob/pull/201. 
This PR replaces command with the extra args needed in the gitjob deployment

draft until https://github.com/rancher/gitjob/pull/201 is merged and a new gitjob release is created