### PR TITLE
[0.9] Backport OCI test changes

### DIFF
--- a/e2e/single-cluster/single_cluster_test.go
+++ b/e2e/single-cluster/single_cluster_test.go
@@ -39,9 +39,9 @@ var _ = Describe("Single Cluster Deployments", func() {
 
 			It("deploys the helm chart", func() {
 				Eventually(func() string {
-					out, _ := k.Namespace("fleet-helm-oci-example").Get("pods")
+					out, _ := k.Namespace("fleet-helm-oci-example").Get("configmaps")
 					return out
-				}).Should(ContainSubstring("frontend-"))
+				}).Should(ContainSubstring("fleet-test-configmap"))
 			})
 		})
 


### PR DESCRIPTION
Any PR against `release/0.9` fails due to this test, which was adapted as part of #1876.