### PR TITLE
Pre-process ClusterGroups' Selector on Spec changes

### DIFF
--- a/integrationtests/controller/bundle/suite_test.go
+++ b/integrationtests/controller/bundle/suite_test.go
@@ -9,21 +9,23 @@ import (
 
 	"github.com/rancher/fleet/integrationtests/utils"
 	"github.com/rancher/fleet/internal/cmd/controller/controllers/bundle"
+	"github.com/rancher/fleet/internal/cmd/controller/controllers/clustergroup"
 	"github.com/rancher/fleet/internal/cmd/controller/target"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/rancher/fleet/internal/manifest"
-	"github.com/rancher/fleet/pkg/durations"
-	"github.com/rancher/fleet/pkg/generated/controllers/fleet.cattle.io"
 	"github.com/rancher/lasso/pkg/cache"
 	lassoclient "github.com/rancher/lasso/pkg/client"
 	"github.com/rancher/lasso/pkg/controller"
 	"github.com/rancher/wrangler/pkg/apply"
 	"github.com/rancher/wrangler/pkg/generated/controllers/core"
 
+	"github.com/rancher/fleet/internal/manifest"
+	"github.com/rancher/fleet/pkg/durations"
+	"github.com/rancher/fleet/pkg/generated/controllers/fleet.cattle.io"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/discovery/cached/memory"
 	"k8s.io/client-go/rest"
@@ -124,6 +126,12 @@ func registerBundleController(cfg *rest.Config, namespace string) fleet.Interfac
 		coreFactory.Core().V1().Namespace().Cache(),
 		manifest.NewStore(factory.Fleet().V1alpha1().Content()),
 		factory.Fleet().V1alpha1().BundleDeployment().Cache())
+
+	clustergroup.Register(ctx,
+		targetManager.ClusterGroupStore,
+		factory.Fleet().V1alpha1().Cluster(),
+		factory.Fleet().V1alpha1().ClusterGroup(),
+	)
 
 	bundle.Register(ctx,
 		wranglerApply,

--- a/internal/cmd/controller/controllers/clustergroup/controller.go
+++ b/internal/cmd/controller/controllers/clustergroup/controller.go
@@ -3,7 +3,6 @@ package clustergroup
 
 import (
 	"context"
-	"k8s.io/apimachinery/pkg/runtime"
 	"sort"
 
 	"github.com/sirupsen/logrus"
@@ -15,6 +14,7 @@ import (
 	"github.com/rancher/wrangler/pkg/kv"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 type Store interface {

--- a/internal/cmd/controller/controllers/controllers.go
+++ b/internal/cmd/controller/controllers/controllers.go
@@ -133,6 +133,7 @@ func Register(ctx context.Context, systemNamespace string, cfg clientcmd.ClientC
 		appCtx.BundleDeployment())
 
 	clustergroup.Register(ctx,
+		appCtx.TargetManager.ClusterGroupStore,
 		appCtx.Cluster(),
 		appCtx.ClusterGroup())
 

--- a/internal/cmd/controller/target/clustergroups.go
+++ b/internal/cmd/controller/target/clustergroups.go
@@ -72,11 +72,9 @@ func (s *ClusterGroupStore) Delete(key string) {
 
 func (s *ClusterGroupStore) GetSelector(cg *fleet.ClusterGroup) (labels.Selector, error) {
 	key := cg.Namespace + "/" + cg.Name
+
 	entry, found := s.getEntry(key)
-	if !found {
-		return nil, nil
-	}
-	if !entry.sameAs(cg) {
+	if !found || !entry.sameAs(cg) {
 		entry = newEntry(cg)
 		s.setEntry(key, entry)
 	}

--- a/internal/cmd/controller/target/clustergroups.go
+++ b/internal/cmd/controller/target/clustergroups.go
@@ -1,11 +1,12 @@
 package target
 
 import (
-	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sync"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+
+	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
 )
 
 type clusterGroupEntry struct {
@@ -53,7 +54,6 @@ func (s *ClusterGroupStore) Store(key string, cg *fleet.ClusterGroup) {
 
 	entry := newEntry(cg)
 	s.setEntry(key, entry)
-	return
 }
 
 func (s *ClusterGroupStore) setEntry(key string, entry *clusterGroupEntry) {
@@ -61,7 +61,6 @@ func (s *ClusterGroupStore) setEntry(key string, entry *clusterGroupEntry) {
 	defer s.mu.Unlock()
 
 	s.store[key] = entry
-	return
 }
 
 func (s *ClusterGroupStore) Delete(key string) {

--- a/internal/cmd/controller/target/clustergroups.go
+++ b/internal/cmd/controller/target/clustergroups.go
@@ -1,0 +1,86 @@
+package target
+
+import (
+	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sync"
+
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+type clusterGroupEntry struct {
+	version int64
+
+	selector      labels.Selector
+	selectorError error
+}
+
+func (e *clusterGroupEntry) sameAs(cg *fleet.ClusterGroup) bool {
+	return e.version == cg.Generation
+}
+
+func newEntry(cg *fleet.ClusterGroup) *clusterGroupEntry {
+	entry := &clusterGroupEntry{version: cg.Generation}
+
+	if cg.Spec.Selector != nil {
+		entry.selector, entry.selectorError = metav1.LabelSelectorAsSelector(cg.Spec.Selector)
+	}
+
+	return entry
+}
+
+type ClusterGroupStore struct {
+	mu    sync.RWMutex
+	store map[string]*clusterGroupEntry
+}
+
+func newClusterGroupStore() *ClusterGroupStore {
+	return &ClusterGroupStore{store: map[string]*clusterGroupEntry{}}
+}
+
+func (s *ClusterGroupStore) getEntry(key string) (*clusterGroupEntry, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	entry, ok := s.store[key]
+	return entry, ok
+}
+
+func (s *ClusterGroupStore) Store(key string, cg *fleet.ClusterGroup) {
+	if entry, ok := s.getEntry(key); ok && entry.sameAs(cg) {
+		return
+	}
+
+	entry := newEntry(cg)
+	s.setEntry(key, entry)
+	return
+}
+
+func (s *ClusterGroupStore) setEntry(key string, entry *clusterGroupEntry) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.store[key] = entry
+	return
+}
+
+func (s *ClusterGroupStore) Delete(key string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	delete(s.store, key)
+}
+
+func (s *ClusterGroupStore) GetSelector(cg *fleet.ClusterGroup) (labels.Selector, error) {
+	key := cg.Namespace + "/" + cg.Name
+	entry, found := s.getEntry(key)
+	if !found {
+		return nil, nil
+	}
+	if !entry.sameAs(cg) {
+		entry = newEntry(cg)
+		s.setEntry(key, entry)
+	}
+
+	return entry.selector, nil
+}


### PR DESCRIPTION
<!-- Specify the issue ID that this pull request is solving -->
Refers to _ToBeCreated_
<!-- Make sure that the referenced issue provides steps to reproduce it -->

We have profiling data that shows how calculating if a Fleet Cluster belongs to a ClusterGroup can cause a considerable use of CPU under certain scenarios. In particular, most of this usage is dedicated to processing the field `.Spec.Selector` from each ClusterGroup, as shown in this screenshot:

![Screenshot 2023-12-14 at 13 18 52](https://github.com/rancher/fleet/assets/4057165/93429232-8b15-42ee-b496-fddeb6e72017)

The changes in this PR add some sort of caching mechanism for this processing, making the `clustergroup` controller to store the relevant object every time a change in the `ClusterGroup` spec is observed. Then the targeting mechanism can reuse this pre-processed selector in a more efficient way.

TODO
------
- [ ] Add unit tests for `Store`