### PR TITLE
E2E: Increase logging

### DIFF
--- a/e2e/single-cluster/suite_test.go
+++ b/e2e/single-cluster/suite_test.go
@@ -3,11 +3,12 @@ package singlecluster_test
 
 import (
 	"testing"
-
-	"github.com/rancher/fleet/e2e/testenv"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	"github.com/rancher/fleet/e2e/testenv"
 )
 
 func TestE2E(t *testing.T) {
@@ -21,6 +22,7 @@ var (
 
 var _ = BeforeSuite(func() {
 	SetDefaultEventuallyTimeout(testenv.Timeout)
+	SetDefaultEventuallyPollingInterval(time.Second)
 	testenv.SetRoot("../..")
 
 	env = testenv.New()

--- a/e2e/testenv/kubectl/kubectl.go
+++ b/e2e/testenv/kubectl/kubectl.go
@@ -6,6 +6,9 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
 )
 
 type Command struct {
@@ -72,7 +75,13 @@ func (c Command) Run(args ...string) (string, error) {
 		args = append([]string{"-n", c.ns}, args...)
 	}
 
-	return c.exec("kubectl", args...)
+	GinkgoWriter.Printf("kubectl %s\n", strings.Join(args, " "))
+	result, err := c.exec("kubectl", args...)
+	if err != nil {
+		GinkgoWriter.Printf("result:%s err:%s\n", result, err)
+	}
+
+	return result, err
 }
 
 func (c Command) exec(command string, args ...string) (string, error) {


### PR DESCRIPTION
<!-- Specify the issue ID that this pull request is solving -->
Part of #1496

<!-- Describe the changes introduced by this pull request -->

<!--
  Please provide a unit or e2e test if possible.

  To simplify the reviewing process of this pull request,
  please explain how it should be tested.
  The following is just an example

## Test

To test this pull request, you can run the following commands:

```shell
cd <to_package_directory>
go test
```

-->

Increases logging in case of errors, or if `-v` is used. Otherwise the verbosity is unchanged.

## Additional Information

### Trade-off

<!-- Please describe, if any, the trade-offs that you found acceptable in this pull request -->

Importing Ginkgo in `e2e/testenv` might make it more difficult to use testenv outside of the context of testing. That said, [this isn't the first occurrence of Ginko in `e2e/testenv`](https://github.com/rancher/fleet/blob/master/e2e/testenv/template.go#L44) (but the second PR to add Ginkgo as dependency to testenv).

### Potential improvement

Error occurring with `kubectl` operations are usually pretty unhelpful. With this change, it'll be evident which command failed and perhaps even why. A remote test from my fork [demonstrates the usefulness](https://github.com/p-se/fleet/actions/runs/6171821087/job/16750825094). You can compare that with other occurrences of the same issue in other PRs [here](https://github.com/rancher/fleet/actions/runs/6121172337/job/16711445433?pr=1765) and [here](https://github.com/rancher/fleet/actions/runs/6121172337/job/16711445433?pr=1765).

Excerpt:

```
 • [FAILED] [1.862 seconds]
Monitoring Git repos via HTTP for change when updating a git repository monitored via webhook [JustBeforeEach] updates the deployment [infra-setup, webhook]
  [JustBeforeEach] /home/runner/work/fleet/fleet/e2e/single-cluster/gitrepo_test.go:123
  [It] /home/runner/work/fleet/fleet/e2e/single-cluster/gitrepo_test.go:192

  Timeline >>
  kubectl -n fleet-local get service git-service -o jsonpath={.status.loadBalancer.ingress[0].ip}
  kubectl -n fleet-local get pod -l app=git-server -o name
  kubectl -n fleet-local exec git-server-664c46bd5b-swlrd -- /bin/sh -c dir=/srv/git/webhook-test; rm -rf "$dir"; mkdir -p "$dir"; git init "$dir" --bare; GIT_DIR="$dir" git update-server-info
  kubectl -n fleet-local cp /tmp/fleet-1503930538/hook_script git-server-664c46bd5b-swlrd:/srv/git/webhook-test/hooks/post-receive
  kubectl -n fleet-local exec git-server-664c46bd5b-swlrd -- chmod +x /srv/git/webhook-test/hooks/post-receive
  result:Error from server: error dialing backend: EOF
   err:exit status 1
  [FAILED] in [JustBeforeEach] - /home/runner/work/fleet/fleet/e2e/single-cluster/gitrepo_test.go:172 @ 09/13/23 11:34:46.18
  kubectl -n fleet-local delete gitrepo gitjob-test27714
  result:Error from server (NotFound): gitrepos.fleet.cattle.io "gitjob-test27714" not found
   err:exit status 1
  << Timeline

  [FAILED] Error from server: error dialing backend: EOF
```

### Additionally

It also showed that `kubectl` commands are rather frequently repeated in conjunction with Gomega's `Eventually`.

> The first optional argument is the timeout (which defaults to 1s), the second is the polling interval (**which defaults to 10ms**)

Therefore, I thought it, might be beneficial to set a perhaps saner default (1s) in the context of E2E tests, which is also part of this PR.


<!-- Please describe, if any, potential improvement that you are envisioning -->

<!-- Please Uncomment following block if looking for QA validation

## Additional QA
### Issue: <link the issue or issues this PR resolves here>
< If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. >
 
### Problem
< Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. >
 
### Solution
< Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue.>
 
### Testing
< Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. >

### Engineering Testing
#### Manual Testing
< Describe what manual testing you did (if no testing was done, explain why). >

#### Automated Testing
<If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. >

### QA Testing Considerations
< Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios >
 
#### Regressions Considerations
< Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions >

-->
