### PR TITLE
Refactorings registration

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -4,11 +4,7 @@ package agent
 import (
 	"context"
 	"fmt"
-	"io"
-	"os"
 	"time"
-
-	"github.com/pkg/errors"
 
 	"github.com/rancher/fleet/modules/cli/pkg/client"
 	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
@@ -23,11 +19,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
-	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
-)
-
-var (
-	ErrNoHostInConfig = errors.New("failed to find cluster server parameter")
 )
 
 type Options struct {
@@ -43,24 +34,30 @@ type Options struct {
 // the agent config inside a configmap.
 //
 // This is used when importing a cluster.
-func AgentWithConfig(ctx context.Context, agentNamespace, controllerNamespace, agentScope string, cg *client.Getter, output io.Writer, tokenName string, opts *Options) error {
+func AgentWithConfig(ctx context.Context, agentNamespace, controllerNamespace, agentScope string, cg *client.Getter, tokenName string, opts *Options) ([]runtime.Object, error) {
 	if opts == nil {
 		opts = &Options{}
 	}
 
-	client, err := cg.Get()
-	if err != nil {
-		return err
+	objs := []runtime.Object{
+		&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: agentNamespace}},
 	}
 
-	objs, err := agentToken(ctx, agentNamespace, controllerNamespace, client, tokenName, opts)
+	client, err := cg.Get()
 	if err != nil {
-		return err
+		return objs, err
 	}
+
+	secret, err := agentBootstrapSecret(ctx, agentNamespace, controllerNamespace, client, tokenName, opts)
+	if err != nil {
+		return objs, err
+	}
+
+	objs = append(objs, secret)
 
 	agentConfig, err := agentConfig(ctx, agentNamespace, controllerNamespace, cg, &opts.ConfigOptions)
 	if err != nil {
-		return err
+		return objs, err
 	}
 
 	objs = append(objs, agentConfig...)
@@ -68,7 +65,7 @@ func AgentWithConfig(ctx context.Context, agentNamespace, controllerNamespace, a
 	// get a fresh config from the API
 	cfg, err := config.Lookup(ctx, controllerNamespace, config.ManagerConfigName, client.Core.ConfigMap())
 	if err != nil {
-		return err
+		return objs, err
 	}
 
 	mo := opts.ManifestOptions
@@ -79,42 +76,29 @@ func AgentWithConfig(ctx context.Context, agentNamespace, controllerNamespace, a
 
 	objs = append(objs, Manifest(agentNamespace, agentScope, mo)...)
 
-	data, err := yaml.Export(objs...)
-	if err != nil {
-		return err
-	}
-
-	_, err = output.Write(data)
-	return err
+	return objs, err
 }
 
-func agentToken(ctx context.Context, agentNamespace, controllerNamespace string, client *client.Client, tokenName string, opts *Options) ([]runtime.Object, error) {
-	token, err := getToken(ctx, controllerNamespace, tokenName, client)
+// agentBootstrapSecret creates the fleet-agent-bootstrap secret
+func agentBootstrapSecret(ctx context.Context, agentNamespace, controllerNamespace string, client *client.Client, tokenName string, opts *Options) (*v1.Secret, error) {
+	data, err := getToken(ctx, controllerNamespace, tokenName, client)
 	if err != nil {
 		return nil, err
 	}
 
 	if opts.Host != "" {
-		token["apiServerURL"] = []byte(opts.Host)
+		data["apiServerURL"] = []byte(opts.Host)
 	}
 	if len(opts.CA) > 0 {
-		token["apiServerCA"] = opts.CA
+		data["apiServerCA"] = opts.CA
 	}
 
-	return []runtime.Object{
-		&v1.Namespace{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: agentNamespace,
-			},
+	return &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      config.AgentBootstrapConfigName,
+			Namespace: agentNamespace,
 		},
-		// fleet-agent-bootstrap
-		&v1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      config.AgentBootstrapConfigName,
-				Namespace: agentNamespace,
-			},
-			Data: token,
-		},
+		Data: data,
 	}, nil
 }
 
@@ -209,36 +193,4 @@ func startWatch(namespace string, sa fleetcontrollers.ClusterRegistrationTokenCl
 		return nil, err
 	}
 	return sa.Watch(namespace, metav1.ListOptions{ResourceVersion: secrets.ResourceVersion})
-}
-
-func GetCAFromConfig(rawConfig clientcmdapi.Config) ([]byte, error) {
-	cluster, ok := rawConfig.Clusters[rawConfig.CurrentContext]
-	if !ok {
-		for _, v := range rawConfig.Clusters {
-			cluster = v
-			break
-		}
-	}
-
-	if cluster != nil {
-		if len(cluster.CertificateAuthorityData) > 0 {
-			return cluster.CertificateAuthorityData, nil
-		}
-		return os.ReadFile(cluster.CertificateAuthority)
-	}
-
-	return nil, nil
-}
-
-func GetHostFromConfig(rawConfig clientcmdapi.Config) (string, error) {
-	cluster, ok := rawConfig.Clusters[rawConfig.CurrentContext]
-	if ok {
-		return cluster.Server, nil
-	}
-
-	for _, v := range rawConfig.Clusters {
-		return v.Server, nil
-	}
-
-	return "", ErrNoHostInConfig
 }

--- a/pkg/controllers/cluster/import.go
+++ b/pkg/controllers/cluster/import.go
@@ -1,7 +1,6 @@
 package cluster
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"net/http"
@@ -24,7 +23,7 @@ import (
 	corecontrollers "github.com/rancher/wrangler/pkg/generated/controllers/core/v1"
 	"github.com/rancher/wrangler/pkg/name"
 	"github.com/rancher/wrangler/pkg/randomtoken"
-	"github.com/rancher/wrangler/pkg/yaml"
+
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -96,7 +95,7 @@ func agentDeployed(cluster *fleet.Cluster) bool {
 }
 
 // OnChange is triggered for manager initiated deployments and the local agent,
-// where KubeConfigSecret is configured
+// where KubeConfigSecret is configured. It updates the client ID.
 func (i *importHandler) OnChange(key string, cluster *fleet.Cluster) (_ *fleet.Cluster, err error) {
 	if cluster == nil {
 		return cluster, nil
@@ -106,6 +105,7 @@ func (i *importHandler) OnChange(key string, cluster *fleet.Cluster) (_ *fleet.C
 		return cluster, nil
 	}
 
+	// NOTE(mm): why is this not done in importCluster?
 	if cluster.Spec.ClientID == "" {
 		logrus.Debugf("Cluster import for '%s/%s'. Agent found, updating ClientID", cluster.Namespace, cluster.Name)
 
@@ -252,18 +252,16 @@ func (i *importHandler) importCluster(cluster *fleet.Cluster, status fleet.Clust
 		return status, nil
 	}
 
-	output := &bytes.Buffer{}
 	agentNamespace := i.systemNamespace
 	if cluster.Spec.AgentNamespace != "" {
 		agentNamespace = cluster.Spec.AgentNamespace
 	}
 	// Notice we only set the agentScope when it's a non-default agentNamespace. This is for backwards compatibility
 	// for when we didn't have agent scope before
-	err = agent.AgentWithConfig(
+	objs, err := agent.AgentWithConfig(
 		i.ctx, agentNamespace, i.systemNamespace,
 		cluster.Spec.AgentNamespace,
 		&client.Getter{Namespace: cluster.Namespace},
-		output,
 		token.Name,
 		&agent.Options{
 			CA:   apiServerCA,
@@ -286,11 +284,6 @@ func (i *importHandler) importCluster(cluster *fleet.Cluster, status fleet.Clust
 		return status, err
 	}
 
-	obj, err := yaml.ToObjects(output)
-	if err != nil {
-		return status, err
-	}
-
 	if cluster.Status.Agent.Namespace != agentNamespace || !cluster.Status.AgentNamespaceMigrated {
 		// delete old agent if moving namespaces for agent
 		if err := i.deleteOldAgentBundle(cluster); err != nil {
@@ -307,7 +300,7 @@ func (i *importHandler) importCluster(cluster *fleet.Cluster, status fleet.Clust
 		return status, err
 	}
 
-	if err := apply.ApplyObjects(obj...); err != nil {
+	if err := apply.ApplyObjects(objs...); err != nil {
 		logrus.Errorf("Failed cluster import for '%s/%s'. Cannot create agent deployment", cluster.Namespace, cluster.Name)
 		return status, err
 	}

--- a/pkg/helmdeployer/deployer.go
+++ b/pkg/helmdeployer/deployer.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/rancher/fleet/pkg/config"
 	"github.com/rancher/fleet/pkg/durations"
 	"github.com/sirupsen/logrus"
 	"helm.sh/helm/v3/pkg/action"
@@ -881,9 +882,9 @@ func GetSetID(bundleID, labelPrefix, labelSuffix string) string {
 	// bundle is fleet-agent bundle, we need to use setID fleet-agent-bootstrap since it was applied with import controller
 	if strings.HasPrefix(bundleID, "fleet-agent") {
 		if labelSuffix == "" {
-			return "fleet-agent-bootstrap"
+			return config.AgentBootstrapConfigName
 		}
-		return name.SafeConcatName("fleet-agent-bootstrap", labelSuffix)
+		return name.SafeConcatName(config.AgentBootstrapConfigName, labelSuffix)
 	}
 	if labelSuffix != "" {
 		return name.SafeConcatName(labelPrefix, bundleID, labelSuffix)


### PR DESCRIPTION
* use the existing constant for "fleet-agent-bootstrap"
* remove io.Writer from AgentWithConfig, return objs instead
* move GetHostFromConfig/GetHostFromConfig into bootstrap package, the
  only consumer, and make them private
* rename agentToken to agentBootstrapSecret and only create the secret
* move buildSecret closer to usage