### PR TITLE
Clean up e2e test resources

### DIFF
--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -104,11 +104,27 @@ jobs:
           HELM_PATH: /usr/local/bin/helm
         run: |
           export CI_OCI_CERTS_DIR="$(git rev-parse --show-toplevel)/FleetCI-RootCA"
-          e2e/testenv/infra/infra setup
 
-          ginkgo e2e/single-cluster e2e/keep-resources
+          # 1. Run test cases not needing infra
+          ginkgo --label-filter='!infra-setup' e2e/single-cluster e2e/keep-resources
 
+          # 2. Run tests requiring only the git server
+          e2e/testenv/infra/infra setup --git-server=true
+          ginkgo --label-filter='infra-setup && !helm-registry && !oci-registry' e2e/single-cluster/
+
+          # 3. Run tests requiring a Helm registry
+          e2e/testenv/infra/infra setup --helm-registry=true
+          ginkgo --label-filter='helm-registry' e2e/single-cluster
+
+          e2e/testenv/infra/infra teardown --helm-registry=true
+
+          # 4. Run tests requiring an OCI registry
+          e2e/testenv/infra/infra setup --oci-registry=true
+          ginkgo --label-filter='oci-registry' e2e/single-cluster
+
+          # 5. Tear down all infra
           e2e/testenv/infra/infra teardown
+
       -
         name: Acceptance Tests for Examples
         if: >

--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -28,6 +28,10 @@ jobs:
           - v1.27.5-k3s1
           - v1.26.8-k3s1
           - v1.24.17-k3s1
+        test_type:
+          - acceptance
+          - e2e-secrets
+          - e2e-nosecrets
     steps:
       -
         uses: actions/checkout@v4
@@ -84,6 +88,7 @@ jobs:
           ./.github/scripts/deploy-fleet.sh
       -
         name: Create Zot certificates for OCI tests
+        if: ${{ matrix.test_type == 'e2e-nosecrets' }}
         env:
           FLEET_E2E_NS: fleet-local
         run: |
@@ -91,6 +96,7 @@ jobs:
           ./.github/scripts/create-zot-certs.sh "FleetCI-RootCA"
       -
         name: E2E Tests
+        if: ${{ matrix.test_type == 'e2e-nosecrets' }}
         env:
           FLEET_E2E_NS: fleet-local
           # Git and OCI credentials are here used in a local, ephemeral environment. Leaks would be harmless.
@@ -108,12 +114,14 @@ jobs:
           e2e/testenv/infra/infra teardown
       -
         name: Acceptance Tests for Examples
+        if: ${{ matrix.test_type == 'acceptance' }}
         env:
           FLEET_E2E_NS: fleet-local
         run: |
           ginkgo e2e/acceptance/single-cluster-examples
       -
         name: Fleet Tests Requiring Github Secrets
+        if: ${{ matrix.test_type == 'e2e-secrets' }}
         env:
           FLEET_E2E_NS: fleet-local
           GIT_REPO_URL: "git@github.com:fleetrepoci/test.git"

--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -107,10 +107,25 @@ jobs:
           HELM_PATH: /usr/local/bin/helm
         run: |
           export CI_OCI_CERTS_DIR="$(git rev-parse --show-toplevel)/FleetCI-RootCA"
-          e2e/testenv/infra/infra setup
 
-          ginkgo e2e/single-cluster e2e/keep-resources
+          # 1. Run test cases not needing infra
+          ginkgo --label-filter='!infra-setup' e2e/single-cluster e2e/keep-resources
 
+          # 2. Run tests requiring only the git server
+          e2e/testenv/infra/infra setup --git-server=true
+          ginkgo --label-filter='infra-setup && !helm-registry && !oci-registry' e2e/single-cluster/
+
+          # 3. Run tests requiring a Helm registry
+          e2e/testenv/infra/infra setup --helm-registry=true
+          ginkgo --label-filter='helm-registry' e2e/single-cluster
+
+          e2e/testenv/infra/infra teardown --helm-registry=true
+
+          # 4. Run tests requiring an OCI registry
+          e2e/testenv/infra/infra setup --oci-registry=true
+          ginkgo --label-filter='oci-registry' e2e/single-cluster
+
+          # 5. Tear down all infra
           e2e/testenv/infra/infra teardown
       -
         name: Acceptance Tests for Examples

