### PR TITLE
Allow skipping Helm's schema validation through fleet.yaml

### DIFF
--- a/charts/fleet-crd/templates/crds.yaml
+++ b/charts/fleet-crd/templates/crds.yaml
@@ -142,6 +142,8 @@ spec:
                   repo:
                     nullable: true
                     type: string
+                  skipSchemaValidation:
+                    type: boolean
                   takeOwnership:
                     type: boolean
                   timeoutSeconds:
@@ -554,6 +556,8 @@ spec:
                         repo:
                           nullable: true
                           type: string
+                        skipSchemaValidation:
+                          type: boolean
                         takeOwnership:
                           type: boolean
                         timeoutSeconds:
@@ -1115,6 +1119,8 @@ spec:
                       repo:
                         nullable: true
                         type: string
+                      skipSchemaValidation:
+                        type: boolean
                       takeOwnership:
                         type: boolean
                       timeoutSeconds:
@@ -1303,6 +1309,8 @@ spec:
                       repo:
                         nullable: true
                         type: string
+                      skipSchemaValidation:
+                        type: boolean
                       takeOwnership:
                         type: boolean
                       timeoutSeconds:

--- a/e2e/assets/single-cluster/helm-options-skip-schema-validation.yaml
+++ b/e2e/assets/single-cluster/helm-options-skip-schema-validation.yaml
@@ -1,0 +1,10 @@
+kind: GitRepo
+apiVersion: fleet.cattle.io/v1alpha1
+metadata:
+  name: helm-options-skip-schema-val # truncate name to control bundle name length
+spec:
+  repo: https://github.com/rancher/fleet-test-data
+  branch: master
+  paths:
+  - helm-schemas/set
+  - helm-schemas/not-set

--- a/e2e/assets/single-cluster/helm-options-skip-schema-validation.yaml
+++ b/e2e/assets/single-cluster/helm-options-skip-schema-validation.yaml
@@ -1,7 +1,7 @@
 kind: GitRepo
 apiVersion: fleet.cattle.io/v1alpha1
 metadata:
-  name: helm-options-skip-schema-val # truncate name to control bundle name length
+  name: helm-options-skip-schema-val 
 spec:
   repo: https://github.com/rancher/fleet-test-data
   branch: master

--- a/e2e/single-cluster/helm_options_test.go
+++ b/e2e/single-cluster/helm_options_test.go
@@ -50,4 +50,28 @@ var _ = Describe("Helm deploy options", func() {
 			})
 		})
 	})
+
+	Describe("SkipSchemaValidation", func() {
+		BeforeEach(func() {
+			asset = "single-cluster/helm-options-skip-schema-validation.yaml"
+		})
+		When("is false", func() {
+			bundleName := "helm-options-skip-schema-val-helm-schemas-not-set"
+			It("fails when schema validation does not pass", func() {
+				Eventually(func() string {
+					out, _ := k.Get("bundle", bundleName, `-o=jsonpath='{.status.conditions[?(@.type=="Ready")].message}'`)
+					return out
+				}).Should(ContainSubstring("values don't meet the specifications of the schema"))
+			})
+		})
+		When("is true", func() {
+			bundleName := "helm-options-skip-schema-val-helm-schemas-set"
+			It("completely skips the schema validation", func() {
+				Eventually(func() string {
+					out, _ := k.Get("bundle", bundleName, `-o=jsonpath={.status.conditions[?(@.type=="Ready")].status}`)
+					return out
+				}).Should(Equal("True"))
+			})
+		})
+	})
 })

--- a/internal/helmdeployer/deployer.go
+++ b/internal/helmdeployer/deployer.go
@@ -225,6 +225,12 @@ func (h *Helm) Deploy(bundleID string, manifest *manifest.Manifest, options flee
 		chart.Metadata.Annotations[CommitAnnotation] = manifest.Commit
 	}
 
+	if options.Helm.SkipSchemaValidation {
+		// TODO: instead of manipulating the chart object, use helm's own functionality when it's available:
+		//       https://github.com/helm/helm/pull/11510
+		chart.Schema = nil
+	}
+
 	if resources, err := h.install(bundleID, manifest, chart, options, true); err != nil {
 		return nil, err
 	} else if h.template {

--- a/pkg/apis/fleet.cattle.io/v1alpha1/bundle.go
+++ b/pkg/apis/fleet.cattle.io/v1alpha1/bundle.go
@@ -515,6 +515,9 @@ type HelmOptions struct {
 
 	// DisableDNS can be used to customize Helm's EnableDNS option, which Fleet sets to `true` by default.
 	DisableDNS bool `json:"disableDNS,omitempty"`
+
+	// SkipSchemaValidation allows skipping schema validation against the chart values
+	SkipSchemaValidation bool `json:"skipSchemaValidation,omitempty"`
 }
 
 // IgnoreOptions defines conditions to be ignored when monitoring the Bundle.


### PR DESCRIPTION
<!-- Specify the issue ID that this pull request is solving -->
Fix #1430

This PR allows preventing Helm to execute the validation of `values.schema.json`, intended to validate the provided chart values.

The implementation is a workaround for helm/helm#10398, since it removes the `Schema` field after loading the `Chart` object, but should be straightforward to replace once the functionality of the mentioned issue is merged and available.

## Test

An end-to-end test have been added to exercise this functionality (see https://github.com/rancher/fleet-test-data/pull/5).

In order to manually test it, you can add the following top-level property to a `fleet.yaml`:

```yaml
helm:
    skipSchemaValidation: true
```

Then it must be applied in a cluster running Fleet, where the updated version of the CRDs are installed and an updated version of the `fleet-controller` and `fleet-agent` images are used.
Then, after a `GitRepo` pointing to the updated `fleet.yaml` file is synced, the resulting bundle CRD object must preserve this property.