### PR TITLE
Add dev scripts to simplify using E2E tests

### DIFF
--- a/dev/README.md
+++ b/dev/README.md
@@ -3,13 +3,79 @@
 These scripts are used for running tests locally in k3d. Don't use these on
 production systems.
 
+## Requirements
+
+- docker
+- git
+- go
+- helm
+- jq
+- k3d
+- kubectl
+- ...
+
+## Running Tests on K3D
+
+These commands should set up k3d and the fleet standalone images for single
+cluster tests and run those.
+
+    source dev/setup-single-cluster
+    ginkgo e2e/single-cluster
+
+Optional flags to `ginkgo` for reporting on long-running tests:
+`--poll-progress-after=10s --poll-progress-interval=10s`.
+
+For multi-cluster tests we need to configure two clusters. You also need to make
+the upstream clusters API accessible to the downstream cluster. The default URL
+in `dev/setup-fleet-downstream` should work with most systems.
+
+    source dev/setup-multi-cluster
+    ginkgo e2e/multi-cluster
+
+### Testing changes incrementally
+
+To test changes incrementally, rebuild just one binary, update the image in k3d
+and restart the controller. Make sure you have sourced the right configuration
+for the current setup.
+
+    dev/update-agent-k3d
+    dev/update-controller-k3d
+
 ## Configuration
 
-You can set these manually, but it is advised to put them in an `.envrc` and
-source them before running any of the scripts.
+### Running scripts manually
+
+You can set these environment variables for configuration manually, but it is
+advised to put them in `.envrc` and source them before running any of the
+scripts (except for `dev/setup-{single,multi}-cluster`), if the scripts are run
+manually. You can rely on the environment variables being set correctly if you
+source the `dev/setup-{single,multi}-cluster` scripts.
+
+```bash
+source .envrc
+```
+
+### Running setup scripts
+
+If you use `dev/setup-single-cluster` or `dev/setup-multi-cluster` you can
+simply put your custom configuration in the root of the repository as
+`env.single-cluster` and `env.multi-cluster`. Those files will then be used
+instead of the defaults in `dev/env.single-cluster-defaults` or
+`dev/env.multi-cluster-defaults`, respectively.
+
+If you occasionally want to specify a different file, you can set the
+`FLEET_TEST_CONFIG` environment variable to point to your custom configuration
+(like `.envrc`) file. This will make those scripts use the file specified in the
+`FLEET_TEST_CONFIG` environment variable instead of the defaults in
+`dev/env.single-cluster-defaults` and `dev/env.multi-cluster-defaults` and also
+instead of the custom configuration in `env.single-cluster` and
+`env.multi-cluster`.
+
+### A list of all environment variables
 
     # use fleet-default for fleet in Rancher, fleet-local for standalone
     export FLEET_E2E_NS=fleet-local
+    export FLEET_E2E_NS_DOWNSTREAM=fleet-default
 
     # running single-cluster tests in Rancher Desktop
     #export FLEET_E2E_CLUSTER=rancher-desktop
@@ -38,66 +104,14 @@ source them before running any of the scripts.
     #export GIT_HTTP_USER="fleet-ci"
     #export GIT_HTTP_PASSWORD="foo"
 
-    # needed for OCI tests, which are currently disabled but part of the
-    # single-cluster tests
+    # needed for OCI tests, which are part of the single-cluster tests
 
     #export CI_OCI_USERNAME="fleet-ci"
     #export CI_OCI_PASSWORD="foo"
     #export CI_OCI_CERTS_DIR="../../FleetCI-RootCA"
-    #export HELM_PATH="/usr/bin/helm" # optional, for selecting Helm versions (see [Troubleshooting](#troubleshooting))
 
