### PR TITLE
Prevent debug images from creating GitHub releases

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -52,8 +52,11 @@ steps:
     instance:
     - drone-publish.rancher.io
     ref:
-    - refs/head/master
-    - refs/tags/*
+      include:
+      - refs/head/master
+      - refs/tags/*
+      exclude:
+      - refs/tags/*-debug-*
     event:
     - tag
 - name: upload-tag
@@ -161,8 +164,11 @@ steps:
     instance:
     - drone-publish.rancher.io
     ref:
-    - refs/head/master
-    - refs/tags/*
+      include:
+      - refs/head/master
+      - refs/tags/*
+      exclude:
+      - refs/tags/*-debug-*
     event:
     - tag
 - name: docker-publish-agent
@@ -245,8 +251,11 @@ steps:
     instance:
     - drone-publish.rancher.io
     ref:
-    - refs/head/master
-    - refs/tags/*
+      include:
+      - refs/head/master
+      - refs/tags/*
+      exclude:
+      - refs/tags/*-debug-*
     event:
     - tag
 - name: docker-publish-agent


### PR DESCRIPTION
Drone CI is pushing new DockerHub images for every tag pushed to the repository, as well as creating a GitHub release with the binaries.
This change will omit this step for debug images, which are tagged like `v<X.Y.Z>-debug-<GH_issue_ID>-<count>`, only causing the release of the images.