### PR TITLE
Helm Storage Backend With Caching

### DIFF
--- a/integrationtests/agent/suite_test.go
+++ b/integrationtests/agent/suite_test.go
@@ -162,6 +162,9 @@ func registerBundleDeploymentController(cfg *rest.Config, namespace string, look
 	err = factory.Start(ctx, 50)
 	Expect(err).ToNot(HaveOccurred())
 
+	err = coreFactory.Start(ctx, 50)
+	Expect(err).ToNot(HaveOccurred())
+
 	return factory.Fleet().V1alpha1().BundleDeployment()
 }
 

--- a/internal/helmdeployer/helmcache/secret.go
+++ b/internal/helmdeployer/helmcache/secret.go
@@ -23,7 +23,7 @@ func NewSecretClient(cache corecontrollers.SecretCache, client kubernetes.Interf
 	return &SecretClient{cache, client, namespace}
 }
 
-func (s *SecretClient) Create(ctx context.Context, secret *v1.Secret, opts metav1.CreateOptions) (result *v1.Secret, err error) {
+func (s *SecretClient) Create(ctx context.Context, secret *v1.Secret, opts metav1.CreateOptions) (*v1.Secret, error) {
 	return s.client.CoreV1().Secrets(s.namespace).Create(ctx, secret, opts)
 }
 

--- a/internal/helmdeployer/helmcache/secret.go
+++ b/internal/helmdeployer/helmcache/secret.go
@@ -13,6 +13,8 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
+// SecretClient implements methods to handle secrets. Get and list will be retrieved from the wrangler cache, the other calls
+// will be make to the Kubernetes API server.
 type SecretClient struct {
 	cache     corecontrollers.SecretCache
 	client    kubernetes.Interface
@@ -23,26 +25,32 @@ func NewSecretClient(cache corecontrollers.SecretCache, client kubernetes.Interf
 	return &SecretClient{cache, client, namespace}
 }
 
+// Create creates a secret using a k8s client that calls the Kubernetes API server
 func (s *SecretClient) Create(ctx context.Context, secret *v1.Secret, opts metav1.CreateOptions) (*v1.Secret, error) {
 	return s.client.CoreV1().Secrets(s.namespace).Create(ctx, secret, opts)
 }
 
+// Update updates a secret using a k8s client that calls the Kubernetes API server
 func (s *SecretClient) Update(ctx context.Context, secret *v1.Secret, opts metav1.UpdateOptions) (*v1.Secret, error) {
 	return s.client.CoreV1().Secrets(s.namespace).Update(ctx, secret, opts)
 }
 
+// Delete deletes a secret using a k8s client that calls the Kubernetes API server
 func (s *SecretClient) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
 	return s.client.CoreV1().Secrets(s.namespace).Delete(ctx, name, opts)
 }
 
+// DeleteCollection deletes a secret collection using a k8s client that calls the Kubernetes API server
 func (s *SecretClient) DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error {
 	return s.client.CoreV1().Secrets(s.namespace).DeleteCollection(ctx, opts, listOpts)
 }
 
+// Get gets a secret from the wrangler cache.
 func (s *SecretClient) Get(ctx context.Context, name string, opts metav1.GetOptions) (*v1.Secret, error) {
 	return s.cache.Get(s.namespace, name)
 }
 
+// List lists secrets from the wrangler cache.
 func (s *SecretClient) List(ctx context.Context, opts metav1.ListOptions) (*v1.SecretList, error) {
 	labels, err := labels.Parse(opts.LabelSelector)
 	if err != nil {
@@ -63,14 +71,17 @@ func (s *SecretClient) List(ctx context.Context, opts metav1.ListOptions) (*v1.S
 	}, nil
 }
 
+// Watch watches a secret using a k8s client that calls the Kubernetes API server
 func (s *SecretClient) Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
 	return s.client.CoreV1().Secrets(s.namespace).Watch(ctx, opts)
 }
 
+// Patch patches a secret using a k8s client that calls the Kubernetes API server
 func (s *SecretClient) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (*v1.Secret, error) {
 	return s.client.CoreV1().Secrets(s.namespace).Patch(ctx, name, pt, data, opts, subresources...)
 }
 
+// Apply applies a secret using a k8s client that calls the Kubernetes API server
 func (s *SecretClient) Apply(ctx context.Context, secretConfiguration *applycorev1.SecretApplyConfiguration, opts metav1.ApplyOptions) (*v1.Secret, error) {
 	return s.client.CoreV1().Secrets(s.namespace).Apply(ctx, secretConfiguration, opts)
 }

--- a/internal/helmdeployer/helmcache/secret.go
+++ b/internal/helmdeployer/helmcache/secret.go
@@ -1,0 +1,76 @@
+package helmcache
+
+import (
+	"context"
+
+	corecontrollers "github.com/rancher/wrangler/pkg/generated/controllers/core/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+	applycorev1 "k8s.io/client-go/applyconfigurations/core/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+type SecretClient struct {
+	cache     corecontrollers.SecretCache
+	client    kubernetes.Interface
+	namespace string
+}
+
+func NewSecretClient(cache corecontrollers.SecretCache, client kubernetes.Interface, namespace string) *SecretClient {
+	return &SecretClient{cache, client, namespace}
+}
+
+func (s *SecretClient) Create(ctx context.Context, secret *v1.Secret, opts metav1.CreateOptions) (result *v1.Secret, err error) {
+	return s.client.CoreV1().Secrets(s.namespace).Create(ctx, secret, opts)
+}
+
+func (s *SecretClient) Update(ctx context.Context, secret *v1.Secret, opts metav1.UpdateOptions) (*v1.Secret, error) {
+	return s.client.CoreV1().Secrets(s.namespace).Update(ctx, secret, opts)
+}
+
+func (s *SecretClient) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
+	return s.client.CoreV1().Secrets(s.namespace).Delete(ctx, name, opts)
+}
+
+func (s *SecretClient) DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error {
+	return s.client.CoreV1().Secrets(s.namespace).DeleteCollection(ctx, opts, listOpts)
+}
+
+func (s *SecretClient) Get(ctx context.Context, name string, opts metav1.GetOptions) (*v1.Secret, error) {
+	return s.cache.Get(s.namespace, name)
+}
+
+func (s *SecretClient) List(ctx context.Context, opts metav1.ListOptions) (*v1.SecretList, error) {
+	labels, err := labels.Parse(opts.LabelSelector)
+	if err != nil {
+		return nil, err
+	}
+	secrets, err := s.cache.List(s.namespace, labels)
+	if err != nil {
+		return nil, err
+	}
+
+	var items []v1.Secret
+	for _, secret := range secrets {
+		items = append(items, *secret)
+	}
+
+	return &v1.SecretList{
+		Items: items,
+	}, nil
+}
+
+func (s *SecretClient) Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
+	return s.client.CoreV1().Secrets(s.namespace).Watch(ctx, opts)
+}
+
+func (s *SecretClient) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (*v1.Secret, error) {
+	return s.client.CoreV1().Secrets(s.namespace).Patch(ctx, name, pt, data, opts, subresources...)
+}
+
+func (s *SecretClient) Apply(ctx context.Context, secretConfiguration *applycorev1.SecretApplyConfiguration, opts metav1.ApplyOptions) (*v1.Secret, error) {
+	return s.client.CoreV1().Secrets(s.namespace).Apply(ctx, secretConfiguration, opts)
+}