-## Running Tests on K3D
-
-These commands should set up k3d, and the fleet standalone images for single
-cluster tests.
-
-    export FLEET_E2E_NS=fleet-local
-    export FLEET_E2E_NS_DOWNSTREAM=fleet-default
-    export FLEET_E2E_CLUSTER=k3d-upstream
-    export FLEET_E2E_CLUSTER_DOWNSTREAM=k3d-upstream
-
-    dev/setup-k3d
-    dev/build-fleet
-    dev/import-images-k3d
-
-    # Needed for gitrepo tests
-    dev/import-images-tests-k3d
-    dev/create-zot-certs 'FleetCI-RootCA' # for OCI tests
-    dev/setup-fleet
-
-    # This should be needed only once
-    cd e2e/testenv/infra
-    go build -o . ./...
-    cd -
-
-    ./e2e/testenv/infra/infra setup
-
-    ginkgo e2e/single-cluster
-
-    ./e2e/testenv/infra teardown # optional
-
-Optional flags for reporting on long-running tests: `--poll-progress-after=10s --poll-progress-interval=10s`.
-
-For multi-cluster tests we need to configure two clusters. You also need to make
-the upstream clusters API accessible to the downstream cluster. The default
-`url` in [dev/setup-fleet-downstream] should work with most systems.
-
-    export FLEET_E2E_NS=fleet-local
-    export FLEET_E2E_CLUSTER=k3d-upstream
-    export FLEET_E2E_CLUSTER_DOWNSTREAM=k3d-downstream
-
-    dev/setup-k3ds
-    dev/build-fleet
-    dev/import-images-k3d
-    dev/setup-fleet-multi-cluster
-
-    ginkgo e2e/multi-cluster
-
-To test changes incrementally, rebuild just one binary, update the image in k3d
-and restart the controller:
-
-    dev/update-agent-k3d
-    dev/update-controller-k3d
+    # optional, for selecting Helm versions (see [Troubleshooting](#troubleshooting))
+    #export HELM_PATH="/usr/bin/helm"
 
 ### Troubleshooting
 
@@ -115,19 +129,9 @@ does not reuse dev scripts, however dev scripts may use CI scripts. We want to
 keep CI scripts short, targeted and readable. Dev scripts may change in an
 incompatible way at any day.
 
-## Requirements
-
-* docker
-* git
-* go
-* helm
-* jq
-* k3d
-* kubectl
-* ...
-
 ## Run integration tests
 
     ./dev/run-integration-tests.sh
 
-This will download and prepare setup-envtest, then it will execute all the integration tests.
+This will download and prepare setup-envtest, then it will execute all the
+integration tests.

--- a/dev/README.md
+++ b/dev/README.md
@@ -85,40 +85,38 @@ export FLEET_E2E_NS=fleet-local
 export FLEET_E2E_NS_DOWNSTREAM=fleet-default
 
 # running single-cluster tests in Rancher Desktop
-#export FLEET_E2E_CLUSTER=rancher-desktop
-#export FLEET_E2E_CLUSTER_DOWNSTREAM=rancher-desktop
+export FLEET_E2E_CLUSTER=rancher-desktop
+export FLEET_E2E_CLUSTER_DOWNSTREAM=rancher-desktop
 
 # running single-cluster tests in k3d (setup-k3d)
-#export FLEET_E2E_CLUSTER=k3d-upstream
-#export FLEET_E2E_CLUSTER_DOWNSTREAM=k3d-upstream
+export FLEET_E2E_CLUSTER=k3d-upstream
+export FLEET_E2E_CLUSTER_DOWNSTREAM=k3d-upstream
 
 # running multi-cluster tests in k3d (setup-k3ds)
-#export FLEET_E2E_CLUSTER=k3d-upstream
-#export FLEET_E2E_CLUSTER_DOWNSTREAM=k3d-downstream
+export FLEET_E2E_CLUSTER=k3d-upstream
+export FLEET_E2E_CLUSTER_DOWNSTREAM=k3d-downstream
 
 # for running tests on darwin/arm64
-#export GOARCH=arm64
+export GOARCH=arm64
 
 # needed for gitrepo tests, which are currently disabled but part of the
 # single-cluster tests
-
-#export FORCE_GIT_SERVER_BUILD="yes" # set to an empty value to skip rebuilds
-#export GIT_REPO_USER="git"
-#export GIT_REPO_URL="git@github.com:yourprivate/repo.git"
-#export GIT_REPO_HOST="github.com"
-#export GIT_SSH_KEY="$HOME/.ssh/id_ecdsa_test"
-#export GIT_SSH_PUBKEY="$HOME/.ssh/id_ecdsa_test.pub"
-#export GIT_HTTP_USER="fleet-ci"
-#export GIT_HTTP_PASSWORD="foo"
+export FORCE_GIT_SERVER_BUILD="yes" # set to an empty value to skip rebuilds
+export GIT_REPO_USER="git"
+export GIT_REPO_URL="git@github.com:yourprivate/repo.git"
+export GIT_REPO_HOST="github.com"
+export GIT_SSH_KEY="$HOME/.ssh/id_ecdsa_test"
+export GIT_SSH_PUBKEY="$HOME/.ssh/id_ecdsa_test.pub"
+export GIT_HTTP_USER="fleet-ci"
+export GIT_HTTP_PASSWORD="foo"
 
 # needed for OCI tests, which are part of the single-cluster tests
