### PR TITLE
Fix Upgrade CI

### DIFF
--- a/.github/scripts/upgrade-rancher-fleet-to-dev-fleet.sh
+++ b/.github/scripts/upgrade-rancher-fleet-to-dev-fleet.sh
@@ -35,8 +35,7 @@ helm upgrade fleet charts/fleet \
   --set image.tag="$fleetTag" \
   --set agentImage.repository="$agentRepo" \
   --set agentImage.tag="$agentTag" \
-  --set agentImage.imagePullPolicy=IfNotPresent \
-  --reuse-values
+  --set agentImage.imagePullPolicy=IfNotPresent
 
 kubectl -n cattle-fleet-system rollout status deploy/fleet-controller
 helm list -A

--- a/.github/workflows/rancher-upgrade-fleet.yml
+++ b/.github/workflows/rancher-upgrade-fleet.yml
@@ -43,7 +43,7 @@ jobs:
           - v2.6.11  # k3s: 1.20 - 1.24
           - v2.7.3  # k3s: 1.23 - 1.24
         fleet_version:
-          - "0.7.0-AGENT-rc.1"
+          - "0.7.0-rc.2"
         exclude:
           - k3s_version: v1.20.15-k3s1
             rancher_version: v2.7.3

--- a/.github/workflows/rancher-upgrade-fleet.yml
+++ b/.github/workflows/rancher-upgrade-fleet.yml
@@ -41,12 +41,12 @@ jobs:
         rancher_version:
           - v2.5.16 # k3s: 1.19 - 1.20
           - v2.6.11  # k3s: 1.20 - 1.24
-          - v2.7.2  # k3s: 1.23 - 1.24
+          - v2.7.3  # k3s: 1.23 - 1.24
         fleet_version:
           - "0.7.0-AGENT-rc.1"
         exclude:
           - k3s_version: v1.20.15-k3s1
-            rancher_version: v2.7.1
+            rancher_version: v2.7.3
           - k3s_version: v1.24.1-k3s1
             rancher_version: v2.5.16
 

--- a/.github/workflows/rancher-upgrade-fleet.yml
+++ b/.github/workflows/rancher-upgrade-fleet.yml
@@ -153,8 +153,7 @@ jobs:
           helm upgrade fleet "$url" \
             --wait -n "$fleetns" \
             --set image.tag="$version" \
-            --set agentImage.tag="$version" \
-            --reuse-values
+            --set agentImage.tag="$version"
           until helm -n "$fleetns" status fleet | grep -q "STATUS: deployed"; do echo waiting for original fleet chart to be deployed; sleep 3; done
           kubectl -n "$fleetns" rollout status deploy/fleet-controller
 

--- a/dev/update-fleet-in-rancher-k3d
+++ b/dev/update-fleet-in-rancher-k3d
@@ -7,7 +7,7 @@ if [ ! -d ./.github/scripts ]; then
   exit 1
 fi
 
-fleet_version="${1-0.6.0-rc.5}"
+fleet_version="${1-0.7.0-rc.2}"
 if [ "$fleet_version" == "dev" ]; then
   echo "don't forget to run dev/build-fleet before running this script"
   dev/import-images-k3d

--- a/dev/update-fleet-in-rancher-k3d
+++ b/dev/update-fleet-in-rancher-k3d
@@ -28,5 +28,4 @@ helm upgrade fleet "$url" \
   --wait -n "$fleetns" \
   --set image.tag="$version" \
   --set agentImage.tag="$version" \
-  --set debug=true --set debugLevel=99 \
-  --reuse-values
+  --set debug=true --set debugLevel=99


### PR DESCRIPTION
 Do not use parameter `--reuse-values` during Fleet upgrades with helm to prevent Gitjob from being updated because its image version reference is stored in the values.
 
 `--reuse-values:  when upgrading, reuse the last release's values and merge in any overrides from the command line via --set and -f. If '--reset-values' is specified, this is ignored`
 
 In general we should consider to move the version information from the value store to the templates.

Github Action Upgrade results:
* [Upgrade Fleet in Rancher to Latest Release](https://github.com/rancher/fleet/actions/runs/4979385018)
* [Upgrade Fleet in Rancher To HEAD](https://github.com/rancher/fleet/actions/runs/4979385765/jobs/8910908099)
* [Upgrade Fleet Standalone to HEAD](https://github.com/rancher/fleet/actions/runs/4979387138/jobs/8911115327)