### PR TITLE
Silence linter warnings for memory aliasing and klogr

### DIFF
--- a/.golangci.json
+++ b/.golangci.json
@@ -65,6 +65,14 @@
         ]
       },
       {
+        "path": "internal/cmd/cli/cleanup/cleanup.go",
+        "text": "G601: Implicit memory aliasing in for loop."
+      },
+      {
+        "path": "internal/cmd/controller/controllers/bundle/controller.go",
+        "text": "G601: Implicit memory aliasing in for loop."
+      },
+      {
         "path": "_test.go",
         "linters": [
           "gocyclo",

--- a/internal/cmd/agent/deployer/internal/diff/diff_options.go
+++ b/internal/cmd/agent/deployer/internal/diff/diff_options.go
@@ -3,8 +3,7 @@ package diff
 
 import (
 	"github.com/go-logr/logr"
-
-	"k8s.io/klog/v2/klogr"
+	"k8s.io/klog/v2/textlogger"
 )
 
 type Option func(*options)
@@ -21,7 +20,7 @@ func applyOptions(opts []Option) options {
 	o := options{
 		ignoreAggregatedRoles: false,
 		normalizer:            GetNoopNormalizer(),
-		log:                   klogr.New(),
+		log:                   textlogger.NewLogger(textlogger.NewConfig()),
 	}
 	for _, opt := range opts {
 		opt(&o)


### PR DESCRIPTION

We previously discussed the "implicit memory aliasing" warnings and came to the conclusion they're false positives. Not sure why the current version of golangci-lint, which contains an updated gosec version, is still producing the warning.

```
internal/cmd/controller/controllers/bundle/controller.go:325:40: G601: Implicit memory aliasing in for loop. (gosec)
			updateTarget(currentTarget, status, &partition.Status)
			                                    ^
internal/cmd/controller/controllers/bundle/controller.go:328:37: G601: Implicit memory aliasing in for loop. (gosec)
		if target.UpdateStatusUnavailable(&partition.Status, partition.Targets) {
		                                  ^
internal/cmd/cli/cleanup/cleanup.go:63:37: G601: Implicit memory aliasing in for loop. (gosec)
		if cr.Status.Granted && ts.Before(&cr.CreationTimestamp) {
		                                  ^
internal/cmd/agent/deployer/internal/diff/diff_options.go:24:26: SA1019: klogr.New is deprecated: this uses a custom, out-dated output format. Use textlogger.NewLogger instead. (staticcheck)
		log:                   klogr.New(),
		                       ^
```