### PR TITLE
[v.0.7] Backport clean up clusterregistrations

### DIFF
--- a/charts/fleet-crd/templates/crds.yaml
+++ b/charts/fleet-crd/templates/crds.yaml
@@ -2423,6 +2423,12 @@ spec:
               agentTolerationsHash:
                 nullable: true
                 type: string
+              apiServerCAHash:
+                nullable: true
+                type: string
+              apiServerURL:
+                nullable: true
+                type: string
               cattleNamespaceMigrated:
                 type: boolean
               conditions:

--- a/pkg/apis/fleet.cattle.io/v1alpha1/target.go
+++ b/pkg/apis/fleet.cattle.io/v1alpha1/target.go
@@ -119,6 +119,9 @@ type ClusterStatus struct {
 	AgentTolerationsHash string `json:"agentTolerationsHash,omitempty"`
 	AgentConfigChanged   bool   `json:"agentConfigChanged,omitempty"`
 
+	APIServerURL    string `json:"apiServerURL,omitempty"`
+	APIServerCAHash string `json:"apiServerCAHash,omitempty"`
+
 	Display ClusterDisplay `json:"display,omitempty"`
 	Agent   AgentStatus    `json:"agent,omitempty"`
 }
@@ -159,8 +162,12 @@ type ClusterRegistrationSpec struct {
 }
 
 type ClusterRegistrationStatus struct {
+	// ClusterName is only set after the registration is granted.
 	ClusterName string `json:"clusterName,omitempty"`
-	Granted     bool   `json:"granted,omitempty"`
+	// Granted is set to true, if the request service account is present
+	// and its token secret exists. This happens directly before creating
+	// the registration secret, roles and rolebindings.
+	Granted bool `json:"granted,omitempty"`
 }
 
 // +genclient

--- a/pkg/controllers/cluster/controller.go
+++ b/pkg/controllers/cluster/controller.go
@@ -8,8 +8,8 @@ import (
 	"github.com/sirupsen/logrus"
 
 	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
-	"github.com/rancher/fleet/pkg/controllers/clusterregistration"
 	fleetcontrollers "github.com/rancher/fleet/pkg/generated/controllers/fleet.cattle.io/v1alpha1"
+	fname "github.com/rancher/fleet/pkg/name"
 	"github.com/rancher/fleet/pkg/summary"
 
 	corecontrollers "github.com/rancher/wrangler/pkg/generated/controllers/core/v1"
@@ -66,6 +66,7 @@ func Register(ctx context.Context,
 		"managed-cluster",
 		h.OnClusterChanged)
 
+	// enqueue cluster event for bundledeployment changes
 	relatedresource.Watch(ctx, "managed-cluster", h.findClusters(namespaces.Cache()), clusters, bundleDeployment)
 }
 
