### PR TITLE
E2E: Fix flaky single cluster tests

### DIFF
--- a/e2e/single-cluster/gitrepo_test.go
+++ b/e2e/single-cluster/gitrepo_test.go
@@ -164,12 +164,16 @@ var _ = Describe("Monitoring Git repos via HTTP for change", Label("infra-setup"
 			// Copy the script into the repo on the server pod
 			hookPathInRepo := fmt.Sprintf("/srv/git/%s/hooks/post-receive", repoName)
 
-			out, err = k.Run("cp", hookScript, fmt.Sprintf("%s:%s", gitServerPod, hookPathInRepo))
-			Expect(err).ToNot(HaveOccurred(), out)
+			Eventually(func() error {
+				out, err = k.Run("cp", hookScript, fmt.Sprintf("%s:%s", gitServerPod, hookPathInRepo))
+				return err
+			}).Should(Not(HaveOccurred()), out)
 
 			// Make hook script executable
-			out, err = k.Run("exec", gitServerPod, "--", "chmod", "+x", hookPathInRepo)
-			Expect(err).ToNot(HaveOccurred(), out)
+			Eventually(func() error {
+				out, err = k.Run("exec", gitServerPod, "--", "chmod", "+x", hookPathInRepo)
+				return err
+			}).ShouldNot(HaveOccurred(), out)
 
 			err = testenv.ApplyTemplate(k, testenv.AssetPath("gitrepo/gitrepo.yaml"), struct {
 				Name            string


### PR DESCRIPTION
<!-- Specify the issue ID that this pull request is solving -->
Part of https://github.com/rancher/fleet/issues/1496

Wraps harmless looking instructions into an `Eventually` because they fail occasionally.

See
* https://github.com/rancher/fleet/actions/runs/6145269754/job/16672311663#step:13:70
* https://github.com/p-se/fleet/actions/runs/6171821087/job/16750825094#step:13:98
* https://github.com/rancher/fleet/actions/runs/6166897811/job/16737086460?pr=1781#step:13:70
* https://github.com/rancher/fleet/actions/runs/6121172337/job/16711445433?pr=1765#step:13:70

