### PR TITLE
Limit configmap cache&watch

### DIFF
--- a/internal/cmd/controller/reconciler/config_controller.go
+++ b/internal/cmd/controller/reconciler/config_controller.go
@@ -70,7 +70,6 @@ func (r *ConfigReconciler) Reconcile(ctx context.Context, _ ctrl.Request) (ctrl.
 // SetupWithManager sets up the controller with the Manager.
 func (r *ConfigReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		// TODO Maybe we can limit this Watch to the system namespace?
 		For(&corev1.ConfigMap{}).
 		WithEventFilter(
 			// we do not trigger for status changes


### PR DESCRIPTION
Refers to #2018 

TODO
* this seems to limit `Get` for configmaps, too. Fails when gitrepo reconciler tries to `CreateOrUpdate` the `target.yaml` configmap
* `DefaultNamespaces` doesn't seem to work for : `"unable to list: test-7af124d because of unknown namespace for the cache"`

Opened: https://github.com/kubernetes-sigs/controller-runtime/issues/2628
