### PR TITLE
Only replace the Chart version during release

### DIFF
--- a/scripts/package-helm
+++ b/scripts/package-helm
@@ -14,7 +14,7 @@ cp -rf charts build/
 rm -rf build/charts/fleet-crd/templates/crds.yaml
 
 sed -i \
-    -e 's/version:.*/version: '${HELM_VERSION}'/' \
+    -e 's/^version:.*/version: '${HELM_VERSION}'/' \
     -e 's/appVersion:.*/appVersion: '${HELM_VERSION}'/' \
     build/charts/fleet/Chart.yaml
 


### PR DESCRIPTION
and not the Gitjob version constraint.
https://github.com/rancher/fleet/blob/master/charts/fleet/Chart.yaml#L16

This fixes the Gitjob version constraint in our future helm-chart release tarballs.
e.g. https://github.com/rancher/fleet/releases/download/v0.7.0/fleet-0.7.0.tgz