### PR TITLE
Always get labels from Bundle when creating a BundleDeployment

### DIFF
--- a/integrationtests/agent/suite_test.go
+++ b/integrationtests/agent/suite_test.go
@@ -32,12 +32,10 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/discovery/cached/memory"
 	"k8s.io/client-go/dynamic"
-	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/restmapper"
 	"k8s.io/client-go/tools/clientcmd"
@@ -80,11 +78,7 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 	Expect(cfg).NotTo(BeNil())
 
-	customScheme := scheme.Scheme
-	customScheme.AddKnownTypes(schema.GroupVersion{Group: "fleet.cattle.io", Version: "v1alpha1"}, &v1alpha1.Bundle{}, &v1alpha1.BundleList{})
-	customScheme.AddKnownTypes(schema.GroupVersion{Group: "fleet.cattle.io", Version: "v1alpha1"}, &v1alpha1.BundleDeployment{}, &v1alpha1.BundleDeploymentList{})
-
-	k8sClient, err = client.New(cfg, client.Options{Scheme: customScheme})
+	k8sClient, err = client.New(cfg, client.Options{})
 	Expect(err).NotTo(HaveOccurred())
 	Expect(k8sClient).NotTo(BeNil())
 

--- a/integrationtests/agent/suite_test.go
+++ b/integrationtests/agent/suite_test.go
@@ -2,15 +2,14 @@ package agent
 
 import (
 	"context"
-	"encoding/hex"
 	"fmt"
-	"math/rand"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/rancher/fleet/integrationtests/utils"
 	"github.com/rancher/fleet/modules/agent/pkg/controllers/bundledeployment"
 	"github.com/rancher/fleet/modules/agent/pkg/deployer"
 	"github.com/rancher/fleet/modules/agent/pkg/trigger"
@@ -91,7 +90,8 @@ var _ = BeforeSuite(func() {
 
 	specEnvs = make(map[string]*specEnv, 2)
 	for id, f := range map[string]specResources{"capabilitybundle": capabilityBundleResources, "orphanbundle": orphanBundeResources} {
-		namespace := newNamespaceName()
+		namespace, err := utils.NewNamespaceName()
+		Expect(err).ToNot(HaveOccurred())
 		fmt.Printf("Creating namespace %s\n", namespace)
 		Expect(k8sClient.Create(ctx, &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
@@ -168,13 +168,6 @@ func registerBundleDeploymentController(cfg *rest.Config, namespace string, look
 	Expect(err).ToNot(HaveOccurred())
 
 	return factory.Fleet().V1alpha1().BundleDeployment()
-}
-
-func newNamespaceName() string {
-	rand.Seed(time.Now().UnixNano())
-	p := make([]byte, 12)
-	rand.Read(p)
-	return fmt.Sprintf("test-%s", hex.EncodeToString(p))[:12]
 }
 
 // restClientGetter is needed to create the helm deployer. We just need to return the rest.Config for this test.

--- a/integrationtests/controller/bundle/bundle_labels_test.go
+++ b/integrationtests/controller/bundle/bundle_labels_test.go
@@ -1,0 +1,127 @@
+package agent
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
+	v1gen "github.com/rancher/fleet/pkg/generated/controllers/fleet.cattle.io/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+var _ = Describe("Bundle labels", func() {
+
+	var (
+		env                        *specEnv
+		bundleController           v1gen.BundleController
+		clusterController          v1gen.ClusterController
+		bundleDeploymentController v1gen.BundleDeploymentController
+	)
+
+	createBundle := func(name, namespace string) {
+		bundle := v1alpha1.Bundle{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+				Labels:    map[string]string{"foo": "bar"},
+			},
+			Spec: v1alpha1.BundleSpec{
+				Targets: []v1alpha1.BundleTarget{
+					{
+						BundleDeploymentOptions: v1alpha1.BundleDeploymentOptions{
+							TargetNamespace: "targetNs",
+						},
+						Name:        "cluster",
+						ClusterName: "cluster",
+					},
+				},
+			},
+		}
+		b, err := bundleController.Create(&bundle)
+		Expect(err).To(BeNil())
+		Expect(b).To(Not(BeNil()))
+	}
+
+	createCluster := func(name, namespace string) {
+		cluster := v1alpha1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+				Labels:    map[string]string{"env": "test"},
+			},
+			Spec: v1alpha1.ClusterSpec{
+				ClientID: "id",
+			},
+		}
+		c, err := clusterController.Create(&cluster)
+		Expect(err).To(BeNil())
+		Expect(c).To(Not(BeNil()))
+		// Need to set the status.Namespace as it is needed to create a BundleDeployment.
+		// Namespace is set by the Cluster controller. We need to do it manually because we are running just the Bundle controller.
+		c.Status.Namespace = namespace
+		c, err = clusterController.UpdateStatus(c)
+		Expect(err).To(BeNil())
+		Expect(c).To(Not(BeNil()))
+	}
+
+	BeforeEach(func() {
+		env = specEnvs["labels"]
+		bundleController = env.fleet.V1alpha1().Bundle()
+		clusterController = env.fleet.V1alpha1().Cluster()
+		bundleDeploymentController = env.fleet.V1alpha1().BundleDeployment()
+
+		DeferCleanup(func() {
+			Expect(env.k8sClient.Delete(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: env.namespace}})).ToNot(HaveOccurred())
+		})
+	})
+
+	When("BundleDeployment labels are updated", func() {
+		BeforeEach(func() {
+			createCluster("cluster", env.namespace)
+			createBundle("name", env.namespace)
+		})
+
+		AfterEach(func() {
+			Expect(bundleController.Delete(env.namespace, "name", nil)).NotTo(HaveOccurred())
+		})
+
+		It("Bundle is created", func() {
+			bundle, err := bundleController.Get(env.namespace, "name", metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(bundle).To(Not(BeNil()))
+
+			bdLabels := map[string]string{
+				"fleet.cattle.io/bundle-name":      bundle.Name,
+				"fleet.cattle.io/bundle-namespace": bundle.Namespace,
+			}
+
+			By("BundleDeployment has the foo label from Bundle")
+			Eventually(func() bool {
+				return expectedLabelValue(bundleDeploymentController, bdLabels, "foo", "bar")
+			}).Should(BeTrue())
+
+			By("Modifying foo label in Bundle")
+			labelPatch := `[{"op":"add","path":"/metadata/labels/foo","value":"modified"}]`
+			bundle, err = bundleController.Patch(bundle.ObjectMeta.Namespace, bundle.Name, types.JSONPatchType, []byte(labelPatch))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(bundle).To(Not(BeNil()))
+
+			By("Should modify foo label in BundleDeployment")
+			Eventually(func() bool {
+				return expectedLabelValue(bundleDeploymentController, bdLabels, "foo", "modified")
+			}).Should(BeTrue())
+
+		})
+	})
+})
+
+func expectedLabelValue(controller v1gen.BundleDeploymentController, bdLabels map[string]string, key, value string) bool {
+	list, err := controller.List("", metav1.ListOptions{LabelSelector: labels.SelectorFromSet(bdLabels).String()})
+	Expect(err).NotTo(HaveOccurred())
+	if len(list.Items) == 1 {
+		return list.Items[0].Labels[key] == value
+	}
+	return false
+}

