### PR TITLE
Add tmate debugging info to Nightly E2E workflow

### DIFF
--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -6,6 +6,11 @@ on:
     # Run everyday day at 7:00 AM
     - cron: '0 7 * * *'
   workflow_dispatch:
+    inputs:
+      enable_tmate:
+        description: 'Enable debugging via tmate'
+        required: false
+        default: "false"
 
 env:
   GOARCH: amd64
@@ -75,6 +80,13 @@ jobs:
         name: Import Images Into k3d
         run: |
           ./.github/scripts/k3d-import-retry.sh rancher/fleet:dev rancher/fleet-agent:dev nginx-git:test
+      -
+        name: Set Up Tmate Debug Session
+        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.enable_tmate == 'true' }}
+        uses: mxschmitt/action-tmate@v3
+        timeout-minutes: 15
+        with:
+          limit-access-to-actor: true
       -
         name: Deploy Fleet
         run: |


### PR DESCRIPTION
This should help troubleshoot failures happening in tests requiring secrets, which can therefore not be run locally nor against Fleet forks.