### PR TITLE
Fix nightly image build workflow YAML

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -11,8 +11,6 @@ permissions:
   contents: read
   packages: write
 
-env:
-
 jobs:
   nightly-release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Empty `env:` is not valid, `env: {}` would work.
