### PR TITLE
[v0.9] Reduce BundleDeployment triggering on deployed resources updates

### DIFF
--- a/.github/scripts/run-integration-tests.sh
+++ b/.github/scripts/run-integration-tests.sh
@@ -2,8 +2,8 @@
 
 set -euxo pipefail
 
-SETUP_ENVTEST_VER=${SETUP_ENVTEST_VER-v0.0.0-20221214170741-69f093833822}
-ENVTEST_K8S_VERSION=${ENVTEST_K8S_VERSION-1.25}
+SETUP_ENVTEST_VER=${SETUP_ENVTEST_VER-v0.0.0-20240115093953-9e6e3b144a69}
+ENVTEST_K8S_VERSION=${ENVTEST_K8S_VERSION-1.28}
 
 # install and prepare setup-envtest
 if ! command -v setup-envtest &> /dev/null
@@ -14,4 +14,4 @@ KUBEBUILDER_ASSETS=$(setup-envtest use --use-env -p path $ENVTEST_K8S_VERSION)
 export KUBEBUILDER_ASSETS
 
 # run integration tests
-go test ./integrationtests/...
+go test ./integrationtests/agent/...

--- a/integrationtests/agent/suite_test.go
+++ b/integrationtests/agent/suite_test.go
@@ -83,7 +83,13 @@ var _ = BeforeSuite(func() {
 	Expect(k8sClient).NotTo(BeNil())
 
 	specEnvs = make(map[string]*specEnv, 2)
-	for id, f := range map[string]specResources{"capabilitybundle": capabilityBundleResources, "orphanbundle": orphanBundeResources} {
+	for id, f := range map[string]specResources{
+		"capabilitybundle": capabilityBundleResources,
+		"orphanbundle":     orphanBundeResources,
+		"watchertrigger": func() map[string][]v1alpha1.BundleResource {
+			return nil
+		},
+	} {
 		namespace, err := utils.NewNamespaceName()
 		Expect(err).ToNot(HaveOccurred())
 		fmt.Printf("Creating namespace %s\n", namespace)

--- a/integrationtests/agent/watcher_trigger_test.go
+++ b/integrationtests/agent/watcher_trigger_test.go
@@ -178,7 +178,7 @@ var _ = Describe("Watches for deployed resources", Ordered, func() {
 				return *triggerCount
 			}).Should(Equal(0))
 		})
-		It("is triggered Spec is changed", func() {
+		It("is triggered on Spec changes", func() {
 			deploy.Spec.Paused = true
 			for i := 1; i <= 5; i++ {
 				deploy.Spec.Replicas = pointer.Int32(int32(i))

--- a/integrationtests/agent/watcher_trigger_test.go
+++ b/integrationtests/agent/watcher_trigger_test.go
@@ -1,0 +1,194 @@
+package agent
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/utils/pointer"
+
+	"github.com/rancher/fleet/internal/cmd/agent/trigger"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("Watches for deployed resources", Ordered, func() {
+
+	var (
+		env    *specEnv
+		triggr *trigger.Trigger
+	)
+
+	BeforeAll(func() {
+		env = specEnvs["watchertrigger"]
+		triggr = trigger.New(ctx, env.k8sClient.RESTMapper(), dynamic.NewForConfigOrDie(cfg))
+		DeferCleanup(func() {
+			Expect(k8sClient.Delete(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: env.namespace}})).ToNot(HaveOccurred())
+		})
+	})
+
+	registerResource := func(key string, objs ...runtime.Object) *int {
+		_ = triggr.Clear(key)
+		var count int
+		Expect(triggr.OnChange(key, env.namespace, func() {
+			count++
+		}, objs...)).ToNot(HaveOccurred())
+		return &count
+	}
+
+	When("watching a deployed configmap", Ordered, func() {
+		createConfigMap := func() *corev1.ConfigMap {
+			cm := corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "test-cm-",
+					Namespace:    env.namespace,
+				},
+			}
+
+			err := env.k8sClient.Create(ctx, &cm)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(cm.UID).ToNot(BeEmpty())
+			return &cm
+		}
+
+		var triggerCount *int
+		var cm *corev1.ConfigMap
+		BeforeEach(func() {
+			cm = createConfigMap()
+			triggerCount = registerResource(env.namespace+"/test-configmap", cm)
+			DeferCleanup(func() {
+				Expect(
+					client.IgnoreNotFound(env.k8sClient.Delete(ctx, cm))).
+					NotTo(HaveOccurred())
+			})
+		})
+		It("is not initially triggered", func() {
+			Consistently(func() int {
+				return *triggerCount
+			}).Should(Equal(0))
+		})
+		It("is triggered on deletion", func() {
+			Expect(env.k8sClient.Delete(ctx, cm)).ToNot(HaveOccurred())
+			Eventually(func() int {
+				return *triggerCount
+			}).WithPolling(100 * time.Millisecond).MustPassRepeatedly(3).
+				Should(Equal(1))
+		})
+		It("is always triggered when modified", func() {
+			cm.Data = map[string]string{"foo": "bar"}
+			Expect(env.k8sClient.Update(ctx, cm)).ToNot(HaveOccurred())
+			Eventually(func() int {
+				return *triggerCount
+			}).WithPolling(100 * time.Millisecond).MustPassRepeatedly(3).
+				Should(Equal(1))
+
+			cm.Data = map[string]string{"bar": "baz"}
+			Expect(env.k8sClient.Update(ctx, cm)).ToNot(HaveOccurred())
+			Eventually(func() int {
+				return *triggerCount
+			}).WithPolling(100 * time.Millisecond).MustPassRepeatedly(3).
+				Should(Equal(2))
+		})
+	})
+	When("watching a deployed deployment", Ordered, func() {
+		createDeployment := func() *appsv1.Deployment {
+			deploy := appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "test-deploy-",
+					Namespace:    env.namespace,
+					Generation:   1,
+				},
+				Spec: appsv1.DeploymentSpec{
+					Replicas: pointer.Int32(0),
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"app": "test",
+						},
+					},
+					Paused: true,
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{
+								"app": "test",
+							},
+						},
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name:  "test",
+									Image: "test-image",
+								},
+							},
+						},
+					},
+				},
+			}
+
+			err := env.k8sClient.Create(ctx, &deploy)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(deploy.UID).ToNot(BeEmpty())
+			// envtest does not return a complete object, which is needed for the trigger to work
+			deploy.TypeMeta = metav1.TypeMeta{
+				Kind:       "Deployment",
+				APIVersion: "apps/v1",
+			}
+			return &deploy
+		}
+		var triggerCount *int
+		var deploy *appsv1.Deployment
+
+		BeforeEach(func() {
+			deploy = createDeployment()
+			triggerCount = registerResource(env.namespace+"/test-deploy", deploy)
+			DeferCleanup(func() {
+				Expect(
+					client.IgnoreNotFound(env.k8sClient.Delete(ctx, deploy))).
+					NotTo(HaveOccurred())
+			})
+		})
+		It("is not initially triggered", func() {
+			Consistently(func() int {
+				return *triggerCount
+			}).Should(Equal(0))
+		})
+		It("is triggered on deletion", func() {
+			Expect(env.k8sClient.Delete(ctx, deploy)).ToNot(HaveOccurred())
+			Eventually(func() int {
+				return *triggerCount
+			}).WithPolling(100 * time.Millisecond).MustPassRepeatedly(3).
+				Should(Equal(1))
+		})
+		It("is not triggered on status updates", func() {
+			deploy.Status.Conditions = []appsv1.DeploymentCondition{
+				{
+					Type:               appsv1.DeploymentAvailable,
+					Status:             corev1.ConditionFalse,
+					LastUpdateTime:     metav1.Now(),
+					LastTransitionTime: metav1.Now(),
+					Message:            "tests",
+					Reason:             "tests",
+				},
+			}
+			Expect(env.k8sClient.Status().Update(ctx, deploy)).ToNot(HaveOccurred())
+			Consistently(func() int {
+				return *triggerCount
+			}).Should(Equal(0))
+		})
+		It("is triggered Spec is changed", func() {
+			deploy.Spec.Paused = true
+			for i := 1; i <= 5; i++ {
+				deploy.Spec.Replicas = pointer.Int32(int32(i))
+				Expect(env.k8sClient.Update(ctx, deploy)).ToNot(HaveOccurred())
+				Eventually(func() int {
+					return *triggerCount
+				}).WithPolling(100 * time.Millisecond).MustPassRepeatedly(3).
+					Should(Equal(i))
+			}
+		})
+	})
+})

