### PR TITLE
Use lightweight chart for Helm OCI tests

### DIFF
--- a/e2e/single-cluster/single_cluster_test.go
+++ b/e2e/single-cluster/single_cluster_test.go
@@ -39,9 +39,9 @@ var _ = Describe("Single Cluster Deployments", func() {
 
 			It("deploys the helm chart", func() {
 				Eventually(func() string {
-					out, _ := k.Namespace("fleet-helm-oci-example").Get("pods")
+					out, _ := k.Namespace("fleet-helm-oci-example").Get("configmaps")
 					return out
-				}).Should(ContainSubstring("frontend-"))
+				}).Should(ContainSubstring("fleet-test-configmap"))
 			})
 		})
 


### PR DESCRIPTION
This may reduce the load on CI runners by using a test chart containing only a config map, instead of a more heavyweight setup with a front-end server and a Redis instance.

See also [fleet-test-data#8](https://github.com/rancher/fleet-test-data/pull/8).

Merging this will fix recent CI failures in cloud runners (see [here](https://github.com/rancher/fleet/actions/runs/6568769187/attempts/1)) caused by Helm OCI end-to-end tests still expecting the old, heavyweight chart.
For more fixes aiming at lowering E2E tests footprint on Github CI runners, see #1876.

Refers to #1866.