### PR TITLE
Unpin ginkgo version installed in CI

### DIFF
--- a/.github/workflows/aks.yml
+++ b/.github/workflows/aks.yml
@@ -43,7 +43,7 @@ jobs:
           go-version: ${{ env.SETUP_GO_VERSION }}
       -
         name: Setup Ginkgo Test Framework
-        run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.8.0
+        run: go install github.com/onsi/ginkgo/v2/ginkgo
 
       # Follow https://github.com/marketplace/actions/azure-login#configure-deployment-credentials
       # az group create --name fleetCI --location eastus2

--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -49,7 +49,7 @@ jobs:
             ${{ runner.os }}-go-
       -
         name: Install Ginkgo CLI
-        run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.8.0
+        run: go install github.com/onsi/ginkgo/v2/ginkgo
       -
         name: Build Fleet Binaries
         run: |

--- a/.github/workflows/e2e-multicluster-ci.yml
+++ b/.github/workflows/e2e-multicluster-ci.yml
@@ -45,7 +45,7 @@ jobs:
             ${{ runner.os }}-go-
       -
         name: Install Ginkgo CLI
-        run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.8.0
+        run: go install github.com/onsi/ginkgo/v2/ginkgo
       -
         name: Build Fleet Binaries
         run: |

--- a/.github/workflows/eks.yml
+++ b/.github/workflows/eks.yml
@@ -51,7 +51,7 @@ jobs:
           go-version: ${{ env.SETUP_GO_VERSION }}
       -
         name: Setup Ginkgo Test Framework
-        run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.8.0
+        run: go install github.com/onsi/ginkgo/v2/ginkgo
       -
         name: Install Dependencies
         run: |

--- a/.github/workflows/fleet-upgrade.yml
+++ b/.github/workflows/fleet-upgrade.yml
@@ -45,7 +45,7 @@ jobs:
             ${{ runner.os }}-go-
       -
         name: Install Ginkgo CLI
-        run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.8.0
+        run: go install github.com/onsi/ginkgo/v2/ginkgo
       -
         name: Provision k3d Cluster
         uses: AbsaOSS/k3d-action@v2

--- a/.github/workflows/gke.yml
+++ b/.github/workflows/gke.yml
@@ -42,7 +42,7 @@ jobs:
           go-version: ${{ env.SETUP_GO_VERSION }}
       -
         name: Setup Ginkgo Test Framework
-        run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.8.0
+        run: go install github.com/onsi/ginkgo/v2/ginkgo
       -
         name: Authenticate to GCP
         uses: 'google-github-actions/auth@v1'

--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -47,7 +47,7 @@ jobs:
             ${{ runner.os }}-go-
       -
         name: Install Ginkgo CLI
-        run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.8.0
+        run: go install github.com/onsi/ginkgo/v2/ginkgo
       -
         name: Build Fleet Binaries
         run: |

--- a/.github/workflows/rancher-integration.yml
+++ b/.github/workflows/rancher-integration.yml
@@ -53,7 +53,7 @@ jobs:
             ${{ runner.os }}-go-
       -
         name: Install Ginkgo CLI
-        run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.8.0
+        run: go install github.com/onsi/ginkgo/v2/ginkgo
       -
         uses: actions/cache@v3
         id: rancher-cli-cache

--- a/.github/workflows/rancher-upgrade-fleet.yml
+++ b/.github/workflows/rancher-upgrade-fleet.yml
@@ -68,7 +68,7 @@ jobs:
             ${{ runner.os }}-go-
       -
         name: Install Ginkgo CLI
-        run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.8.0
+        run: go install github.com/onsi/ginkgo/v2/ginkgo
       -
         uses: actions/cache@v3
         id: rancher-cli-cache


### PR DESCRIPTION
This will eliminate warnings about version mismatches, since Fleet tests now make use of a more recent, frequently updated version of Ginkgo.

## Test

Checks passing on this PR without warnings about Ginkgo version mismatches should validate it.

## Additional Information

### Assumption

When Ginkgo releases versions beyond v2, package URLs should change to be suffixed with eg. `/v3/ginkgo` instead of the current `/v2/ginkgo`.