### PR TITLE
Do not restart agents when adopting them with a bundle

### DIFF
--- a/internal/cmd/controller/agent/manifest.go
+++ b/internal/cmd/controller/agent/manifest.go
@@ -33,7 +33,6 @@ type ManifestOptions struct {
 	AgentImagePullPolicy  string
 	AgentTolerations      []corev1.Toleration
 	CheckinInterval       string
-	Generation            string
 	PrivateRepoURL        string // PrivateRepoURL = registry.yourdomain.com:5000
 	SystemDefaultRegistry string
 	AgentAffinity         *corev1.Affinity
@@ -173,7 +172,6 @@ func agentDeployment(namespace string, agentScope string, opts ManifestOptions, 
 								},
 								{Name: "AGENT_SCOPE", Value: agentScope},
 								{Name: "CHECKIN_INTERVAL", Value: opts.CheckinInterval},
-								{Name: "GENERATION", Value: opts.Generation},
 							},
 						},
 					},

--- a/internal/cmd/controller/agent/manifest_test.go
+++ b/internal/cmd/controller/agent/manifest_test.go
@@ -52,7 +52,6 @@ func TestManifestAgentTolerations(t *testing.T) {
 		AgentImagePullPolicy:  "Always",
 		AgentTolerations:      []corev1.Toleration{},
 		CheckinInterval:       "1s",
-		Generation:            "100",
 		PrivateRepoURL:        "private.rancher.com:5000",
 		SystemDefaultRegistry: "default.rancher.com",
 	}

--- a/internal/cmd/controller/controllers/cluster/import.go
+++ b/internal/cmd/controller/controllers/cluster/import.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"strconv"
 
 	"github.com/sirupsen/logrus"
 
@@ -328,7 +327,6 @@ func (i *importHandler) importCluster(cluster *fleet.Cluster, status fleet.Clust
 				AgentEnvVars:     cluster.Spec.AgentEnvVars,
 				AgentTolerations: cluster.Spec.AgentTolerations,
 				CheckinInterval:  cfg.AgentCheckinInterval.Duration.String(),
-				Generation:       string(cluster.UID) + "-" + strconv.FormatInt(cluster.Generation, 10), // initial value for the agent deployment
 				PrivateRepoURL:   cluster.Spec.PrivateRepoURL,
 				AgentAffinity:    cluster.Spec.AgentAffinity,
 				AgentResources:   cluster.Spec.AgentResources,

--- a/internal/cmd/controller/controllers/manageagent/manageagent.go
+++ b/internal/cmd/controller/controllers/manageagent/manageagent.go
@@ -258,7 +258,6 @@ func (h *handler) newAgentBundle(ns string, cluster *fleet.Cluster) (runtime.Obj
 			AgentImagePullPolicy:  cfg.AgentImagePullPolicy,
 			AgentTolerations:      cluster.Spec.AgentTolerations,
 			CheckinInterval:       cfg.AgentCheckinInterval.Duration.String(),
-			Generation:            "bundle", // adopted by bundle
 			PrivateRepoURL:        cluster.Spec.PrivateRepoURL,
 			SystemDefaultRegistry: cfg.SystemDefaultRegistry,
 			AgentAffinity:         cluster.Spec.AgentAffinity,


### PR DESCRIPTION
Refers to https://github.com/rancher/fleet/issues/1679 (see also #1388 and #1651)

There is a GENERATION env var on the agent deployment, which makes the agent restart every time it is changed.

When a cluster is created, the agent is deployed via `import.go`. The value is set to correspond to the `cluster.Generation`.  
The cluster event also triggers a namespace event for `manageagent` and it will create/update  the `bundles` for all `clusters`. These bundles contain an identical agent deployment, except for the `GENERATION` env var, which is set to 'bundle'. 

As soon as the agent is registered it will update itself from the bundle and restart itself, since a change to an env var of a deployment's pod spec triggers an update.

To avoid that restart, we cannot replace "bundled" with the value from import. If re-use the cluster generation in the bundle, the agent would update itself for every cluster change.

We can however remove `GENERATION`.

The `GENERATION` env var might have some use before the registration succeeds, e.g. in migration scenarios. However `importCluster` does delete existing agents, so there would never be a restart.


## Solution

We remove the `GENERATION` completely.


## Concerns from previous attempt:

> *  uninstallation, the downstream agent will remain in the cluster, only the helm history is deleted. if the agent is adopted, a restart might be needed.

Works without generation change.

> *    re-installation via chart. Maybe needs restart to re-register?

Works without generation change.

> *    re-installation via cluster.Spec.RedeployAgentGeneration (not the same generation, use cluster.Status.AgentDeployedGeneration instead). Maybe needs restart to re-register?

Works by re-creating the deployment from `import.go`.

> *    expired token/registration?

Works without generation change.
