### PR TITLE
Agent registration recovery

### DIFF
--- a/charts/fleet-crd/templates/crds.yaml
+++ b/charts/fleet-crd/templates/crds.yaml
@@ -2402,6 +2402,8 @@ spec:
               agentAffinityHash:
                 nullable: true
                 type: string
+              agentConfigChanged:
+                type: boolean
               agentDeployedGeneration:
                 nullable: true
                 type: integer

--- a/pkg/apis/fleet.cattle.io/v1alpha1/target.go
+++ b/pkg/apis/fleet.cattle.io/v1alpha1/target.go
@@ -117,6 +117,7 @@ type ClusterStatus struct {
 	AgentAffinityHash    string `json:"agentAffinityHash,omitempty"`
 	AgentResourcesHash   string `json:"agentResourcesHash,omitempty"`
 	AgentTolerationsHash string `json:"agentTolerationsHash,omitempty"`
+	AgentConfigChanged   bool   `json:"agentConfigChanged,omitempty"`
 
 	Display ClusterDisplay `json:"display,omitempty"`
 	Agent   AgentStatus    `json:"agent,omitempty"`

--- a/pkg/controllers/cluster/import.go
+++ b/pkg/controllers/cluster/import.go
@@ -71,6 +71,10 @@ func RegisterImport(
 }
 
 func agentDeployed(cluster *fleet.Cluster) bool {
+	if cluster.Status.AgentConfigChanged {
+		return false
+	}
+
 	if !cluster.Status.AgentMigrated {
 		return false
 	}
@@ -333,6 +337,7 @@ func (i *importHandler) importCluster(cluster *fleet.Cluster, status fleet.Clust
 		Namespace: cluster.Spec.AgentNamespace,
 	}
 	status.AgentNamespaceMigrated = true
+	status.AgentConfigChanged = false
 	return status, nil
 }
 

--- a/pkg/controllers/cluster/import.go
+++ b/pkg/controllers/cluster/import.go
@@ -68,6 +68,42 @@ func RegisterImport(
 
 	clusters.OnChange(ctx, "import-cluster", h.OnChange)
 	fleetcontrollers.RegisterClusterStatusHandler(ctx, clusters, "Imported", "import-cluster", h.importCluster)
+	config.OnChange(ctx, h.onConfig)
+}
+
+// onConfig triggers clusters which rely on the fallback config in the
+// fleet-controller config map. This is important for changes to apiServerURL
+// and apiServerCA, as they are needed e.g. to update the fleet-agent-bootstrap
+// secret.
+func (i *importHandler) onConfig(config *config.Config) error {
+	clusters, err := i.clusters.List("", metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+
+	if len(clusters.Items) == 0 {
+		return nil
+	}
+
+	for _, cluster := range clusters.Items {
+		if cluster.Spec.KubeConfigSecret == "" {
+			continue
+		}
+		secret, err := i.secrets.Get(cluster.Namespace, cluster.Spec.KubeConfigSecret)
+		if err != nil {
+			return err
+		}
+		if string(secret.Data["apiServerURL"]) == "" || string(secret.Data["apiServerCA"]) == "" {
+			logrus.Debugf("API server fallback-config changed, trigger cluster import for cluster %s/%s", cluster.Namespace, cluster.Name)
+			c := cluster.DeepCopy()
+			c.Status.AgentConfigChanged = true
+			_, err := i.clusters.UpdateStatus(c)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
 }
 
 func agentDeployed(cluster *fleet.Cluster) bool {
@@ -200,6 +236,7 @@ func (i *importHandler) importCluster(cluster *fleet.Cluster, status fleet.Clust
 		if len(cfg.APIServerURL) == 0 {
 			return status, fmt.Errorf("missing apiServerURL in fleet config for cluster auto registration")
 		}
+		logrus.Debugf("Cluster import for '%s/%s'. Using apiServerURL from fleet-controller config", cluster.Namespace, cluster.Name)
 		apiServerURL = cfg.APIServerURL
 	}
 

--- a/pkg/controllers/manageagent/manageagent.go
+++ b/pkg/controllers/manageagent/manageagent.go
@@ -81,8 +81,12 @@ func (h *handler) onClusterStatusChange(cluster *fleet.Cluster, status fleet.Clu
 	}
 
 	if vars || changed {
+		// trigger importCluster to re-create the deployment, in case
+		// the agent cannot update itself from the bundle
+		status.AgentConfigChanged = true
 		h.namespaces.Enqueue(cluster.Namespace)
 	}
+
 	return status, nil
 }
 


### PR DESCRIPTION
This fixes two issues with recovering from an unsuccessful agent deployment. 

## The agent cannot start and is unable to update itself to a good configuration

We taint the nodes on a downstream cluster `kubectl taint nodes k3d-downstream-server-0 key1=value1:NoSchedule`.
After `dev/setup-fleet`, we try to register the downstream cluster with `dev/setup-fleet-managed-downstream`. 
The deployment is created on the downstream cluster, but cannot start since all nodes are tainted.
We update the cluster resource so it tolerates the taint:

```
  agentTolerations:
  - effect: NoSchedule
    key: key1
    operator: Equal
    value: value1
  - effect: NoSchedule
    key: key1
    operator: Exists
```

Result: The deployment is not updated with the taint. The bundle is updated, but the fleet-agent is not running and can't update itself. 

## Fleet is installed with invalid settings and bootstrap is disabled

This happens when starting Rancher with `--no-cacerts` and updating the CA setting later. Updating the setting will re-install the fleet-controller and update the fleet-controller configmap with new values.
However, the new values are not propagated to the fleet-agent.

After running
`helm -n cattle-fleet-system upgrade --install --create-namespace --wait --reset-values --set apiServerCA="" --set bootstrap.enabled=false --set apiServerURL=https://172.19.0.2:6443 --set debug=true --set debugLevel=99 fleet charts/fleet`, we create a local cluster resource with a correct `kubeConfigSecret`, like fleetcluster.go in Rancher would.

The fleet-agent cannot register: `time="2023-06-02T13:03:30Z" level=error msg="Failed to register agent: looking up secret cattle-fleet-system/fleet-agent-bootstrap: Post \"https://172.19.0.2:6443/apis/fleet.cattle.io/v1alpha1/namespaces/fleet-local/clusterregistrations\": tls: failed to verify certificate: x509: certificate signed by unknown authority"`.

We now re-install fleet with the correct `--set apiServerCA="<data>"`, the config map is updated, but the agent does not recover. The `fleet-agent-bootstrap` secret is not updated.

Previously this was, maybe, mitigated by a second apiServerCA field in the cluster resource's `kubeConfigSecret`, which we no longer use with `bootstrap.enabled=false`.