### PR TITLE
Fix BundleNamespaceMapping ignoring bundle selector

### DIFF
--- a/e2e/assets/multi-cluster/bundle-namespace-mapping.yaml
+++ b/e2e/assets/multi-cluster/bundle-namespace-mapping.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: {{.ProjectNamespace}}
+{{if .Restricted}}
 ---
 kind: GitRepoRestriction
 apiVersion: fleet.cattle.io/v1alpha1
@@ -12,6 +13,7 @@ metadata:
 
 allowedTargetNamespaces:
   - project1simpleapp
+{{end}}
 ---
 kind: BundleNamespaceMapping
 apiVersion: fleet.cattle.io/v1alpha1
@@ -21,7 +23,7 @@ metadata:
 
 bundleSelector:
   matchLabels:
-    team: one
+    team: {{ .BundleSelectorLabel }}
 
 namespaceSelector:
   matchLabels:

--- a/e2e/testenv/env.go
+++ b/e2e/testenv/env.go
@@ -2,6 +2,9 @@
 package testenv
 
 import (
+	"encoding/hex"
+	"fmt"
+	"math/rand"
 	"os"
 	"time"
 
@@ -39,4 +42,10 @@ func (e *Env) getShellEnv() {
 	if val := os.Getenv("FLEET_E2E_NS"); val != "" {
 		e.Namespace = val
 	}
+}
+func NewNamespaceName(name string) string {
+	rand.Seed(time.Now().UnixNano())
+	p := make([]byte, 12)
+	rand.Read(p) // nolint:gosec // Non-crypto use
+	return fmt.Sprintf("test-%.20s-%.12s", name, hex.EncodeToString(p))
 }

--- a/pkg/apis/fleet.cattle.io/v1alpha1/bundle.go
+++ b/pkg/apis/fleet.cattle.io/v1alpha1/bundle.go
@@ -62,6 +62,7 @@ type BundleNamespaceMapping struct {
 type BundleSpec struct {
 	BundleDeploymentOptions
 
+	// Paused if set to true, will stop any BundleDeployments from being updated.
 	Paused             bool                      `json:"paused,omitempty"`
 	RolloutStrategy    *RolloutStrategy          `json:"rolloutStrategy,omitempty"`
 	Resources          []BundleResource          `json:"resources,omitempty"`

--- a/pkg/apis/fleet.cattle.io/v1alpha1/target.go
+++ b/pkg/apis/fleet.cattle.io/v1alpha1/target.go
@@ -58,6 +58,7 @@ type Cluster struct {
 }
 
 type ClusterSpec struct {
+	// Paused if set to true, will stop any BundleDeployments from being updated.
 	Paused                  bool   `json:"paused,omitempty"`
 	ClientID                string `json:"clientID,omitempty"`
 	KubeConfigSecret        string `json:"kubeConfigSecret,omitempty"`

--- a/pkg/target/target.go
+++ b/pkg/target/target.go
@@ -223,12 +223,14 @@ func (m *Manager) getNamespacesForBundle(bundle *fleet.Bundle) ([]string, error)
 			logrus.Errorf("invalid BundleNamespaceMapping %s/%s skipping: %v", mapping.Namespace, mapping.Name, err)
 			continue
 		}
-		namespaces, err := matcher.Namespaces()
-		if err != nil {
-			return nil, err
-		}
-		for _, namespace := range namespaces {
-			nses.Insert(namespace.Name)
+		if matcher.Matches(bundle) {
+			namespaces, err := matcher.Namespaces()
+			if err != nil {
+				return nil, err
+			}
+			for _, namespace := range namespaces {
+				nses.Insert(namespace.Name)
+			}
 		}
 	}
 


### PR DESCRIPTION
Adds test for https://github.com/rancher/fleet/pull/1401 and cherry picks the fix.

> We noticed that the custom resource ignores the configured bundle selector. If you create a BundleNamespaceMapping all bundles in this namespace will be mapped to the downstream clusters.
> We already tested this change with our custom build which you can reach here: johnjcool/fleet:0.6.0-rc.5.7


refers to issue #1427