--- a/internal/helmdeployer/helmcache/secret_test.go
+++ b/internal/helmdeployer/helmcache/secret_test.go
@@ -1,0 +1,178 @@
+package helmcache
+
+import (
+	"context"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/google/go-cmp/cmp"
+	"github.com/rancher/fleet/internal/cmd/controller/mocks"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+	applycorev1 "k8s.io/client-go/applyconfigurations/core/v1"
+	v1 "k8s.io/client-go/applyconfigurations/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+const (
+	secretName      = "test"
+	secretNamespace = "test-ns"
+)
+
+var secret = corev1.Secret{
+	ObjectMeta: metav1.ObjectMeta{
+		Name:      secretName,
+		Namespace: secretNamespace,
+	},
+}
+
+func TestGet(t *testing.T) {
+	ctlr := gomock.NewController(t)
+	mockCache := mocks.NewMockSecretCache(ctlr)
+	secretClient := NewSecretClient(mockCache, nil, secretNamespace)
+	mockCache.EXPECT().Get(secretNamespace, secretName).Return(&secret, nil)
+
+	secretGot, err := secretClient.Get(context.TODO(), secretName, metav1.GetOptions{})
+
+	if err != nil {
+		t.Errorf("unexpected error %v", err)
+	}
+	if !cmp.Equal(&secret, secretGot) {
+		t.Errorf("expected secret %v, got %v", secret, secretGot)
+	}
+}
+
+func TestList(t *testing.T) {
+	ctlr := gomock.NewController(t)
+	mockCache := mocks.NewMockSecretCache(ctlr)
+	secretClient := NewSecretClient(mockCache, nil, secretNamespace)
+	labelSelector, err := labels.Parse("foo=bar")
+	if err != nil {
+		t.Errorf("unexpected error %v", err)
+	}
+	mockCache.EXPECT().List(secretNamespace, labelSelector).Return([]*corev1.Secret{&secret}, nil)
+	secretList, err := secretClient.List(context.TODO(), metav1.ListOptions{LabelSelector: "foo=bar"})
+
+	if err != nil {
+		t.Errorf("unexpected error %v", err)
+	}
+	secretListExpected := &corev1.SecretList{Items: []corev1.Secret{secret}}
+	if !cmp.Equal(secretListExpected, secretList) {
+		t.Errorf("expected secret %v, got %v", secretListExpected, secretList)
+	}
+}
+
+func TestCreate(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	secretClient := NewSecretClient(nil, client, secretNamespace)
+	secretCreated, err := secretClient.Create(context.TODO(), &secret, metav1.CreateOptions{})
+
+	if err != nil {
+		t.Errorf("unexpected error %v", err)
+	}
+	if !cmp.Equal(&secret, secretCreated) {
+		t.Errorf("expected secret %v, got %v", secret, secretCreated)
+	}
+}
+
+func TestUpdate(t *testing.T) {
+	secretUpdate := corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretName,
+			Namespace: secretNamespace,
+		},
+		Data: map[string][]byte{"test": []byte("data")},
+	}
+	client := fake.NewSimpleClientset(&secret)
+	secretClient := NewSecretClient(nil, client, secretNamespace)
+	secretUpdated, err := secretClient.Update(context.TODO(), &secretUpdate, metav1.UpdateOptions{})
+
+	if err != nil {
+		t.Errorf("unexpected error %v", err)
+	}
+	if !cmp.Equal(&secretUpdate, secretUpdated) {
+		t.Errorf("expected secret %v, got %v", secretUpdate, secretUpdated)
+	}
+}
+
+func TestDelete(t *testing.T) {
+	client := fake.NewSimpleClientset(&secret)
+	secretClient := NewSecretClient(nil, client, secretNamespace)
+	err := secretClient.Delete(context.TODO(), secretName, metav1.DeleteOptions{})
+
+	if err != nil {
+		t.Errorf("unexpected error %v", err)
+	}
+}
+
+func TestDeleteCollection(t *testing.T) {
+	client := fake.NewSimpleClientset(&secret)
+	secretClient := NewSecretClient(nil, client, secretNamespace)
+	err := secretClient.DeleteCollection(context.TODO(), metav1.DeleteOptions{}, metav1.ListOptions{FieldSelector: "name=" + secretName})
+
+	if err != nil {
+		t.Errorf("unexpected error %v", err)
+	}
+}
+
+func TestWatch(t *testing.T) {
+	client := fake.NewSimpleClientset(&secret)
+	secretClient := NewSecretClient(nil, client, secretNamespace)
+	watch, err := secretClient.Watch(context.TODO(), metav1.ListOptions{FieldSelector: "name=" + secretName})
+
+	if err != nil {
+		t.Errorf("unexpected error %v", err)
+	}
+	if watch == nil {
+		t.Errorf("watch should not be nil")
+	}
+}
+
+func TestPatch(t *testing.T) {
+	secretPatch := corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretName,
+			Namespace: secretNamespace,
+		},
+		Data: map[string][]byte{"test": []byte("content")},
+	}
+	client := fake.NewSimpleClientset(&secret)
+	secretClient := NewSecretClient(nil, client, secretNamespace)
+	patch := []byte(`{"data":{"test":"Y29udGVudA=="}}`)
+	secretPatched, err := secretClient.Patch(context.TODO(), secretName, types.StrategicMergePatchType, patch, metav1.PatchOptions{})
+
+	if err != nil {
+		t.Errorf("unexpected error %v", err)
+	}
+	if !cmp.Equal(&secretPatch, secretPatched) {
+		t.Errorf("expected secret %v, got %v", secretPatch, secretPatched)
+	}
+}
+
+func TestApply(t *testing.T) {
+	secretApply := corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretName,
+			Namespace: secretNamespace,
+		},
+		Data: map[string][]byte{"test": []byte("content")},
+	}
+	client := fake.NewSimpleClientset(&secret)
+	secretClient := NewSecretClient(nil, client, secretNamespace)
+	secretName := "test"
+	secretApplied, err := secretClient.Apply(context.TODO(), &applycorev1.SecretApplyConfiguration{
+		ObjectMetaApplyConfiguration: &v1.ObjectMetaApplyConfiguration{
+			Name: &secretName,
+		},
+		Data: map[string][]byte{"test": []byte("content")},
+	}, metav1.ApplyOptions{})
+
+	if err != nil {
+		t.Errorf("unexpected error %v", err)
+	}
+	if !cmp.Equal(&secretApply, secretApplied) {
+		t.Errorf("expected secret %v, got %v", secretApply, secretApplied)
+	}
+}

