### PR TITLE
Incorrect agent's DebugLevel when settings propagation is set

### DIFF
--- a/internal/cmd/controller/root.go
+++ b/internal/cmd/controller/root.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path"
 	"runtime/pprof"
+	"strconv"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -56,7 +57,11 @@ func App() *cobra.Command {
 // setupDebug parses debug flags and configures the relevant log levels
 func setupDebug() {
 	debugConfig.MustSetupDebug()
-	if debugConfig.Debug {
+
+	// if debug is enabled in controller, enable in agents too (unless otherwise specified)
+	propagateDebug, _ := strconv.ParseBool(os.Getenv("FLEET_PROPAGATE_DEBUG_SETTINGS_TO_AGENTS"))
+	if propagateDebug && debugConfig.Debug {
+		agent.DebugEnabled = true
 		agent.DebugLevel = debugConfig.DebugLevel
 	}
 }

--- a/internal/cmd/controller/root.go
+++ b/internal/cmd/controller/root.go
@@ -33,17 +33,13 @@ type FleetManager struct {
 }
 
 func (f *FleetManager) Run(cmd *cobra.Command, args []string) error {
+	setupDebug()
 	setupCpuPprof(cmd.Context())
 	go func() {
 		log.Println(http.ListenAndServe("localhost:6060", nil)) // nolint:gosec // Debugging only
 	}()
-	debugConfig.MustSetupDebug()
 	if err := start(cmd.Context(), f.Namespace, f.Kubeconfig, f.DisableGitops, f.DisableBootstrap); err != nil {
 		return err
-	}
-
-	if debugConfig.Debug {
-		agent.DebugLevel = debugConfig.DebugLevel
 	}
 
 	<-cmd.Context().Done()
@@ -55,6 +51,14 @@ func App() *cobra.Command {
 		Version: version.FriendlyVersion(),
 	})
 	return command.AddDebug(cmd, &debugConfig)
+}
+
+// setupDebug parses debug flags and configures the relevant log levels
+func setupDebug() {
+	debugConfig.MustSetupDebug()
+	if debugConfig.Debug {
+		agent.DebugLevel = debugConfig.DebugLevel
+	}
 }
 
 // setupCpuPprof starts a goroutine that captures a cpu pprof profile


### PR DESCRIPTION
<!-- Specify the issue ID that this pull request is solving -->
Fixes #1694

The variable used to populate the agent's `--debug-level` flag was being set after starting the controller, which is causing the value not to be ready by the time it's accessed.

I've also taken the chance to move the handling of the environment variable that controls this propagation to the root command.

# Testing

I confirmed the issue by installing Fleet controller with debug enabled, then checking the `fleet-agent` deployment that gets automatically installed:

```
❯ kubectl -n cattle-fleet-system get deploy/fleet-agent -o=jsonpath='{.spec.template.spec.containers[0].command}'
["fleetagent","--debug","--debug-level","0"]
```

After my changes, we can see that the debug level flag matches the value used in the controller:
```
❯ kubectl -n cattle-fleet-system get deploy/fleet-agent -o=jsonpath='{.spec.template.spec.containers[0].command}'
["fleetagent","--debug","--debug-level","99"]
```