### PR TITLE
Add SecurityContext to job container that executes fleet apply

### DIFF
--- a/internal/cmd/controller/controllers/git/git.go
+++ b/internal/cmd/controller/controllers/git/git.go
@@ -474,6 +474,15 @@ func (h *handler) OnChange(gitrepo *fleet.GitRepo, status fleet.GitRepoStatus) (
 									WorkingDir:      "/workspace/source",
 									VolumeMounts:    volumeMounts,
 									Env:             envs,
+									SecurityContext: &corev1.SecurityContext{
+										AllowPrivilegeEscalation: &[]bool{false}[0],
+										Privileged:               &[]bool{false}[0],
+										RunAsNonRoot:             &[]bool{true}[0],
+										SeccompProfile: &corev1.SeccompProfile{
+											Type: corev1.SeccompProfileTypeRuntimeDefault,
+										},
+										Capabilities: &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
+									},
 								},
 							},
 							NodeSelector: map[string]string{"kubernetes.io/os": "linux"},

--- a/internal/cmd/controller/controllers/image/image.go
+++ b/internal/cmd/controller/controllers/image/image.go
@@ -219,7 +219,8 @@ func (h handler) onChangeGitRepo(gitrepo *v1alpha1.GitRepo, status v1alpha1.GitR
 	lock.Lock()
 	defer lock.Unlock()
 	// todo: maybe we should preserve the dir
-	tmp, err := os.MkdirTemp("", fmt.Sprintf("%s-%s", gitrepo.Namespace, gitrepo.Name))
+	tmp := fmt.Sprintf("%s-%s", gitrepo.Namespace, gitrepo.Name)
+	err = os.Mkdir(tmp, os.ModePerm)
 	if err != nil {
 		kstatus.SetError(gitrepo, err.Error())
 		return status, err
@@ -290,12 +291,13 @@ func (h handler) onChangeGitRepo(gitrepo *v1alpha1.GitRepo, status v1alpha1.GitR
 }
 
 func setupKnownHosts(gitrepo *v1alpha1.GitRepo, data []byte) error {
-	tmpdir, err := os.MkdirTemp("", fmt.Sprintf("ssh-%s-%s-", gitrepo.Namespace, gitrepo.Name))
-	if err != nil {
+	sshDir := fmt.Sprintf("ssh-%s-%s-", gitrepo.Namespace, gitrepo.Name)
+	err := os.Mkdir(sshDir, os.ModePerm)
+	if err != nil && !errors.Is(err, os.ErrExist) {
 		return err
 	}
 
-	known := path.Join(tmpdir, "known_hosts")
+	known := path.Join(sshDir, "known_hosts")
 	err = os.Setenv("SSH_KNOWN_HOSTS", known)
 	if err != nil {
 		return err


### PR DESCRIPTION
[wip] needs to be tested

Make sure the fleet job container runs in an unprivileged securityContext. The following securityContext is added to the job:
```
 securityContext: 
   allowPrivilegeEscalation: false 
   readOnlyRootFilesystem: true 
   privileged: false 
   capabilities: 
     drop: 
     - ALL 
```

Writing to `/tmp` is not possible because of `readOnlyRootFilesystem`. So this PR creates a folder in the user directory instead of using the `/tmp` dir. 

refers to https://github.com/rancher/fleet/issues/1845