### PR TITLE
Agent only selects windows nodes

### DIFF
--- a/pkg/agent/manifest.go
+++ b/pkg/agent/manifest.go
@@ -175,6 +175,7 @@ func agentDeployment(namespace string, agentScope string, opts ManifestOptions, 
 							},
 						},
 					},
+					NodeSelector: map[string]string{"kubernetes.io/os": "linux"},
 					Affinity: &corev1.Affinity{
 						NodeAffinity: &corev1.NodeAffinity{
 							PreferredDuringSchedulingIgnoredDuringExecution: []corev1.PreferredSchedulingTerm{


### PR DESCRIPTION
<!-- Specify the issue ID that this pullrequest is solving -->
Fix #993

<!-- Describe the changes introduced by this pull request -->

<!--
  Please provide a unit or e2e test if possible.

  To simplify the reviewing process of this pullrequest,
  please explain how it should be tested.
  The following is just an exammple

## Test

To test this pull request, you can run the following commands:

```shell
cd <to_package_directory>
go test
```

-->

## Additional Information

Makes it impossible to schedule agents on windows nodes, which is not supported. 

