### PR TITLE
Fix `.fleetignore` entry propagation to subdirectories

### DIFF
--- a/internal/bundlereader/loaddirectory.go
+++ b/internal/bundlereader/loaddirectory.go
@@ -82,13 +82,15 @@ func (xt *ignoreTree) addNode(dir string) error {
 // Returns a slice representing all relevant nodes in the path to the destination, in order of traversal from the root.
 // The last element of that slice is the destination node.
 func (xt *ignoreTree) findNode(path string, isDir bool, nodesRoute []*ignoreTree) []*ignoreTree {
-	if path == xt.path {
-		return append(nodesRoute, xt)
-	}
-
 	// The path doesn't even belong in the tree. This should never happen.
 	if !strings.HasPrefix(path, xt.path) {
 		return nil
+	}
+
+	nodesRoute = append(nodesRoute, xt)
+
+	if path == xt.path {
+		return nodesRoute
 	}
 
 	for _, c := range xt.children {

--- a/internal/bundlereader/loaddirectory_test.go
+++ b/internal/bundlereader/loaddirectory_test.go
@@ -262,6 +262,64 @@ func TestGetContent(t *testing.T) {
 				"subdir2/in_dir.yaml": []byte("from dir 2"),
 			},
 		},
+		{
+			name: "entries from parent directories' .fleetignore files are added in lower directories",
+			directoryStructure: fsNode{
+				isDir: true,
+				name:  "add-parent-entries",
+				children: []fsNode{
+					{
+						name:     "something.yaml",
+						contents: "foo",
+					},
+					{
+						name:     ".fleetignore",
+						contents: "ignore-always.yaml",
+					},
+					{
+						name:  "foo",
+						isDir: true,
+						children: []fsNode{
+							{
+								name:     "ignore-always.yaml",
+								contents: "will be ignored",
+							},
+							{
+								name:     "something.yaml",
+								contents: "something",
+							},
+						},
+					},
+					{
+						name:  "bar",
+						isDir: true,
+						children: []fsNode{
+							{
+								name:     ".fleetignore",
+								contents: "something.yaml",
+							},
+							{
+								name:     "something.yaml",
+								contents: "something",
+							},
+							{
+								name:     "something2.yaml",
+								contents: "something2",
+							},
+							{
+								name:     "ignore-always.yaml",
+								contents: "will be ignored",
+							},
+						},
+					},
+				},
+			},
+			expectedFiles: map[string][]byte{
+				"something.yaml":      []byte("foo"),
+				"foo/something.yaml":  []byte("something"),
+				"bar/something2.yaml": []byte("something2"),
+			},
+		},
 	}
 
 	base, err := os.MkdirTemp("", "test-fleet")


### PR DESCRIPTION
This fixes a bug where a `.fleetignore` entry in a parent directory would be ignored in a subdirectory which had its own `.fleetignore` file.

Refers to #583

## Test

To test this pull request, you can run the following commands:

```shell
go test ./internal/bundlereader
```

<!-- Please Uncomment following block if looking for QA validation

## Additional QA
### Issue: <link the issue or issues this PR resolves here>
< If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. >
 
### Problem
< Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. >
 
### Solution
< Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue.>
 
### Testing
< Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. >

### Engineering Testing
#### Manual Testing
< Describe what manual testing you did (if no testing was done, explain why). >

#### Automated Testing
<If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. >

### QA Testing Considerations
< Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios >
 
#### Regressions Considerations
< Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions >

-->
