### PR TITLE
Bump golangci-lint to latest version

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -29,7 +29,7 @@ jobs:
         uses: golangci/golangci-lint-action@v3.7.0
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.53
+          version: v1.55
 
           args: --timeout=10m --config=.golangci.json
 


### PR DESCRIPTION
This should eliminate typecheck errors happening in the standard library.