--- a/integrationtests/agent/watcher_trigger_test.go
+++ b/integrationtests/agent/watcher_trigger_test.go
@@ -33,7 +33,6 @@ var _ = Describe("Watches for deployed resources", Ordered, func() {
 	})
 
 	registerResource := func(key string, objs ...runtime.Object) *int {
-		_ = triggr.Clear(key)
 		var count int
 		Expect(triggr.OnChange(key, env.namespace, func() {
 			count++

--- a/integrationtests/agent/watcher_trigger_test.go
+++ b/integrationtests/agent/watcher_trigger_test.go
@@ -179,7 +179,6 @@ var _ = Describe("Watches for deployed resources", Ordered, func() {
 			}).Should(Equal(0))
 		})
 		It("is triggered on Spec changes", func() {
-			deploy.Spec.Paused = true
 			for i := 1; i <= 5; i++ {
 				deploy.Spec.Replicas = pointer.Int32(int32(i))
 				Expect(env.k8sClient.Update(ctx, deploy)).ToNot(HaveOccurred())

--- a/internal/cmd/agent/trigger/watcher.go
+++ b/internal/cmd/agent/trigger/watcher.go
@@ -4,9 +4,6 @@ package trigger
 import (
 	"context"
 	"sync"
-	"time"
-
-	"github.com/rancher/fleet/pkg/durations"
 
 	"github.com/rancher/wrangler/v2/pkg/objectset"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -186,7 +183,6 @@ func (w *watcher) Start(ctx context.Context) {
 		}
 		w.Unlock()
 
-		time.Sleep(durations.TriggerSleep)
 		resp, err := w.client.Resource(w.gvr).Watch(ctx, metav1.ListOptions{
 			AllowWatchBookmarks: true,
 			ResourceVersion:     resourceVersion,

--- a/internal/cmd/agent/trigger/watcher.go
+++ b/internal/cmd/agent/trigger/watcher.go
@@ -132,11 +132,10 @@ func (t *Trigger) OnChange(key string, defaultNamespace string, trigger func(), 
 	return nil
 }
 
-func (t *Trigger) storeObjectGeneration(uid types.UID, generation int64) *atomic.Int64 {
+func (t *Trigger) storeObjectGeneration(uid types.UID, generation int64) {
 	value := new(atomic.Int64)
 	value.Store(generation)
 	t.seenGenerations.Store(uid, value)
-	return value
 }
 
 func (t *Trigger) call(gvk schema.GroupVersionKind, obj metav1.Object, deleted bool) {

--- a/internal/cmd/agent/trigger/watcher.go
+++ b/internal/cmd/agent/trigger/watcher.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/rancher/wrangler/v2/pkg/objectset"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -13,6 +14,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/dynamic"
+
+	"github.com/rancher/fleet/pkg/durations"
 )
 
 type Trigger struct {
@@ -225,6 +228,7 @@ func (w *watcher) Start(ctx context.Context) {
 		})
 		if err != nil {
 			resourceVersion = ""
+			time.Sleep(durations.WatchErrorRetrySleep)
 			continue
 		}
 

--- a/internal/cmd/agent/trigger/watcher.go
+++ b/internal/cmd/agent/trigger/watcher.go
@@ -210,7 +210,8 @@ func (w *watcher) Start(ctx context.Context) {
 			resourceVersion = obj.GetResourceVersion()
 
 			switch event.Type {
-			case watch.Added, watch.Modified, watch.Deleted:
+			// Only trigger for Modified or Deleted objects, ignore the rest
+			case watch.Modified, watch.Deleted:
 				w.t.call(w.gvk, obj)
 			}
 		}

--- a/pkg/durations/durations.go
+++ b/pkg/durations/durations.go
@@ -24,6 +24,7 @@ const (
 	RestConfigTimeout              = time.Second * 15
 	ServiceTokenSleep              = time.Second * 2
 	TokenClusterEnqueueDelay       = time.Second * 2
+	WatchErrorRetrySleep           = time.Second * 2
 	DefaultCpuPprofPeriod          = time.Minute
 	ReleaseCacheTTL                = time.Minute * 5
 )

--- a/pkg/durations/durations.go
+++ b/pkg/durations/durations.go
@@ -24,7 +24,6 @@ const (
 	RestConfigTimeout              = time.Second * 15
 	ServiceTokenSleep              = time.Second * 2
 	TokenClusterEnqueueDelay       = time.Second * 2
-	TriggerSleep                   = time.Second * 2
 	DefaultCpuPprofPeriod          = time.Minute
 	ReleaseCacheTTL                = time.Minute * 5
 )


### PR DESCRIPTION
<!-- Specify the issue ID that this pull request is solving -->
Refers to #2058

These changes aim for reducing the number of time that the BundleDeployment reconciler is executed. This happens due to the Fleet Agent configuring a watcher on every deployed resources, which will trigger a requeue of the BundleDeployment handler in the agent for every watch event. Since this handler refreshes the conditions timestamp in the BundleDeployment status, this has a direct effect on the Fleet controller as well, which will react to the update in the BundleDeployment object.

This patch consists of the following changes:
 - The `TriggerSleep` delay has been removed, since it could cause modification events happening in that time window to be missed (this was the case for the integration tests). This is connected to the next change:
 - `ADDED` watch events are now ignored:
   - The informer creates an initial `ADDED` event for every object, but this does not make sense for objects that were just created. 
   - The only interesting events are `MODIFIED` and `DELETED`, which are the ultimate interest of the trigger (detecting modified or deleted resources). If an object is deleted and later created by the user, the controller may still need to redeploy in order to achieve a stable situation.
- Filters modified events based on `Generation` field, for those kinds that make use of it.
  - Kinds that do not implement this metadata field (e.g. ConfigMaps) will keep the existing behavior.
  - Resources that set the `Generation` field will be checked: based on their UID, if `Generation` didn't change from a previous event, it will be interpreted as the spec didn't change, so will skip the trigger, effectively omitting status updates.

<!--
  Please provide a unit, integration (`./integrationtests/`) or e2e (`./e2e/`) test if possible.
-->