### PR TITLE
Provide release.yaml charts version as array

### DIFF
--- a/.github/scripts/release-against-charts.sh
+++ b/.github/scripts/release-against-charts.sh
@@ -37,7 +37,7 @@ fi
 
 for i in fleet fleet-crd fleet-agent; do
     yq --inplace "del( .${i}.[] | select(. == \"${PREV_CHART_VERSION}+up${PREV_FLEET_VERSION}\") )" release.yaml
-    yq --inplace ".${i} += \"${NEW_CHART_VERSION}+up${NEW_FLEET_VERSION}\"" release.yaml
+    yq --inplace ".${i} += [\"${NEW_CHART_VERSION}+up${NEW_FLEET_VERSION}\"]" release.yaml
 done
 
 git add packages/fleet release.yaml


### PR DESCRIPTION
to prevent issues like these: https://github.com/rancher/charts/actions/runs/7006122483/job/19057305976?pr=3237

I think the issue does not appear if there is already a Fleet array in the release.yaml, that's why the issue did not appear before.