### PR TITLE
Add support for spec field identifying KUBECONFIG namespace for imported clusters

### DIFF
--- a/charts/fleet-crd/templates/crds.yaml
+++ b/charts/fleet-crd/templates/crds.yaml
@@ -2501,6 +2501,9 @@ spec:
               kubeConfigSecret:
                 nullable: true
                 type: string
+              kubeConfigSecretNamespace:
+                nullable: true
+                type: string
               paused:
                 type: boolean
               privateRepoURL:

--- a/internal/cmd/controller/controllers/cluster/import.go
+++ b/internal/cmd/controller/controllers/cluster/import.go
@@ -229,12 +229,19 @@ func (i *importHandler) importCluster(cluster *fleet.Cluster, status fleet.Clust
 		cluster.Spec.ClientID == "" {
 		return status, nil
 	}
-	secret, err := i.secrets.Get(cluster.Namespace, cluster.Spec.KubeConfigSecret)
+
+	kubeConfigSecretNamespace := cluster.Namespace
+	if cluster.Spec.KubeConfigSecretNamespace != "" {
+		kubeConfigSecretNamespace = cluster.Spec.KubeConfigSecretNamespace
+	}
+	logrus.Debugf("Cluster import for '%s/%s'. Getting kubeconfig from secret in namespace %s", cluster.Namespace, cluster.Name, kubeConfigSecretNamespace)
+
+	secret, err := i.secrets.Get(kubeConfigSecretNamespace, cluster.Spec.KubeConfigSecret)
 	if err != nil {
 		return status, err
 	}
 
-	logrus.Debugf("Cluster import for '%s/%s'. Setting up agent with kubeconfig from secret '%s'", cluster.Namespace, cluster.Name, cluster.Spec.KubeConfigSecret)
+	logrus.Debugf("Cluster import for '%s/%s'. Setting up agent with kubeconfig from secret '%s/%s'", cluster.Namespace, cluster.Name, kubeConfigSecretNamespace, cluster.Spec.KubeConfigSecret)
 	var (
 		cfg          = config.Get()
 		apiServerURL = string(secret.Data["apiServerURL"])

--- a/pkg/apis/fleet.cattle.io/v1alpha1/target.go
+++ b/pkg/apis/fleet.cattle.io/v1alpha1/target.go
@@ -112,6 +112,10 @@ type ClusterSpec struct {
 	// KubeConfigSecret is the name of the secret containing the kubeconfig for the downstream cluster.
 	KubeConfigSecret string `json:"kubeConfigSecret,omitempty"`
 
+	// KubeConfigSecretNamespace is the namespace of the secret containing the kubeconfig for the downstream cluster.
+	// If unset, it will be assumed the secret can be found in the namespace that the Cluster object resides within.
+	KubeConfigSecretNamespace string `json:"kubeConfigSecretNamespace,omitempty"`
+
 	// RedeployAgentGeneration can be used to force redeploying the agent.
 	RedeployAgentGeneration int64 `json:"redeployAgentGeneration,omitempty"`
 


### PR DESCRIPTION
<!-- Specify the issue ID that this pull request is solving -->
Fix https://github.com/rancher/fleet/issues/1787

<!-- Describe the changes introduced by this pull request -->

Introduce the `.spec.kubeConfigSecretNamespace` annotation to facilitate specifying an alternate namespace for grabbing the KUBECONFIG of an imported cluster. This should only affect manager-based registration since it's only affecting the imported cluster workflow.

<!--
  Please provide a unit or e2e test if possible.

  To simplify the reviewing process of this pull request,
  please explain how it should be tested.
  The following is just an example

## Test

To test this pull request, you can run the following commands:

```shell
cd <to_package_directory>
go test
```

-->

## Additional Information

### Trade-off

<!-- Please describe, if any, the trade-offs that you found acceptable in this pull request -->

Listed in issue

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->

<!-- Please Uncomment following block if looking for QA validation

Unblocks Rancher Provisioning V2 team. See issue.

## Additional QA
### Issue: <link the issue or issues this PR resolves here>
< If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. >

Testing that this works for an imported cluster if you specify all KUBECONFIGs in exactly one namespace (the standalone Fleet use case)
 
Testing that modifying this annotation later will have the Fleet cluster looking in the right location.

### Problem
< Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. >
 
In issue.

### Solution
< Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue.>

In issue.
 
### Testing
< Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. >

No testing done. This is a simple change.

### Engineering Testing
#### Manual Testing
< Describe what manual testing you did (if no testing was done, explain why). >

None.

#### Automated Testing
<If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. >

None.

### QA Testing Considerations
< Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios >
 
Listed above.

#### Regressions Considerations
< Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions >

-->

No regression possibilities. This is an opt-in feature.