### PR TITLE
Revert Gitjob image tag change

### DIFF
--- a/charts/fleet/charts/gitjob/templates/deployment.yaml
+++ b/charts/fleet/charts/gitjob/templates/deployment.yaml
@@ -13,14 +13,14 @@ spec:
     spec:
       serviceAccountName: gitjob
       containers:
-        - image: "{{ template "system_default_registry" . }}{{ .Values.gitjob.repository }}:{{ .Values.gitjob.tag | default (printf "v%s" .Chart.AppVersion) }}"
+        - image: "{{ template "system_default_registry" . }}{{ .Values.gitjob.repository }}:{{ .Values.gitjob.tag }}"
           name: gitjob
           args:
           {{- if .Values.debug }}
           - --debug
           {{- end }}
           - --tekton-image
-          - "{{ template "system_default_registry" . }}{{ .Values.tekton.repository }}:{{ .Values.tekton.tag | default "v0.1.22" }}"
+          - "{{ template "system_default_registry" . }}{{ .Values.tekton.repository }}:{{ .Values.tekton.tag }}"
           env:
             - name: NAMESPACE
               valueFrom:

--- a/charts/fleet/charts/gitjob/values.yaml
+++ b/charts/fleet/charts/gitjob/values.yaml
@@ -1,8 +1,10 @@
 gitjob:
   repository: rancher/gitjob
+  tag: v0.1.54
 
 tekton:
   repository: rancher/tekton-utils
+  tag: v0.1.22
 
 global:
   cattle:


### PR DESCRIPTION
to allow support of the rancher-images.txt generation scripts.

https://github.com/rancher/charts/blob/dev-v2.7/README.md#supporting-images-in-airgap

Fixes https://github.com/rancher/rancher/issues/41778