### PR TITLE
Use separate gitrepo resource for test case requiring secret

### DIFF
--- a/e2e/assets/gitrepo/gitrepo_with_auth.yaml
+++ b/e2e/assets/gitrepo/gitrepo_with_auth.yaml
@@ -1,0 +1,12 @@
+kind: GitRepo
+apiVersion: fleet.cattle.io/v1alpha1
+metadata:
+  name: gitrepo-test
+spec:
+  repo: {{.Repo}}
+  clientSecretName: git-auth
+  branch: {{.Branch}}
+  pollingInterval: {{.PollingInterval}}
+  paths:
+  - examples
+

--- a/e2e/require-secrets/gitrepo_test.go
+++ b/e2e/require-secrets/gitrepo_test.go
@@ -48,7 +48,7 @@ var _ = Describe("Git Repo", func() {
 		)
 		Expect(err).ToNot(HaveOccurred(), out)
 
-		err = testenv.ApplyTemplate(k, testenv.AssetPath("gitrepo/gitrepo.yaml"), struct {
+		err = testenv.ApplyTemplate(k, testenv.AssetPath("gitrepo/gitrepo_with_auth.yaml"), struct {
 			Repo            string
 			Branch          string
 			PollingInterval string


### PR DESCRIPTION
This restores a required client secret required by gitrepo tests pointing to a Github repo. That secret had been accidentally removed when writing locally-runnable end-to-end test cases, which use in-URL credentials for HTTP authentication to a git server.

## Test

See [this e2e workflow run](https://github.com/rancher/fleet/actions/runs/5424606556/jobs/9896359317), with `e2e/require-secrets` tests now passing again.

## Additional Information

### Tradeoff

* I have decided to duplicate a `gitrepo.yaml` file so that:
    * `e2e/require-secrets` tests use `gitrepo-with-auth.yaml`
    * `e2e/single-cluster` tests use `gitrepo.yaml`
    
### Potential improvement

Ideally, `e2e/single-cluster` gitrepo tests would support a secret for HTTP auth against git, which would eliminate the need for the above mentioned file duplication. For some reason, this does not seem to work though, which is why those tests make use of in-URL credentials for now.
This could be revisited when git implementations are unified.