### PR TITLE
Fix targeting issues

### DIFF
--- a/integrationtests/controller/bundle/bundle_targets_test.go
+++ b/integrationtests/controller/bundle/bundle_targets_test.go
@@ -37,10 +37,11 @@ var _ = Describe("Bundle targets", Ordered, func() {
 	})
 
 	var (
-		targets            []v1alpha1.BundleTarget
-		targetRestrictions []v1alpha1.BundleTarget
-		bundleName         string
-		bdLabels           map[string]string
+		targets                           []v1alpha1.BundleTarget
+		targetRestrictions                []v1alpha1.BundleTarget
+		bundleName                        string
+		bdLabels                          map[string]string
+		expectedNumberOfBundleDeployments int
 	)
 
 	JustBeforeEach(func() {
@@ -60,6 +61,7 @@ var _ = Describe("Bundle targets", Ordered, func() {
 				"fleet.cattle.io/bundle-name":      bundleName,
 				"fleet.cattle.io/bundle-namespace": env.namespace,
 			}
+			expectedNumberOfBundleDeployments = 3
 			// simulate targets in GitRepo. All targets in GitRepo are also added to targetRestrictions, which acts as a white list
 			targets = []v1alpha1.BundleTarget{
 				{
@@ -71,7 +73,7 @@ var _ = Describe("Bundle targets", Ordered, func() {
 		})
 
 		It("creates three BundleDeployments", func() {
-			var bdList = verifyBundlesDeploymentsAreCreated(3, bdLabels)
+			var bdList = verifyBundlesDeploymentsAreCreated(expectedNumberOfBundleDeployments, bdLabels)
 			By("and BundleDeployments don't have values from customizations")
 			for _, bd := range bdList.Items {
 				Expect(bd.Spec.Options.Helm.Values).To(BeNil())
@@ -86,6 +88,7 @@ var _ = Describe("Bundle targets", Ordered, func() {
 				"fleet.cattle.io/bundle-name":      bundleName,
 				"fleet.cattle.io/bundle-namespace": env.namespace,
 			}
+			expectedNumberOfBundleDeployments = 3
 			// simulate targets in fleet.yaml which are used for customization
 			targets = []v1alpha1.BundleTarget{
 				{
@@ -114,7 +117,7 @@ var _ = Describe("Bundle targets", Ordered, func() {
 		})
 
 		It("three BundleDeployments are created", func() {
-			var bdList = verifyBundlesDeploymentsAreCreated(3, bdLabels)
+			var bdList = verifyBundlesDeploymentsAreCreated(expectedNumberOfBundleDeployments, bdLabels)
 			By("and BundleDeployments have values from customizations")
 			for _, bd := range bdList.Items {
 				Expect(bd.Spec.Options.Helm.Values.Data).To(Equal(map[string]interface{}{"replicas": "3"}))
@@ -129,6 +132,7 @@ var _ = Describe("Bundle targets", Ordered, func() {
 				"fleet.cattle.io/bundle-name":      bundleName,
 				"fleet.cattle.io/bundle-namespace": env.namespace,
 			}
+			expectedNumberOfBundleDeployments = 3
 			// simulate targets in fleet.yaml which are used for customization
 			targets = []v1alpha1.BundleTarget{
 				{
@@ -165,7 +169,7 @@ var _ = Describe("Bundle targets", Ordered, func() {
 		})
 
 		It("three BundleDeployments are created", func() {
-			var bdList = verifyBundlesDeploymentsAreCreated(3, bdLabels)
+			var bdList = verifyBundlesDeploymentsAreCreated(expectedNumberOfBundleDeployments, bdLabels)
 			By("and just BundleDeployment from cluster one and two are customized")
 			for _, bd := range bdList.Items {
 				if strings.Contains(bd.ObjectMeta.Namespace, "cluster-one") {
@@ -186,6 +190,7 @@ var _ = Describe("Bundle targets", Ordered, func() {
 				"fleet.cattle.io/bundle-name":      bundleName,
 				"fleet.cattle.io/bundle-namespace": env.namespace,
 			}
+			expectedNumberOfBundleDeployments = 3
 			// simulate targets in fleet.yaml which are used for customization
 			targets = []v1alpha1.BundleTarget{
 				{
@@ -222,7 +227,7 @@ var _ = Describe("Bundle targets", Ordered, func() {
 		})
 
 		It("three BundleDeployments are created", func() {
-			var bdList = verifyBundlesDeploymentsAreCreated(3, bdLabels)
+			var bdList = verifyBundlesDeploymentsAreCreated(expectedNumberOfBundleDeployments, bdLabels)
 			By("and just BundleDeployment from cluster one is customized")
 			for _, bd := range bdList.Items {
 				if strings.Contains(bd.ObjectMeta.Namespace, "cluster-one") {
@@ -241,6 +246,7 @@ var _ = Describe("Bundle targets", Ordered, func() {
 				"fleet.cattle.io/bundle-name":      bundleName,
 				"fleet.cattle.io/bundle-namespace": env.namespace,
 			}
+			expectedNumberOfBundleDeployments = 1
 			// simulate targets in fleet.yaml which are used for customization
 			targets = []v1alpha1.BundleTarget{
 				{
@@ -269,7 +275,7 @@ var _ = Describe("Bundle targets", Ordered, func() {
 		})
 
 		It("one BundleDeployment is created", func() {
-			var bdList = verifyBundlesDeploymentsAreCreated(1, bdLabels)
+			var bdList = verifyBundlesDeploymentsAreCreated(expectedNumberOfBundleDeployments, bdLabels)
 			By("and the BundleDeployment is customized")
 			for _, bd := range bdList.Items {
 				Expect(bd.Spec.Options.Helm.Values.Data).To(Equal(map[string]interface{}{"replicas": "2"}))

--- a/integrationtests/controller/bundle/bundle_targets_test.go
+++ b/integrationtests/controller/bundle/bundle_targets_test.go
@@ -1,0 +1,369 @@
+package agent
+
+import (
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/rancher/fleet/integrationtests/utils"
+	"github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
+	v1gen "github.com/rancher/fleet/pkg/generated/controllers/fleet.cattle.io/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+var (
+	env                        *specEnv
+	bundleController           v1gen.BundleController
+	clusterController          v1gen.ClusterController
+	bundleDeploymentController v1gen.BundleDeploymentController
+	clusterGroupController     v1gen.ClusterGroupController
+)
+
+var _ = Describe("Bundle targets", Ordered, func() {
+	BeforeAll(func() {
+		env = specEnvs["targets"]
+		bundleController = env.fleet.V1alpha1().Bundle()
+		clusterController = env.fleet.V1alpha1().Cluster()
+		bundleDeploymentController = env.fleet.V1alpha1().BundleDeployment()
+		clusterGroupController = env.fleet.V1alpha1().ClusterGroup()
+
+		createClustersAndClusterGroups()
+
+		DeferCleanup(func() {
+			Expect(env.k8sClient.Delete(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: env.namespace}})).ToNot(HaveOccurred())
+		})
+	})
+
+	var (
+		targets            []v1alpha1.BundleTarget
+		targetRestrictions []v1alpha1.BundleTarget
+		bundleName         string
+		bdLabels           map[string]string
+	)
+
+	JustBeforeEach(func() {
+		bundle, err := createBundle(bundleName, env.namespace, bundleController, targets, targetRestrictions)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(bundle).To(Not(BeNil()))
+	})
+
+	AfterEach(func() {
+		Expect(bundleController.Delete(env.namespace, bundleName, nil)).NotTo(HaveOccurred())
+	})
+
+	When("target all clusters without customization", func() {
+		BeforeEach(func() {
+			bundleName = "all"
+			bdLabels = map[string]string{
+				"fleet.cattle.io/bundle-name":      bundleName,
+				"fleet.cattle.io/bundle-namespace": env.namespace,
+			}
+			// simulate targets in GitRepo. All targets in GitRepo are also added to targetRestrictions, which acts as a white list
+			targets = []v1alpha1.BundleTarget{
+				{
+					ClusterGroup: "all",
+				},
+			}
+			targetRestrictions = make([]v1alpha1.BundleTarget, len(targets))
+			copy(targetRestrictions, targets)
+		})
+
+		It("three BundleDeployments are created", func() {
+			var bdList = verifyBundlesDeploymentsAreCreated(3, bdLabels)
+			By("and BundleDeployments don't have values from customizations")
+			for _, bd := range bdList.Items {
+				Expect(bd.Spec.Options.Helm.Values).To(BeNil())
+			}
+		})
+	})
+
+	When("target customization for all clusters", func() {
+		BeforeEach(func() {
+			bundleName = "all-customized"
+			bdLabels = map[string]string{
+				"fleet.cattle.io/bundle-name":      bundleName,
+				"fleet.cattle.io/bundle-namespace": env.namespace,
+			}
+			// simulate targets in fleet.yaml which are used for customization
+			targets = []v1alpha1.BundleTarget{
+				{
+					BundleDeploymentOptions: v1alpha1.BundleDeploymentOptions{
+						Helm: &v1alpha1.HelmOptions{
+							Values: &v1alpha1.GenericMap{Data: map[string]interface{}{"replicas": "3"}},
+						},
+					},
+					ClusterGroup: "all",
+				},
+			}
+			// simulate targets in GitRepo. All targets in GitRepo are also added to targetRestrictions, which acts as a white list
+			targetsInGitRepo := []v1alpha1.BundleTarget{
+				{
+					BundleDeploymentOptions: v1alpha1.BundleDeploymentOptions{
+						Helm: &v1alpha1.HelmOptions{
+							Values: &v1alpha1.GenericMap{Data: map[string]interface{}{"replicas": "1"}},
+						},
+					},
+					ClusterGroup: "all",
+				},
+			}
+			targetRestrictions = make([]v1alpha1.BundleTarget, len(targetsInGitRepo))
+			copy(targetRestrictions, targetsInGitRepo)
+			targets = append(targets, targetsInGitRepo...)
+		})
+
+		It("three BundleDeployments are created", func() {
+			var bdList = verifyBundlesDeploymentsAreCreated(3, bdLabels)
+			By("and BundleDeployments have values from customizations")
+			for _, bd := range bdList.Items {
+				Expect(bd.Spec.Options.Helm.Values.Data).To(Equal(map[string]interface{}{"replicas": "3"}))
+			}
+		})
+	})
+
+	When("target customization for clusters one and two", func() {
+		BeforeEach(func() {
+			bundleName = "one-customized"
+			bdLabels = map[string]string{
+				"fleet.cattle.io/bundle-name":      bundleName,
+				"fleet.cattle.io/bundle-namespace": env.namespace,
+			}
+			// simulate targets in fleet.yaml which are used for customization
+			targets = []v1alpha1.BundleTarget{
+				{
+					BundleDeploymentOptions: v1alpha1.BundleDeploymentOptions{
+						Helm: &v1alpha1.HelmOptions{
+							Values: &v1alpha1.GenericMap{Data: map[string]interface{}{"replicas": "1"}},
+						},
+					},
+					ClusterGroup: "one",
+				},
+				{
+					BundleDeploymentOptions: v1alpha1.BundleDeploymentOptions{
+						Helm: &v1alpha1.HelmOptions{
+							Values: &v1alpha1.GenericMap{Data: map[string]interface{}{"replicas": "2"}},
+						},
+					},
+					ClusterGroup: "two",
+				},
+			}
+			// simulate targets in GitRepo. All targets in GitRepo are also added to targetRestrictions, which acts as a white list
+			targetsInGitRepo := []v1alpha1.BundleTarget{
+				{
+					BundleDeploymentOptions: v1alpha1.BundleDeploymentOptions{
+						Helm: &v1alpha1.HelmOptions{
+							Values: &v1alpha1.GenericMap{Data: map[string]interface{}{"replicas": "4"}},
+						},
+					},
+					ClusterGroup: "all",
+				},
+			}
+			targetRestrictions = make([]v1alpha1.BundleTarget, len(targetsInGitRepo))
+			copy(targetRestrictions, targetsInGitRepo)
+			targets = append(targets, targetsInGitRepo...)
+		})
+
+		It("three BundleDeployments are created", func() {
+			var bdList = verifyBundlesDeploymentsAreCreated(3, bdLabels)
+			By("and just BundleDeployment from cluster one and two are customized")
+			for _, bd := range bdList.Items {
+				if strings.Contains(bd.ObjectMeta.Namespace, "cluster-one") {
+					Expect(bd.Spec.Options.Helm.Values.Data).To(Equal(map[string]interface{}{"replicas": "1"}))
+				} else if strings.Contains(bd.ObjectMeta.Namespace, "cluster-two") {
+					Expect(bd.Spec.Options.Helm.Values.Data).To(Equal(map[string]interface{}{"replicas": "2"}))
+				} else {
+					Expect(bd.Spec.Options.Helm.Values.Data).To(Equal(map[string]interface{}{"replicas": "4"}))
+				}
+			}
+		})
+	})
+
+	When("target customization for cluster one and all clusters", func() {
+		BeforeEach(func() {
+			bundleName = "one-all-customized"
+			bdLabels = map[string]string{
+				"fleet.cattle.io/bundle-name":      bundleName,
+				"fleet.cattle.io/bundle-namespace": env.namespace,
+			}
+			// simulate targets in fleet.yaml which are used for customization
+			targets = []v1alpha1.BundleTarget{
+				{
+					BundleDeploymentOptions: v1alpha1.BundleDeploymentOptions{
+						Helm: &v1alpha1.HelmOptions{
+							Values: &v1alpha1.GenericMap{Data: map[string]interface{}{"replicas": "1"}},
+						},
+					},
+					ClusterGroup: "one",
+				},
+				{
+					BundleDeploymentOptions: v1alpha1.BundleDeploymentOptions{
+						Helm: &v1alpha1.HelmOptions{
+							Values: &v1alpha1.GenericMap{Data: map[string]interface{}{"replicas": "4"}},
+						},
+					},
+					ClusterGroup: "all",
+				},
+			}
+			// simulate targets in GitRepo. All targets in GitRepo are also added to targetRestrictions, which acts as a white list
+			targetsInGitRepo := []v1alpha1.BundleTarget{
+				{
+					BundleDeploymentOptions: v1alpha1.BundleDeploymentOptions{
+						Helm: &v1alpha1.HelmOptions{
+							Values: &v1alpha1.GenericMap{Data: map[string]interface{}{"replicas": "5"}},
+						},
+					},
+					ClusterGroup: "all",
+				},
+			}
+			targetRestrictions = make([]v1alpha1.BundleTarget, len(targetsInGitRepo))
+			copy(targetRestrictions, targetsInGitRepo)
+			targets = append(targets, targetsInGitRepo...)
+		})
+
+		It("three BundleDeployments are created", func() {
+			var bdList = verifyBundlesDeploymentsAreCreated(3, bdLabels)
+			By("and just BundleDeployment from cluster one is customized")
+			for _, bd := range bdList.Items {
+				if strings.Contains(bd.ObjectMeta.Namespace, "cluster-one") {
+					Expect(bd.Spec.Options.Helm.Values.Data).To(Equal(map[string]interface{}{"replicas": "1"}))
+				} else {
+					Expect(bd.Spec.Options.Helm.Values.Data).To(Equal(map[string]interface{}{"replicas": "4"}))
+				}
+			}
+		})
+	})
+
+	When("target customization for all cluster when targeting just cluster one", func() {
+		BeforeEach(func() {
+			bundleName = "one-target-all-customized"
+			bdLabels = map[string]string{
+				"fleet.cattle.io/bundle-name":      bundleName,
+				"fleet.cattle.io/bundle-namespace": env.namespace,
+			}
+			// simulate targets in fleet.yaml which are used for customization
+			targets = []v1alpha1.BundleTarget{
+				{
+					BundleDeploymentOptions: v1alpha1.BundleDeploymentOptions{
+						Helm: &v1alpha1.HelmOptions{
+							Values: &v1alpha1.GenericMap{Data: map[string]interface{}{"replicas": "2"}},
+						},
+					},
+					ClusterGroup: "all",
+				},
+			}
+			// simulate targets in GitRepo. All targets in GitRepo are also added to targetRestrictions, which acts as a white list
+			targetsInGitRepo := []v1alpha1.BundleTarget{
+				{
+					BundleDeploymentOptions: v1alpha1.BundleDeploymentOptions{
+						Helm: &v1alpha1.HelmOptions{
+							Values: &v1alpha1.GenericMap{Data: map[string]interface{}{"replicas": "1"}},
+						},
+					},
+					ClusterGroup: "one",
+				},
+			}
+			targetRestrictions = make([]v1alpha1.BundleTarget, len(targetsInGitRepo))
+			copy(targetRestrictions, targetsInGitRepo)
+			targets = append(targets, targetsInGitRepo...)
+		})
+
+		It("one BundleDeployment is created", func() {
+			var bdList = verifyBundlesDeploymentsAreCreated(1, bdLabels)
+			By("and the BundleDeployment is customized")
+			for _, bd := range bdList.Items {
+				Expect(bd.Spec.Options.Helm.Values.Data).To(Equal(map[string]interface{}{"replicas": "2"}))
+			}
+		})
+	})
+})
+
+func verifyBundlesDeploymentsAreCreated(numBundleDeployments int, bdLabels map[string]string) *v1alpha1.BundleDeploymentList {
+	var bdList *v1alpha1.BundleDeploymentList
+	var err error
+	Eventually(func() int {
+		bdList, err = bundleDeploymentController.List("", metav1.ListOptions{LabelSelector: labels.SelectorFromSet(bdLabels).String()})
+		Expect(err).NotTo(HaveOccurred())
+
+		return len(bdList.Items)
+	}).Should(Equal(numBundleDeployments))
+
+	return bdList
+}
+
+// creates:
+// - three clusters
+// - four cluster groups: one per cluster and another that matches all clusters
+// - a namespace per cluster. This is to simulate the namespace created for placing the BundleDeployments, this
+// is done by another controller, then it is set in the status field.
+func createClustersAndClusterGroups() {
+	clusterNs, err := utils.NewNamespaceName()
+	Expect(err).ToNot(HaveOccurred())
+	clusterNs = clusterNs + "cluster-one"
+	Expect(env.k8sClient.Create(ctx, &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: clusterNs,
+		},
+	})).ToNot(HaveOccurred())
+	DeferCleanup(func() {
+		Expect(env.k8sClient.Delete(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: clusterNs}})).ToNot(HaveOccurred())
+	})
+
+	clusterOne, err := createCluster("one", env.namespace, clusterController, map[string]string{"cluster": "one", "env": "test"}, clusterNs)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(clusterOne).To(Not(BeNil()))
+
+	clusterNs, err = utils.NewNamespaceName()
+	Expect(err).ToNot(HaveOccurred())
+	clusterNs = clusterNs + "cluster-two"
+	Expect(env.k8sClient.Create(ctx, &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: clusterNs,
+		},
+	})).ToNot(HaveOccurred())
+	DeferCleanup(func() {
+		Expect(env.k8sClient.Delete(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: clusterNs}})).ToNot(HaveOccurred())
+	})
+	clusterTwo, err := createCluster("two", env.namespace, clusterController, map[string]string{"cluster": "two", "env": "test"}, clusterNs)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(clusterTwo).To(Not(BeNil()))
+
+	clusterNs, err = utils.NewNamespaceName()
+	Expect(err).ToNot(HaveOccurred())
+	clusterNs = clusterNs + "cluster-three"
+	Expect(env.k8sClient.Create(ctx, &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: clusterNs,
+		},
+	})).ToNot(HaveOccurred())
+	DeferCleanup(func() {
+		Expect(env.k8sClient.Delete(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: clusterNs}})).ToNot(HaveOccurred())
+	})
+	clusterThree, err := createCluster("three", env.namespace, clusterController, map[string]string{"cluster": "three", "env": "test"}, clusterNs)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(clusterThree).To(Not(BeNil()))
+
+	clusterGroupOne, err := createClusterGroup("one", env.namespace, clusterGroupController, &metav1.LabelSelector{
+		MatchLabels: map[string]string{"cluster": "one"},
+	})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(clusterGroupOne).To(Not(BeNil()))
+
+	clusterGroupTwo, err := createClusterGroup("two", env.namespace, clusterGroupController, &metav1.LabelSelector{
+		MatchLabels: map[string]string{"cluster": "two"},
+	})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(clusterGroupTwo).To(Not(BeNil()))
+
+	clusterGroupThree, err := createClusterGroup("three", env.namespace, clusterGroupController, &metav1.LabelSelector{
+		MatchLabels: map[string]string{"cluster": "three"},
+	})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(clusterGroupThree).To(Not(BeNil()))
+
+	clusterGroupAll, err := createClusterGroup("all", env.namespace, clusterGroupController, &metav1.LabelSelector{
+		MatchLabels: map[string]string{"env": "test"},
+	})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(clusterGroupAll).To(Not(BeNil()))
+}

--- a/integrationtests/controller/bundle/bundle_targets_test.go
+++ b/integrationtests/controller/bundle/bundle_targets_test.go
@@ -81,7 +81,7 @@ var _ = Describe("Bundle targets", Ordered, func() {
 		})
 	})
 
-	When("target customization for all clusters", func() {
+	When("a target customization is specified for all clusters", func() {
 		BeforeEach(func() {
 			bundleName = "all-customized"
 			bdLabels = map[string]string{
@@ -116,7 +116,7 @@ var _ = Describe("Bundle targets", Ordered, func() {
 			targets = append(targets, targetsInGitRepo...)
 		})
 
-		It("three BundleDeployments are created", func() {
+		It("creates three BundleDeployments", func() {
 			var bdList = verifyBundlesDeploymentsAreCreated(expectedNumberOfBundleDeployments, bdLabels)
 			By("and BundleDeployments have values from customizations")
 			for _, bd := range bdList.Items {
@@ -125,7 +125,7 @@ var _ = Describe("Bundle targets", Ordered, func() {
 		})
 	})
 
-	When("target customization for clusters one and two", func() {
+	When("target customizations are specified for clusters one and two", func() {
 		BeforeEach(func() {
 			bundleName = "one-customized"
 			bdLabels = map[string]string{
@@ -168,7 +168,7 @@ var _ = Describe("Bundle targets", Ordered, func() {
 			targets = append(targets, targetsInGitRepo...)
 		})
 
-		It("three BundleDeployments are created", func() {
+		It("creates three BundleDeployments", func() {
 			var bdList = verifyBundlesDeploymentsAreCreated(expectedNumberOfBundleDeployments, bdLabels)
 			By("and just BundleDeployment from cluster one and two are customized")
 			for _, bd := range bdList.Items {
@@ -183,7 +183,7 @@ var _ = Describe("Bundle targets", Ordered, func() {
 		})
 	})
 
-	When("target customization for cluster one and all clusters", func() {
+	When("target customizations are specified both for cluster one, and for all clusters", func() {
 		BeforeEach(func() {
 			bundleName = "one-all-customized"
 			bdLabels = map[string]string{
@@ -226,7 +226,7 @@ var _ = Describe("Bundle targets", Ordered, func() {
 			targets = append(targets, targetsInGitRepo...)
 		})
 
-		It("three BundleDeployments are created", func() {
+		It("creates three BundleDeployments", func() {
 			var bdList = verifyBundlesDeploymentsAreCreated(expectedNumberOfBundleDeployments, bdLabels)
 			By("and just BundleDeployment from cluster one is customized")
 			for _, bd := range bdList.Items {
@@ -239,7 +239,7 @@ var _ = Describe("Bundle targets", Ordered, func() {
 		})
 	})
 
-	When("target customization for all clusters when targeting just cluster one", func() {
+	When("target customizations are specified for all clusters but the GitRepo targets only cluster one", func() {
 		BeforeEach(func() {
 			bundleName = "one-target-all-customized"
 			bdLabels = map[string]string{
@@ -274,7 +274,7 @@ var _ = Describe("Bundle targets", Ordered, func() {
 			targets = append(targets, targetsInGitRepo...)
 		})
 
-		It("one BundleDeployment is created", func() {
+		It("creates one BundleDeployment", func() {
 			var bdList = verifyBundlesDeploymentsAreCreated(expectedNumberOfBundleDeployments, bdLabels)
 			By("and the BundleDeployment is customized")
 			for _, bd := range bdList.Items {

--- a/integrationtests/controller/bundle/bundle_targets_test.go
+++ b/integrationtests/controller/bundle/bundle_targets_test.go
@@ -303,7 +303,6 @@ func verifyBundlesDeploymentsAreCreated(numBundleDeployments int, bdLabels map[s
 // - a namespace per cluster. This is to simulate the namespace created for placing the BundleDeployments, this
 // is done by another controller, then it is set in the status field.
 func createClustersAndClusterGroups() {
-
 	clusterNames := []string{"one", "two", "three"}
 	for _, cn := range clusterNames {
 		clusterNs, err := utils.NewNamespaceName()

--- a/integrationtests/controller/bundle/suite_test.go
+++ b/integrationtests/controller/bundle/suite_test.go
@@ -66,8 +66,8 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 	Expect(k8sClient).NotTo(BeNil())
 
-	specEnvs = make(map[string]*specEnv, 1)
-	for _, id := range []string{"labels"} {
+	specEnvs = make(map[string]*specEnv, 2)
+	for _, id := range []string{"labels", "targets"} {
 		namespace, err := utils.NewNamespaceName()
 		Expect(err).ToNot(HaveOccurred())
 		fmt.Printf("Creating namespace %s\n", namespace)

--- a/integrationtests/controller/bundle/utils.go
+++ b/integrationtests/controller/bundle/utils.go
@@ -1,0 +1,67 @@
+package agent
+
+import (
+	"github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
+	v1gen "github.com/rancher/fleet/pkg/generated/controllers/fleet.cattle.io/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func createBundle(name, namespace string, bundleController v1gen.BundleController, targets []v1alpha1.BundleTarget, targetRestrictions []v1alpha1.BundleTarget) (*v1alpha1.Bundle, error) {
+	// All Targets from the GitRepo are copied into TargetRestrictions. TargetRestrictions acts as a whitelist to prevent
+	// the creation of BundleDeployments from Targets created from the TargetCustomizations in the fleet.yaml
+	// we replicate this behaviour here since this is run in an integration tests that runs just the BundleController.
+	restrictions := []v1alpha1.BundleTargetRestriction{}
+	for _, r := range targetRestrictions {
+		restrictions = append(restrictions, v1alpha1.BundleTargetRestriction{
+			Name:                 r.Name,
+			ClusterName:          r.ClusterName,
+			ClusterSelector:      r.ClusterSelector,
+			ClusterGroup:         r.ClusterGroup,
+			ClusterGroupSelector: r.ClusterGroupSelector,
+		})
+	}
+	bundle := v1alpha1.Bundle{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    map[string]string{"foo": "bar"},
+		},
+		Spec: v1alpha1.BundleSpec{
+			Targets:            targets,
+			TargetRestrictions: restrictions,
+		},
+	}
+
+	return bundleController.Create(&bundle)
+}
+
+func createCluster(name, namespace string, clusterController v1gen.ClusterController, labels map[string]string, clusterNs string) (*v1alpha1.Cluster, error) {
+	cluster := v1alpha1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    labels,
+		},
+	}
+	c, err := clusterController.Create(&cluster)
+	if err != nil {
+		return nil, err
+	}
+	// Need to set the status.Namespace as it is needed to create a BundleDeployment.
+	// Namespace is set by the Cluster controller. We need to do it manually because we are running just the Bundle controller.
+	c.Status.Namespace = clusterNs
+	return clusterController.UpdateStatus(c)
+}
+
+func createClusterGroup(name, namespace string, clusterGroupController v1gen.ClusterGroupController, selector *metav1.LabelSelector) (*v1alpha1.ClusterGroup, error) {
+	cg := v1alpha1.ClusterGroup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: v1alpha1.ClusterGroupSpec{
+			Selector: selector,
+		},
+	}
+	return clusterGroupController.Create(&cg)
+}

--- a/integrationtests/controller/bundle/utils.go
+++ b/integrationtests/controller/bundle/utils.go
@@ -35,11 +35,11 @@ func createBundle(name, namespace string, bundleController v1gen.BundleControlle
 	return bundleController.Create(&bundle)
 }
 
-func createCluster(name, namespace string, clusterController v1gen.ClusterController, labels map[string]string, clusterNs string) (*v1alpha1.Cluster, error) {
+func createCluster(name, controllerNs string, clusterController v1gen.ClusterController, labels map[string]string, clusterNs string) (*v1alpha1.Cluster, error) {
 	cluster := v1alpha1.Cluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
-			Namespace: namespace,
+			Namespace: controllerNs,
 			Labels:    labels,
 		},
 	}

--- a/integrationtests/controller/bundle/utils.go
+++ b/integrationtests/controller/bundle/utils.go
@@ -6,10 +6,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// createBundle copies all targets from the GitRepo into TargetRestrictions. TargetRestrictions acts as a whitelist to prevent
+// the creation of BundleDeployments from Targets created from the TargetCustomizations in the fleet.yaml
+// we replicate this behaviour here since this is run in an integration tests that runs just the BundleController.
 func createBundle(name, namespace string, bundleController v1gen.BundleController, targets []v1alpha1.BundleTarget, targetRestrictions []v1alpha1.BundleTarget) (*v1alpha1.Bundle, error) {
-	// All Targets from the GitRepo are copied into TargetRestrictions. TargetRestrictions acts as a whitelist to prevent
-	// the creation of BundleDeployments from Targets created from the TargetCustomizations in the fleet.yaml
-	// we replicate this behaviour here since this is run in an integration tests that runs just the BundleController.
 	restrictions := []v1alpha1.BundleTargetRestriction{}
 	for _, r := range targetRestrictions {
 		restrictions = append(restrictions, v1alpha1.BundleTargetRestriction{

--- a/pkg/bundlematcher/match.go
+++ b/pkg/bundlematcher/match.go
@@ -11,6 +11,8 @@ type BundleMatch struct {
 	matcher *matcher
 }
 
+type findCriteriaMatch func(targetMatch targetMatch, clusterName, clusterGroup string, clusterGroupLabels, clusterLabels map[string]string) bool
+
 func New(bundle *fleet.Bundle) (*BundleMatch, error) {
 	bm := &BundleMatch{
 		bundle: bundle,
@@ -28,15 +30,25 @@ func (a *BundleMatch) MatchForTarget(name string) *fleet.BundleTarget {
 	return nil
 }
 
+// Match returns the first BundleTarget that matches the target criteria. Targets are evaluated in order
+// It checks for restrictions, which means that just targets included in the GitRepo can be returned. TargetCustomizations
+// described in the fleet.yaml will be ignored.
+// All GitRepo targets are added as TargetRestrictions, which acts as a whitelist.
 func (a *BundleMatch) Match(clusterName string, clusterGroups map[string]map[string]string, clusterLabels map[string]string) *fleet.BundleTarget {
-	for clusterGroup, clusterGroupLabels := range clusterGroups {
-		if m := a.matcher.Match(clusterName, clusterGroup, clusterGroupLabels, clusterLabels); m != nil {
-			return m
-		}
+	if m := a.matcher.match(clusterName, clusterLabels, clusterGroups, a.matcher.criteriaWithRestrictions); m != nil {
+		return m
 	}
-	if len(clusterGroups) == 0 {
-		return a.matcher.Match(clusterName, "", nil, clusterLabels)
+
+	return nil
+}
+
+// MatchTargetCustomizations returns the first BundleTarget that matches the target criteria. Targets are evaluated in order
+// It doesn't check for restrictions, which means TargetCustomizations described in the fleet.yaml are considered.
+func (a *BundleMatch) MatchTargetCustomizations(clusterName string, clusterGroups map[string]map[string]string, clusterLabels map[string]string) *fleet.BundleTarget {
+	if m := a.matcher.match(clusterName, clusterLabels, clusterGroups, criteriaWithoutRestrictions); m != nil {
+		return m
 	}
+
 	return nil
 }
 
@@ -94,14 +106,34 @@ func (m *matcher) isRestricted(clusterName, clusterGroup string, clusterGroupLab
 	return true
 }
 
-func (m *matcher) Match(clusterName, clusterGroup string, clusterGroupLabels, clusterLabels map[string]string) *fleet.BundleTarget {
-	if m.isRestricted(clusterName, clusterGroup, clusterGroupLabels, clusterLabels) {
-		return nil
+// checks if criteria is matched just if the target is inside the targetRestrictions. This is used for Targets defined
+// in the GitRepo, since these targets are also added as targetRestrictions.
+func (m *matcher) criteriaWithRestrictions(targetMatch targetMatch, clusterName, clusterGroup string, clusterGroupLabels, clusterLabels map[string]string) bool {
+	if !m.isRestricted(clusterName, clusterGroup, clusterGroupLabels, clusterLabels) &&
+		targetMatch.criteria.Match(clusterName, clusterGroup, clusterGroupLabels, clusterLabels) {
+		return true
 	}
 
+	return false
+}
+
+// doesn't check if target is inside the targetRestrictions. This is used for TargetCustomizations
+func criteriaWithoutRestrictions(targetMatch targetMatch, clusterName, clusterGroup string, clusterGroupLabels, clusterLabels map[string]string) bool {
+	return targetMatch.criteria.Match(clusterName, clusterGroup, clusterGroupLabels, clusterLabels)
+}
+
+func (m *matcher) match(clusterName string, clusterLabels map[string]string, clusterGroups map[string]map[string]string, findCriteriaMatch findCriteriaMatch) *fleet.BundleTarget {
 	for _, targetMatch := range m.matches {
-		if targetMatch.criteria.Match(clusterName, clusterGroup, clusterGroupLabels, clusterLabels) {
-			return targetMatch.bundleTarget
+		if len(clusterGroups) == 0 {
+			if findCriteriaMatch(targetMatch, clusterName, "", nil, clusterLabels) {
+				return targetMatch.bundleTarget
+			}
+		} else {
+			for clusterGroup, clusterGroupLabels := range clusterGroups {
+				if findCriteriaMatch(targetMatch, clusterName, clusterGroup, clusterGroupLabels, clusterLabels) {
+					return targetMatch.bundleTarget
+				}
+			}
 		}
 	}
 

--- a/pkg/bundlematcher/match.go
+++ b/pkg/bundlematcher/match.go
@@ -30,7 +30,7 @@ func (a *BundleMatch) MatchForTarget(name string) *fleet.BundleTarget {
 	return nil
 }
 
-// Match returns the first BundleTarget that matches the target criteria. Targets are evaluated in order
+// Match returns the first BundleTarget that matches the target criteria. Targets are evaluated in order.
 // It checks for restrictions, which means that just targets included in the GitRepo can be returned. TargetCustomizations
 // described in the fleet.yaml will be ignored.
 // All GitRepo targets are added as TargetRestrictions, which acts as a whitelist.
@@ -42,7 +42,7 @@ func (a *BundleMatch) Match(clusterName string, clusterGroups map[string]map[str
 	return nil
 }
 
-// MatchTargetCustomizations returns the first BundleTarget that matches the target criteria. Targets are evaluated in order
+// MatchTargetCustomizations returns the first BundleTarget that matches the target criteria. Targets are evaluated in order.
 // It doesn't check for restrictions, which means TargetCustomizations described in the fleet.yaml are considered.
 func (a *BundleMatch) MatchTargetCustomizations(clusterName string, clusterGroups map[string]map[string]string, clusterLabels map[string]string) *fleet.BundleTarget {
 	if m := a.matcher.match(clusterName, clusterLabels, clusterGroups, criteriaWithoutRestrictions); m != nil {
@@ -117,11 +117,12 @@ func (m *matcher) criteriaWithRestrictions(targetMatch targetMatch, clusterName,
 	return false
 }
 
-// doesn't check if target is inside the targetRestrictions. This is used for TargetCustomizations
+// Checks targetMatch's criteria for a match on the specified cluster name, group and labels, without checking if target is inside the targetRestrictions. This is used for TargetCustomizations.
 func criteriaWithoutRestrictions(targetMatch targetMatch, clusterName, clusterGroup string, clusterGroupLabels, clusterLabels map[string]string) bool {
 	return targetMatch.criteria.Match(clusterName, clusterGroup, clusterGroupLabels, clusterLabels)
 }
 
+// match returns the first BundleTarget, from the matcher's target matches, which matches the specified cluster name, groups and labels, using matching logic implemented via findCriteriaMatch.
 func (m *matcher) match(clusterName string, clusterLabels map[string]string, clusterGroups map[string]map[string]string, findCriteriaMatch findCriteriaMatch) *fleet.BundleTarget {
 	for _, targetMatch := range m.matches {
 		if len(clusterGroups) == 0 {

--- a/pkg/controllers/git/git.go
+++ b/pkg/controllers/git/git.go
@@ -109,7 +109,9 @@ func targetsOrDefault(targets []fleet.GitTarget) []fleet.GitTarget {
 }
 
 // getConfig builds a config map, containing the GitTarget cluster matchers, converted to BundleTargets.
-// The BundleTargets are duplicated into TargetRestrictions.
+// The BundleTargets are duplicated into TargetRestrictions. TargetRestrictions is a whilelist. A BundleDeployment
+// will be created for a Target just if it is inside a TargetRestrictions. If it is not inside TargetRestrictions a Target
+// is a TargetCustomization.
 func (h *handler) getConfig(repo *fleet.GitRepo) (*corev1.ConfigMap, error) {
 	spec := &fleet.BundleSpec{}
 	for _, target := range targetsOrDefault(repo.Spec.Targets) {

--- a/pkg/target/target.go
+++ b/pkg/target/target.go
@@ -272,8 +272,13 @@ func (m *Manager) Targets(bundle *fleet.Bundle, manifest *manifest.Manifest) ([]
 			if target == nil {
 				continue
 			}
-
-			opts := options.Merge(bundle.Spec.BundleDeploymentOptions, target.BundleDeploymentOptions)
+			// check if there is any matching targetCustomization that should be applied
+			targetOpts := target.BundleDeploymentOptions
+			targetCustomized := bm.MatchTargetCustomizations(cluster.Name, clusterGroupsToLabelMap(clusterGroups), cluster.Labels)
+			if targetCustomized != nil {
+				targetOpts = targetCustomized.BundleDeploymentOptions
+			}
+			opts := options.Merge(bundle.Spec.BundleDeploymentOptions, targetOpts)
 			err = preprocessHelmValues(&opts, cluster)
 			if err != nil {
 				return nil, err

--- a/pkg/target/target.go
+++ b/pkg/target/target.go
@@ -278,6 +278,7 @@ func (m *Manager) Targets(bundle *fleet.Bundle, manifest *manifest.Manifest) ([]
 			if targetCustomized != nil {
 				targetOpts = targetCustomized.BundleDeploymentOptions
 			}
+
 			opts := options.Merge(bundle.Spec.BundleDeploymentOptions, targetOpts)
 			err = preprocessHelmValues(&opts, cluster)
 			if err != nil {


### PR DESCRIPTION
There are two types of Targets:
- `Targets` defined in a `GitRepo`. These targets are used to create `BundleDeployments`, and are duplicated into `TargetRestrictions`
- `TargetCustomizations` defined in `fleet.yaml`. There are used just for customization

This PR fixes two issues:

- Check if there is any `TargetCustomization` that should be applied, and it is not in the `TargetRestrictions`. Before we were matching target just if they were inside `TargetRestrictions`. This was causing some customizations to be ignored

- We were iteration a map [here](https://github.com/rancher/fleet/blob/v0.6.0/pkg/bundlematcher/match.go#L32) which order might be different in different executions. This was causing [this issue](https://github.com/rancher/fleet/issues/1254#issuecomment-1490433878). This PR adds the iteration for clusters groups inside the loop of matches, that guarantees the order will never be different. 

refers to https://github.com/rancher/fleet/issues/1254