### PR TITLE
Add acceptance tests to AKS and GKE CI workflows

### DIFF
--- a/.github/workflows/aks.yml
+++ b/.github/workflows/aks.yml
@@ -19,7 +19,6 @@ env:
   CGO_ENABLED: 0
   GINKGO_NODES: 1
   FLAKE_ATTEMPTS: 1
-  AWS_REGION: 'us-east-2'
   AKS_MACHINE_TYPE: 'Standard_D3_v2'
 
 jobs:
@@ -132,12 +131,19 @@ jobs:
           echo "${{ steps.meta-fleet.outputs.tags }} ${{ steps.meta-fleet-agent.outputs.tags }}"
           ./.github/scripts/deploy-fleet.sh ${{ steps.meta-fleet.outputs.tags }} ${{ steps.meta-fleet-agent.outputs.tags }}
       -
-        name: Fleet Examples Tests
+        name: Fleet E2E Tests
         env:
           FLEET_E2E_NS: fleet-local
         run: |
           export KUBECONFIG="$GITHUB_WORKSPACE/kubeconfig-fleet-ci"
-          ginkgo --label-filter="!infra-setup" e2e/single-cluster
+          ginkgo --label-filter="!infra-setup" e2e/single-cluster e2e/keep-resources
+      -
+        name: Acceptance Tests for Examples
+        env:
+          FLEET_E2E_NS: fleet-local
+        run: |
+          export KUBECONFIG="$GITHUB_WORKSPACE/kubeconfig-fleet-ci"
+          ginkgo e2e/acceptance/single-cluster-examples
       -
         name: Fleet Tests Requiring Github Secrets
         # These tests can't run for PRs, because PRs don't have access to the secrets

--- a/.github/workflows/gke.yml
+++ b/.github/workflows/gke.yml
@@ -135,11 +135,17 @@ jobs:
           echo "${{ steps.meta-fleet.outputs.tags }} ${{ steps.meta-fleet-agent.outputs.tags }}"
           ./.github/scripts/deploy-fleet.sh ${{ steps.meta-fleet.outputs.tags }} ${{ steps.meta-fleet-agent.outputs.tags }}
       -
-        name: Fleet Examples Tests
+        name: Fleet E2E Tests
         env:
           FLEET_E2E_NS: fleet-local
         run: |
-          ginkgo --label-filter="!infra-setup" e2e/single-cluster
+          ginkgo --label-filter="!infra-setup" e2e/single-cluster e2e/keep-resources
+      -
+        name: Acceptance Tests for Examples
+        env:
+          FLEET_E2E_NS: fleet-local
+        run: |
+          ginkgo e2e/acceptance/single-cluster-examples
       -
         name: Fleet Tests Requiring Github Secrets
         # These tests can't run for PRs, because PRs don't have access to the secrets


### PR DESCRIPTION
Refers to #1866.

## Test

See [this AKS run](https://github.com/rancher/fleet/actions/runs/6692075203/job/18180527152) and [this GKE run](https://github.com/rancher/fleet/actions/runs/6692077842/job/18180535541).

## Additional Information

### Trade-off

Multi-cluster tests are still not included in those workflows because they are more complex to set up in hyperscaler environments.