### PR TITLE
Rationalize Helm history

### DIFF
--- a/pkg/helmdeployer/deployer.go
+++ b/pkg/helmdeployer/deployer.go
@@ -45,6 +45,7 @@ const (
 	DefaultServiceAccount        = "fleet-default"
 	KeepResourcesAnnotation      = "fleet.cattle.io/keep-resources"
 	HelmUpgradeInterruptedError  = "another operation (install/upgrade/rollback) is in progress"
+	MaxHelmHistory               = 5
 )
 
 var (
@@ -115,7 +116,7 @@ func NewHelm(namespace, defaultNamespace, labelPrefix, labelSuffix string, gette
 	if err := h.globalCfg.Init(getter, "", "secrets", logrus.Infof); err != nil {
 		return nil, err
 	}
-	h.globalCfg.Releases.MaxHistory = 5
+	h.globalCfg.Releases.MaxHistory = MaxHelmHistory
 	return h, nil
 }
 
@@ -310,7 +311,7 @@ func (h *Helm) getCfg(namespace, serviceAccountName string) (action.Configuratio
 	kClient.Namespace = namespace
 
 	err = cfg.Init(getter, namespace, "secrets", logrus.Infof)
-	cfg.Releases.MaxHistory = 5
+	cfg.Releases.MaxHistory = MaxHelmHistory
 	cfg.KubeClient = kClient
 
 	cfg.Capabilities, _ = getCapabilities(cfg)
@@ -404,7 +405,7 @@ func (h *Helm) install(bundleID string, manifest *manifest.Manifest, chart *char
 	u.Atomic = options.Helm.Atomic
 	u.MaxHistory = options.Helm.MaxHistory
 	if u.MaxHistory == 0 {
-		u.MaxHistory = 10
+		u.MaxHistory = MaxHelmHistory
 	}
 	u.Namespace = defaultNamespace
 	u.Timeout = timeout

--- a/pkg/helmdeployer/deployer.go
+++ b/pkg/helmdeployer/deployer.go
@@ -45,7 +45,7 @@ const (
 	DefaultServiceAccount        = "fleet-default"
 	KeepResourcesAnnotation      = "fleet.cattle.io/keep-resources"
 	HelmUpgradeInterruptedError  = "another operation (install/upgrade/rollback) is in progress"
-	MaxHelmHistory               = 5
+	MaxHelmHistory               = 2
 )
 
 var (


### PR DESCRIPTION
Helps with #1465/[SURE-6125](https://jira.suse.com/browse/SURE-6125)

This patch reduces the number of Helm history entries per deployment from 10 or 5 (defaults were not consistent) down to 2.

Rationale:
1. retrieving the Helm history can be a costly operation in terms of downstream control plane load
1. Helm history retrieval load grows (roughly linearly) with the maximum number of entries kept
1. fleet only ever needs the present and immediately previous entries (at least according to my understanding)
1. users should not interact with Helm directly

Note: current users will see their Helm histories trimmed at first round of updates of the respective deployment bundles/releases. For a one-off cleanup, where needed, this script can be used:

https://gist.github.com/moio/2c9a58cba986a5c771a08de0343d8ced

## Test

This has been tested manually and by users in the context of SURE-6125.

Remarks:
 - main risk is that this patch inadvertently breaks some functionality (my understanding in point 3. above is wrong) - current e2e tests should have that covered
 - `helm history RELEASE_NAME` can be used on the downstream cluster to ensure no more than 2 releases are kept. Open to think about how to test this if it's a blocker


