### PR TITLE
dev-scripts: Change apiServerURL for setup-fleet-downstream

### DIFF
--- a/dev/setup-fleet-downstream
+++ b/dev/setup-fleet-downstream
@@ -54,13 +54,16 @@ else
 fi
 
 # docker network inspect bridge -f '{{(index .IPAM.Config 0).Gateway}}'
-public_hostname="${public_hostname-172.17.0.1.omg.howdoi.website}"
+# public_hostname="${public_hostname-172.17.0.1.omg.howdoi.website}"
+
+# works due to same network of k3d clustres and patched SAN cert
+public_hostname="${public_hostname-k3d-upstream-server-0}"
 
 kubectl config use-context "$downstream_ctx"
 helm -n cattle-fleet-system upgrade --install --create-namespace --wait fleet-agent charts/fleet-agent \
   --set-string labels.env=test \
   --set apiServerCA="$ca" \
-  --set apiServerURL="https://$public_hostname:36443" \
+  --set apiServerURL="https://$public_hostname:6443" \
   --set clusterNamespace="$ns" \
   --set token="$token"
   #--set systemRegistrationNamespace="fleet-clusters-system" \

--- a/dev/setup-k3ds
+++ b/dev/setup-k3ds
@@ -22,7 +22,7 @@ fi
 # https://hub.docker.com/r/rancher/k3s/tags
 #args="$args -i docker.io/rancher/k3s:v1.22.15-k3s1"
 
-k3d cluster create upstream --servers 3 --api-port 36443 -p '80:80@server:0' -p '443:443@server:0' $args
+k3d cluster create upstream --servers 3 --api-port 36443 -p '80:80@server:0' -p '443:443@server:0' --k3s-arg '--tls-san=k3d-upstream-server-0@server:0' $args
 k3d cluster create downstream --servers 1 --api-port 36444 -p '5080:80@server:0' -p '3444:443@server:0' $args
 #k3d cluster create downstream2 --servers 1 --api-port 36445 -p '6080:80@server:0' -p '3445:443@server:0' $args
 #k3d cluster create downstream3 --servers 1 --api-port 36446 -p '7080:80@server:0' -p '3446:443@server:0' $args


### PR DESCRIPTION
The dev scripts failed to work on a customized setup of docker where `/etc/docker/daemon.json` contains the following JSON to prevent conflicts on the host with a different configuration.

```json
{
  "bip": "172.26.0.1/16",
  "default-address-pools": [
    {
      "base": "172.27.0.0/16",
      "size": 24
    },
    {
      "base": "172.28.0.0/16",
      "size": 24
    },
    {
      "base": "172.29.0.0/16",
      "size": 24
    },
    {
      "base": "172.30.0.0/16",
      "size": 24
    },
    {
      "base": "172.31.0.0/16",
      "size": 24
    },
    {
      "base": "172.32.0.0/16",
      "size": 24
    }
  ]
}
```

The update makes the certificate usable for the internal DNS name of the upstream cluster. The `apiServerURL` is then configured to talk to the upstream server directly rather than through the bridge of the host.

<!-- Specify the issue ID that this pull request is solving -->
Refers to #XXX
<!-- Make sure that the referenced issue provides steps to reproduce it -->

<!-- Describe the changes introduced by this pull request -->

<!--
  Please provide a unit, integration (`./integrationtests/`) or e2e (`./e2e/`) test if possible.
-->