### PR TITLE
Fix patch_crd_descriptions.sh when yq is not installed

### DIFF
--- a/cmd/codegen/hack/patch_crd_descriptions.sh
+++ b/cmd/codegen/hack/patch_crd_descriptions.sh
@@ -18,7 +18,7 @@ run_yq() {
     image="fleet-codegen-hack:yq"
     log "yq (from https://github.com/kislyuk/yq) is missing, building a helper docker image ($image)..."
 
-    docker build -t $image - << EOF
+    docker build -t $image - >&2 << EOF
 FROM bitnami/python:3.10
 
 RUN install_packages jq


### PR DESCRIPTION
Docker build output was appended to the `crds.yaml` when `yq` is not installed. 

This PR discards the output of the docker build command, so it doesn't get appended to the `crds.yaml`