--- a/integrationtests/controller/bundle/suite_test.go
+++ b/integrationtests/controller/bundle/suite_test.go
@@ -1,0 +1,148 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/rancher/fleet/integrationtests/utils"
+	"github.com/rancher/fleet/pkg/controllers/bundle"
+	"github.com/rancher/fleet/pkg/target"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/rancher/fleet/pkg/durations"
+	"github.com/rancher/fleet/pkg/generated/controllers/fleet.cattle.io"
+	"github.com/rancher/fleet/pkg/manifest"
+	"github.com/rancher/lasso/pkg/cache"
+	lassoclient "github.com/rancher/lasso/pkg/client"
+	"github.com/rancher/lasso/pkg/controller"
+	"github.com/rancher/wrangler/pkg/apply"
+	"github.com/rancher/wrangler/pkg/generated/controllers/core"
+
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/discovery/cached/memory"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/restmapper"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+)
+
+var (
+	cfg      *rest.Config
+	testEnv  *envtest.Environment
+	ctx      context.Context
+	cancel   context.CancelFunc
+	specEnvs map[string]*specEnv
+)
+
+const (
+	timeout = 30 * time.Second
+)
+
+func TestFleet(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Fleet Bundle Suite")
+}
+
+var _ = BeforeSuite(func() {
+	SetDefaultEventuallyTimeout(timeout)
+	ctx, cancel = context.WithCancel(context.TODO())
+	testEnv = &envtest.Environment{
+		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "charts", "fleet-crd", "templates", "crds.yaml")},
+		ErrorIfCRDPathMissing: true,
+	}
+
+	var err error
+	cfg, err = testEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(cfg).NotTo(BeNil())
+
+	k8sClient, err := client.New(cfg, client.Options{})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(k8sClient).NotTo(BeNil())
+
+	specEnvs = make(map[string]*specEnv, 1)
+	for _, id := range []string{"labels"} {
+		namespace, err := utils.NewNamespaceName()
+		Expect(err).ToNot(HaveOccurred())
+		fmt.Printf("Creating namespace %s\n", namespace)
+		Expect(k8sClient.Create(ctx, &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: namespace,
+			},
+		})).ToNot(HaveOccurred())
+
+		fleet := registerBundleController(cfg, namespace)
+
+		specEnvs[id] = &specEnv{fleet: fleet, k8sClient: k8sClient, namespace: namespace}
+	}
+})
+
+var _ = AfterSuite(func() {
+	cancel()
+	Expect(testEnv.Stop()).ToNot(HaveOccurred())
+})
+
+func registerBundleController(cfg *rest.Config, namespace string) fleet.Interface {
+	d, err := discovery.NewDiscoveryClientForConfig(cfg)
+	Expect(err).ToNot(HaveOccurred())
+	disc := memory.NewMemCacheClient(d)
+	mapper := restmapper.NewDeferredDiscoveryRESTMapper(disc)
+	cf, err := lassoclient.NewSharedClientFactory(cfg, &lassoclient.SharedClientFactoryOptions{
+		Mapper: mapper,
+	})
+	Expect(err).ToNot(HaveOccurred())
+
+	sharedFactory := controller.NewSharedControllerFactory(cache.NewSharedCachedFactory(cf, &cache.SharedCacheFactoryOptions{
+		DefaultNamespace: namespace,
+		DefaultResync:    durations.DefaultResyncAgent,
+	}), nil)
+
+	// this factory will watch Bundles just for the namespace provided
+	factory, err := fleet.NewFactoryFromConfigWithOptions(cfg, &fleet.FactoryOptions{
+		SharedControllerFactory: sharedFactory,
+	})
+	Expect(err).ToNot(HaveOccurred())
+
+	coreFactory, err := core.NewFactoryFromConfig(cfg)
+	Expect(err).ToNot(HaveOccurred())
+
+	wranglerApply, err := apply.NewForConfig(cfg)
+	Expect(err).ToNot(HaveOccurred())
+	wranglerApply = wranglerApply.WithSetOwnerReference(false, false)
+
+	targetManager := target.New(
+		factory.Fleet().V1alpha1().Cluster().Cache(),
+		factory.Fleet().V1alpha1().ClusterGroup().Cache(),
+		factory.Fleet().V1alpha1().Bundle().Cache(),
+		factory.Fleet().V1alpha1().BundleNamespaceMapping().Cache(),
+		coreFactory.Core().V1().Namespace().Cache(),
+		manifest.NewStore(factory.Fleet().V1alpha1().Content()),
+		factory.Fleet().V1alpha1().BundleDeployment().Cache())
+
+	bundle.Register(ctx,
+		wranglerApply,
+		mapper,
+		targetManager,
+		factory.Fleet().V1alpha1().Bundle(),
+		factory.Fleet().V1alpha1().Cluster(),
+		factory.Fleet().V1alpha1().ImageScan(),
+		factory.Fleet().V1alpha1().GitRepo().Cache(),
+		factory.Fleet().V1alpha1().BundleDeployment())
+
+	err = factory.Start(ctx, 50)
+	Expect(err).ToNot(HaveOccurred())
+
+	return factory.Fleet()
+}
+
+type specEnv struct {
+	fleet     fleet.Interface
+	namespace string
+	k8sClient client.Client
+}

