### PR TITLE
[0.8] Backport OCI auth test changes

### DIFF
--- a/e2e/require-secrets/oci_auth_test.go
+++ b/e2e/require-secrets/oci_auth_test.go
@@ -73,9 +73,9 @@ var _ = Describe("Single Cluster Examples", func() {
 
 			It("deploys the helm chart", func() {
 				Eventually(func() string {
-					out, _ := k.Namespace("fleet-helm-oci-with-auth-example").Get("pods")
+					out, _ := k.Namespace("fleet-helm-oci-with-auth-example").Get("configmaps")
 					return out
-				}).Should(ContainSubstring("frontend-"))
+				}).Should(ContainSubstring("fleet-test-configmap"))
 			})
 		})
 	})


### PR DESCRIPTION
Backporting part of #1898
Twin PR on `release/v0.9`: #1961