--- a/e2e/assets/single-cluster/helm-oci.yaml
+++ b/e2e/assets/single-cluster/helm-oci.yaml
@@ -4,6 +4,7 @@ metadata:
   name: helm
 spec:
   repo: https://github.com/rancher/fleet-test-data
+  branch: helm-oci-configmap-chart
   paths:
   - helm-oci
   targets:

--- a/e2e/assets/single-cluster/helm-oci.yaml
+++ b/e2e/assets/single-cluster/helm-oci.yaml
@@ -4,7 +4,6 @@ metadata:
   name: helm
 spec:
   repo: https://github.com/rancher/fleet-test-data
-  branch: helm-oci-configmap-chart
   paths:
   - helm-oci
   targets:

--- a/e2e/drift/suite_test.go
+++ b/e2e/drift/suite_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestE2E(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "E2E Suite for Single-Cluster Examples")
+	RunSpecs(t, "E2E Suite for drift correction")
 }
 
 var (

--- a/e2e/keep-resources/keep_resources_test.go
+++ b/e2e/keep-resources/keep_resources_test.go
@@ -16,6 +16,13 @@ var _ = Describe("Keep resources", func() {
 
 	BeforeEach(func() {
 		k = env.Kubectl.Namespace(env.Namespace)
+
+		DeferCleanup(func() {
+			// Let's delete the namespace and its resources anyway once done, as this may free up precious
+			// resources, especially on CI runners.
+			// Redis pods may take over a minute to terminate, hence we skip the wait here.
+			_, _ = k.Delete("ns", namespace, "--wait=false")
+		})
 	})
 
 	JustBeforeEach(func() {

--- a/e2e/keep-resources/suite_test.go
+++ b/e2e/keep-resources/suite_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestE2E(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "E2E Suite for Single-Cluster Examples")
+	RunSpecs(t, "E2E Suite for keepResources")
 }
 
 var (

--- a/e2e/single-cluster/helm_auth_test.go
+++ b/e2e/single-cluster/helm_auth_test.go
@@ -44,7 +44,7 @@ var _ = Describe("Single Cluster Examples", Label("infra-setup"), func() {
 	})
 
 	When("creating a gitrepo resource", func() {
-		Context("containing a private OCI-based helm chart", func() {
+		Context("containing a private OCI-based helm chart", Label("oci-registry"), func() {
 			BeforeEach(func() {
 				gitRepoPath = "oci-with-auth"
 				k = env.Kubectl.Namespace(env.Namespace)
@@ -59,7 +59,7 @@ var _ = Describe("Single Cluster Examples", Label("infra-setup"), func() {
 				}).Should(ContainSubstring("sleeper-"))
 			})
 		})
-		Context("containing a private HTTP-based helm chart with repo path", func() {
+		Context("containing a private HTTP-based helm chart with repo path", Label("helm-registry"), func() {
 			BeforeEach(func() {
 				gitRepoPath = "http-with-auth-repo-path"
 				k = env.Kubectl.Namespace(env.Namespace)
@@ -74,7 +74,7 @@ var _ = Describe("Single Cluster Examples", Label("infra-setup"), func() {
 				}).Should(ContainSubstring("sleeper-"))
 			})
 		})
-		Context("containing a private HTTP-based helm chart with chart path", func() {
+		Context("containing a private HTTP-based helm chart with chart path", Label("helm-registry"), func() {
 			BeforeEach(func() {
 				gitRepoPath = "http-with-auth-chart-path"
 				k = env.Kubectl.Namespace(env.Namespace)

--- a/e2e/single-cluster/single_cluster_test.go
+++ b/e2e/single-cluster/single_cluster_test.go
@@ -39,9 +39,9 @@ var _ = Describe("Single Cluster Deployments", func() {
 
 			It("deploys the helm chart", func() {
 				Eventually(func() string {
-					out, _ := k.Namespace("fleet-helm-oci-example").Get("pods")
+					out, _ := k.Namespace("fleet-helm-oci-example").Get("configmaps")
 					return out
-				}).Should(ContainSubstring("frontend-"))
+				}).Should(ContainSubstring("fleet-test-configmap"))
 			})
 		})
 

--- a/e2e/testenv/infra/cmd/root.go
+++ b/e2e/testenv/infra/cmd/root.go
@@ -6,12 +6,14 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// rootCmd represents the base command when called without any subcommands
-var rootCmd = &cobra.Command{
-	Use:   "testenv",
-	Short: "root test env command",
-	Long:  `This command should not be run directly.`,
-}
+var (
+	rootCmd = &cobra.Command{
+		Use:   "testenv",
+		Short: "root test env command",
+		Long:  `This command should not be run directly.`,
+	}
+	withGitServer, withHelmRegistry, withChartMuseum bool
+)
 
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
@@ -23,4 +25,10 @@ func Execute() {
 }
 
 func init() {
+	rootCmd.AddCommand(setupCmd)
+	rootCmd.AddCommand(teardownCmd)
+
+	rootCmd.PersistentFlags().BoolVarP(&withGitServer, "git-server", "g", false, "with git server")
+	rootCmd.PersistentFlags().BoolVarP(&withHelmRegistry, "helm-registry", "r", false, "with Helm registry")
+	rootCmd.PersistentFlags().BoolVarP(&withChartMuseum, "chart-museum", "c", false, "with ChartMuseum")
 }

--- a/e2e/testenv/infra/cmd/root.go
+++ b/e2e/testenv/infra/cmd/root.go
@@ -12,7 +12,7 @@ var (
 		Short: "root test env command",
 		Long:  `This command should not be run directly.`,
 	}
-	withGitServer, withHelmRegistry, withChartMuseum bool
+	withGitServer, withHelmRegistry, withOCIRegistry bool
 )
 
 // Execute adds all child commands to the root command and sets flags appropriately.
@@ -30,5 +30,5 @@ func init() {
 
 	rootCmd.PersistentFlags().BoolVarP(&withGitServer, "git-server", "g", false, "with git server")
 	rootCmd.PersistentFlags().BoolVarP(&withHelmRegistry, "helm-registry", "r", false, "with Helm registry")
-	rootCmd.PersistentFlags().BoolVarP(&withChartMuseum, "chart-museum", "c", false, "with ChartMuseum")
+	rootCmd.PersistentFlags().BoolVarP(&withOCIRegistry, "oci-registry", "c", false, "with OCI registry")
 }

--- a/e2e/testenv/infra/cmd/teardown.go
+++ b/e2e/testenv/infra/cmd/teardown.go
@@ -10,7 +10,7 @@ import (
 
 // teardownCmd represents the teardown command
 var teardownCmd = &cobra.Command{
-	Use:   "teardown",
+	Use:   "teardown [--git-server=(true|false)|--helm-registry=(true|false)|--chart-museum=(true|false)]",
 	Short: "Tear down an end-to-end test environment",
 	Long:  `This tears down the git server, Helm registry and associated resources needed to run end-to-end tests.`,
 	Run: func(cmd *cobra.Command, args []string) {
@@ -19,23 +19,34 @@ var teardownCmd = &cobra.Command{
 		env := testenv.New()
 		k := env.Kubectl.Namespace(env.Namespace)
 
+		// Only act on specified components, unless none is specified in which case all are affected.
+		if !withGitServer && !withHelmRegistry && !withChartMuseum {
+			withGitServer, withHelmRegistry, withChartMuseum = true, true, true
+		}
+
 		_, _ = k.Delete("gitrepo", "helm")
-		_, _ = k.Delete("deployment", "git-server")
-		_, _ = k.Delete("service", "git-service")
 
-		_, _ = k.Delete("configmap", "zot-config")
-		_, _ = k.Delete("deployment", "zot")
-		_, _ = k.Delete("service", "zot-service")
-		_, _ = k.Delete("secret", "zot-htpasswd")
+		if withGitServer {
+			_, _ = k.Delete("deployment", "git-server")
+			_, _ = k.Delete("service", "git-service")
+		}
 
-		_, _ = k.Delete("deployment", "chartmuseum")
-		_, _ = k.Delete("service", "chartmuseum-service")
+		if withHelmRegistry {
+			_, _ = k.Delete("configmap", "zot-config")
+			_, _ = k.Delete("deployment", "zot")
+			_, _ = k.Delete("service", "zot-service")
+			_, _ = k.Delete("secret", "zot-htpasswd")
+		}
 
-		_, _ = k.Delete("secret", "helm-tls")
-		_, _ = k.Delete("secret", "helm-secret")
+		if withChartMuseum {
+			_, _ = k.Delete("deployment", "chartmuseum")
+			_, _ = k.Delete("service", "chartmuseum-service")
+		}
+
+		if withHelmRegistry && withChartMuseum {
+			_, _ = k.Delete("secret", "helm-tls")
+			_, _ = k.Delete("secret", "helm-secret")
+		}
+
 	},
-}
-
-func init() {
-	rootCmd.AddCommand(teardownCmd)
 }

--- a/e2e/testenv/infra/cmd/teardown.go
+++ b/e2e/testenv/infra/cmd/teardown.go
@@ -10,9 +10,10 @@ import (
 
 // teardownCmd represents the teardown command
 var teardownCmd = &cobra.Command{
-	Use:   "teardown [--git-server=(true|false)|--helm-registry=(true|false)|--chart-museum=(true|false)]",
+	Use:   "teardown [--git-server=(true|false)|--helm-registry=(true|false)|--oci-registry=(true|false)]",
 	Short: "Tear down an end-to-end test environment",
-	Long:  `This tears down the git server, Helm registry and associated resources needed to run end-to-end tests.`,
+	Long: `This tears down the git server, Helm registry, OCI registry, either separately or together, and
+	associated resources needed to run end-to-end tests.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Println("Tearing down test environment...")
 
@@ -20,8 +21,8 @@ var teardownCmd = &cobra.Command{
 		k := env.Kubectl.Namespace(env.Namespace)
 
 		// Only act on specified components, unless none is specified in which case all are affected.
-		if !withGitServer && !withHelmRegistry && !withChartMuseum {
-			withGitServer, withHelmRegistry, withChartMuseum = true, true, true
+		if !withGitServer && !withHelmRegistry && !withOCIRegistry {
+			withGitServer, withOCIRegistry, withHelmRegistry = true, true, true
 		}
 
 		_, _ = k.Delete("gitrepo", "helm")
@@ -31,19 +32,19 @@ var teardownCmd = &cobra.Command{
 			_, _ = k.Delete("service", "git-service")
 		}
 
-		if withHelmRegistry {
+		if withOCIRegistry {
 			_, _ = k.Delete("configmap", "zot-config")
 			_, _ = k.Delete("deployment", "zot")
 			_, _ = k.Delete("service", "zot-service")
 			_, _ = k.Delete("secret", "zot-htpasswd")
 		}
 
-		if withChartMuseum {
+		if withHelmRegistry {
 			_, _ = k.Delete("deployment", "chartmuseum")
 			_, _ = k.Delete("service", "chartmuseum-service")
 		}
 
-		if withHelmRegistry && withChartMuseum {
+		if withHelmRegistry && withOCIRegistry {
 			_, _ = k.Delete("secret", "helm-tls")
 			_, _ = k.Delete("secret", "helm-secret")
 		}


### PR DESCRIPTION
Refers to #1866

This provides a few improvements to minimise the footprint of E2E tests, in the hope of reducing their flakiness when running on Github runners:
* cleans up resources created by `keep-resources` tests once done
* runs each test type (acceptance tests, E2E tests without secrets, E2E tests with secrets) on a separate Github runner
* sets up and tears down the minimal set of test infrastructure (git server, Helm registry, OCI registry) depending on each set of test cases, which are now labeled for those sets to be easier to manage
* uses a [minimal chart](https://github.com/orgs/rancher/packages/container/package/fleet-test-configmap-chart) containing only a config map, instead of a `guestbook` chart including a front-end server and a Redis instance, to test Helm chart resolution via OCI URLs with a reduced footprint → Depends on [fleet-test-data#8](https://github.com/rancher/fleet-test-data/pull/8) being merged.

## Additional Information

### Trade-off

This is but a temporary fix, as new additions to our end-to-end test suites may increase the load on Github runners.

### Potential improvement

We could run our end-to-end tests against cloud (eg. GCP) runners, set up on-the-fly, to prevent newly added tests from causing resource shortages on Github runners, breaking our CI.