### PR TITLE
Move cleanup to a different container

### DIFF
--- a/charts/fleet/templates/deployment.yaml
+++ b/charts/fleet/templates/deployment.yaml
@@ -74,6 +74,34 @@ spec:
           - mountPath: /tmp/pprof
             name: pprof
         {{- end }}
+      - env:
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        {{- if .Values.debug }}
+        - name: CATTLE_DEV_MODE
+          value: "true"
+        {{- end }}
+        image: '{{ template "system_default_registry" . }}{{ .Values.image.repository }}:{{ .Values.image.tag }}'
+        name: fleet-cleanup
+        imagePullPolicy: "{{ .Values.image.imagePullPolicy }}"
+        command:
+        - fleetcontroller
+        - cleanup
+        {{- if .Values.debug }}
+        - --debug
+        - --debug-level
+        - {{ quote .Values.debugLevel }}
+        {{- else }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          privileged: false
+          capabilities:
+            drop:
+            - ALL
+        {{- end }}
       volumes:
         - name: tmp
           emptyDir: {}

--- a/internal/cmd/controller/cleanup/controllers/controllers.go
+++ b/internal/cmd/controller/cleanup/controllers/controllers.go
@@ -1,0 +1,135 @@
+package controllers
+
+import (
+	"context"
+
+	"github.com/rancher/fleet/internal/cmd/controller/cleanup/controllers/cleanup"
+	"github.com/rancher/fleet/internal/cmd/controller/controllers"
+	"github.com/rancher/fleet/pkg/generated/controllers/fleet.cattle.io"
+	fleetcontrollers "github.com/rancher/fleet/pkg/generated/controllers/fleet.cattle.io/v1alpha1"
+	"github.com/rancher/wrangler/v2/pkg/apply"
+	"github.com/rancher/wrangler/v2/pkg/generated/controllers/core"
+	corecontrollers "github.com/rancher/wrangler/v2/pkg/generated/controllers/core/v1"
+	"github.com/rancher/wrangler/v2/pkg/generated/controllers/rbac"
+	rbaccontrollers "github.com/rancher/wrangler/v2/pkg/generated/controllers/rbac/v1"
+	"github.com/rancher/wrangler/v2/pkg/ratelimit"
+	"github.com/rancher/wrangler/v2/pkg/start"
+	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+type AppContext struct {
+	fleetcontrollers.Interface
+
+	K8s          kubernetes.Interface
+	Core         corecontrollers.Interface
+	RBAC         rbaccontrollers.Interface
+	RESTMapper   meta.RESTMapper
+	Apply        apply.Apply
+	ClientConfig clientcmd.ClientConfig
+	starters     []start.Starter
+}
+
+func (a *AppContext) Start(ctx context.Context) error {
+	return start.All(ctx, 50, a.starters...)
+}
+
+func Register(ctx context.Context, appCtx *AppContext) error {
+	cleanup.Register(ctx,
+		appCtx.Apply.WithCacheTypes(
+			appCtx.Core.Secret(),
+			appCtx.Core.ServiceAccount(),
+			appCtx.RBAC.Role(),
+			appCtx.RBAC.RoleBinding(),
+			appCtx.RBAC.ClusterRole(),
+			appCtx.RBAC.ClusterRoleBinding(),
+			appCtx.Bundle(),
+			appCtx.ClusterRegistrationToken(),
+			appCtx.ClusterRegistration(),
+			appCtx.ClusterGroup(),
+			appCtx.Cluster(),
+			appCtx.Core.Namespace()),
+		appCtx.Core.Secret(),
+		appCtx.Core.ServiceAccount(),
+		appCtx.BundleDeployment(),
+		appCtx.RBAC.Role(),
+		appCtx.RBAC.RoleBinding(),
+		appCtx.RBAC.ClusterRole(),
+		appCtx.RBAC.ClusterRoleBinding(),
+		appCtx.Core.Namespace(),
+		appCtx.Cluster().Cache(),
+		appCtx.Bundle(),
+		appCtx.ImageScan(),
+		appCtx.GitRepo().Cache(),
+	)
+
+	if err := appCtx.Start(ctx); err != nil {
+		logrus.Fatal(err)
+	}
+
+	return nil
+}
+
+func NewAppContext(cfg clientcmd.ClientConfig) (*AppContext, error) {
+	client, err := cfg.ClientConfig()
+	if err != nil {
+		return nil, err
+	}
+	client.RateLimiter = ratelimit.None
+
+	scf, err := controllers.ControllerFactory(client)
+	if err != nil {
+		return nil, err
+	}
+
+	core, err := core.NewFactoryFromConfigWithOptions(client, &core.FactoryOptions{
+		SharedControllerFactory: scf,
+	})
+	if err != nil {
+		return nil, err
+	}
+	corev := core.Core().V1()
+
+	fleet, err := fleet.NewFactoryFromConfigWithOptions(client, &fleet.FactoryOptions{
+		SharedControllerFactory: scf,
+	})
+	if err != nil {
+		return nil, err
+	}
+	fleetv := fleet.Fleet().V1alpha1()
+
+	rbac, err := rbac.NewFactoryFromConfigWithOptions(client, &rbac.FactoryOptions{
+		SharedControllerFactory: scf,
+	})
+	if err != nil {
+		return nil, err
+	}
+	rbacv := rbac.Rbac().V1()
+
+	apply, err := apply.NewForConfig(client)
+	if err != nil {
+		return nil, err
+	}
+	apply = apply.WithSetOwnerReference(false, false)
+
+	k8s, err := kubernetes.NewForConfig(client)
+	if err != nil {
+		return nil, err
+	}
+
+	return &AppContext{
+		K8s:          k8s,
+		Interface:    fleetv,
+		Core:         corev,
+		RBAC:         rbacv,
+		Apply:        apply,
+		ClientConfig: cfg,
+		starters: []start.Starter{
+			core,
+			fleet,
+			rbac,
+		},
+	}, nil
+}

--- a/internal/cmd/controller/cleanup/root.go
+++ b/internal/cmd/controller/cleanup/root.go
@@ -1,0 +1,38 @@
+package cleanup
+
+import (
+	"fmt"
+
+	command "github.com/rancher/fleet/internal/cmd"
+	"github.com/rancher/fleet/pkg/version"
+	"github.com/spf13/cobra"
+)
+
+type CleanUp struct {
+	command.DebugConfig
+	Kubeconfig string `usage:"kubeconfig file"`
+	Namespace  string `usage:"namespace to watch" env:"NAMESPACE"`
+}
+
+func (c *CleanUp) Run(cmd *cobra.Command, args []string) error {
+	if err := c.SetupDebug(); err != nil {
+		return fmt.Errorf("failed to setup debug logging: %w", err)
+	}
+
+	if c.Namespace == "" {
+		return fmt.Errorf("--namespace or env NAMESPACE is required to be set")
+	}
+	if err := start(cmd.Context(), c.Kubeconfig, c.Namespace); err != nil {
+		return err
+	}
+	<-cmd.Context().Done()
+
+	return nil
+}
+
+func App() *cobra.Command {
+	return command.Command(&CleanUp{}, cobra.Command{
+		Version: version.FriendlyVersion(),
+		Use:     "cleanup",
+	})
+}

--- a/internal/cmd/controller/cleanup/root.go
+++ b/internal/cmd/controller/cleanup/root.go
@@ -17,12 +17,7 @@ func (c *CleanUp) Run(cmd *cobra.Command, args []string) error {
 	if c.Namespace == "" {
 		return fmt.Errorf("--namespace or env NAMESPACE is required to be set")
 	}
-	if err := start(cmd.Context(), c.Kubeconfig, c.Namespace); err != nil {
-		return err
-	}
-	<-cmd.Context().Done()
-
-	return nil
+	return start(cmd.Context(), c.Kubeconfig, c.Namespace)
 }
 
 func App() *cobra.Command {

--- a/internal/cmd/controller/cleanup/root.go
+++ b/internal/cmd/controller/cleanup/root.go
@@ -9,16 +9,11 @@ import (
 )
 
 type CleanUp struct {
-	command.DebugConfig
 	Kubeconfig string `usage:"kubeconfig file"`
 	Namespace  string `usage:"namespace to watch" env:"NAMESPACE"`
 }
 
 func (c *CleanUp) Run(cmd *cobra.Command, args []string) error {
-	if err := c.SetupDebug(); err != nil {
-		return fmt.Errorf("failed to setup debug logging: %w", err)
-	}
-
 	if c.Namespace == "" {
 		return fmt.Errorf("--namespace or env NAMESPACE is required to be set")
 	}

--- a/internal/cmd/controller/cleanup/start.go
+++ b/internal/cmd/controller/cleanup/start.go
@@ -1,0 +1,46 @@
+package cleanup
+
+import (
+	"context"
+
+	"github.com/rancher/fleet/internal/cmd/controller/cleanup/content"
+	"github.com/rancher/fleet/internal/cmd/controller/cleanup/controllers"
+	"github.com/rancher/wrangler/v2/pkg/kubeconfig"
+	"github.com/rancher/wrangler/v2/pkg/leader"
+	"github.com/rancher/wrangler/v2/pkg/ratelimit"
+	"github.com/sirupsen/logrus"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+func start(ctx context.Context, kubeConfig, namespace string) error {
+	clientConfig := kubeconfig.GetNonInteractiveClientConfig(kubeConfig)
+	kc, err := clientConfig.ClientConfig()
+	if err != nil {
+		return err
+	}
+
+	// try to claim leadership lease without rate limiting
+	localConfig := rest.CopyConfig(kc)
+	localConfig.RateLimiter = ratelimit.None
+	k8s, err := kubernetes.NewForConfig(localConfig)
+	if err != nil {
+		return err
+	}
+
+	leader.RunOrDie(ctx, namespace, "fleet-cleanup-lock", k8s, func(ctx context.Context) {
+		appCtx, err := controllers.NewAppContext(clientConfig)
+		if err != nil {
+			logrus.Fatal(err)
+		}
+		if err := controllers.Register(ctx, appCtx); err != nil {
+			logrus.Fatal(err)
+		}
+		content.PurgeOrphanedInBackground(ctx, appCtx.Content(), appCtx.BundleDeployment(), appCtx.Core.Namespace())
+		if err := appCtx.Start(ctx); err != nil {
+			logrus.Fatal(err)
+		}
+	})
+
+	return nil
+}

--- a/internal/cmd/controller/controllers/controllers.go
+++ b/internal/cmd/controller/controllers/controllers.go
@@ -10,13 +10,11 @@ import (
 
 	"github.com/rancher/fleet/internal/cmd/controller/controllers/bootstrap"
 	"github.com/rancher/fleet/internal/cmd/controller/controllers/bundle"
-	"github.com/rancher/fleet/internal/cmd/controller/controllers/cleanup"
 	"github.com/rancher/fleet/internal/cmd/controller/controllers/cluster"
 	"github.com/rancher/fleet/internal/cmd/controller/controllers/clustergroup"
 	"github.com/rancher/fleet/internal/cmd/controller/controllers/clusterregistration"
 	"github.com/rancher/fleet/internal/cmd/controller/controllers/clusterregistrationtoken"
 	"github.com/rancher/fleet/internal/cmd/controller/controllers/config"
-	"github.com/rancher/fleet/internal/cmd/controller/controllers/content"
 	"github.com/rancher/fleet/internal/cmd/controller/controllers/display"
 	"github.com/rancher/fleet/internal/cmd/controller/controllers/git"
 	"github.com/rancher/fleet/internal/cmd/controller/controllers/image"
@@ -144,11 +142,6 @@ func Register(ctx context.Context, systemNamespace string, cfg clientcmd.ClientC
 		appCtx.Cluster(),
 		appCtx.ClusterGroup())
 
-	content.Register(ctx,
-		appCtx.Content(),
-		appCtx.BundleDeployment(),
-		appCtx.Core.Namespace())
-
 	clusterregistrationtoken.Register(ctx,
 		systemNamespace,
 		systemRegistrationNamespace,
@@ -161,30 +154,6 @@ func Register(ctx context.Context, systemNamespace string, cfg clientcmd.ClientC
 		appCtx.Core.ServiceAccount(),
 		appCtx.Core.Secret().Cache(),
 		appCtx.Core.Secret())
-
-	cleanup.Register(ctx,
-		appCtx.Apply.WithCacheTypes(
-			appCtx.Core.Secret(),
-			appCtx.Core.ServiceAccount(),
-			appCtx.RBAC.Role(),
-			appCtx.RBAC.RoleBinding(),
-			appCtx.RBAC.ClusterRole(),
-			appCtx.RBAC.ClusterRoleBinding(),
-			appCtx.Bundle(),
-			appCtx.ClusterRegistrationToken(),
-			appCtx.ClusterRegistration(),
-			appCtx.ClusterGroup(),
-			appCtx.Cluster(),
-			appCtx.Core.Namespace()),
-		appCtx.Core.Secret(),
-		appCtx.Core.ServiceAccount(),
-		appCtx.BundleDeployment(),
-		appCtx.RBAC.Role(),
-		appCtx.RBAC.RoleBinding(),
-		appCtx.RBAC.ClusterRole(),
-		appCtx.RBAC.ClusterRoleBinding(),
-		appCtx.Core.Namespace(),
-		appCtx.Cluster().Cache())
 
 	manageagent.Register(ctx,
 		systemNamespace,
@@ -246,7 +215,7 @@ func Register(ctx context.Context, systemNamespace string, cfg clientcmd.ClientC
 	return nil
 }
 
-func controllerFactory(rest *rest.Config) (controller.SharedControllerFactory, error) {
+func ControllerFactory(rest *rest.Config) (controller.SharedControllerFactory, error) {
 	rateLimit := workqueue.NewItemExponentialFailureRateLimiter(durations.FailureRateLimiterBase, durations.FailureRateLimiterMax)
 	clusterRateLimiter := workqueue.NewItemExponentialFailureRateLimiter(durations.SlowFailureRateLimiterBase, durations.SlowFailureRateLimiterMax)
 	clientFactory, err := client.NewSharedClientFactory(rest, nil)
@@ -272,7 +241,7 @@ func newContext(cfg clientcmd.ClientConfig) (*appContext, error) {
 	}
 	client.RateLimiter = ratelimit.None
 
-	scf, err := controllerFactory(client)
+	scf, err := ControllerFactory(client)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/cmd/controller/root.go
+++ b/internal/cmd/controller/root.go
@@ -17,6 +17,7 @@ import (
 
 	command "github.com/rancher/fleet/internal/cmd"
 	"github.com/rancher/fleet/internal/cmd/controller/agent"
+	"github.com/rancher/fleet/internal/cmd/controller/cleanup"
 	"github.com/rancher/fleet/pkg/durations"
 	"github.com/rancher/fleet/pkg/version"
 )
@@ -58,9 +59,12 @@ func (r *FleetManager) PersistentPre(_ *cobra.Command, _ []string) error {
 }
 
 func App() *cobra.Command {
-	return command.Command(&FleetManager{}, cobra.Command{
+	cmd := command.Command(&FleetManager{}, cobra.Command{
 		Version: version.FriendlyVersion(),
 	})
+	cmd.AddCommand(cleanup.App())
+
+	return cmd
 }
 
 // setupCpuPprof starts a goroutine that captures a cpu pprof profile


### PR DESCRIPTION
Move the cleanup controller and the code that's cleaning orphan `contents`,  `bundles` and `imageScans` to a different binary.

Run the fleet-cleanup in a different container
