### PR TITLE
Fix linting errors

### DIFF
--- a/e2e/single-cluster/gitrepo_test.go
+++ b/e2e/single-cluster/gitrepo_test.go
@@ -170,7 +170,6 @@ var _ = Describe("Monitoring Git repos via HTTP for change", Label("infra-setup"
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-
 		It("updates the deployment", func() {
 			By("checking the pod exists")
 			Eventually(func() string {

--- a/internal/bundlereader/loaddirectory_test.go
+++ b/internal/bundlereader/loaddirectory_test.go
@@ -23,6 +23,7 @@ type fsNode struct {
 	isDir bool
 }
 
+// nolint: funlen
 func TestGetContent(t *testing.T) {
 	cases := []struct {
 		name               string

--- a/internal/cmd/agent/deployer/monitor.go
+++ b/internal/cmd/agent/deployer/monitor.go
@@ -233,7 +233,7 @@ func modified(plan apply.Plan, resourcesPreviousRelease *helmdeployer.Resources)
 	for gvk, keys := range plan.Create {
 		for _, key := range keys {
 			if len(result) >= 10 {
-				return
+				return result
 			}
 
 			apiVersion, kind := gvk.ToAPIVersionAndKind()
@@ -250,7 +250,7 @@ func modified(plan apply.Plan, resourcesPreviousRelease *helmdeployer.Resources)
 	for gvk, keys := range plan.Delete {
 		for _, key := range keys {
 			if len(result) >= 10 {
-				return
+				return result
 			}
 
 			apiVersion, kind := gvk.ToAPIVersionAndKind()
@@ -310,7 +310,7 @@ func nonReady(plan apply.Plan, ignoreOptions fleet.IgnoreOptions) (result []flee
 
 	for _, obj := range plan.Objects {
 		if len(result) >= 10 {
-			return
+			return result
 		}
 		if u, ok := obj.(*unstructured.Unstructured); ok {
 			if ignoreOptions.Conditions != nil {

--- a/internal/cmd/controller/target/target.go
+++ b/internal/cmd/controller/target/target.go
@@ -327,7 +327,7 @@ func preprocessHelmValues(opts *fleet.BundleDeploymentOptions, cluster *fleet.Cl
 		}
 	}
 	if len(clusterLabels) == 0 {
-		return
+		return nil
 	}
 
 	if opts.Helm == nil {


### PR DESCRIPTION
This fixes a few (mostly formatting) errors output by the linter, although not all of them. The following are left:

```
internal/cmd/agent/deployer/internal/scheme/scheme.go:7:2: blank-imports: a blank import should be only in a main or test package, or have a comment justifying it (revive)
        _ "k8s.io/kubernetes/pkg/apis/admission/install"
        ^
internal/cmd/controller/controllers/clusterregistration/controller.go:39:2: G101: Potential hardcoded credentials (gosec)
        AgentCredentialSecretType     = "fleet.cattle.io/agent-credential"
        ^
internal/cmd/agent/register/register.go:266:15: G107: Potential HTTP request made with variable url (gosec)
        if _, err := http.Get(apiServerURL); err == nil {
                     ^
internal/cmd/agent/deployer/internal/normalizers/knowntypes_normalizer.go:32:79: unexported-return: exported func NewKnownTypesNormalizer returns unexported type *normalizers.knownTypesNormalizer, which can be annoying to use (revive)
func NewKnownTypesNormalizer(overrides map[string]resource.ResourceOverride) (*knownTypesNormalizer, error) {
```