### PR TITLE
Use configmap example for `keepResources` E2E tests

### DIFF
--- a/e2e/assets/keep-resources/do-not-keep/gitrepo.yaml
+++ b/e2e/assets/keep-resources/do-not-keep/gitrepo.yaml
@@ -3,10 +3,10 @@ apiVersion: fleet.cattle.io/v1alpha1
 metadata:
   name: dont-keep
 spec:
-  repo: https://github.com/rancher/fleet-examples
+  repo: https://github.com/rancher/fleet-test-data
   branch: master
   paths:
-  - simple
+  - helm-verify
   targetNamespace: do-not-keep-resources
   targets:
     - clusterSelector:

--- a/e2e/assets/keep-resources/keep/gitrepo.yaml
+++ b/e2e/assets/keep-resources/keep/gitrepo.yaml
@@ -3,10 +3,10 @@ apiVersion: fleet.cattle.io/v1alpha1
 metadata:
   name: keep
 spec:
-  repo: https://github.com/rancher/fleet-examples
+  repo: https://github.com/rancher/fleet-test-data
   branch: master
   paths:
-  - simple
+  - helm-verify
   targetNamespace: keep-resources
   keepResources: true
   targets:

--- a/e2e/keep-resources/keep_resources_test.go
+++ b/e2e/keep-resources/keep_resources_test.go
@@ -22,9 +22,9 @@ var _ = Describe("Keep resources", func() {
 		out, err := k.Apply("-f", testenv.AssetPath(asset))
 		Expect(err).ToNot(HaveOccurred(), out)
 		Eventually(func() string {
-			out, _ := k.Namespace(namespace).Get("pods")
+			out, _ := k.Namespace(namespace).Get("configmaps")
 			return out
-		}).Should(ContainSubstring("frontend-"))
+		}).Should(ContainSubstring("app-config"))
 	})
 
 	When("GitRepo does not contain keepResources", func() {
@@ -38,7 +38,7 @@ var _ = Describe("Keep resources", func() {
 			Expect(err).ToNot(HaveOccurred(), out)
 
 			Eventually(func() string {
-				out, _ := k.Namespace(namespace).Get("deployments", "frontend")
+				out, _ := k.Namespace(namespace).Get("configmap", "app-config")
 				return out
 			}).Should(ContainSubstring("Error from server (NotFound)"))
 		})
@@ -62,7 +62,7 @@ var _ = Describe("Keep resources", func() {
 
 			By("checking resources are not deleted")
 			Eventually(func() string {
-				out, _ := k.Namespace(namespace).Get("deployments", "frontend", "-o", "yaml")
+				out, _ := k.Namespace(namespace).Get("configmap", "app-config", "-o", "yaml")
 				return out
 			}).Should(SatisfyAll(
 				Not(ContainSubstring("Error from server (NotFound)")),


### PR DESCRIPTION
This covers a similar use case but with a lower footprint than via a full-blown example using Redis pods.

Refers to #1866.