--- a/integrationtests/utils/utils.go
+++ b/integrationtests/utils/utils.go
@@ -1,0 +1,19 @@
+package utils
+
+import (
+	cryptorand "crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"math/rand"
+	"time"
+)
+
+func NewNamespaceName() (string, error) {
+	rand.Seed(time.Now().UnixNano())
+	p := make([]byte, 12)
+	_, err := cryptorand.Read(p)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("test-%s", hex.EncodeToString(p))[:12], nil
+}

--- a/pkg/controllers/bundle/controller.go
+++ b/pkg/controllers/bundle/controller.go
@@ -298,7 +298,7 @@ func bundleDeployments(targets []*target.Target, bundle *fleet.Bundle) (result [
 			ObjectMeta: v1.ObjectMeta{
 				Name:      target.Deployment.Name,
 				Namespace: target.Deployment.Namespace,
-				Labels:    target.Deployment.Labels,
+				Labels:    target.BundleDeploymentLabels(),
 			},
 			Spec: target.Deployment.Spec,
 		}

--- a/pkg/controllers/bundle/controller.go
+++ b/pkg/controllers/bundle/controller.go
@@ -287,13 +287,15 @@ func setResourceKey(status *fleet.BundleStatus, bundle *fleet.Bundle, manifest *
 }
 
 // bundleDeployments copies BundleDeployments out of targets and into a new slice of runtime.Object
-// discarding Status, and replacing DependsOn with the bundle's DependsOn (pure function)
+// discarding Status, replacing DependsOn with the bundle's DependsOn (pure function) and replacing the labels with the
+// bundle's labels
 func bundleDeployments(targets []*target.Target, bundle *fleet.Bundle) (result []runtime.Object) {
 	for _, target := range targets {
 		if target.Deployment == nil {
 			continue
 		}
 		// NOTE we don't use the existing BundleDeployment, we discard annotations, status, etc
+		// copy labels from Bundle as they might have changed
 		dp := &fleet.BundleDeployment{
 			ObjectMeta: v1.ObjectMeta{
 				Name:      target.Deployment.Name,

--- a/pkg/target/target.go
+++ b/pkg/target/target.go
@@ -421,18 +421,24 @@ func (t *Target) IsPaused() bool {
 
 // ResetDeployment replaces the BundleDeployment for the target with a new one
 func (t *Target) ResetDeployment() {
+	t.Deployment = &fleet.BundleDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      t.Bundle.Name,
+			Namespace: t.Cluster.Status.Namespace,
+			Labels:    t.BundleDeploymentLabels(),
+		},
+	}
+}
+
+// BundleDeploymentLabels returns all labels from the Bundle
+func (t *Target) BundleDeploymentLabels() map[string]string {
 	labels := map[string]string{}
 	for k, v := range deploymentLabelsForNewBundle(t.Bundle) {
 		labels[k] = v
 	}
 	labels[fleet.ManagedLabel] = "true"
-	t.Deployment = &fleet.BundleDeployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      t.Bundle.Name,
-			Namespace: t.Cluster.Status.Namespace,
-			Labels:    labels,
-		},
-	}
+
+	return labels
 }
 
 // getRollout returns the rollout strategy for the specified targets (pure function)


### PR DESCRIPTION
When a label is modified in the `fleet.yaml` is also modified in the `Bundle`, but no in the `BundleDeployment`

`BundleDeployment` labels are not being updated when changed in the `fleet.yaml`. This is because we just get the labels from the `Bundle` the first time the `BundleDeployment` is created, this is done in the [resetDeployment method](https://github.com/rancher/fleet/blob/c7b02620e82b16afdca91bc466b527fa7c6232aa/pkg/target/target.go#L433). 

This PR always get the labels from the `Bundle` when creating a `BundleDeployment`

BundleDeployment patch was failing in the integration tests because wrangler was using `application/strategic-merge-patch+json` strategy for the patch. Then I was getting the error:
```
time="2023-03-24T17:04:02+01:00" level=error msg="error syncing 'test-0e60e6e/name': handler bundle: failed to update test-0e60e6e/name fleet.cattle.io/v1alpha1, Kind=BundleDeployment for bundle test-0e60e6e/name: the body of the request was in an unknown format - accepted media types include: application/json-patch+json, application/merge-patch+json, application/apply-patch+yaml, requeuing"
```
This was happening because I registered the `Bundle` and `BundleDeployment` in the client, then wrangler was choosing this strategy [here](https://github.com/rancher/wrangler/blob/v1.1.1/pkg/patch/style.go#L64). I fixed this by not registering the `Bundle` and `BundleDeployment` in the client as they are not needed, then I did the same for the `BundleDeployment` integration tests [here](https://github.com/rancher/fleet/pull/1428/commits/db34da7a96eb94492b42de41e9615d1e09fff315) in order to prevent this error in the future.

refers to https://github.com/rancher/fleet/issues/1153
