### PR TITLE
Remove bd requeue, rely on drift correction

### DIFF
--- a/internal/cmd/agent/controller/bundledeployment_controller.go
+++ b/internal/cmd/agent/controller/bundledeployment_controller.go
@@ -142,7 +142,7 @@ func (r *BundleDeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Req
 			}
 		}
 
-		if len(bd.Status.ModifiedStatus) > 0 && monitor.IsAgent(bd) && monitor.ShouldRedeploy(bd) {
+		if len(bd.Status.ModifiedStatus) > 0 && monitor.ShouldRedeployAgent(bd) {
 			bd.Status.AppliedDeploymentID = ""
 			if err := r.Cleanup.OldAgent(ctx, status.ModifiedStatus); err != nil {
 				merr = append(merr, fmt.Errorf("failed cleaning old agent: %w", err))

--- a/internal/cmd/agent/controller/bundledeployment_controller.go
+++ b/internal/cmd/agent/controller/bundledeployment_controller.go
@@ -10,7 +10,6 @@ import (
 	"github.com/rancher/fleet/internal/cmd/agent/deployer/driftdetect"
 	"github.com/rancher/fleet/internal/cmd/agent/deployer/monitor"
 	fleetv1 "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
-	"github.com/rancher/fleet/pkg/durations"
 
 	"github.com/rancher/wrangler/v2/pkg/condition"
 
@@ -143,16 +142,10 @@ func (r *BundleDeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Req
 			}
 		}
 
-		// TODO is this needed with drift correction?
-		if len(bd.Status.ModifiedStatus) > 0 && monitor.ShouldRedeploy(bd) {
-			result.RequeueAfter = durations.MonitorBundleDelay
-			logger.Info("Redeploying, by resetting the appliedDeploymentID")
+		if len(bd.Status.ModifiedStatus) > 0 && monitor.IsAgent(bd) && monitor.ShouldRedeploy(bd) {
 			bd.Status.AppliedDeploymentID = ""
-
-			if monitor.IsAgent(bd) {
-				if err := r.Cleanup.OldAgent(ctx, status.ModifiedStatus); err != nil {
-					merr = append(merr, fmt.Errorf("failed cleaning old agent: %w", err))
-				}
+			if err := r.Cleanup.OldAgent(ctx, status.ModifiedStatus); err != nil {
+				merr = append(merr, fmt.Errorf("failed cleaning old agent: %w", err))
 			}
 		}
 	}

--- a/internal/cmd/agent/deployer/monitor/updatestatus.go
+++ b/internal/cmd/agent/deployer/monitor/updatestatus.go
@@ -46,8 +46,8 @@ func New(apply apply.Apply, mapper meta.RESTMapper, deployer *helmdeployer.Helm,
 	}
 }
 
-func ShouldRedeploy(bd *fleet.BundleDeployment) bool {
-	if IsAgent(bd) {
+func ShouldRedeployAgent(bd *fleet.BundleDeployment) bool {
+	if isAgent(bd) {
 		return true
 	}
 	if bd.Spec.Options.ForceSyncGeneration <= 0 {
@@ -59,7 +59,7 @@ func ShouldRedeploy(bd *fleet.BundleDeployment) bool {
 	return *bd.Status.SyncGeneration != bd.Spec.Options.ForceSyncGeneration
 }
 
-func IsAgent(bd *fleet.BundleDeployment) bool {
+func isAgent(bd *fleet.BundleDeployment) bool {
 	return strings.HasPrefix(bd.Name, "fleet-agent")
 }
 


### PR DESCRIPTION
This is a follow-up to https://github.com/rancher/fleet/pull/1772

We discussed if that re-queue is still needed. Also, why are agent resources deleted?