### PR TITLE
Fix Helm release name generation to prevent double dashes

### DIFF
--- a/internal/name/name.go
+++ b/internal/name/name.go
@@ -32,7 +32,17 @@ func Limit(s string, count int) string {
 	if count <= 6 {
 		return s[:count]
 	}
-	return fmt.Sprintf("%s-%s", s[:count-6], Hex(s, 5))
+
+	separator := "-"
+	nbCharsBeforeTrim := count - 6
+
+	// If the last character of the truncated string is the separator, include it instead of the separator.
+	if string(s[nbCharsBeforeTrim-1]) == separator {
+		separator = ""
+		nbCharsBeforeTrim++
+	}
+
+	return fmt.Sprintf("%s%s%s", s[:nbCharsBeforeTrim], separator, Hex(s, 5))
 }
 
 // Hex returns a hex-encoded hash of the string and truncates it to length.

--- a/internal/name/name_test.go
+++ b/internal/name/name_test.go
@@ -31,6 +31,7 @@ var _ = Describe("Name", func() {
 			{arg: "12345678", n: 8, result: "12345678"},
 			{arg: "12345678", n: 7, result: "1-25d55"},
 			{arg: "123456789", n: 8, result: "12-25f9e"},
+			{arg: "1-3456789", n: 8, result: "1-39b657"}, // no double dash in the result
 		}
 
 		It("matches expected results", func() {
@@ -51,6 +52,8 @@ var _ = Describe("Name", func() {
 			{arg: "long-name-test-0.App_ ", result: "long-name-test-0-app-5bf6b3fb"},
 			{arg: "long-name-test--App_-_12.factor", result: "long-name-test-app-12-factor-0efbac37"},
 			{arg: "bundle.name.example.com", result: "bundle-name-example-com-645ef821"},
+			// no double dash in the result
+			{arg: str53[0:46] + "-1234567", result: "1234567890123456789012345678901234567890123456-1d0bce"},
 		}
 
 		It("matches expected results", func() {


### PR DESCRIPTION
A Helm release name is generated for each bundle deployed by Fleet. In case that name is longer than 53 characters, the maximum length of Helm release names, it is then truncated to 46 characters and the remaining characters are a dash followed by a hash.

This fixes an edge case where the truncated release name already ends with a dash, leading to the final release name (in the form `<truncated>-<hash>`) containing a double dash. Since this caused discrepancies between deployed release names and what the Fleet agent would expect to be deployed, Fleet would frequently delete and re-create bundles as a result.

Refers to #1511

## Test

To test this pull request, you can run the following commands:

```shell
go test ./internal/name/...
```