### PR TITLE
Replace deprecated command with environment file

### DIFF
--- a/.github/workflows/aks.yml
+++ b/.github/workflows/aks.yml
@@ -61,7 +61,7 @@ jobs:
         shell: bash
         run: |
           id=$RANDOM
-          echo '::set-output name=ID::'$id
+          echo "ID=$id" >> $GITHUB_OUTPUT
           az aks create --resource-group fleetCI \
           --node-vm-size ${{ env.AKS_MACHINE_TYPE }} \
           --name fleetCI$id \
@@ -90,7 +90,7 @@ jobs:
       -
         name: Get UUID
         id: uuid
-        run: echo "::set-output name=uuid::$(uuidgen)"
+        run: echo "uuid=$(uuidgen)" >> $GITHUB_OUTPUT
       -
         id: meta-fleet
         uses: docker/metadata-action@v4

--- a/.github/workflows/eks.yml
+++ b/.github/workflows/eks.yml
@@ -76,7 +76,7 @@ jobs:
         id: create-cluster
         run: |
           id=$RANDOM
-          echo '::set-output name=ID::'$id
+          echo "ID=$id" >> $GITHUB_OUTPUT
           eksctl create cluster --name=fleet-ci$id \
           --region=${{ env.AWS_REGION }} \
           --nodes=2 \
@@ -97,7 +97,7 @@ jobs:
       -
         name: Get UUID
         id: uuid
-        run: echo "::set-output name=uuid::$(uuidgen)"
+        run: echo "uuid=$(uuidgen)" >> $GITHUB_OUTPUT
       -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v2

--- a/.github/workflows/gke.yml
+++ b/.github/workflows/gke.yml
@@ -62,7 +62,7 @@ jobs:
         id: create-cluster
         run: |
           id=$RANDOM
-          echo '::set-output name=ID::'$id
+          echo "ID=$id" >> $GITHUB_OUTPUT
           gcloud container clusters create fleetci$id \
           --disk-size 100 \
           --num-nodes=1 \
@@ -94,7 +94,7 @@ jobs:
       -
         name: Get UUID
         id: uuid
-        run: echo "::set-output name=uuid::$(uuidgen)"
+        run: echo "uuid=$(uuidgen)" >> $GITHUB_OUTPUT
       -
         id: meta-fleet
         uses: docker/metadata-action@v4


### PR DESCRIPTION
## Description
<!-- Specify the issue ID that this pullrequest is solving -->
Fix #1499 

<!-- Describe the changes introduced by this pull request -->

Update workflows to use environment file instead of deprecated `set-output` command. 

I found the workflow files that use `set-output` command through the following command:

```bash
$ find . -name '*.yml' -o -name '*.yaml' | xargs egrep '\bset-output\b'
```

**AS-IS**

```yml
echo '::set-output name=ID::'$id
```

```yml
run: echo "::set-output name=uuid::$(uuidgen)"
```

**TO-BE**

```yml
echo "ID=$id" >> $GITHUB_OUTPUT
```

```yml
run: echo "uuid=$(uuidgen)" >> $GITHUB_OUTPUT
```

## Test

N/A

## Additional Information

For more information, see: [https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)


