### PR TITLE
Filter namespaces by the kubernetes.io/metadata.name label

### DIFF
--- a/internal/cmd/agent/deployer/deployer.go
+++ b/internal/cmd/agent/deployer/deployer.go
@@ -177,14 +177,14 @@ func (d *Deployer) fetchNamespace(ctx context.Context, releaseID string) (*corev
 	return &list.Items[0], nil
 }
 
-// addLabelsFromOptions updates nsLabels so that it only contains all labels specified in optLabels, plus the `kubernetes.io/metadata.name` labels added by Helm when creating the namespace.
+// addLabelsFromOptions updates nsLabels so that it only contains all labels specified in optLabels, plus the `kubernetes.io/metadata.name` labels added by kubernetes when creating the namespace.
 func addLabelsFromOptions(nsLabels map[string]string, optLabels map[string]string) {
 	for k, v := range optLabels {
 		nsLabels[k] = v
 	}
 
 	// Delete labels not defined in the options.
-	// Keep the`kubernetes.io/metadata.name` label as it is added by kubernetes when creating the namespace.
+	// Keep the `kubernetes.io/metadata.name` label as it is added by kubernetes when creating the namespace.
 	for k := range nsLabels {
 		if _, ok := optLabels[k]; k != corev1.LabelMetadataName && !ok {
 			delete(nsLabels, k)

--- a/internal/cmd/agent/deployer/deployer.go
+++ b/internal/cmd/agent/deployer/deployer.go
@@ -166,7 +166,7 @@ func (d *Deployer) fetchNamespace(ctx context.Context, releaseID string) (*corev
 	namespace := strings.Split(releaseID, "/")[0]
 	list := &corev1.NamespaceList{}
 	err := d.client.List(ctx, list, client.MatchingLabels{
-		"name": namespace,
+		corev1.LabelMetadataName: namespace,
 	})
 	if err != nil {
 		return nil, err
@@ -184,9 +184,9 @@ func addLabelsFromOptions(nsLabels map[string]string, optLabels map[string]strin
 	}
 
 	// Delete labels not defined in the options.
-	// Keep the name label as it is added by helm when creating the namespace.
+	// Keep the corev1.LabelMetadataName label as it is added by kubernetes when creating the namespace.
 	for k := range nsLabels {
-		if _, ok := optLabels[k]; k != "name" && !ok {
+		if _, ok := optLabels[k]; k != corev1.LabelMetadataName && !ok {
 			delete(nsLabels, k)
 		}
 	}

--- a/internal/cmd/agent/deployer/deployer.go
+++ b/internal/cmd/agent/deployer/deployer.go
@@ -177,14 +177,14 @@ func (d *Deployer) fetchNamespace(ctx context.Context, releaseID string) (*corev
 	return &list.Items[0], nil
 }
 
-// addLabelsFromOptions updates nsLabels so that it only contains all labels specified in optLabels, plus the `name` labels added by Helm when creating the namespace.
+// addLabelsFromOptions updates nsLabels so that it only contains all labels specified in optLabels, plus the `kubernetes.io/metadata.name` labels added by Helm when creating the namespace.
 func addLabelsFromOptions(nsLabels map[string]string, optLabels map[string]string) {
 	for k, v := range optLabels {
 		nsLabels[k] = v
 	}
 
 	// Delete labels not defined in the options.
-	// Keep the corev1.LabelMetadataName label as it is added by kubernetes when creating the namespace.
+	// Keep the`kubernetes.io/metadata.name` label as it is added by kubernetes when creating the namespace.
 	for k := range nsLabels {
 		if _, ok := optLabels[k]; k != corev1.LabelMetadataName && !ok {
 			delete(nsLabels, k)

--- a/internal/cmd/agent/deployer/deployer_test.go
+++ b/internal/cmd/agent/deployer/deployer_test.go
@@ -33,13 +33,13 @@ func TestSetNamespaceLabelsAndAnnotations(t *testing.T) {
 			ns: corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:   "namespace1234",
-					Labels: map[string]string{"name": "namespace"},
+					Labels: map[string]string{"kubernetes.io/metadata.name": "namespace"},
 				},
 			},
 			release: "namespace/foo/bar",
 			expectedNs: corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels:      map[string]string{"name": "namespace", "optLabel1": "optValue1", "optLabel2": "optValue2"},
+					Labels:      map[string]string{"kubernetes.io/metadata.name": "namespace", "optLabel1": "optValue1", "optLabel2": "optValue2"},
 					Annotations: map[string]string{"optAnn1": "optValue1"},
 				},
 			},
@@ -55,14 +55,14 @@ func TestSetNamespaceLabelsAndAnnotations(t *testing.T) {
 			ns: corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        "namespace1234",
-					Labels:      map[string]string{"nsLabel": "nsValue", "name": "namespace"},
+					Labels:      map[string]string{"nsLabel": "nsValue", "kubernetes.io/metadata.name": "namespace"},
 					Annotations: map[string]string{"nsAnn": "nsValue"},
 				},
 			},
 			release: "namespace/foo/bar",
 			expectedNs: corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels:      map[string]string{"optLabel": "optValue", "name": "namespace"},
+					Labels:      map[string]string{"optLabel": "optValue", "kubernetes.io/metadata.name": "namespace"},
 					Annotations: map[string]string{},
 				},
 			},
@@ -78,14 +78,14 @@ func TestSetNamespaceLabelsAndAnnotations(t *testing.T) {
 			ns: corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        "namespace1234",
-					Labels:      map[string]string{"bdLabel": "nsValue", "name": "namespace"},
+					Labels:      map[string]string{"bdLabel": "nsValue", "kubernetes.io/metadata.name": "namespace"},
 					Annotations: map[string]string{"bdAnn": "nsValue"},
 				},
 			},
 			release: "namespace/foo/bar",
 			expectedNs: corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels:      map[string]string{"bdLabel": "labelUpdated", "name": "namespace"},
+					Labels:      map[string]string{"bdLabel": "labelUpdated", "kubernetes.io/metadata.name": "namespace"},
 					Annotations: map[string]string{"bdAnn": "annUpdated"},
 				},
 			},


### PR DESCRIPTION
We are using the label `name` to retrieve the namespace used for the fleet deployment. The label `name` is added to all namespaces created by Fleet (and all namespaces created with helm). However, this label is missing for namespaces created in other ways (e.g. kubectl).

This PRs changes the `client.MatchingLabels` to use the `kubernetes.io/metadata.name` label instead. `kubernetes.io/metadata.name` is added to all namespaces.

Refers to https://github.com/rancher/fleet/issues/1994
