### PR TITLE
Clusteregistration less aggressive cleanup

### DIFF
--- a/internal/cmd/controller/controllers/cleanup/handler.go
+++ b/internal/cmd/controller/controllers/cleanup/handler.go
@@ -98,11 +98,11 @@ func (h *handler) cleanupNamespace(key string, obj *corev1.Namespace) (*corev1.N
 		return obj, nil
 	}
 
-	logrus.Debugf("Cleaning up fleet-managed namespace %s", obj.Name)
-
 	// check if the cluster for this cluster namespace still exists, otherwise clean up the namespace
 	_, err := h.clusters.Get(obj.Annotations[fleet.ClusterNamespaceAnnotation], obj.Annotations[fleet.ClusterAnnotation])
 	if apierrors.IsNotFound(err) {
+		logrus.Infof("Cleaning up fleet-managed namespace %s", obj.Name)
+
 		err = h.namespaces.Delete(key, nil)
 		return obj, err
 	}
@@ -118,7 +118,7 @@ func (h *handler) cleanup(obj runtime.Object) error {
 		return nil
 	}
 
-	logrus.Debugf("Cleaning up fleet-managed resource %s", meta.GetName())
+	// If orphaned, purge the fleet-managed resource, this is often a no-op
 	err = h.apply.PurgeOrphan(obj)
 	if apierrors.IsNotFound(err) {
 		return nil

--- a/internal/cmd/controller/controllers/clusterregistration/controller.go
+++ b/internal/cmd/controller/controllers/clusterregistration/controller.go
@@ -128,7 +128,7 @@ func (h *handler) OnCluster(key string, cluster *fleet.Cluster) (*fleet.Cluster,
 	}
 	for _, cr := range crs {
 		if !cr.Status.Granted {
-			logrus.Infof("Namespace assigned to %s/%s triggering %s/%s", cluster.Namespace, cluster.Name,
+			logrus.Infof("Namespace assigned to cluster '%s/%s' enqueues cluster registration '%s/%s'", cluster.Namespace, cluster.Name,
 				cr.Namespace, cr.Name)
 			h.clusterRegistration.Enqueue(cr.Namespace, cr.Name)
 		}
@@ -182,7 +182,7 @@ func (h *handler) OnChange(request *fleet.ClusterRegistration, status fleet.Clus
 	sa, err := h.serviceAccountCache.Get(cluster.Status.Namespace, saName)
 	if err == nil {
 		if secret, err := h.authorizeCluster(sa, cluster, request); err != nil {
-			return nil, status, err
+			return nil, status, fmt.Errorf("failed to authorize cluster: %w", err)
 		} else if secret != nil {
 			status.Granted = true
 			objects = append(objects, secret)
@@ -191,18 +191,17 @@ func (h *handler) OnChange(request *fleet.ClusterRegistration, status fleet.Clus
 
 	logrus.Infof("Cluster registration request '%s/%s', cluster '%s/%s' granted [%v], creating cluster and request service account",
 		request.Namespace, request.Name, cluster.Namespace, cluster.Name, status.Granted)
+
 	if status.Granted {
-		logrus.Debugf("Cluster registration request '%s/%s', creating registration secret", request.Namespace, request.Name)
-	}
+		logrus.Debugf("Cluster registration request '%s/%s' granted, creating registration secret", request.Namespace, request.Name)
 
-	// delete old clusterregistrations
-	crlist, _ := h.clusterRegistration.List(request.Namespace, metav1.ListOptions{})
-
-	for _, creg := range crlist.Items {
-		if creg.Spec.ClientID == request.Spec.ClientID && creg.Spec.ClientRandom != request.Spec.ClientRandom {
-			logrus.Infof("Deleting old clusterregistration %s/%s", creg.Namespace, creg.Name)
-			if err := h.clusterRegistration.Delete(creg.Namespace, creg.Name, nil); err != nil && !apierrors.IsNotFound(err) {
-				return nil, status, err
+		crlist, _ := h.clusterRegistration.List(request.Namespace, metav1.ListOptions{})
+		for _, creg := range crlist.Items {
+			if shouldDelete(creg, *request) {
+				logrus.Infof("Deleting old clusterregistration '%s/%s', now at '%s'", creg.Namespace, creg.Name, request.Name)
+				if err := h.clusterRegistration.Delete(creg.Namespace, creg.Name, nil); err != nil && !apierrors.IsNotFound(err) {
+					return nil, status, err
+				}
 			}
 		}
 	}
@@ -315,6 +314,14 @@ func (h *handler) OnChange(request *fleet.ClusterRegistration, status fleet.Clus
 			},
 		},
 	), status, nil
+}
+
+// shouldDelete returns true for any other cluster registration with the same clientID, but different random and older creation timestamp
+func shouldDelete(creg fleet.ClusterRegistration, request fleet.ClusterRegistration) bool {
+	return creg.Spec.ClientID == request.Spec.ClientID &&
+		creg.Spec.ClientRandom != request.Spec.ClientRandom &&
+		creg.Name != request.Name &&
+		creg.CreationTimestamp.Time.Before(request.CreationTimestamp.Time)
 }
 
 func (h *handler) createOrGetCluster(request *fleet.ClusterRegistration) (*fleet.Cluster, error) {

--- a/internal/cmd/controller/secret/util.go
+++ b/internal/cmd/controller/secret/util.go
@@ -63,7 +63,7 @@ func createServiceAccountTokenSecret(sa *corev1.ServiceAccount, secretsControlle
 		}
 	}
 	//Kubernetes auto populates the secret token after it is created, for which we should wait
-	logrus.Infof("waiting for service account token key to be populated for secret %s/%s", secret.Namespace, secret.Name)
+	logrus.Infof("Waiting for service account token key to be populated for secret %s/%s", secret.Namespace, secret.Name)
 	if _, ok := secret.Data[corev1.ServiceAccountTokenKey]; !ok {
 		for {
 			logrus.Debugf("wait for svc account secret to be populated with token %s", secret.Name)


### PR DESCRIPTION
Refers to #1651

Previous fix would clean up cluster registrations that were still used by the agent, if the agent restarted quickly.