-
-#export CI_OCI_USERNAME="fleet-ci"
-#export CI_OCI_PASSWORD="foo"
-#export CI_OCI_CERTS_DIR="../../FleetCI-RootCA"
+export CI_OCI_USERNAME="fleet-ci"
+export CI_OCI_PASSWORD="foo"
+export CI_OCI_CERTS_DIR="../../FleetCI-RootCA"
 
 # optional, for selecting Helm versions (see [Troubleshooting](#troubleshooting))
-#export HELM_PATH="/usr/bin/helm"
+export HELM_PATH="/usr/bin/helm"
 ```
 ### Troubleshooting
 

--- a/dev/README.md
+++ b/dev/README.md
@@ -19,8 +19,10 @@ production systems.
 These commands should set up k3d and the fleet standalone images for single
 cluster tests and run those.
 
-    source dev/setup-single-cluster
-    ginkgo e2e/single-cluster
+```bash
+source dev/setup-single-cluster
+ginkgo e2e/single-cluster
+```
 
 Optional flags to `ginkgo` for reporting on long-running tests:
 `--poll-progress-after=10s --poll-progress-interval=10s`.
@@ -29,8 +31,10 @@ For multi-cluster tests we need to configure two clusters. You also need to make
 the upstream clusters API accessible to the downstream cluster. The default URL
 in `dev/setup-fleet-downstream` should work with most systems.
 
-    source dev/setup-multi-cluster
-    ginkgo e2e/multi-cluster
+```bash
+source dev/setup-multi-cluster
+ginkgo e2e/multi-cluster
+```
 
 ### Testing changes incrementally
 
@@ -38,8 +42,10 @@ To test changes incrementally, rebuild just one binary, update the image in k3d
 and restart the controller. Make sure you have sourced the right configuration
 for the current setup.
 
-    dev/update-agent-k3d
-    dev/update-controller-k3d
+```bash
+dev/update-agent-k3d
+dev/update-controller-k3d
+```
 
 ## Configuration
 
@@ -73,46 +79,47 @@ instead of the custom configuration in `env.single-cluster` and
 
 ### A list of all environment variables
 
-    # use fleet-default for fleet in Rancher, fleet-local for standalone
-    export FLEET_E2E_NS=fleet-local
-    export FLEET_E2E_NS_DOWNSTREAM=fleet-default
+```bash
+# use fleet-default for fleet in Rancher, fleet-local for standalone
+export FLEET_E2E_NS=fleet-local
+export FLEET_E2E_NS_DOWNSTREAM=fleet-default
 
-    # running single-cluster tests in Rancher Desktop
-    #export FLEET_E2E_CLUSTER=rancher-desktop
-    #export FLEET_E2E_CLUSTER_DOWNSTREAM=rancher-desktop
+# running single-cluster tests in Rancher Desktop
+#export FLEET_E2E_CLUSTER=rancher-desktop
+#export FLEET_E2E_CLUSTER_DOWNSTREAM=rancher-desktop
 
-    # running single-cluster tests in k3d (setup-k3d)
-    #export FLEET_E2E_CLUSTER=k3d-upstream
-    #export FLEET_E2E_CLUSTER_DOWNSTREAM=k3d-upstream
+# running single-cluster tests in k3d (setup-k3d)
+#export FLEET_E2E_CLUSTER=k3d-upstream
+#export FLEET_E2E_CLUSTER_DOWNSTREAM=k3d-upstream
 
-    # running multi-cluster tests in k3d (setup-k3ds)
-    #export FLEET_E2E_CLUSTER=k3d-upstream
-    #export FLEET_E2E_CLUSTER_DOWNSTREAM=k3d-downstream
+# running multi-cluster tests in k3d (setup-k3ds)
+#export FLEET_E2E_CLUSTER=k3d-upstream
+#export FLEET_E2E_CLUSTER_DOWNSTREAM=k3d-downstream
 
-    # for running tests on darwin/arm64
-    #export GOARCH=arm64
+# for running tests on darwin/arm64
+#export GOARCH=arm64
 
-    # needed for gitrepo tests, which are currently disabled but part of the
-    # single-cluster tests
+# needed for gitrepo tests, which are currently disabled but part of the
+# single-cluster tests
 
