### PR TITLE
Fix e2e tests requiring secrets

### DIFF
--- a/e2e/require-secrets/gitrepo_test.go
+++ b/e2e/require-secrets/gitrepo_test.go
@@ -49,11 +49,13 @@ var _ = Describe("Git Repo", func() {
 		Expect(err).ToNot(HaveOccurred(), out)
 
 		err = testenv.ApplyTemplate(k, testenv.AssetPath("gitrepo/gitrepo.yaml"), struct {
-			Repo   string
-			Branch string
+			Repo            string
+			Branch          string
+			PollingInterval string
 		}{
 			gh.GetURL(),
 			gh.Branch,
+			"15s", // default
 		})
 		Expect(err).ToNot(HaveOccurred(), out)
 

--- a/e2e/require-secrets/oci_auth_test.go
+++ b/e2e/require-secrets/oci_auth_test.go
@@ -44,7 +44,7 @@ var _ = Describe("Single Cluster Examples", func() {
 
 	AfterEach(func() {
 		os.RemoveAll(tmpdir)
-		out, err := k.Delete("-f", testenv.AssetPath(asset))
+		out, err := k.Delete("gitrepo", "helm")
 		Expect(err).ToNot(HaveOccurred(), out)
 	})
 


### PR DESCRIPTION
After merging #1613 , I noticed that end-to-end tests requiring secrets were:
* [failing](https://github.com/rancher/fleet/actions/runs/5375871548/jobs/9752249661) because of templating issues caused by recent additions to the `single-cluster` test suite
* ~no longer triggered automatically~ → they are scheduled to run [nightly](https://github.com/rancher/fleet/actions/workflows/nightly-ci.yml).

## Test

Not sure if there is any other option to test this than merging it...