@@ -110,7 +111,7 @@ func clusterNamespace(clusterNamespace, clusterName string) string {
 	return name.SafeConcatName("cluster",
 		clusterNamespace,
 		clusterName,
-		clusterregistration.KeyHash(clusterNamespace+"::"+clusterName))
+		fname.KeyHash(clusterNamespace+"::"+clusterName))
 }
 
 func (h *handler) OnClusterChanged(cluster *fleet.Cluster, status fleet.ClusterStatus) (fleet.ClusterStatus, error) {

--- a/pkg/controllers/clusterregistration/controller.go
+++ b/pkg/controllers/clusterregistration/controller.go
@@ -6,8 +6,6 @@ package clusterregistration
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"fmt"
 	"time"
 
@@ -18,6 +16,7 @@ import (
 	"github.com/rancher/fleet/pkg/config"
 	"github.com/rancher/fleet/pkg/durations"
 	fleetcontrollers "github.com/rancher/fleet/pkg/generated/controllers/fleet.cattle.io/v1alpha1"
+	fname "github.com/rancher/fleet/pkg/name"
 	"github.com/rancher/fleet/pkg/registration"
 	secretutil "github.com/rancher/fleet/pkg/secret"
 
@@ -138,41 +137,6 @@ func (h *handler) OnCluster(key string, cluster *fleet.Cluster) (*fleet.Cluster,
 	return cluster, nil
 }
 
-func (h *handler) authorizeCluster(sa *v1.ServiceAccount, cluster *fleet.Cluster, req *fleet.ClusterRegistration) (*v1.Secret, error) {
-	var secret *v1.Secret
-	var err error
-	if len(sa.Secrets) != 0 {
-		secret, err = h.secretsCache.Get(sa.Namespace, sa.Secrets[0].Name)
-		if apierrors.IsNotFound(err) {
-			// secrets can be slow to propagate to the cache
-			secret, err = h.secrets.Get(sa.Namespace, sa.Secrets[0].Name, metav1.GetOptions{})
-		}
-	} else {
-		secret, err = secretutil.GetServiceAccountTokenSecret(sa, h.secrets)
-	}
-	if err != nil || secret == nil {
-		return nil, err
-	}
-	return &v1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      registration.SecretName(req.Spec.ClientID, req.Spec.ClientRandom),
-			Namespace: h.systemRegistrationNamespace,
-			Labels: map[string]string{
-				fleet.ClusterAnnotation: cluster.Name,
-				fleet.ManagedLabel:      "true",
-			},
-		},
-		Type: AgentCredentialSecretType,
-		Data: map[string][]byte{
-			"token":               secret.Data["token"],
-			"deploymentNamespace": []byte(cluster.Status.Namespace),
-			"clusterNamespace":    []byte(cluster.Namespace),
-			"clusterName":         []byte(cluster.Name),
-			"systemNamespace":     []byte(h.systemNamespace),
-		},
-	}, nil
-}
-
 func (h *handler) OnSecretChange(key string, secret *v1.Secret) (*v1.Secret, error) {
 	if secret == nil || secret.Namespace != h.systemRegistrationNamespace ||
 		secret.Labels[fleet.ClusterAnnotation] == "" {
@@ -188,6 +152,12 @@ func (h *handler) OnSecretChange(key string, secret *v1.Secret) (*v1.Secret, err
 	return secret, nil
 }
 
+// OnChange creates the service account and roles for a cluster registration.
+// The service account's token is deployed to the downstream cluster, via the
+// fleet-secret. It allows the downstream fleet-agent to list
+// bundledeployments and update their status in its own cluster namespace on upstream.
+// It can also get content resources, but not list them. The name of content
+// resources is random.
 func (h *handler) OnChange(request *fleet.ClusterRegistration, status fleet.ClusterRegistrationStatus) ([]runtime.Object, fleet.ClusterRegistrationStatus, error) {
 	var (
 		objects []runtime.Object
@@ -225,9 +195,23 @@ func (h *handler) OnChange(request *fleet.ClusterRegistration, status fleet.Clus
 		logrus.Debugf("Cluster registration request '%s/%s', creating registration secret", request.Namespace, request.Name)
 	}
 
+	// delete old clusterregistrations
+	crlist, _ := h.clusterRegistration.List(request.Namespace, metav1.ListOptions{})
+
+	for _, creg := range crlist.Items {
+		if creg.Spec.ClientID == request.Spec.ClientID && creg.Spec.ClientRandom != request.Spec.ClientRandom {
+			logrus.Infof("Deleting old clusterregistration %s/%s", creg.Namespace, creg.Name)
+			if err := h.clusterRegistration.Delete(creg.Namespace, creg.Name, nil); err != nil && !apierrors.IsNotFound(err) {
+				return nil, status, err
+			}
+		}
+	}
+
 	status.ClusterName = cluster.Name
-	// e.g. request- in the cluster namespace
+
 	return append(objects,
+		// Update the existing service account 'request-UID' in the
+		// cluster namespace, e.g. 'cluster-fleet-default-NAME-ID'
 		&v1.ServiceAccount{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      saName,
@@ -242,6 +226,11 @@ func (h *handler) OnChange(request *fleet.ClusterRegistration, status fleet.Clus
 				},
 			},
 		},
+		// Add role bindings to manage bundledeployments and contents,
+		// the agent could previously only access secrets in
+		// 'cattle-fleet-clusters-system' and clusterregistrations in
+		// the cluster registration namespace (e.g. 'fleet-default'). See
+		// clusterregistrationtoken controller for details.
 		&rbacv1.Role{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      request.Name,
@@ -324,14 +313,6 @@ func (h *handler) OnChange(request *fleet.ClusterRegistration, status fleet.Clus
 	), status, nil
 }
 
-func KeyHash(s string) string {
-	if len(s) > 100 {
-		s = s[:100]
-	}
-	d := sha256.Sum256([]byte(s))
-	return hex.EncodeToString(d[:])[:12]
-}
-
 func (h *handler) createOrGetCluster(request *fleet.ClusterRegistration) (*fleet.Cluster, error) {
 	clusters, err := h.clusterCache.GetByIndex(clusterByClientID, fmt.Sprintf("%s/%s", request.Namespace, request.Spec.ClientID))
 	if err == nil && len(clusters) > 0 {
@@ -340,7 +321,7 @@ func (h *handler) createOrGetCluster(request *fleet.ClusterRegistration) (*fleet
 		return nil, err
 	}
 
-	clusterName := name.SafeConcatName("cluster", KeyHash(request.Spec.ClientID))
+	clusterName := name.SafeConcatName("cluster", fname.KeyHash(request.Spec.ClientID))
 	if cluster, err := h.clusterCache.Get(request.Namespace, clusterName); !apierrors.IsNotFound(err) {
 		if cluster.Spec.ClientID != request.Spec.ClientID {
 			// This would happen with a hash collision
@@ -377,4 +358,39 @@ func (h *handler) createOrGetCluster(request *fleet.ClusterRegistration) (*fleet
 		logrus.Infof("Created cluster %s/%s", request.Namespace, clusterName)
 	}
 	return cluster, err
+}
+
+func (h *handler) authorizeCluster(sa *v1.ServiceAccount, cluster *fleet.Cluster, req *fleet.ClusterRegistration) (*v1.Secret, error) {
+	var secret *v1.Secret
+	var err error
+	if len(sa.Secrets) != 0 {
+		secret, err = h.secretsCache.Get(sa.Namespace, sa.Secrets[0].Name)
+		if apierrors.IsNotFound(err) {
+			// secrets can be slow to propagate to the cache
+			secret, err = h.secrets.Get(sa.Namespace, sa.Secrets[0].Name, metav1.GetOptions{})
+		}
+	} else {
+		secret, err = secretutil.GetServiceAccountTokenSecret(sa, h.secrets)
+	}
+	if err != nil || secret == nil {
+		return nil, err
+	}
+	return &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      registration.SecretName(req.Spec.ClientID, req.Spec.ClientRandom),
+			Namespace: h.systemRegistrationNamespace,
+			Labels: map[string]string{
+				fleet.ClusterAnnotation: cluster.Name,
+				fleet.ManagedLabel:      "true",
+			},
+		},
+		Type: AgentCredentialSecretType,
+		Data: map[string][]byte{
+			"token":               secret.Data["token"],
+			"deploymentNamespace": []byte(cluster.Status.Namespace),
+			"clusterNamespace":    []byte(cluster.Namespace),
+			"clusterName":         []byte(cluster.Name),
+			"systemNamespace":     []byte(h.systemNamespace),
+		},
+	}, nil
 }

--- a/pkg/controllers/clusterregistrationtoken/handler.go
+++ b/pkg/controllers/clusterregistrationtoken/handler.go
@@ -128,7 +128,11 @@ func (h *handler) OnChange(token *fleet.ClusterRegistrationToken, status fleet.C
 		status.Expires = &metav1.Time{Time: token.CreationTimestamp.Add(token.Spec.TTL.Duration)}
 	}
 
-	// e.g.: import-token-local in system-registration-namespace
+	// Add service account, e.g.: import-token-local in the system
+	// registration namespace. This account is used during registration to
+	// access secrets in the system registration namespace
+	// 'cattle-fleet-clusters-system' and clusterregistrations in the
+	// cluster registration namespace (e.g. 'fleet-default').
 	return append([]runtime.Object{
 		&corev1.ServiceAccount{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/controllers/git/git.go
+++ b/pkg/controllers/git/git.go
@@ -15,9 +15,9 @@ import (
 
 	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
 	"github.com/rancher/fleet/pkg/config"
-	"github.com/rancher/fleet/pkg/controllers/clusterregistration"
 	"github.com/rancher/fleet/pkg/display"
 	fleetcontrollers "github.com/rancher/fleet/pkg/generated/controllers/fleet.cattle.io/v1alpha1"
+	fname "github.com/rancher/fleet/pkg/name"
 	"github.com/rancher/fleet/pkg/summary"
 
 	gitjob "github.com/rancher/gitjob/pkg/apis/gitjob.cattle.io/v1"
@@ -129,7 +129,7 @@ func (h *handler) getConfig(repo *fleet.GitRepo) (*corev1.ConfigMap, error) {
 		return nil, err
 	}
 
-	hash := clusterregistration.KeyHash(string(data))
+	hash := fname.KeyHash(string(data))
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name.SafeConcatName(repo.Name, "config", hash),

--- a/pkg/controllers/manageagent/manageagent.go
+++ b/pkg/controllers/manageagent/manageagent.go
@@ -58,7 +58,9 @@ func Register(ctx context.Context,
 			WithCacheTypes(bundle),
 	}
 
+	// update the agent bundles for all clusters in the triggered namespace
 	namespaces.OnChange(ctx, "manage-agent", h.OnNamespace)
+	// enqueue events for the agent bundle's namespace when clusters change
 	relatedresource.WatchClusterScoped(ctx, "manage-agent-resolver", h.resolveNS, namespaces, clusters)
 	fleetcontrollers.RegisterClusterStatusHandler(ctx,
 		clusters,
@@ -199,6 +201,7 @@ func (h *handler) resolveNS(namespace, _ string, obj runtime.Object) ([]relatedr
 	return nil, nil
 }
 
+// OnNamespace updates agent bundles for all clusters in the namespace
 func (h *handler) OnNamespace(key string, namespace *corev1.Namespace) (*corev1.Namespace, error) {
 	if namespace == nil {
 		return nil, nil

--- a/pkg/name/keyhash.go
+++ b/pkg/name/keyhash.go
@@ -1,0 +1,16 @@
+package name
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+)
+
+// KeyHash returns the first 12 hex characters of the hash of the first 100 chars
+// of the input string
+func KeyHash(s string) string {
+	if len(s) > 100 {
+		s = s[:100]
+	}
+	d := sha256.Sum256([]byte(s))
+	return hex.EncodeToString(d[:])[:12]
+}


### PR DESCRIPTION
Refers to https://github.com/rancher/fleet/issues/1656

* Delete old clusterregistrations when granting a new one
* Remember the api server for each cluster in the status
* Clean cattle.io cluster labels from registration

  The labels of the existing cluster, were put into the agents config map on the downstream cluster.
  Then the agent used them when creating the cluster registration resource.
  If the cluster resource doesn't exist (anymore), fleet-controller would
  create a new one and use these labels.

  They're not needed by the downstream agent.

  Example of old labels:
  ```
  clusterLabels:
    management.cattle.io/cluster-display-name: sec
    management.cattle.io/cluster-name: c-m-h57lm9n4
    objectset.rio.cattle.io/hash: 790691648d4c0e69c36440a3bc4f6bddc6d9109d
    provider.cattle.io: k3s
  ```

* Add comments to cluster handlers
* Add more verbose error messages around cluster import and agent startup
* Move helper func below consumer
* Move KeyHash func into name package