### PR TITLE
Fix flaky smoke test for cluster registration

### DIFF
--- a/internal/cmd/agent/register/register_test.go
+++ b/internal/cmd/agent/register/register_test.go
@@ -61,6 +61,7 @@ func TestRunRegistrationLabelSmokeTest(t *testing.T) {
 	agentSecret, err := runRegistration(context.Background(), mockCoreController, namespace, "my-clusterID")
 
 	assert.Nil(t, agentSecret)
-	// expecting a timeout at cluster registration creation time because the API server URL is a dummy.
-	assert.Regexp(t, regexp.MustCompile("cannot create clusterregistration.*timeout"), err.Error())
+	// expecting an error at cluster registration creation time because the API server URL is a dummy.
+	// this may be a timeout or a simple 'connection refused' error.
+	assert.Regexp(t, regexp.MustCompile("cannot create clusterregistration.*"), err.Error())
 }


### PR DESCRIPTION
Registering a cluster with a made up API server URL, not pointing to any actual server, will fail. Whether it fails with a timeout or a `connection refused` error is not relevant; what matters in this smoke test case is that the agent does not crash (see test case description).

See [this run](https://github.com/rancher/fleet/actions/runs/6646995070/job/18061545739?pr=1901) for an example of a failure fixed by this PR.

Refers to #1866.

## Test

To test this pull request, you can run the following commands:

```shell
go test ./internal/cmd/agent/register/...
```