### PR TITLE
Allow correctDrift to be overridden in target customization

### DIFF
--- a/charts/fleet-crd/templates/crds.yaml
+++ b/charts/fleet-crd/templates/crds.yaml
@@ -50,6 +50,7 @@ spec:
                 correctDrift:
                   description: CorrectDrift specifies how drift correction should
                     work.
+                  nullable: true
                   properties:
                     enabled:
                       description: Enabled correct drift if true.
@@ -137,6 +138,7 @@ spec:
                     correctDrift:
                       description: CorrectDrift specifies how drift correction should
                         work.
+                      nullable: true
                       properties:
                         enabled:
                           description: Enabled correct drift if true.
@@ -441,6 +443,7 @@ spec:
                     correctDrift:
                       description: CorrectDrift specifies how drift correction should
                         work.
+                      nullable: true
                       properties:
                         enabled:
                           description: Enabled correct drift if true.
@@ -1081,6 +1084,7 @@ spec:
                 correctDrift:
                   description: CorrectDrift specifies how drift correction should
                     work.
+                  nullable: true
                   properties:
                     enabled:
                       description: Enabled correct drift if true.
@@ -1847,6 +1851,7 @@ spec:
                       correctDrift:
                         description: CorrectDrift specifies how drift correction should
                           work.
+                        nullable: true
                         properties:
                           enabled:
                             description: Enabled correct drift if true.
@@ -4920,6 +4925,7 @@ spec:
                 correctDrift:
                   description: CorrectDrift specifies how drift correction should
                     work.
+                  nullable: true
                   properties:
                     enabled:
                       description: Enabled correct drift if true.

--- a/internal/bundlereader/read.go
+++ b/internal/bundlereader/read.go
@@ -34,7 +34,7 @@ type Options struct {
 	Auth             Auth
 	HelmRepoURLRegex string
 	KeepResources    bool
-	CorrectDrift     fleet.CorrectDrift
+	CorrectDrift     *fleet.CorrectDrift
 }
 
 // Open reads the fleet.yaml, from stdin, or basedir, or a file in basedir.
@@ -261,7 +261,7 @@ func read(ctx context.Context, name, baseDir string, bundleSpecReader io.Reader,
 		bundle.Spec.KeepResources = opts.KeepResources
 	}
 
