### PR TITLE
Add DoNotDeploy and OverrideTargets

### DIFF
--- a/charts/fleet-crd/templates/crds.yaml
+++ b/charts/fleet-crd/templates/crds.yaml
@@ -496,6 +496,8 @@ spec:
                           nullable: true
                           type: array
                       type: object
+                    doNotDeploy:
+                      type: boolean
                     forceSyncGeneration:
                       type: integer
                     helm:

--- a/integrationtests/cli/apply/apply_test.go
+++ b/integrationtests/cli/apply/apply_test.go
@@ -3,20 +3,34 @@ package apply
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gbytes"
 	"github.com/rancher/fleet/integrationtests/cli"
 	"github.com/rancher/fleet/modules/cli/apply"
 )
 
 var _ = Describe("Fleet apply", Ordered, func() {
-	When("simple resources", func() {
-		It("fleet apply is called", func() {
-			err := fleetApply("simple", []string{cli.AssetsPath + "simple"}, apply.Options{})
-			Expect(err).NotTo(HaveOccurred())
+
+	var (
+		dirs    []string
+		name    string
+		options apply.Options
+	)
+
+	JustBeforeEach(func() {
+		err := fleetApply(name, dirs, options)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	When("folder contains simple resources", func() {
+		BeforeEach(func() {
+			name = "simple"
+			options = apply.Options{Output: gbytes.NewBuffer()}
+			dirs = []string{cli.AssetsPath + "simple"}
 		})
 
 		It("then a Bundle is created with all the resources and keepResources is false", func() {
 			Eventually(func() bool {
-				bundle, err := cli.GetBundleFromOutput(buf)
+				bundle, err := cli.GetBundleFromOutput(options.Output)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(len(bundle.Spec.Resources)).To(Equal(2))
 				isSvcPresent, err := cli.IsResourcePresentInBundle(cli.AssetsPath+"simple/svc.yaml", bundle.Spec.Resources)
@@ -29,14 +43,15 @@ var _ = Describe("Fleet apply", Ordered, func() {
 		})
 	})
 	When("simple resources in a nested folder", func() {
-		It("fleet apply is called", func() {
-			err := fleetApply("nested_simple", []string{cli.AssetsPath + "nested_simple"}, apply.Options{})
-			Expect(err).NotTo(HaveOccurred())
+		BeforeEach(func() {
+			name = "nested_simple"
+			options = apply.Options{Output: gbytes.NewBuffer()}
+			dirs = []string{cli.AssetsPath + "nested_simple"}
 		})
 
 		It("then a Bundle is created with all the resources", func() {
 			Eventually(func() bool {
-				bundle, err := cli.GetBundleFromOutput(buf)
+				bundle, err := cli.GetBundleFromOutput(options.Output)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(len(bundle.Spec.Resources)).To(Equal(3))
 				isSvcPresent, err := cli.IsResourcePresentInBundle(cli.AssetsPath+"nested_simple/simple/svc.yaml", bundle.Spec.Resources)
@@ -51,14 +66,15 @@ var _ = Describe("Fleet apply", Ordered, func() {
 		})
 	})
 	When("simple resources in a nested folder with two levels", func() {
-		It("fleet apply is called", func() {
-			err := fleetApply("nested_two_levels", []string{cli.AssetsPath + "nested_two_levels"}, apply.Options{})
-			Expect(err).NotTo(HaveOccurred())
+		BeforeEach(func() {
+			name = "nested_two_levels"
+			options = apply.Options{Output: gbytes.NewBuffer()}
+			dirs = []string{cli.AssetsPath + "nested_two_levels"}
 		})
 
 		It("then a Bundle is created with all the resources", func() {
 			Eventually(func() bool {
-				bundle, err := cli.GetBundleFromOutput(buf)
+				bundle, err := cli.GetBundleFromOutput(options.Output)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(len(bundle.Spec.Resources)).To(Equal(2))
 				isSvcPresent, err := cli.IsResourcePresentInBundle(cli.AssetsPath+"nested_two_levels/nested/svc/svc.yaml", bundle.Spec.Resources)
@@ -71,14 +87,15 @@ var _ = Describe("Fleet apply", Ordered, func() {
 		})
 	})
 	When("multiple fleet.yaml in a nested folder", func() {
-		It("fleet apply is called", func() {
-			err := fleetApply("nested_multiple", []string{cli.AssetsPath + "nested_multiple"}, apply.Options{})
-			Expect(err).NotTo(HaveOccurred())
+		BeforeEach(func() {
+			name = "nested_multiple"
+			options = apply.Options{Output: gbytes.NewBuffer()}
+			dirs = []string{cli.AssetsPath + "nested_multiple"}
 		})
 
 		It("then 3 Bundles are created with the relevant resources", func() {
 			Eventually(func() bool {
-				bundle, err := cli.GetBundleListFromOutput(buf)
+				bundle, err := cli.GetBundleListFromOutput(options.Output)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(len(bundle)).To(Equal(3))
 				deploymentA := bundle[0]
@@ -107,14 +124,15 @@ var _ = Describe("Fleet apply", Ordered, func() {
 		})
 	})
 	When("multiple fleet.yaml mixed with simple resources in a nested folder", func() {
-		It("fleet apply is called", func() {
-			err := fleetApply("nested_mixed_two_levels", []string{cli.AssetsPath + "nested_mixed_two_levels"}, apply.Options{})
-			Expect(err).NotTo(HaveOccurred())
+		BeforeEach(func() {
+			name = "nested_mixed_two_levels"
+			options = apply.Options{Output: gbytes.NewBuffer()}
+			dirs = []string{cli.AssetsPath + "nested_mixed_two_levels"}
 		})
 
 		It("then Bundles are created with all the resources", func() {
 			Eventually(func() bool {
-				bundle, err := cli.GetBundleListFromOutput(buf)
+				bundle, err := cli.GetBundleListFromOutput(options.Output)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(len(bundle)).To(Equal(3))
 				root := bundle[0]
@@ -147,14 +165,15 @@ var _ = Describe("Fleet apply", Ordered, func() {
 		})
 	})
 	When("containing keepResources in the fleet.yaml", func() {
-		It("fleet apply is called", func() {
-			err := fleetApply("keepResources", []string{cli.AssetsPath + "keep_resources"}, apply.Options{})
-			Expect(err).NotTo(HaveOccurred())
+		BeforeEach(func() {
+			name = "keep_resources"
+			options = apply.Options{Output: gbytes.NewBuffer()}
+			dirs = []string{cli.AssetsPath + "keep_resources"}
 		})
 
 		It("then a Bundle is created with keepResources", func() {
 			Eventually(func() bool {
-				bundle, err := cli.GetBundleFromOutput(buf)
+				bundle, err := cli.GetBundleFromOutput(options.Output)
 				Expect(err).NotTo(HaveOccurred())
 				return bundle.Spec.KeepResources
 			}).Should(BeTrue())

--- a/integrationtests/cli/apply/suite_test.go
+++ b/integrationtests/cli/apply/suite_test.go
@@ -9,10 +9,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/onsi/gomega/gbytes"
 )
-
-var buf *gbytes.Buffer
 
 func TestFleet(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -21,8 +18,6 @@ func TestFleet(t *testing.T) {
 
 // simulates fleet cli execution
 func fleetApply(name string, dirs []string, options apply.Options) error {
-	buf = gbytes.NewBuffer()
-	options.Output = buf
 
 	return apply.Apply(context.Background(), client.NewGetter("", "", "fleet-local"), name, dirs, options)
 }

--- a/integrationtests/cli/apply/target_test.go
+++ b/integrationtests/cli/apply/target_test.go
@@ -1,0 +1,123 @@
+package apply
+
+import (
+	"encoding/json"
+	"os"
+
+	"github.com/rancher/fleet/integrationtests/cli"
+	"github.com/rancher/fleet/modules/cli/apply"
+	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gbytes"
+)
+
+var _ = Describe("Fleet apply targets", func() {
+	var (
+		dirs    []string
+		options apply.Options
+	)
+
+	JustBeforeEach(func() {
+		err := fleetApply("targets", dirs, options)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	When("Targets file is empty, and overrideTargets is not provided", func() {
+		BeforeEach(func() {
+			options = apply.Options{Output: gbytes.NewBuffer()}
+			dirs = []string{cli.AssetsPath + "targets/simple"}
+		})
+
+		It("Bundle contains the default target", func() {
+			bundle, err := cli.GetBundleFromOutput(options.Output)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(len(bundle.Spec.Targets)).To(Equal(1))
+			Expect(bundle.Spec.Targets[0].ClusterGroup).To(Equal("default"))
+			Expect(len(bundle.Spec.TargetRestrictions)).To(Equal(0))
+		})
+	})
+
+	When("Targets file is empty, and overrideTargets is provided", func() {
+		BeforeEach(func() {
+			options = apply.Options{Output: gbytes.NewBuffer()}
+			dirs = []string{cli.AssetsPath + "targets/override"}
+		})
+
+		It("Bundle contains targets and targetRestrictions from override", func() {
+			bundle, err := cli.GetBundleFromOutput(options.Output)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(len(bundle.Spec.Targets)).To(Equal(1))
+			Expect(bundle.Spec.Targets[0].ClusterName).To(Equal("overridden"))
+			Expect(len(bundle.Spec.TargetRestrictions)).To(Equal(1))
+			Expect(bundle.Spec.TargetRestrictions[0].ClusterName).To(Equal("overridden"))
+		})
+	})
+
+	When("Targets file contains one target, and overrideTargets is not provided", func() {
+		var (
+			targets            []fleet.BundleTarget
+			targetRestrictions []fleet.BundleTargetRestriction
+		)
+
+		BeforeEach(func() {
+			targets = []fleet.BundleTarget{{Name: "target1", ClusterName: "test1"}}
+			targetRestrictions = []fleet.BundleTargetRestriction{{Name: "target1", ClusterName: "test1"}}
+			file := createTargetsFile(targets, targetRestrictions)
+			options = apply.Options{Output: gbytes.NewBuffer(), TargetsFile: file.Name()}
+			dirs = []string{cli.AssetsPath + "targets/simple"}
+		})
+
+		It("Bundle contains targets and targetRestrictions from the targets file", func() {
+			bundle, err := cli.GetBundleFromOutput(options.Output)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(bundle.Spec.Targets).To(Equal(targets))
+			Expect(bundle.Spec.TargetRestrictions).To(Equal(targetRestrictions))
+		})
+	})
+
+	When("Targets file contains one target, and overrideTargets is provided", func() {
+		var (
+			targets            []fleet.BundleTarget
+			targetRestrictions []fleet.BundleTargetRestriction
+		)
+
+		BeforeEach(func() {
+			targets = []fleet.BundleTarget{{Name: "target1", ClusterName: "test1"}}
+			targetRestrictions = []fleet.BundleTargetRestriction{{Name: "target1", ClusterName: "test1"}}
+			file := createTargetsFile(targets, targetRestrictions)
+			options = apply.Options{Output: gbytes.NewBuffer(), TargetsFile: file.Name()}
+			dirs = []string{cli.AssetsPath + "targets/override"}
+		})
+
+		It("Bundle contains targets and targetRestrictions from override", func() {
+			bundle, err := cli.GetBundleFromOutput(options.Output)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(bundle.Spec.Targets).To(Not(Equal(targets)))
+			Expect(bundle.Spec.TargetRestrictions).To(Not(Equal(targetRestrictions)))
+			Expect(len(bundle.Spec.Targets)).To(Equal(1))
+			Expect(bundle.Spec.Targets[0].ClusterName).To(Equal("overridden"))
+			Expect(len(bundle.Spec.TargetRestrictions)).To(Equal(1))
+			Expect(bundle.Spec.TargetRestrictions[0].ClusterName).To(Equal("overridden"))
+		})
+	})
+})
+
+func createTargetsFile(targets []fleet.BundleTarget, targetRestrictions []fleet.BundleTargetRestriction) *os.File {
+	tmpDir := GinkgoT().TempDir()
+	file, err := os.CreateTemp(tmpDir, "targets")
+	Expect(err).NotTo(HaveOccurred())
+	spec := &fleet.BundleSpec{
+		Targets:            targets,
+		TargetRestrictions: targetRestrictions,
+	}
+
+	data, err := json.Marshal(spec)
+	Expect(err).NotTo(HaveOccurred())
+
+	_, err = file.Write(data)
+	Expect(err).NotTo(HaveOccurred())
+
+	return file
+}

--- a/integrationtests/cli/assets/targets/override/fleet.yaml
+++ b/integrationtests/cli/assets/targets/override/fleet.yaml
@@ -1,0 +1,3 @@
+namespace: test
+overrideTargets:
+  - clusterName: overridden

--- a/integrationtests/cli/assets/targets/simple/fleet.yaml
+++ b/integrationtests/cli/assets/targets/simple/fleet.yaml
@@ -1,0 +1,1 @@
+namespace: test

--- a/integrationtests/cli/helpers.go
+++ b/integrationtests/cli/helpers.go
@@ -1,6 +1,8 @@
 package cli
 
 import (
+	"errors"
+	"io"
 	"os"
 	"strings"
 
@@ -16,7 +18,11 @@ const (
 	apiVersion = "apiVersion: fleet.cattle.io/v1alpha1"
 )
 
-func GetBundleFromOutput(buf *gbytes.Buffer) (*v1alpha1.Bundle, error) {
+func GetBundleFromOutput(w io.Writer) (*v1alpha1.Bundle, error) {
+	buf, ok := w.(*gbytes.Buffer)
+	if !ok {
+		return nil, errors.New("can't convert to gbytes.Buffer")
+	}
 	bundle := &v1alpha1.Bundle{}
 	err := yaml.Unmarshal(buf.Contents(), bundle)
 	if err != nil {
@@ -26,7 +32,11 @@ func GetBundleFromOutput(buf *gbytes.Buffer) (*v1alpha1.Bundle, error) {
 	return bundle, nil
 }
 
-func GetBundleListFromOutput(buf *gbytes.Buffer) ([]*v1alpha1.Bundle, error) {
+func GetBundleListFromOutput(w io.Writer) ([]*v1alpha1.Bundle, error) {
+	buf, ok := w.(*gbytes.Buffer)
+	if !ok {
+		return nil, errors.New("can't convert to gbytes.Buffer")
+	}
 	bundles := []*v1alpha1.Bundle{}
 	bundlesWithSeparator := strings.ReplaceAll(string(buf.Contents()), apiVersion, separator+apiVersion)
 	bundlesStr := strings.Split(bundlesWithSeparator, separator)

--- a/pkg/apis/fleet.cattle.io/v1alpha1/bundle.go
+++ b/pkg/apis/fleet.cattle.io/v1alpha1/bundle.go
@@ -124,6 +124,7 @@ type BundleTarget struct {
 	ClusterSelector      *metav1.LabelSelector `json:"clusterSelector,omitempty"`
 	ClusterGroup         string                `json:"clusterGroup,omitempty"`
 	ClusterGroupSelector *metav1.LabelSelector `json:"clusterGroupSelector,omitempty"`
+	DoNotDeploy          bool                  `json:"doNotDeploy,omitempty"`
 }
 
 type BundleSummary struct {

--- a/pkg/target/target.go
+++ b/pkg/target/target.go
@@ -276,6 +276,10 @@ func (m *Manager) Targets(bundle *fleet.Bundle, manifest *manifest.Manifest) ([]
 			targetOpts := target.BundleDeploymentOptions
 			targetCustomized := bm.MatchTargetCustomizations(cluster.Name, clusterGroupsToLabelMap(clusterGroups), cluster.Labels)
 			if targetCustomized != nil {
+				if targetCustomized.DoNotDeploy {
+					logrus.Debugf("BundleDeployment creation for Bundle '%s' was skipped because doNotDeploy is set to true.", bundle.Name)
+					continue
+				}
 				targetOpts = targetCustomized.BundleDeploymentOptions
 			}
 


### PR DESCRIPTION
### DoNotDeploy

`BundleDeployments` will not be created for targets that matches a `targetCustomization` that has `DoNotDeploy` set to true, which means no resources will be deployed. If a `targetCustomization` match has `DoNotDeploy` set to true we skip this `BundleDeployment` creation [here](https://github.com/raulcabello/fleet/blob/4e36ea8f82b6bf9b2a805a169850bb234f55183f/pkg/target/target.go#L279-L282). `targetCustomization`  are defined in the `fleet.yaml`.

In the following example:
```yaml
targetCustomizations:
- name: test
  doNotDeploy: true
  clusterSelector:
    matchLabels:
      env: test
```
Resources will not be deployed for `Clusters` that contains the `env: test` label.

### OverrideTargets

Targets defined in a `GitRepo` will be overridden if a `Bundle` defines `overrideTargets` in the `fleet.yaml`. 

Fleet controller creates a target file that contains targets defined in the GitRepo. Then passes this file to `fleet apply` that runs in the job. This PR replaces the content of this file when executing the `fleet apply` command if `overrideTargets` is found in the `fleet.yaml`

For example if a `fleet.yaml` contains:

```yaml
overrideTargets:
- clusterSelector:
     matchLabels:
        env: test
```

The `Bundle` created for this directory will have the targets defined in `overrideTargets` , which means that targets from `GItRepo` will not be used. 


relates to https://github.com/rancher/fleet/issues/1552