### PR TITLE
Cleanup command takes string durations as arguments

### DIFF
--- a/integrationtests/cli/cleanup/cleanup_test.go
+++ b/integrationtests/cli/cleanup/cleanup_test.go
@@ -43,7 +43,7 @@ var _ = Describe("Fleet CLI cleanup", Ordered, func() {
 		return cleanup.ClusterRegistrations(context.TODO(), &getter, options)
 	}
 
-	When("cleanining up", func() {
+	When("cleaning up", func() {
 		BeforeEach(func() {
 			options = cleanup.Options{Min: 1, Max: 1}
 			clusters = []fleetv1.Cluster{

--- a/internal/cmd/cli/cleanup.go
+++ b/internal/cmd/cli/cleanup.go
@@ -37,7 +37,7 @@ func (a *CleanUp) Run(cmd *cobra.Command, args []string) error {
 			return err
 		}
 		if min <= 0 {
-			return errors.New("min cannot be negative")
+			return errors.New("min cannot be zero or less")
 		}
 	}
 

--- a/internal/cmd/cli/cleanup.go
+++ b/internal/cmd/cli/cleanup.go
@@ -48,7 +48,7 @@ func (a *CleanUp) Run(cmd *cobra.Command, args []string) error {
 			return err
 		}
 		if max <= 0 {
-			return errors.New("max cannot be negative")
+			return errors.New("max cannot be zero or less")
 		}
 	}
 

--- a/internal/cmd/cli/cleanup/cleanup.go
+++ b/internal/cmd/cli/cleanup/cleanup.go
@@ -20,8 +20,8 @@ type Getter interface {
 }
 
 type Options struct {
-	Min    int
-	Max    int
+	Min    time.Duration
+	Max    time.Duration
 	Factor float64
 }
 
@@ -67,8 +67,8 @@ func ClusterRegistrations(ctx context.Context, client Getter, opts Options) erro
 
 	// sleep to not overload the API server
 	b := &backoff.Backoff{
-		Min:    time.Duration(opts.Min) * time.Millisecond,
-		Max:    time.Duration(opts.Max) * time.Second,
+		Min:    opts.Min,
+		Max:    opts.Max,
 		Factor: opts.Factor,
 		Jitter: true,
 	}


### PR DESCRIPTION
Fix notes from code review, having ms and s was confusing. Instead properly parse durations from string aruments, e.g. "10s" and make "factor" an argument, too.

Refers to https://github.com/rancher/fleet/pull/1689