-    #export FORCE_GIT_SERVER_BUILD="yes" # set to an empty value to skip rebuilds
-    #export GIT_REPO_USER="git"
-    #export GIT_REPO_URL="git@github.com:yourprivate/repo.git"
-    #export GIT_REPO_HOST="github.com"
-    #export GIT_SSH_KEY="$HOME/.ssh/id_ecdsa_test"
-    #export GIT_SSH_PUBKEY="$HOME/.ssh/id_ecdsa_test.pub"
-    #export GIT_HTTP_USER="fleet-ci"
-    #export GIT_HTTP_PASSWORD="foo"
+#export FORCE_GIT_SERVER_BUILD="yes" # set to an empty value to skip rebuilds
+#export GIT_REPO_USER="git"
+#export GIT_REPO_URL="git@github.com:yourprivate/repo.git"
+#export GIT_REPO_HOST="github.com"
+#export GIT_SSH_KEY="$HOME/.ssh/id_ecdsa_test"
+#export GIT_SSH_PUBKEY="$HOME/.ssh/id_ecdsa_test.pub"
+#export GIT_HTTP_USER="fleet-ci"
+#export GIT_HTTP_PASSWORD="foo"
 
-    # needed for OCI tests, which are part of the single-cluster tests
+# needed for OCI tests, which are part of the single-cluster tests
 
-    #export CI_OCI_USERNAME="fleet-ci"
-    #export CI_OCI_PASSWORD="foo"
-    #export CI_OCI_CERTS_DIR="../../FleetCI-RootCA"
+#export CI_OCI_USERNAME="fleet-ci"
+#export CI_OCI_PASSWORD="foo"
+#export CI_OCI_CERTS_DIR="../../FleetCI-RootCA"
 