--- a/internal/helmdeployer/helmcache/secret_test.go
+++ b/internal/helmdeployer/helmcache/secret_test.go
@@ -140,7 +140,7 @@ func TestPatch(t *testing.T) {
 	}
 	client := fake.NewSimpleClientset(&secret)
 	secretClient := NewSecretClient(nil, client, secretNamespace)
-	patch := []byte(`{"data":{"test":"Y29udGVudA=="}}`)
+	patch := []byte(`{"data":{"test":"Y29udGVudA=="}}`) // "content", base64-encoded
 	secretPatched, err := secretClient.Patch(context.TODO(), secretName, types.StrategicMergePatchType, patch, metav1.PatchOptions{})
 
 	if err != nil {


### PR DESCRIPTION
Helm is internally listing all secrets each time we retrieve information about the release. We were using the helm storage secrets driver, which is meant to be used as a cli. It uses a k8s client to get/list/create.. secrets, and it doesn't use any cache (see implementation [here](https://github.com/helm/helm/blob/v3.12.3/pkg/action/lazyclient.go#L60-L125))

This PR adds a new helm storage driver that uses the `SecretCache` from wrangler for getting and listing secrets. All other operations uses a k8s client like the helm secrets driver does.  `SecretCache` from wrangler is internally using a `ShareInformer` for creating the cache.

This PR undoes the cache implemented in https://github.com/rancher/fleet/commit/8b0d9b7031570b7f6c0b8b5e969e34542339d181

The helm globalCfg is created with an [empty namespace](https://github.com/rancher/fleet/blob/v0.8.0/internal/helmdeployer/deployer.go#L116), which means that it will list secrets from all namespaces. We are using it in some [places](https://github.com/rancher/fleet/blob/v0.8.0/internal/helmdeployer/deployer.go#L598) for retrieving releases information. That means we are unnecessarily listing secrets from all namespaces, and that could cause issues if two releases have the same name in two different namespaces. This will be fixed in a separate PR. 

refers to https://github.com/rancher/fleet/issues/1738