### PR TITLE
Retry k3d image import in workflows

### DIFF
--- a/.github/scripts/k3d-import-retry.sh
+++ b/.github/scripts/k3d-import-retry.sh
@@ -2,21 +2,13 @@
 
 set -euxo pipefail
 
-container=${1:-k3d-upstream}
-name=${2:-fleet}
-shift
-shift
-
-echo "Run k3d import with \"$*\" and retry if '$name' is not found in 'critcl images' output"
-
 i=0
-while ! ( docker exec "$container"-server-0 /bin/crictl images | grep -q "$name" ); do
+while k3d image import "$@" -m direct | grep -q "failed to import"; do
   i=$((i + 1))
   if (( i > 3 )); then
     echo "failed to import images"
     exit 1
   fi
-  k3d image import "$@"
-  # crictl images doesn't show the image immediately after import
-  sleep 20
+  echo "retrying... $i"
+  sleep 1
 done

--- a/.github/scripts/k3d-import-retry.sh
+++ b/.github/scripts/k3d-import-retry.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+container=${1:-k3d-upstream}
+name=${2:-fleet}
+shift
+shift
+
+echo "Run k3d import with \"$*\" and retry if '$name' is not found in 'critcl images' output"
+
+i=0
+while ! ( docker exec "$container"-server-0 /bin/crictl images | grep -q "$name" ); do
+  i=$((i + 1))
+  if (( i > 3 )); then
+    echo "failed to import images"
+    exit 1
+  fi
+  k3d image import "$@"
+  # crictl images doesn't show the image immediately after import
+  sleep 20
+done

--- a/.github/scripts/k3d-import-retry.sh
+++ b/.github/scripts/k3d-import-retry.sh
@@ -3,7 +3,8 @@
 set -euxo pipefail
 
 i=0
-while k3d image import "$@" -m direct | grep -q "failed to import"; do
+# direct mode exits with 1 in case of an error, tool mode doesn't
+while ! k3d image import "$@" -m direct; do
   i=$((i + 1))
   if (( i > 3 )); then
     echo "failed to import images"

--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -81,8 +81,10 @@ jobs:
       -
         name: Import Images Into k3d
         run: |
-          k3d image import rancher/fleet:dev rancher/fleet-agent:dev
-          k3d image import nginx-git:test nginx-git:test
+          ./.github/scripts/k3d-import-retry.sh k3d-k3s-default fleet \
+            rancher/fleet:dev rancher/fleet-agent:dev
+          ./.github/scripts/k3d-import-retry.sh k3d-k3s-default nginx-git \
+            nginx-git:test nginx-git:test
       -
         name: Set Up Tmate Debug Session
         if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.enable_tmate == 'true' }}

--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -81,10 +81,7 @@ jobs:
       -
         name: Import Images Into k3d
         run: |
-          ./.github/scripts/k3d-import-retry.sh k3d-k3s-default fleet \
-            rancher/fleet:dev rancher/fleet-agent:dev
-          ./.github/scripts/k3d-import-retry.sh k3d-k3s-default nginx-git \
-            nginx-git:test nginx-git:test
+          ./.github/scripts/k3d-import-retry.sh rancher/fleet:dev rancher/fleet-agent:dev nginx-git:test
       -
         name: Set Up Tmate Debug Session
         if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.enable_tmate == 'true' }}

--- a/.github/workflows/e2e-multicluster-ci.yml
+++ b/.github/workflows/e2e-multicluster-ci.yml
@@ -85,8 +85,10 @@ jobs:
       -
         name: Import Images Into k3d
         run: |
-          k3d image import rancher/fleet:dev rancher/fleet-agent:dev -c upstream
-          k3d image import rancher/fleet-agent:dev -c downstream
+          ./.github/scripts/k3d-import-retry.sh k3d-upstream fleet \
+            rancher/fleet:dev rancher/fleet-agent:dev -c upstream
+          ./.github/scripts/k3d-import-retry.sh k3d-downstream fleet-agent \
+            rancher/fleet-agent:dev -c downstream
       -
         name: Set Up Tmate Debug Session
         if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.enable_tmate == 'true' }}

--- a/.github/workflows/e2e-multicluster-ci.yml
+++ b/.github/workflows/e2e-multicluster-ci.yml
@@ -85,10 +85,8 @@ jobs:
       -
         name: Import Images Into k3d
         run: |
-          ./.github/scripts/k3d-import-retry.sh k3d-upstream fleet \
-            rancher/fleet:dev rancher/fleet-agent:dev -c upstream
-          ./.github/scripts/k3d-import-retry.sh k3d-downstream fleet-agent \
-            rancher/fleet-agent:dev -c downstream
+          ./.github/scripts/k3d-import-retry.sh rancher/fleet:dev rancher/fleet-agent:dev -c upstream
+          ./.github/scripts/k3d-import-retry.sh rancher/fleet-agent:dev -c downstream
       -
         name: Set Up Tmate Debug Session
         if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.enable_tmate == 'true' }}

--- a/.github/workflows/fleet-upgrade.yml
+++ b/.github/workflows/fleet-upgrade.yml
@@ -87,7 +87,8 @@ jobs:
       -
         name: Import Images Into k3d
         run: |
-          k3d image import rancher/fleet:dev rancher/fleet-agent:dev -c upstream
+          ./.github/scripts/k3d-import-retry.sh k3d-upstream fleet \
+            rancher/fleet:dev rancher/fleet-agent:dev -c upstream
       -
         name: Verify Example Workload
         run: |

--- a/.github/workflows/fleet-upgrade.yml
+++ b/.github/workflows/fleet-upgrade.yml
@@ -87,8 +87,7 @@ jobs:
       -
         name: Import Images Into k3d
         run: |
-          ./.github/scripts/k3d-import-retry.sh k3d-upstream fleet \
-            rancher/fleet:dev rancher/fleet-agent:dev -c upstream
+          ./.github/scripts/k3d-import-retry.sh rancher/fleet:dev rancher/fleet-agent:dev -c upstream
       -
         name: Verify Example Workload
         run: |

--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -77,8 +77,10 @@ jobs:
       -
         name: Import Images Into k3d
         run: |
-          k3d image import rancher/fleet:dev rancher/fleet-agent:dev
-          k3d image import nginx-git:test nginx-git:test
+          ./.github/scripts/k3d-import-retry.sh k3d-k3s-default fleet \
+            rancher/fleet:dev rancher/fleet-agent:dev
+          ./.github/scripts/k3d-import-retry.sh k3d-k3s-default nginx-git \
+            nginx-git:test
       -
         name: Deploy Fleet
         run: |

--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -77,10 +77,7 @@ jobs:
       -
         name: Import Images Into k3d
         run: |
-          ./.github/scripts/k3d-import-retry.sh k3d-k3s-default fleet \
-            rancher/fleet:dev rancher/fleet-agent:dev
-          ./.github/scripts/k3d-import-retry.sh k3d-k3s-default nginx-git \
-            nginx-git:test
+          ./.github/scripts/k3d-import-retry.sh rancher/fleet:dev rancher/fleet-agent:dev nginx-git:test
       -
         name: Deploy Fleet
         run: |


### PR DESCRIPTION
Refers to https://github.com/rancher/fleet/issues/1496

This is a workaround until [k3d import is fixed upstream](https://github.com/k3d-io/k3d/issues/1072).