-    # optional, for selecting Helm versions (see [Troubleshooting](#troubleshooting))
-    #export HELM_PATH="/usr/bin/helm"
-
+# optional, for selecting Helm versions (see [Troubleshooting](#troubleshooting))
+#export HELM_PATH="/usr/bin/helm"
+```
 ### Troubleshooting
 
 If running the `infra setup` script returns an error about flag
@@ -131,7 +138,9 @@ incompatible way at any day.
 
 ## Run integration tests
 
-    ./dev/run-integration-tests.sh
+```bash
+./dev/run-integration-tests.sh
+```
 
 This will download and prepare setup-envtest, then it will execute all the
 integration tests.

--- a/dev/env.multi-cluster-defaults
+++ b/dev/env.multi-cluster-defaults
@@ -1,0 +1,14 @@
+export FLEET_E2E_NS=fleet-local
+export FLEET_E2E_NS_DOWNSTREAM=fleet-default
+
+export FLEET_E2E_CLUSTER=k3d-upstream
+export FLEET_E2E_CLUSTER_DOWNSTREAM=k3d-downstream
+
+export GIT_HTTP_USER=fleet-ci
+export GIT_HTTP_PASSWORD=foo
+
+export CI_OCI_USERNAME=fleet-ci
+export CI_OCI_PASSWORD=foo
+export CI_OCI_CERTS_DIR=FleetCI-RootCA/
+
+export HELM_PATH=/usr/bin/helm

--- a/dev/env.single-cluster-defaults
+++ b/dev/env.single-cluster-defaults
@@ -1,0 +1,13 @@
+export FLEET_E2E_NS=fleet-local
+
+export FLEET_E2E_CLUSTER=k3d-upstream
+export FLEET_E2E_CLUSTER_DOWNSTREAM=k3d-upstream
+
+export GIT_HTTP_USER=fleet-ci
+export GIT_HTTP_PASSWORD=foo
+
+export CI_OCI_USERNAME=fleet-ci
+export CI_OCI_PASSWORD=foo
+export CI_OCI_CERTS_DIR=FleetCI-RootCA/
+
+export HELM_PATH=/usr/bin/helm

--- a/dev/k3d-act-clean
+++ b/dev/k3d-act-clean
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+set -e
+
+function k3d-cluster-delete {
+    if [ -z "$1" ]; then
+        return
+    fi
+
+    k3d cluster delete "$1"
+}
+
+function docker-clean-by-name {
+    if [ -z "$1" ]; then
+        return
+    fi
+
+    ids=$(docker ps -a --filter name="$1" --format "{{.ID}}")
+    if [ -z "$ids" ]; then
+        return
+    fi
+
+    for id in $ids; do
+        docker stop "$id"
+        docker rm "$id"
+    done
+}
+
+if [[ -n "$FLEET_E2E_CLUSTER" || -n "$FLEET_E2E_CLUSTER_DOWNSTREAM" ]]; then
+    k3d-cluster-delete "$FLEET_E2E_CLUSTER"
+    k3d-cluster-delete "$FLEET_E2E_CLUSTER_DOWNSTREAM"
+
+    docker-clean-by-name "$FLEET_E2E_CLUSTER"
+    docker-clean-by-name "$FLEET_E2E_CLUSTER_DOWNSTREAM"
+else
+    configs=(
+        dev/env.single-cluster-defaults
+        dev/env.multi-cluster-defaults
+    )
+    for config in "${configs[@]}"; do
+        # shellcheck source=/dev/null
+        source "$config"
+
+        config_vars=(
+            "$FLEET_E2E_CLUSTER"
+            "$FLEET_E2E_CLUSTER_DOWNSTREAM"
+        )
+
+        for config_var in "${config_vars[@]}"; do
+            k3d-cluster-delete "$config_var"
+            docker-clean-by-name "$config_var"
+        done
+    done
+fi
+
+docker-clean-by-name "act"

--- a/dev/setup-cluster-config
+++ b/dev/setup-cluster-config
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+set -ex
+
+if [ "$1" = "teardown" ]; then
+    ./e2e/testenv/infra/infra teardown
+    exit 0
+fi
+
+if [ ! -f "$DEFAULT_CONFIG" ]; then
+    echo >&2 "Run this from the root of the repo"
+    exit 1
+fi
+
+if [ -n "$FLEET_TEST_CONFIG" ]; then
+    if [ ! -f "$FLEET_TEST_CONFIG" ]; then
+        echo >&2 "File not found: \$FLEET_TEST_CONFIG: $FLEET_TEST_CONFIG"
+        exit 1
+    fi
+    echo "Using custom config file: $FLEET_TEST_CONFIG"
+    # shellcheck source=/dev/null
+    source "$FLEET_TEST_CONFIG"
+elif [ -f "$CUSTOM_CONFIG_FILE" ]; then
+    echo "Using custom config file: $CUSTOM_CONFIG_FILE"
+    # shellcheck source=/dev/null
+    source "$CUSTOM_CONFIG_FILE"
+else
+    echo "Using default config file: $DEFAULT_CONFIG"
+    # shellcheck source=/dev/null
+    source "$DEFAULT_CONFIG"
+fi

--- a/dev/setup-multi-cluster
+++ b/dev/setup-multi-cluster
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+export DEFAULT_CONFIG="dev/env.multi-cluster-defaults"
+export CUSTOM_CONFIG_FILE="env.multi-cluster"
+
+# shellcheck source=dev/setup-cluster-config
+source dev/setup-cluster-config
+
+# Cleans with settings sourced, so it should be rather selective.
+./dev/k3d-act-clean
+
+./dev/setup-k3ds
+./dev/build-fleet
+./dev/import-images-k3d
+./dev/setup-fleet-multi-cluster
+
+# needed for gitrepo tests
+./dev/import-images-tests-k3d
+./dev/create-zot-certs 'FleetCI-RootCA' # for OCI tests
+./e2e/testenv/infra/infra setup

--- a/dev/setup-single-cluster
+++ b/dev/setup-single-cluster
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+export DEFAULT_CONFIG="dev/env.single-cluster-defaults"
+export CUSTOM_CONFIG_FILE="env.single-cluster"
+
+# shellcheck source=dev/setup-cluster-config
+source ./dev/setup-cluster-config
+
+# Cleans with settings sourced, so it should be rather selective.
+./dev/k3d-act-clean
+
+./dev/setup-k3d
+./dev/build-fleet
+./dev/import-images-k3d
+./dev/setup-fleet
+
+# needed for gitrepo tests
+./dev/import-images-tests-k3d
+./dev/create-zot-certs 'FleetCI-RootCA' # for OCI tests
+./e2e/testenv/infra/infra setup


### PR DESCRIPTION
<!-- Specify the issue ID that this pull request is solving -->
Part of #1496

Adding scripts to not have to copy and paste instructions from `dev/README.md` with sane defaults to spin up the environment and run the tests out-of-the-box. Contains appropriate adaptations of the `dev/README.md`.