### PR TITLE
Bump golangci-lint to 1.53

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -31,7 +31,7 @@ jobs:
         uses: golangci/golangci-lint-action@v3.6.0
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.52
+          version: v1.53
 
           args: --timeout=10m --config=.golangci.json
 


### PR DESCRIPTION
The CI action is failing its scheduled runs: https://github.com/rancher/fleet/actions/workflows/golangci-lint.yml