-	if opts.CorrectDrift.Enabled {
+	if opts.CorrectDrift != nil && opts.CorrectDrift.Enabled {
 		bundle.Spec.CorrectDrift = opts.CorrectDrift
 	}
 

--- a/internal/cmd/agent/deployer/monitor.go
+++ b/internal/cmd/agent/deployer/monitor.go
@@ -174,7 +174,7 @@ func (m *Manager) UpdateBundleDeploymentStatus(mapper meta.RESTMapper, bd *fleet
 	}
 	if len(bd.Status.ModifiedStatus) == 0 {
 		bd.Status.NonModified = true
-	} else if bd.Spec.CorrectDrift.Enabled {
+	} else if bd.Spec.CorrectDrift != nil && bd.Spec.CorrectDrift.Enabled {
 		err = m.deployer.RemoveExternalChanges(bd)
 		if err != nil {
 			// Update BundleDeployment status as wrangler doesn't update the status if error is not nil.

--- a/internal/cmd/cli/apply/apply.go
+++ b/internal/cmd/cli/apply/apply.go
@@ -181,7 +181,7 @@ func readBundle(ctx context.Context, name, baseDir string, opts *Options) (*flee
 		Auth:             opts.Auth,
 		HelmRepoURLRegex: opts.HelmRepoURLRegex,
 		KeepResources:    opts.KeepResources,
-		CorrectDrift: fleet.CorrectDrift{
+		CorrectDrift: &fleet.CorrectDrift{
 			Enabled:         opts.CorrectDrift,
 			Force:           opts.CorrectDriftForce,
 			KeepFailHistory: opts.CorrectDriftKeepFailHistory,

--- a/internal/cmd/controller/controllers/git/git.go
+++ b/internal/cmd/controller/controllers/git/git.go
@@ -759,7 +759,7 @@ func argsAndEnvs(gitrepo *fleet.GitRepo) ([]string, []corev1.EnvVar) {
 		args = append(args, "--keep-resources")
 	}
 
-	if gitrepo.Spec.CorrectDrift.Enabled {
+	if gitrepo.Spec.CorrectDrift != nil && gitrepo.Spec.CorrectDrift.Enabled {
 		args = append(args, "--correct-drift")
 		if gitrepo.Spec.CorrectDrift.Force {
 			args = append(args, "--correct-drift-force")

--- a/internal/cmd/controller/options/calculate.go
+++ b/internal/cmd/controller/options/calculate.go
@@ -104,6 +104,9 @@ func Merge(base, custom fleet.BundleDeploymentOptions) fleet.BundleDeploymentOpt
 		result.ForceSyncGeneration = custom.ForceSyncGeneration
 	}
 	result.KeepResources = result.KeepResources || custom.KeepResources
+	if custom.CorrectDrift != nil {
+		result.CorrectDrift = custom.CorrectDrift
+	}
 
 	return result
 }

--- a/pkg/apis/fleet.cattle.io/v1alpha1/bundledeployment_types.go
+++ b/pkg/apis/fleet.cattle.io/v1alpha1/bundledeployment_types.go
@@ -71,7 +71,7 @@ type BundleDeploymentOptions struct {
 	IgnoreOptions `json:"ignore,omitempty"`
 
 	// CorrectDrift specifies how drift correction should work.
-	CorrectDrift CorrectDrift `json:"correctDrift,omitempty"`
+	CorrectDrift *CorrectDrift `json:"correctDrift,omitempty"`
 
 	// NamespaceLabels are labels that will be appended to the namespace created by Fleet.
 	NamespaceLabels *map[string]string `json:"namespaceLabels,omitempty"`
@@ -242,7 +242,7 @@ type BundleDeploymentSpec struct {
 	// DependsOn refers to the bundles which must be ready before this bundle can be deployed.
 	DependsOn []BundleRef `json:"dependsOn,omitempty"`
 	// CorrectDrift specifies how drift correction should work.
-	CorrectDrift CorrectDrift `json:"correctDrift,omitempty"`
+	CorrectDrift *CorrectDrift `json:"correctDrift,omitempty"`
 }
 
 // BundleDeploymentResource contains the metadata of a deployed resource.

--- a/pkg/apis/fleet.cattle.io/v1alpha1/gitrepo_types.go
+++ b/pkg/apis/fleet.cattle.io/v1alpha1/gitrepo_types.go
@@ -95,7 +95,7 @@ type GitRepoSpec struct {
 	KeepResources bool `json:"keepResources,omitempty"`
 
 	// CorrectDrift specifies how drift correction should work.
-	CorrectDrift CorrectDrift `json:"correctDrift,omitempty"`
+	CorrectDrift *CorrectDrift `json:"correctDrift,omitempty"`
 }
 
 // GitTarget is a cluster or cluster group to deploy to.

--- a/pkg/apis/fleet.cattle.io/v1alpha1/zz_generated_deepcopy.go
+++ b/pkg/apis/fleet.cattle.io/v1alpha1/zz_generated_deepcopy.go
@@ -201,7 +201,11 @@ func (in *BundleDeploymentOptions) DeepCopyInto(out *BundleDeploymentOptions) {
 		(*in).DeepCopyInto(*out)
 	}
 	in.IgnoreOptions.DeepCopyInto(&out.IgnoreOptions)
-	out.CorrectDrift = in.CorrectDrift
+	if in.CorrectDrift != nil {
+		in, out := &in.CorrectDrift, &out.CorrectDrift
+		*out = new(CorrectDrift)
+		**out = **in
+	}
 	if in.NamespaceLabels != nil {
 		in, out := &in.NamespaceLabels, &out.NamespaceLabels
 		*out = new(map[string]string)
@@ -266,7 +270,11 @@ func (in *BundleDeploymentSpec) DeepCopyInto(out *BundleDeploymentSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
-	out.CorrectDrift = in.CorrectDrift
+	if in.CorrectDrift != nil {
+		in, out := &in.CorrectDrift, &out.CorrectDrift
+		*out = new(CorrectDrift)
+		**out = **in
+	}
 	return
 }
 
@@ -1563,7 +1571,11 @@ func (in *GitRepoSpec) DeepCopyInto(out *GitRepoSpec) {
 		**out = **in
 	}
 	out.ImageScanCommit = in.ImageScanCommit
-	out.CorrectDrift = in.CorrectDrift
+	if in.CorrectDrift != nil {
+		in, out := &in.CorrectDrift, &out.CorrectDrift
+		*out = new(CorrectDrift)
+		**out = **in
+	}
 	return
 }
 


### PR DESCRIPTION
This PR overrides `correctDrift` if it appears in `targetCustomizations`. This allows user to override this setting per cluster.

refers to https://github.com/rancher/fleet/issues/1794