### PR TITLE
Remove k8s 1.20 from PR CI matrix

### DIFF
--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -28,7 +28,6 @@ jobs:
           # https://hub.docker.com/r/rancher/k3s/tags
           - v1.25.4-k3s1
           - v1.22.10-k3s1
-          - v1.20.15-k3s1
     steps:
       -
         uses: actions/checkout@v3
@@ -75,7 +74,7 @@ jobs:
           k3d-version: ${{ env.SETUP_K3D_VERSION }}
           cluster-name: "k3s-default"
           args: >-
-            --agents 3
+            --agents 1
             --network "nw01"
             --image docker.io/rancher/k3s:${{matrix.k3s_version}}
       -

--- a/.github/workflows/e2e-multicluster-ci.yml
+++ b/.github/workflows/e2e-multicluster-ci.yml
@@ -68,7 +68,7 @@ jobs:
             -p "80:80@agent:0:direct"
             -p "443:443@agent:0:direct"
             --api-port 6443
-            --agents 3
+            --agents 1
             --network "nw01"
       -
         name: Provision k3d Downstream Cluster

--- a/internal/cmd/controller/controllers/clusterregistration/controller_test.go
+++ b/internal/cmd/controller/controllers/clusterregistration/controller_test.go
@@ -183,7 +183,7 @@ var _ = Describe("ClusterRegistration OnChange", func() {
 		When("service account secret is missing", func() {
 			BeforeEach(func() {
 				cluster.Status = fleet.ClusterStatus{Namespace: "fleet-default"}
-				// post k8s 1.22 service account without sa.Secrets list
+				// post k8s 1.24 service account without sa.Secrets list
 				sa = &corev1.ServiceAccount{}
 				saCache.EXPECT().Get(gomock.Any(), gomock.Any()).Return(sa, nil)
 			})
@@ -204,7 +204,7 @@ var _ = Describe("ClusterRegistration OnChange", func() {
 
 			Context("authorizeCluster returns nil,nil", func() {
 				BeforeEach(func() {
-					// pre k8s 1.22 service account has sa.Secrets list
+					// pre k8s 1.24 service account has sa.Secrets list
 					sa.Secrets = []corev1.ObjectReference{{Name: "tokensecret"}}
 					secretCache.EXPECT().Get(gomock.Any(), gomock.Any()).Return(nil, notFound)
 					secretController.EXPECT().Get(gomock.Any(), "tokensecret", gomock.Any()).Return(nil, nil)


### PR DESCRIPTION
We have a couple of flakes in our CI, however the setup itself seems unstable. It's not just specific tests.

This reduces the k3d docker containers to one.

Also remove the two year old `rancher/k3s:v1.20.15-k3s1` from the matrix. 1.20 is no longer in the support matrix of Rancher manager: https://www.suse.com/suse-rancher/support-matrix/all-supported-versions/rancher-v2-7-1/
