### PR TITLE
Add SecurityContext to job container

### DIFF
--- a/internal/cmd/controller/controllers/git/git.go
+++ b/internal/cmd/controller/controllers/git/git.go
@@ -38,6 +38,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
+const fleetHomeDir = "/fleet-home"
+
 var (
 	two = int32(2)
 )
@@ -652,7 +654,7 @@ func volumes(
 		},
 		{
 			Name:      emptyDirHomeVolumeName,
-			MountPath: "/home/fleet-apply",
+			MountPath: fleetHomeDir,
 		},
 	}
 
@@ -767,7 +769,12 @@ func argsAndEnvs(gitrepo *fleet.GitRepo) ([]string, []corev1.EnvVar) {
 		}
 	}
 
-	var env []corev1.EnvVar
+	env := []corev1.EnvVar{
+		{
+			Name:  "HOME",
+			Value: fleetHomeDir,
+		},
+	}
 	if gitrepo.Spec.HelmSecretNameForPaths != "" {
 		helmArgs := []string{
 			"--helm-credentials-by-path-file",

--- a/internal/cmd/controller/controllers/git/git.go
+++ b/internal/cmd/controller/controllers/git/git.go
@@ -474,6 +474,16 @@ func (h *handler) OnChange(gitrepo *fleet.GitRepo, status fleet.GitRepoStatus) (
 									WorkingDir:      "/workspace/source",
 									VolumeMounts:    volumeMounts,
 									Env:             envs,
+									SecurityContext: &corev1.SecurityContext{
+										AllowPrivilegeEscalation: &[]bool{false}[0],
+										ReadOnlyRootFilesystem:   &[]bool{true}[0],
+										Privileged:               &[]bool{false}[0],
+										RunAsNonRoot:             &[]bool{true}[0],
+										SeccompProfile: &corev1.SeccompProfile{
+											Type: corev1.SeccompProfileTypeRuntimeDefault,
+										},
+										Capabilities: &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
+									},
 								},
 							},
 							NodeSelector: map[string]string{"kubernetes.io/os": "linux"},
@@ -600,9 +610,15 @@ func volumes(
 	gitrepo *fleet.GitRepo,
 	configMap *corev1.ConfigMap,
 ) ([]corev1.Volume, []corev1.VolumeMount) {
+	const (
+		emptyDirTmpVolumeName  = "fleet-tmp-empty-dir"
+		emptyDirHomeVolumeName = "fleet-home-empty-dir"
+		configVolumeName       = "config"
+	)
+
 	volumes := []corev1.Volume{
 		{
-			Name: "config",
+			Name: configVolumeName,
 			VolumeSource: corev1.VolumeSource{
 				ConfigMap: &corev1.ConfigMapVolumeSource{
 					LocalObjectReference: corev1.LocalObjectReference{
@@ -611,12 +627,32 @@ func volumes(
 				},
 			},
 		},
+		{
+			Name: emptyDirTmpVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
+			},
+		},
+		{
+			Name: emptyDirHomeVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
+			},
+		},
 	}
 
 	volumeMounts := []corev1.VolumeMount{
 		{
-			Name:      "config",
+			Name:      configVolumeName,
 			MountPath: "/run/config",
+		},
+		{
+			Name:      emptyDirTmpVolumeName,
+			MountPath: "/tmp",
+		},
+		{
+			Name:      emptyDirHomeVolumeName,
+			MountPath: "/home/fleet-apply",
 		},
 	}
 


### PR DESCRIPTION
Make sure the `gitjob` pod and the job init container runs in an unprivileged `securityContext`. The following `securityContext` has been added:
```
securityContext:
  allowPrivilegeEscalation: false
  readOnlyRootFilesystem: true
  privileged: false
  runAsNonRoot: true
  seccompProfile:
    type: RuntimeDefault
  capabilities:
    drop:
      - ALL
```

`emptyDir` volume is mounted in the ` /tmp` dir in order to prevent issues when creating temporary files as `readOnlyRootFilesystem` is set to true.

`emptyDir` volume is mounted in the ` /home/fleet-ci` dir in order to prevent issue when creating helm config in the home directory.

refers to https://github.com/rancher/fleet/issues/1845