### PR TITLE
Install `tar` in linux-amd64/fossa Drone CI pipeline

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -23,7 +23,7 @@ steps:
     FOSSA_API_KEY:
       from_secret: FOSSA_API_KEY
   commands:
-    - zypper -n install curl unzip
+    - zypper -n install curl unzip tar
     - "curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install-latest.sh | bash"
     - fossa analyze
     - fossa test


### PR DESCRIPTION
That package was missing and led to the pipeline failing.
See [this example](https://drone-publish.rancher.io/rancher/fleet/1863/1/3).