### PR TITLE
Add docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ For more information, have a look at Fleet's [documentation](https://fleet.ranch
 Get `helm` if you don't have it.  Helm 3 is just a CLI and won't do bad insecure
 things to your cluster.
 
+For instance, using Homebrew:
 ```
 brew install helm
 ```
@@ -66,7 +67,7 @@ kubectl apply -f example.yaml
 
 ## Get Status
 
-Get status of what fleet is doing
+Get status of what Fleet is doing:
 
 ```shell
 kubectl -n fleet-local get fleet

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ deploy everything in the cluster. This gives a high degree of control, consisten
 the ability to scale, but to give one a high degree of control and visibility to exactly what is installed on the cluster.
 
 # Quick Start
-Who needs documentation, let's just run this thing!
+
+For more information, have a look at Fleet's [documentation](https://fleet.rancher.io/).
 
 ## Install
 


### PR DESCRIPTION
Because users most likely want to know about Fleet's documentation as early as possible.