### PR TITLE
Remove schedule run for "Upgrade Fleet in Rancher to Latest Release CI"

### DIFF
--- a/.github/workflows/rancher-upgrade-fleet.yml
+++ b/.github/workflows/rancher-upgrade-fleet.yml
@@ -2,9 +2,6 @@
 name: Upgrade Fleet in Rancher to Latest Release
 
 on:
-  schedule:
-    # Run every other day at 1:00 PM
-    - cron: '0 13 */2 * *'
   workflow_dispatch:
     inputs:
       ref:


### PR DESCRIPTION
because the test was not reliable enough and is partly covered by other upgrade tests.