### PR TITLE
Switch controllers to statefulsets

### DIFF
--- a/charts/fleet-agent/templates/deployment.yaml
+++ b/charts/fleet-agent/templates/deployment.yaml
@@ -1,5 +1,5 @@
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: fleet-agent
 spec:

--- a/charts/fleet/templates/deployment.yaml
+++ b/charts/fleet/templates/deployment.yaml
@@ -1,5 +1,5 @@
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: fleet-controller
 spec:

--- a/dev/setup-fleet
+++ b/dev/setup-fleet
@@ -21,9 +21,9 @@ helm -n cattle-fleet-system upgrade --install --create-namespace --wait --reset-
   --set debug=true --set debugLevel=99 fleet charts/fleet
 
 # wait for controller and agent rollout
-kubectl -n cattle-fleet-system rollout status deploy/fleet-controller
+kubectl -n cattle-fleet-system rollout status statefulset/fleet-controller
 { grep -E -q -m 1 "fleet-agent-local.*1/1"; kill $!; } < <(kubectl get bundles -n fleet-local -w)
-kubectl -n cattle-fleet-system rollout status deploy/fleet-agent
+kubectl -n cattle-fleet-system rollout status statefulset/fleet-agent
 
 # label local cluster
 kubectl patch clusters.fleet.cattle.io -n fleet-local local --type=json -p '[{"op": "add", "path": "/metadata/labels/management.cattle.io~1cluster-display-name", "value": "local" }]'

--- a/internal/cmd/controller/agent/manifest.go
+++ b/internal/cmd/controller/agent/manifest.go
@@ -133,17 +133,17 @@ func resolve(global, prefix, image string) string {
 	return image
 }
 
-func agentDeployment(namespace string, agentScope string, opts ManifestOptions) *appsv1.Deployment {
+func agentDeployment(namespace string, agentScope string, opts ManifestOptions) *appsv1.StatefulSet {
 	name := DefaultName
 	serviceAccount := DefaultName
 	image := resolve(opts.SystemDefaultRegistry, opts.PrivateRepoURL, opts.AgentImage)
 
-	dep := &appsv1.Deployment{
+	dep := &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
 			Name:      name,
 		},
-		Spec: appsv1.DeploymentSpec{
+		Spec: appsv1.StatefulSetSpec{
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"app": name,


### PR DESCRIPTION
Deployments may run multiple instances, even when their replica count is set to one. This happens for example during the update of the controller.

See `https://github.com/kubernetes-sigs/kubebuilder/issues/535` for a discussion, however fleet controllers do work outside the leaderelection, like cleaning up resources.

We also expect changes to leaderelection in the future. For example, the agent will likely drop leader election to become more light-weight. 

We might have to revisit the change for fleet-controller once we implement sharding.

Fix https://github.com/rancher/fleet/issues/1837