### PR TITLE
Restrict registration to leader agent

### DIFF
--- a/internal/cmd/agent/controllers/bundledeployment/controller.go
+++ b/internal/cmd/agent/controllers/bundledeployment/controller.go
@@ -105,13 +105,16 @@ func (h *handler) Cleanup(key string, bd *fleet.BundleDeployment) (*fleet.Bundle
 func (h *handler) DeployBundle(bd *fleet.BundleDeployment, status fleet.BundleDeploymentStatus) (fleet.BundleDeploymentStatus, error) {
 	if bd.Spec.Paused {
 		// nothing to do
+		logrus.Debugf("Bundle %s/%s is paused", bd.Namespace, bd.Name)
 		return status, nil
 	}
 
 	if err := h.checkDependency(bd); err != nil {
+		logrus.Debugf("Bundle %s/%s has a dependency that is not ready: %v", bd.Namespace, bd.Name, err)
 		return status, err
 	}
 
+	logrus.Infof("Deploying bundle %s/%s", bd.Namespace, bd.Name)
 	release, err := h.deployManager.Deploy(bd)
 	if err != nil {
 		// When an error from DeployBundle is returned it causes DeployBundle

--- a/internal/cmd/agent/register/register.go
+++ b/internal/cmd/agent/register/register.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"os"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -168,6 +169,9 @@ func createAgentSecret(ctx context.Context, clusterID string, k8s corecontroller
 
 		clusterID = string(kubeSystem.UID)
 	}
+
+	// add the name of the pod that created the registration for debugging
+	cfg.Labels["fleet.cattle.io/created-by-agent-pod"] = os.Getenv("HOSTNAME")
 
 	logrus.Infof("Creating clusterregistration with id '%s' for new token", clusterID)
 	request, err := fc.Fleet().V1alpha1().ClusterRegistration().Create(&fleet.ClusterRegistration{

--- a/internal/cmd/agent/register/register.go
+++ b/internal/cmd/agent/register/register.go
@@ -169,6 +169,7 @@ func createAgentSecret(ctx context.Context, clusterID string, k8s corecontroller
 		clusterID = string(kubeSystem.UID)
 	}
 
+	logrus.Infof("Creating clusterregistration with id '%s' for new token", clusterID)
 	request, err := fc.Fleet().V1alpha1().ClusterRegistration().Create(&fleet.ClusterRegistration{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: "request-",

--- a/internal/cmd/agent/start.go
+++ b/internal/cmd/agent/start.go
@@ -2,20 +2,22 @@ package agent
 
 import (
 	"context"
-	"sync"
 	"time"
 
 	"github.com/rancher/fleet/internal/cmd/agent/controllers"
 	"github.com/rancher/fleet/internal/cmd/agent/register"
+	"github.com/sirupsen/logrus"
 
 	"github.com/rancher/lasso/pkg/mapper"
 	"github.com/rancher/wrangler/pkg/kubeconfig"
+	"github.com/rancher/wrangler/pkg/leader"
 	"github.com/rancher/wrangler/pkg/ratelimit"
 	"github.com/rancher/wrangler/pkg/ticker"
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/discovery/cached/memory"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/restmapper"
 	"k8s.io/client-go/tools/clientcmd"
@@ -42,59 +44,62 @@ func start(ctx context.Context, kubeConfig, namespace, agentScope string, opts *
 		return err
 	}
 
-	agentInfo, err := register.Register(ctx, namespace, opts.ClusterID, kc)
+	// try to claim leadership lease without rate limiting
+	localConfig := rest.CopyConfig(kc)
+	localConfig.RateLimiter = ratelimit.None
+	k8s, err := kubernetes.NewForConfig(localConfig)
 	if err != nil {
 		return err
 	}
 
-	fleetNamespace, _, err := agentInfo.ClientConfig.Namespace()
-	if err != nil {
-		return err
-	}
+	leader.RunOrDie(ctx, namespace, "fleet-agent-lock", k8s, func(ctx context.Context) {
+		// try to register with upstream fleet controller by obtaining
+		// a kubeconfig for the upstream cluster
+		agentInfo, err := register.Register(ctx, namespace, opts.ClusterID, kc)
+		if err != nil {
+			logrus.Fatal(err)
+		}
 
-	fleetRestConfig, err := agentInfo.ClientConfig.ClientConfig()
-	if err != nil {
-		return err
-	}
+		fleetNamespace, _, err := agentInfo.ClientConfig.Namespace()
+		if err != nil {
+			logrus.Fatal(err)
+		}
 
-	fleetMapper, mapper, discovery, err := newMappers(ctx, fleetRestConfig, clientConfig)
-	if err != nil {
-		return err
-	}
+		fleetRESTConfig, err := agentInfo.ClientConfig.ClientConfig()
+		if err != nil {
+			logrus.Fatal(err)
+		}
 
-	return controllers.Register(ctx,
-		fleetNamespace,
-		namespace,
-		opts.DefaultNamespace,
-		agentScope,
-		agentInfo.ClusterNamespace,
-		agentInfo.ClusterName,
-		opts.CheckinInterval,
-		fleetRestConfig,
-		clientConfig,
-		fleetMapper,
-		mapper,
-		discovery)
+		fleetMapper, mapper, discovery, err := newMappers(ctx, fleetRESTConfig, clientConfig)
+		if err != nil {
+			logrus.Fatal(err)
+		}
+
+		appCtx, err := controllers.NewAppContext(
+			fleetNamespace, namespace, agentInfo.ClusterNamespace, agentInfo.ClusterName,
+			fleetRESTConfig, clientConfig, fleetMapper, mapper, discovery)
+		if err != nil {
+			logrus.Fatal(err)
+		}
+
+		err = controllers.Register(ctx,
+			appCtx,
+			fleetNamespace, opts.DefaultNamespace,
+			agentScope,
+			opts.CheckinInterval)
+		if err != nil {
+			logrus.Fatal(err)
+		}
+
+		if err := appCtx.Start(ctx); err != nil {
+			logrus.Fatal(err)
+		}
+	})
+
+	return nil
 }
 
-var (
-	mapperLock        sync.Mutex
-	cachedFleetMapper meta.RESTMapper
-	cachedMapper      meta.RESTMapper
-	cachedDiscovery   discovery.CachedDiscoveryInterface
-)
-
-// Share mappers across simulators
 func newMappers(ctx context.Context, fleetRESTConfig *rest.Config, clientconfig clientcmd.ClientConfig) (meta.RESTMapper, meta.RESTMapper, discovery.CachedDiscoveryInterface, error) {
-	mapperLock.Lock()
-	defer mapperLock.Unlock()
-
-	if cachedFleetMapper != nil &&
-		cachedMapper != nil &&
-		cachedDiscovery != nil {
-		return cachedFleetMapper, cachedMapper, cachedDiscovery, nil
-	}
-
 	fleetMapper, err := mapper.New(fleetRESTConfig)
 	if err != nil {
 		return nil, nil, nil, err
@@ -119,10 +124,6 @@ func newMappers(ctx context.Context, fleetRESTConfig *rest.Config, clientconfig 
 			mapper.Reset()
 		}
 	}()
-
-	cachedFleetMapper = fleetMapper
-	cachedMapper = mapper
-	cachedDiscovery = discovery
 
 	return fleetMapper, mapper, discovery, nil
 }

--- a/internal/cmd/controller/controllers/data.go
+++ b/internal/cmd/controller/controllers/data.go
@@ -9,6 +9,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// applyBootstrapResources creates the cluster roles, system namespace and system registration namespace
 func applyBootstrapResources(systemNamespace, systemRegistrationNamespace string, appCtx *appContext) error {
 	return appCtx.Apply.
 		WithSetID("fleet-bootstrap-data").


### PR DESCRIPTION
Refers to https://github.com/rancher/fleet/issues/1679 (see also https://github.com/rancher/fleet/issues/1388 and https://github.com/rancher/fleet/issues/1651)

# Problem

When upgrading fleet  the agent's deployment is deleted and recreated and maybe updated. 
The k8s deployment controller doesn't ensure that only one pod is running. In fact it tries to keep the old pod running, so that it can finish remaining requests, while it simultaneously starts the new pod for new requests. Even switching to a "replace" update strategy doesn't guarantee that only one pod is running.

However, when the agent pod starts up and a `fleet-bootstrap-secret` is present, it will run the cluster registration. Once the registration is finished the bootstrap secret is deleted. The cluster registration in `register.Register` is a blocking loop, that keeps k8s from terminating the pod. 
Registration also has to wait for the upstream cluster to generate the service account's token secret, so it might exit with an error and restart itself. Only once it has a valid kubeconfig for the upstream cluster and can reach the API server, it will delete the bootstrap secret and register controllers to watch for events.

Since the agent update is simultaneously initiated from fleet-controller's "import.go", as well as the agent itself (due to the bundle update from "manageagent"), the possibility of two pods being started at once is high. It seems the agressive re-registering code in "import.go" makes this worse, by deleting the deployment, then immediately deleting the deployment's pods and creating a new deployment. Deleting a deployment also orphans the pods, so k8s garbage collection tries to delete them at the same time.

See https://fleet.rancher.io/ref-registration#fleet-agent---clusterregistration for more information.

# Solution

This PR moves the registration code inside the leader election. That way, only pods that won the election can register. 

# Notes

- [x] clean up code after moving it inside RunOrDie
- [x] remove debug sleep
- [x] add pod label for debugging
- [x] ~~switch agent to statefulset/just pod?~~

This adds the agent's pod hostname to the clusterregistration's labels for debugging: ` "fleet.cattle.io/created-by-agent-pod"] = os.Getenv("HOSTNAME")`

Not switching the agent deployment to a pod/statefulset at this time. With all the registration code only running on "leaders", we should see less registrations.


Note: There is no way to configure an agent's replica count, so normally there is only one agent running. Multiple agents only run at the same time  during deployment upgrades. Switching to the `recreate` rollout strategy didn't change that, probably because multiple controllers are updating the deployment, even [deleting its pods(s) directly](https://github.com/rancher/fleet/blob/e6946481ce04bc36bc89ded29eeccb6976a83a4b/internal/cmd/controller/controllers/cluster/import.go#L203-L205), at the same time.