### PR TITLE
Use index when listing BundleDeployments by Bundle 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,9 @@ module github.com/rancher/fleet
 
 go 1.19
 
+// Use changes from https://github.com/rancher/wrangler/pull/324
+replace github.com/rancher/wrangler => github.com/aruiz14/wrangler v1.1.2-0.20231011150039-8d1c2348c934
+
 replace (
 	github.com/rancher/fleet/pkg/apis => ./pkg/apis
 	helm.sh/helm/v3 => github.com/rancher/helm/v3 v3.11.1-rancher1

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/rancher/fleet
 go 1.19
 
 // Use changes from https://github.com/rancher/wrangler/pull/324
-replace github.com/rancher/wrangler => github.com/aruiz14/wrangler v1.1.2-0.20231011162916-0fc2de307f49
+replace github.com/rancher/wrangler => github.com/aruiz14/wrangler v1.1.2-0.20231013094521-a5a0006ce136
 
 replace (
 	github.com/rancher/fleet/pkg/apis => ./pkg/apis

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/rancher/fleet
 go 1.19
 
 // Use changes from https://github.com/rancher/wrangler/pull/324
-replace github.com/rancher/wrangler => github.com/aruiz14/wrangler v1.1.2-0.20231011150039-8d1c2348c934
+replace github.com/rancher/wrangler => github.com/aruiz14/wrangler v1.1.2-0.20231011162916-0fc2de307f49
 
 replace (
 	github.com/rancher/fleet/pkg/apis => ./pkg/apis

--- a/go.sum
+++ b/go.sum
@@ -251,8 +251,8 @@ github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmV
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
-github.com/aruiz14/wrangler v1.1.2-0.20231011162916-0fc2de307f49 h1:vOcOnelJHBIZSB84AUNIrTZaS67Ln5iYghYMfRko+Yo=
-github.com/aruiz14/wrangler v1.1.2-0.20231011162916-0fc2de307f49/go.mod h1:ioVbKupzcBOdzsl55MvEDN0R1wdGggj8iNCYGFI5JvM=
+github.com/aruiz14/wrangler v1.1.2-0.20231013094521-a5a0006ce136 h1:mrvc57yFPGH/zlJMyPfGdKdE9BnEc40WsErZVSky9h8=
+github.com/aruiz14/wrangler v1.1.2-0.20231013094521-a5a0006ce136/go.mod h1:ioVbKupzcBOdzsl55MvEDN0R1wdGggj8iNCYGFI5JvM=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d h1:Byv0BzEl3/e6D5CLfI0j/7hiIEtvGVFPCZ7Ei2oq8iQ=
 github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=

--- a/go.sum
+++ b/go.sum
@@ -251,6 +251,8 @@ github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmV
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
+github.com/aruiz14/wrangler v1.1.2-0.20231011150039-8d1c2348c934 h1:B8pGRzvgrGTD7lq2R8UnMCOTNnrwNIw1IfILNj2QAJQ=
+github.com/aruiz14/wrangler v1.1.2-0.20231011150039-8d1c2348c934/go.mod h1:ioVbKupzcBOdzsl55MvEDN0R1wdGggj8iNCYGFI5JvM=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d h1:Byv0BzEl3/e6D5CLfI0j/7hiIEtvGVFPCZ7Ei2oq8iQ=
 github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
@@ -835,8 +837,6 @@ github.com/rancher/helm/v3 v3.11.1-rancher1 h1:mZnVc7MXTUW8u2+PgKEQkiXXZyAHcdNID
 github.com/rancher/helm/v3 v3.11.1-rancher1/go.mod h1:z/Bu/BylToGno/6dtNGuSmjRqxKq5gaH+FU0BPO+AQ8=
 github.com/rancher/lasso v0.0.0-20221227210133-6ea88ca2fbcc h1:29VHrInLV4qSevvcvhBj5UhQWkPShxrxv4AahYg2Scw=
 github.com/rancher/lasso v0.0.0-20221227210133-6ea88ca2fbcc/go.mod h1:dEfC9eFQigj95lv/JQ8K5e7+qQCacWs1aIA6nLxKzT8=
-github.com/rancher/wrangler v1.1.1 h1:wmqUwqc2M7ADfXnBCJTFkTB5ZREWpD78rnZMzmxwMvM=
-github.com/rancher/wrangler v1.1.1/go.mod h1:ioVbKupzcBOdzsl55MvEDN0R1wdGggj8iNCYGFI5JvM=
 github.com/rancher/wrangler-cli v0.0.0-20220624114648-479c5692ba22 h1:ADMwgJyVwmLXJBSm/nNobB1XGSmFCTA+TY/otxgIPu4=
 github.com/rancher/wrangler-cli v0.0.0-20220624114648-479c5692ba22/go.mod h1:vyO9SU60oplNFa5ZqoEAFWmYKgj2F6remdy8p6H0SgI=
 github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=

--- a/go.sum
+++ b/go.sum
@@ -251,8 +251,8 @@ github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmV
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
-github.com/aruiz14/wrangler v1.1.2-0.20231011150039-8d1c2348c934 h1:B8pGRzvgrGTD7lq2R8UnMCOTNnrwNIw1IfILNj2QAJQ=
-github.com/aruiz14/wrangler v1.1.2-0.20231011150039-8d1c2348c934/go.mod h1:ioVbKupzcBOdzsl55MvEDN0R1wdGggj8iNCYGFI5JvM=
+github.com/aruiz14/wrangler v1.1.2-0.20231011162916-0fc2de307f49 h1:vOcOnelJHBIZSB84AUNIrTZaS67Ln5iYghYMfRko+Yo=
+github.com/aruiz14/wrangler v1.1.2-0.20231011162916-0fc2de307f49/go.mod h1:ioVbKupzcBOdzsl55MvEDN0R1wdGggj8iNCYGFI5JvM=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d h1:Byv0BzEl3/e6D5CLfI0j/7hiIEtvGVFPCZ7Ei2oq8iQ=
 github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=

--- a/pkg/apis/fleet.cattle.io/v1alpha1/git.go
+++ b/pkg/apis/fleet.cattle.io/v1alpha1/git.go
@@ -7,6 +7,7 @@ import (
 
 var (
 	RepoLabel            = "fleet.cattle.io/repo-name"
+	BundleLabel          = "fleet.cattle.io/bundle-name"
 	BundleNamespaceLabel = "fleet.cattle.io/bundle-namespace"
 )
 

--- a/pkg/controllers/controllers.go
+++ b/pkg/controllers/controllers.go
@@ -228,6 +228,18 @@ func Register(ctx context.Context, systemNamespace string, cfg clientcmd.ClientC
 		appCtx.GitRepo(),
 		appCtx.ImageScan())
 
+	// Enabling the index by hash for any type we apply to
+	if err := apply.AddHashIndexer(
+		appCtx.Bundle().Informer(),
+		appCtx.BundleDeployment().Informer(),
+		appCtx.Cluster().Informer(),
+		appCtx.ClusterRegistrationToken().Informer(),
+		appCtx.ClusterRegistration().Informer(),
+		appCtx.ClusterGroup().Informer(),
+	); err != nil {
+		return err
+	}
+
 	leader.RunOrDie(ctx, systemNamespace, "fleet-controller-lock", appCtx.K8s, func(ctx context.Context) {
 		if err := appCtx.start(ctx); err != nil {
 			logrus.Fatal(err)

--- a/pkg/controllers/controllers.go
+++ b/pkg/controllers/controllers.go
@@ -228,18 +228,6 @@ func Register(ctx context.Context, systemNamespace string, cfg clientcmd.ClientC
 		appCtx.GitRepo(),
 		appCtx.ImageScan())
 
-	// Enabling the index by hash for any type we apply to
-	if err := apply.AddHashIndexer(
-		appCtx.Bundle().Informer(),
-		appCtx.BundleDeployment().Informer(),
-		appCtx.Cluster().Informer(),
-		appCtx.ClusterRegistrationToken().Informer(),
-		appCtx.ClusterRegistration().Informer(),
-		appCtx.ClusterGroup().Informer(),
-	); err != nil {
-		return err
-	}
-
 	leader.RunOrDie(ctx, systemNamespace, "fleet-controller-lock", appCtx.K8s, func(ctx context.Context) {
 		if err := appCtx.start(ctx); err != nil {
 			logrus.Fatal(err)

--- a/pkg/target/target.go
+++ b/pkg/target/target.go
@@ -48,7 +48,7 @@ const (
 	clusterLabelPrefix        = "global.fleet.clusterLabels."
 
 	// Indexer name for indexing bundledeployments by their respective bundles
-	byBundle = "IndexByBundle"
+	byBundle = "fleet.byBundle"
 )
 
 type Manager struct {

--- a/pkg/target/target.go
+++ b/pkg/target/target.go
@@ -46,6 +46,9 @@ var (
 const (
 	maxTemplateRecursionDepth = 50
 	clusterLabelPrefix        = "global.fleet.clusterLabels."
+
+	// Indexer name for indexing bundledeployments by their respective bundles
+	byBundle = "IndexByBundle"
 )
 
 type Manager struct {
@@ -66,6 +69,17 @@ func New(
 	namespaceCache corecontrollers.NamespaceCache,
 	contentStore manifest.Store,
 	bundleDeployments fleetcontrollers.BundleDeploymentCache) *Manager {
+
+	bundleDeployments.AddIndexer(byBundle, func(bd *fleet.BundleDeployment) ([]string, error) {
+		if bdLabels := bd.GetLabels(); bdLabels != nil {
+			bundleNamespace := bdLabels[fleet.BundleNamespaceLabel]
+			bundleName := bdLabels[fleet.BundleLabel]
+			if bundleNamespace != "" && bundleName != "" {
+				return []string{bundleNamespace + "/" + bundleName}, nil
+			}
+		}
+		return nil, nil
+	})
 
 	return &Manager{
 		clusterGroups:               clusterGroups,
@@ -191,8 +205,8 @@ func (m *Manager) BundlesForCluster(cluster *fleet.Cluster) (bundlesToRefresh, b
 	return
 }
 
-func (m *Manager) GetBundleDeploymentsForBundleInCluster(app *fleet.Bundle, cluster *fleet.Cluster) (result []*fleet.BundleDeployment, err error) {
-	bundleDeployments, err := m.bundleDeploymentCache.List("", labels.SelectorFromSet(deploymentLabelsForSelector(app)))
+func (m *Manager) GetBundleDeploymentsForBundleInCluster(bundle *fleet.Bundle, cluster *fleet.Cluster) (result []*fleet.BundleDeployment, err error) {
+	bundleDeployments, err := m.bundleDeploymentCache.GetByIndex(byBundle, bundleIndexKey(bundle))
 	if err != nil {
 		return nil, err
 	}
@@ -374,7 +388,7 @@ func toDict(values map[string]string) map[string]interface{} {
 
 // foldInDeployments adds the existing bundledeployments to the targets.
 func (m *Manager) foldInDeployments(bundle *fleet.Bundle, targets []*Target) error {
-	bundleDeployments, err := m.bundleDeploymentCache.List("", labels.SelectorFromSet(deploymentLabelsForSelector(bundle)))
+	bundleDeployments, err := m.bundleDeploymentCache.GetByIndex(byBundle, bundleIndexKey(bundle))
 	if err != nil {
 		return err
 	}
@@ -406,9 +420,13 @@ func deploymentLabelsForNewBundle(bundle *fleet.Bundle) map[string]string {
 
 func deploymentLabelsForSelector(bundle *fleet.Bundle) map[string]string {
 	return map[string]string{
-		"fleet.cattle.io/bundle-name":      bundle.Name,
-		"fleet.cattle.io/bundle-namespace": bundle.Namespace,
+		fleet.BundleLabel:          bundle.Name,
+		fleet.BundleNamespaceLabel: bundle.Namespace,
 	}
+}
+
+func bundleIndexKey(bundle *fleet.Bundle) string {
+	return bundle.Namespace + "/" + bundle.Name
 }
 
 type Target struct {


### PR DESCRIPTION
Relates to #1842
Depends on rancher/wrangler#324

These changes add an indexer for BundleDeployments' Informer, which will build an index of BundleDeployment based on the Bundle that generated them (uniquely idenfied by their namespace + name). This provides an optimization over constantly using `List` with multiple label selectors.