### PR TITLE
[v0.8] Use UniqueApplyForResourceVersion in Bundle and GitRepo GeneratingHandlers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -53,7 +53,7 @@ require (
 	github.com/rancher/fleet/pkg/apis v0.0.0
 	github.com/rancher/gitjob v0.1.36
 	github.com/rancher/lasso v0.0.0-20221227210133-6ea88ca2fbcc
-	github.com/rancher/wrangler v1.1.1
+	github.com/rancher/wrangler v1.1.2
 	github.com/rancher/wrangler-cli v0.0.0-20220624114648-479c5692ba22
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -831,8 +831,8 @@ github.com/rancher/helm/v3 v3.11.1-rancher1 h1:mZnVc7MXTUW8u2+PgKEQkiXXZyAHcdNID
 github.com/rancher/helm/v3 v3.11.1-rancher1/go.mod h1:z/Bu/BylToGno/6dtNGuSmjRqxKq5gaH+FU0BPO+AQ8=
 github.com/rancher/lasso v0.0.0-20221227210133-6ea88ca2fbcc h1:29VHrInLV4qSevvcvhBj5UhQWkPShxrxv4AahYg2Scw=
 github.com/rancher/lasso v0.0.0-20221227210133-6ea88ca2fbcc/go.mod h1:dEfC9eFQigj95lv/JQ8K5e7+qQCacWs1aIA6nLxKzT8=
-github.com/rancher/wrangler v1.1.1 h1:wmqUwqc2M7ADfXnBCJTFkTB5ZREWpD78rnZMzmxwMvM=
-github.com/rancher/wrangler v1.1.1/go.mod h1:ioVbKupzcBOdzsl55MvEDN0R1wdGggj8iNCYGFI5JvM=
+github.com/rancher/wrangler v1.1.2 h1:oXbXo9k7y/H4drUpb4RM1c++vT9O3rpoNEfyusGykiU=
+github.com/rancher/wrangler v1.1.2/go.mod h1:2k9MyhlBdjcutcBGoOJSUAz0HgDAXnMjv81d3n/AaQc=
 github.com/rancher/wrangler-cli v0.0.0-20220624114648-479c5692ba22 h1:ADMwgJyVwmLXJBSm/nNobB1XGSmFCTA+TY/otxgIPu4=
 github.com/rancher/wrangler-cli v0.0.0-20220624114648-479c5692ba22/go.mod h1:vyO9SU60oplNFa5ZqoEAFWmYKgj2F6remdy8p6H0SgI=
 github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=

--- a/internal/cmd/controller/controllers/bundle/controller.go
+++ b/internal/cmd/controller/controllers/bundle/controller.go
@@ -70,7 +70,8 @@ func Register(ctx context.Context,
 		"bundle",
 		h.OnBundleChange,
 		&generic.GeneratingHandlerOptions{
-			AllowClusterScoped: true,
+			AllowClusterScoped:            true,
+			UniqueApplyForResourceVersion: true,
 		})
 
 	relatedresource.Watch(ctx, "app", h.resolveBundle, bundles, bundleDeployments)

--- a/internal/cmd/controller/controllers/git/git.go
+++ b/internal/cmd/controller/controllers/git/git.go
@@ -24,6 +24,7 @@ import (
 	v1 "github.com/rancher/gitjob/pkg/generated/controllers/gitjob.cattle.io/v1"
 	"github.com/rancher/wrangler/pkg/apply"
 	corev1controller "github.com/rancher/wrangler/pkg/generated/controllers/core/v1"
+	"github.com/rancher/wrangler/pkg/generic"
 	"github.com/rancher/wrangler/pkg/genericcondition"
 	"github.com/rancher/wrangler/pkg/kv"
 	"github.com/rancher/wrangler/pkg/name"
@@ -64,7 +65,15 @@ func Register(ctx context.Context,
 
 	gitRepos.OnChange(ctx, "gitjob-purge", h.DeleteOnChange)
 	// this will update the lastUpdateTime of the Accepted condition
-	fleetcontrollers.RegisterGitRepoGeneratingHandler(ctx, gitRepos, apply, "Accepted", "gitjobs", h.OnChange, nil)
+	fleetcontrollers.RegisterGitRepoGeneratingHandler(
+		ctx,
+		gitRepos,
+		apply,
+		"Accepted",
+		"gitjobs",
+		h.OnChange,
+		&generic.GeneratingHandlerOptions{UniqueApplyForResourceVersion: true},
+	)
 	// enqueue gitrepo when gitjob changes
 	relatedresource.Watch(ctx, "gitjobs",
 		relatedresource.OwnerResolver(true, fleet.SchemeGroupVersion.String(), "GitRepo"), gitRepos, gitJobs)

--- a/pkg/generated/controllers/fleet.cattle.io/v1alpha1/bundle.go
+++ b/pkg/generated/controllers/fleet.cattle.io/v1alpha1/bundle.go
@@ -20,6 +20,7 @@ package v1alpha1
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	v1alpha1 "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
@@ -263,10 +264,14 @@ func (c *bundleCache) GetByIndex(indexName, key string) (result []*v1alpha1.Bund
 	return result, nil
 }
 
+// BundleStatusHandler is executed for every added or modified Bundle. Should return the new status to be updated
 type BundleStatusHandler func(obj *v1alpha1.Bundle, status v1alpha1.BundleStatus) (v1alpha1.BundleStatus, error)
 
+// BundleGeneratingHandler is the top-level handler that is executed for every Bundle event. It extends BundleStatusHandler by a returning a slice of child objects to be passed to apply.Apply
 type BundleGeneratingHandler func(obj *v1alpha1.Bundle, status v1alpha1.BundleStatus) ([]runtime.Object, v1alpha1.BundleStatus, error)
 
+// RegisterBundleStatusHandler configures a BundleController to execute a BundleStatusHandler for every events observed.
+// If a non-empty condition is provided, it will be updated in the status conditions for every handler execution
 func RegisterBundleStatusHandler(ctx context.Context, controller BundleController, condition condition.Cond, name string, handler BundleStatusHandler) {
 	statusHandler := &bundleStatusHandler{
 		client:    controller,
@@ -276,6 +281,8 @@ func RegisterBundleStatusHandler(ctx context.Context, controller BundleControlle
 	controller.AddGenericHandler(ctx, name, FromBundleHandlerToHandler(statusHandler.sync))
 }
 
+// RegisterBundleGeneratingHandler configures a BundleController to execute a BundleGeneratingHandler for every events observed, passing the returned objects to the provided apply.Apply.
+// If a non-empty condition is provided, it will be updated in the status conditions for every handler execution
 func RegisterBundleGeneratingHandler(ctx context.Context, controller BundleController, apply apply.Apply,
 	condition condition.Cond, name string, handler BundleGeneratingHandler, opts *generic.GeneratingHandlerOptions) {
 	statusHandler := &bundleGeneratingHandler{
@@ -297,6 +304,7 @@ type bundleStatusHandler struct {
 	handler   BundleStatusHandler
 }
 
+// sync is executed on every resource addition or modification. Executes the configured handlers and sends the updated status to the Kubernetes API
 func (a *bundleStatusHandler) sync(key string, obj *v1alpha1.Bundle) (*v1alpha1.Bundle, error) {
 	if obj == nil {
 		return obj, nil
@@ -342,8 +350,10 @@ type bundleGeneratingHandler struct {
 	opts  generic.GeneratingHandlerOptions
 	gvk   schema.GroupVersionKind
 	name  string
+	seen  sync.Map
 }
 
+// Remove handles the observed deletion of a resource, cascade deleting every associated resource previously applied
 func (a *bundleGeneratingHandler) Remove(key string, obj *v1alpha1.Bundle) (*v1alpha1.Bundle, error) {
 	if obj != nil {
 		return obj, nil
@@ -353,12 +363,17 @@ func (a *bundleGeneratingHandler) Remove(key string, obj *v1alpha1.Bundle) (*v1a
 	obj.Namespace, obj.Name = kv.RSplit(key, "/")
 	obj.SetGroupVersionKind(a.gvk)
 
+	if a.opts.UniqueApplyForResourceVersion {
+		a.seen.Delete(key)
+	}
+
 	return nil, generic.ConfigureApplyForObject(a.apply, obj, &a.opts).
 		WithOwner(obj).
 		WithSetID(a.name).
 		ApplyObjects()
 }
 
+// Handle executes the configured BundleGeneratingHandler and pass the resulting objects to apply.Apply, finally returning the new status of the resource
 func (a *bundleGeneratingHandler) Handle(obj *v1alpha1.Bundle, status v1alpha1.BundleStatus) (v1alpha1.BundleStatus, error) {
 	if !obj.DeletionTimestamp.IsZero() {
 		return status, nil
@@ -368,9 +383,41 @@ func (a *bundleGeneratingHandler) Handle(obj *v1alpha1.Bundle, status v1alpha1.B
 	if err != nil {
 		return newStatus, err
 	}
+	if !a.isNewResourceVersion(obj) {
+		return newStatus, nil
+	}
 
-	return newStatus, generic.ConfigureApplyForObject(a.apply, obj, &a.opts).
+	err = generic.ConfigureApplyForObject(a.apply, obj, &a.opts).
 		WithOwner(obj).
 		WithSetID(a.name).
 		ApplyObjects(objs...)
+	if err != nil {
+		return newStatus, err
+	}
+	a.storeResourceVersion(obj)
+	return newStatus, nil
+}
+
+// isNewResourceVersion detects if a specific resource version was already successfully processed.
+// Only used if UniqueApplyForResourceVersion is set in generic.GeneratingHandlerOptions
+func (a *bundleGeneratingHandler) isNewResourceVersion(obj *v1alpha1.Bundle) bool {
+	if !a.opts.UniqueApplyForResourceVersion {
+		return true
+	}
+
+	// Apply once per resource version
+	key := obj.Namespace + "/" + obj.Name
+	previous, ok := a.seen.Load(key)
+	return !ok || previous != obj.ResourceVersion
+}
+
+// storeResourceVersion keeps track of the latest resource version of an object for which Apply was executed
+// Only used if UniqueApplyForResourceVersion is set in generic.GeneratingHandlerOptions
+func (a *bundleGeneratingHandler) storeResourceVersion(obj *v1alpha1.Bundle) {
+	if !a.opts.UniqueApplyForResourceVersion {
+		return
+	}
+
+	key := obj.Namespace + "/" + obj.Name
+	a.seen.Store(key, obj.ResourceVersion)
 }

--- a/pkg/generated/controllers/fleet.cattle.io/v1alpha1/bundledeployment.go
+++ b/pkg/generated/controllers/fleet.cattle.io/v1alpha1/bundledeployment.go
@@ -20,6 +20,7 @@ package v1alpha1
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	v1alpha1 "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
@@ -263,10 +264,14 @@ func (c *bundleDeploymentCache) GetByIndex(indexName, key string) (result []*v1a
 	return result, nil
 }
 
+// BundleDeploymentStatusHandler is executed for every added or modified BundleDeployment. Should return the new status to be updated
 type BundleDeploymentStatusHandler func(obj *v1alpha1.BundleDeployment, status v1alpha1.BundleDeploymentStatus) (v1alpha1.BundleDeploymentStatus, error)
 
+// BundleDeploymentGeneratingHandler is the top-level handler that is executed for every BundleDeployment event. It extends BundleDeploymentStatusHandler by a returning a slice of child objects to be passed to apply.Apply
 type BundleDeploymentGeneratingHandler func(obj *v1alpha1.BundleDeployment, status v1alpha1.BundleDeploymentStatus) ([]runtime.Object, v1alpha1.BundleDeploymentStatus, error)
 
+// RegisterBundleDeploymentStatusHandler configures a BundleDeploymentController to execute a BundleDeploymentStatusHandler for every events observed.
+// If a non-empty condition is provided, it will be updated in the status conditions for every handler execution
 func RegisterBundleDeploymentStatusHandler(ctx context.Context, controller BundleDeploymentController, condition condition.Cond, name string, handler BundleDeploymentStatusHandler) {
 	statusHandler := &bundleDeploymentStatusHandler{
 		client:    controller,
@@ -276,6 +281,8 @@ func RegisterBundleDeploymentStatusHandler(ctx context.Context, controller Bundl
 	controller.AddGenericHandler(ctx, name, FromBundleDeploymentHandlerToHandler(statusHandler.sync))
 }
 
+// RegisterBundleDeploymentGeneratingHandler configures a BundleDeploymentController to execute a BundleDeploymentGeneratingHandler for every events observed, passing the returned objects to the provided apply.Apply.
+// If a non-empty condition is provided, it will be updated in the status conditions for every handler execution
 func RegisterBundleDeploymentGeneratingHandler(ctx context.Context, controller BundleDeploymentController, apply apply.Apply,
 	condition condition.Cond, name string, handler BundleDeploymentGeneratingHandler, opts *generic.GeneratingHandlerOptions) {
 	statusHandler := &bundleDeploymentGeneratingHandler{
@@ -297,6 +304,7 @@ type bundleDeploymentStatusHandler struct {
 	handler   BundleDeploymentStatusHandler
 }
 
+// sync is executed on every resource addition or modification. Executes the configured handlers and sends the updated status to the Kubernetes API
 func (a *bundleDeploymentStatusHandler) sync(key string, obj *v1alpha1.BundleDeployment) (*v1alpha1.BundleDeployment, error) {
 	if obj == nil {
 		return obj, nil
@@ -342,8 +350,10 @@ type bundleDeploymentGeneratingHandler struct {
 	opts  generic.GeneratingHandlerOptions
 	gvk   schema.GroupVersionKind
 	name  string
+	seen  sync.Map
 }
 
+// Remove handles the observed deletion of a resource, cascade deleting every associated resource previously applied
 func (a *bundleDeploymentGeneratingHandler) Remove(key string, obj *v1alpha1.BundleDeployment) (*v1alpha1.BundleDeployment, error) {
 	if obj != nil {
 		return obj, nil
@@ -353,12 +363,17 @@ func (a *bundleDeploymentGeneratingHandler) Remove(key string, obj *v1alpha1.Bun
 	obj.Namespace, obj.Name = kv.RSplit(key, "/")
 	obj.SetGroupVersionKind(a.gvk)
 
+	if a.opts.UniqueApplyForResourceVersion {
+		a.seen.Delete(key)
+	}
+
 	return nil, generic.ConfigureApplyForObject(a.apply, obj, &a.opts).
 		WithOwner(obj).
 		WithSetID(a.name).
 		ApplyObjects()
 }
 
+// Handle executes the configured BundleDeploymentGeneratingHandler and pass the resulting objects to apply.Apply, finally returning the new status of the resource
 func (a *bundleDeploymentGeneratingHandler) Handle(obj *v1alpha1.BundleDeployment, status v1alpha1.BundleDeploymentStatus) (v1alpha1.BundleDeploymentStatus, error) {
 	if !obj.DeletionTimestamp.IsZero() {
 		return status, nil
@@ -368,9 +383,41 @@ func (a *bundleDeploymentGeneratingHandler) Handle(obj *v1alpha1.BundleDeploymen
 	if err != nil {
 		return newStatus, err
 	}
+	if !a.isNewResourceVersion(obj) {
+		return newStatus, nil
+	}
 
-	return newStatus, generic.ConfigureApplyForObject(a.apply, obj, &a.opts).
+	err = generic.ConfigureApplyForObject(a.apply, obj, &a.opts).
 		WithOwner(obj).
 		WithSetID(a.name).
 		ApplyObjects(objs...)
+	if err != nil {
+		return newStatus, err
+	}
+	a.storeResourceVersion(obj)
+	return newStatus, nil
+}
+
+// isNewResourceVersion detects if a specific resource version was already successfully processed.
+// Only used if UniqueApplyForResourceVersion is set in generic.GeneratingHandlerOptions
+func (a *bundleDeploymentGeneratingHandler) isNewResourceVersion(obj *v1alpha1.BundleDeployment) bool {
+	if !a.opts.UniqueApplyForResourceVersion {
+		return true
+	}
+
+	// Apply once per resource version
+	key := obj.Namespace + "/" + obj.Name
+	previous, ok := a.seen.Load(key)
+	return !ok || previous != obj.ResourceVersion
+}
+
+// storeResourceVersion keeps track of the latest resource version of an object for which Apply was executed
+// Only used if UniqueApplyForResourceVersion is set in generic.GeneratingHandlerOptions
+func (a *bundleDeploymentGeneratingHandler) storeResourceVersion(obj *v1alpha1.BundleDeployment) {
+	if !a.opts.UniqueApplyForResourceVersion {
+		return
+	}
+
+	key := obj.Namespace + "/" + obj.Name
+	a.seen.Store(key, obj.ResourceVersion)
 }

--- a/pkg/generated/controllers/fleet.cattle.io/v1alpha1/cluster.go
+++ b/pkg/generated/controllers/fleet.cattle.io/v1alpha1/cluster.go
@@ -20,6 +20,7 @@ package v1alpha1
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	v1alpha1 "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
@@ -263,10 +264,14 @@ func (c *clusterCache) GetByIndex(indexName, key string) (result []*v1alpha1.Clu
 	return result, nil
 }
 
+// ClusterStatusHandler is executed for every added or modified Cluster. Should return the new status to be updated
 type ClusterStatusHandler func(obj *v1alpha1.Cluster, status v1alpha1.ClusterStatus) (v1alpha1.ClusterStatus, error)
 
+// ClusterGeneratingHandler is the top-level handler that is executed for every Cluster event. It extends ClusterStatusHandler by a returning a slice of child objects to be passed to apply.Apply
 type ClusterGeneratingHandler func(obj *v1alpha1.Cluster, status v1alpha1.ClusterStatus) ([]runtime.Object, v1alpha1.ClusterStatus, error)
 
+// RegisterClusterStatusHandler configures a ClusterController to execute a ClusterStatusHandler for every events observed.
+// If a non-empty condition is provided, it will be updated in the status conditions for every handler execution
 func RegisterClusterStatusHandler(ctx context.Context, controller ClusterController, condition condition.Cond, name string, handler ClusterStatusHandler) {
 	statusHandler := &clusterStatusHandler{
 		client:    controller,
@@ -276,6 +281,8 @@ func RegisterClusterStatusHandler(ctx context.Context, controller ClusterControl
 	controller.AddGenericHandler(ctx, name, FromClusterHandlerToHandler(statusHandler.sync))
 }
 
+// RegisterClusterGeneratingHandler configures a ClusterController to execute a ClusterGeneratingHandler for every events observed, passing the returned objects to the provided apply.Apply.
+// If a non-empty condition is provided, it will be updated in the status conditions for every handler execution
 func RegisterClusterGeneratingHandler(ctx context.Context, controller ClusterController, apply apply.Apply,
 	condition condition.Cond, name string, handler ClusterGeneratingHandler, opts *generic.GeneratingHandlerOptions) {
 	statusHandler := &clusterGeneratingHandler{
@@ -297,6 +304,7 @@ type clusterStatusHandler struct {
 	handler   ClusterStatusHandler
 }
 
+// sync is executed on every resource addition or modification. Executes the configured handlers and sends the updated status to the Kubernetes API
 func (a *clusterStatusHandler) sync(key string, obj *v1alpha1.Cluster) (*v1alpha1.Cluster, error) {
 	if obj == nil {
 		return obj, nil
@@ -342,8 +350,10 @@ type clusterGeneratingHandler struct {
 	opts  generic.GeneratingHandlerOptions
 	gvk   schema.GroupVersionKind
 	name  string
+	seen  sync.Map
 }
 
+// Remove handles the observed deletion of a resource, cascade deleting every associated resource previously applied
 func (a *clusterGeneratingHandler) Remove(key string, obj *v1alpha1.Cluster) (*v1alpha1.Cluster, error) {
 	if obj != nil {
 		return obj, nil
@@ -353,12 +363,17 @@ func (a *clusterGeneratingHandler) Remove(key string, obj *v1alpha1.Cluster) (*v
 	obj.Namespace, obj.Name = kv.RSplit(key, "/")
 	obj.SetGroupVersionKind(a.gvk)
 
+	if a.opts.UniqueApplyForResourceVersion {
+		a.seen.Delete(key)
+	}
+
 	return nil, generic.ConfigureApplyForObject(a.apply, obj, &a.opts).
 		WithOwner(obj).
 		WithSetID(a.name).
 		ApplyObjects()
 }
 
+// Handle executes the configured ClusterGeneratingHandler and pass the resulting objects to apply.Apply, finally returning the new status of the resource
 func (a *clusterGeneratingHandler) Handle(obj *v1alpha1.Cluster, status v1alpha1.ClusterStatus) (v1alpha1.ClusterStatus, error) {
 	if !obj.DeletionTimestamp.IsZero() {
 		return status, nil
@@ -368,9 +383,41 @@ func (a *clusterGeneratingHandler) Handle(obj *v1alpha1.Cluster, status v1alpha1
 	if err != nil {
 		return newStatus, err
 	}
+	if !a.isNewResourceVersion(obj) {
+		return newStatus, nil
+	}
 
-	return newStatus, generic.ConfigureApplyForObject(a.apply, obj, &a.opts).
+	err = generic.ConfigureApplyForObject(a.apply, obj, &a.opts).
 		WithOwner(obj).
 		WithSetID(a.name).
 		ApplyObjects(objs...)
+	if err != nil {
+		return newStatus, err
+	}
+	a.storeResourceVersion(obj)
+	return newStatus, nil
+}
+
+// isNewResourceVersion detects if a specific resource version was already successfully processed.
+// Only used if UniqueApplyForResourceVersion is set in generic.GeneratingHandlerOptions
+func (a *clusterGeneratingHandler) isNewResourceVersion(obj *v1alpha1.Cluster) bool {
+	if !a.opts.UniqueApplyForResourceVersion {
+		return true
+	}
+
+	// Apply once per resource version
+	key := obj.Namespace + "/" + obj.Name
+	previous, ok := a.seen.Load(key)
+	return !ok || previous != obj.ResourceVersion
+}
+
+// storeResourceVersion keeps track of the latest resource version of an object for which Apply was executed
+// Only used if UniqueApplyForResourceVersion is set in generic.GeneratingHandlerOptions
+func (a *clusterGeneratingHandler) storeResourceVersion(obj *v1alpha1.Cluster) {
+	if !a.opts.UniqueApplyForResourceVersion {
+		return
+	}
+
+	key := obj.Namespace + "/" + obj.Name
+	a.seen.Store(key, obj.ResourceVersion)
 }

--- a/pkg/generated/controllers/fleet.cattle.io/v1alpha1/clustergroup.go
+++ b/pkg/generated/controllers/fleet.cattle.io/v1alpha1/clustergroup.go
@@ -20,6 +20,7 @@ package v1alpha1
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	v1alpha1 "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
@@ -263,10 +264,14 @@ func (c *clusterGroupCache) GetByIndex(indexName, key string) (result []*v1alpha
 	return result, nil
 }
 
+// ClusterGroupStatusHandler is executed for every added or modified ClusterGroup. Should return the new status to be updated
 type ClusterGroupStatusHandler func(obj *v1alpha1.ClusterGroup, status v1alpha1.ClusterGroupStatus) (v1alpha1.ClusterGroupStatus, error)
 
+// ClusterGroupGeneratingHandler is the top-level handler that is executed for every ClusterGroup event. It extends ClusterGroupStatusHandler by a returning a slice of child objects to be passed to apply.Apply
 type ClusterGroupGeneratingHandler func(obj *v1alpha1.ClusterGroup, status v1alpha1.ClusterGroupStatus) ([]runtime.Object, v1alpha1.ClusterGroupStatus, error)
 
+// RegisterClusterGroupStatusHandler configures a ClusterGroupController to execute a ClusterGroupStatusHandler for every events observed.
+// If a non-empty condition is provided, it will be updated in the status conditions for every handler execution
 func RegisterClusterGroupStatusHandler(ctx context.Context, controller ClusterGroupController, condition condition.Cond, name string, handler ClusterGroupStatusHandler) {
 	statusHandler := &clusterGroupStatusHandler{
 		client:    controller,
@@ -276,6 +281,8 @@ func RegisterClusterGroupStatusHandler(ctx context.Context, controller ClusterGr
 	controller.AddGenericHandler(ctx, name, FromClusterGroupHandlerToHandler(statusHandler.sync))
 }
 
+// RegisterClusterGroupGeneratingHandler configures a ClusterGroupController to execute a ClusterGroupGeneratingHandler for every events observed, passing the returned objects to the provided apply.Apply.
+// If a non-empty condition is provided, it will be updated in the status conditions for every handler execution
 func RegisterClusterGroupGeneratingHandler(ctx context.Context, controller ClusterGroupController, apply apply.Apply,
 	condition condition.Cond, name string, handler ClusterGroupGeneratingHandler, opts *generic.GeneratingHandlerOptions) {
 	statusHandler := &clusterGroupGeneratingHandler{
@@ -297,6 +304,7 @@ type clusterGroupStatusHandler struct {
 	handler   ClusterGroupStatusHandler
 }
 
+// sync is executed on every resource addition or modification. Executes the configured handlers and sends the updated status to the Kubernetes API
 func (a *clusterGroupStatusHandler) sync(key string, obj *v1alpha1.ClusterGroup) (*v1alpha1.ClusterGroup, error) {
 	if obj == nil {
 		return obj, nil
@@ -342,8 +350,10 @@ type clusterGroupGeneratingHandler struct {
 	opts  generic.GeneratingHandlerOptions
 	gvk   schema.GroupVersionKind
 	name  string
+	seen  sync.Map
 }
 
+// Remove handles the observed deletion of a resource, cascade deleting every associated resource previously applied
 func (a *clusterGroupGeneratingHandler) Remove(key string, obj *v1alpha1.ClusterGroup) (*v1alpha1.ClusterGroup, error) {
 	if obj != nil {
 		return obj, nil
@@ -353,12 +363,17 @@ func (a *clusterGroupGeneratingHandler) Remove(key string, obj *v1alpha1.Cluster
 	obj.Namespace, obj.Name = kv.RSplit(key, "/")
 	obj.SetGroupVersionKind(a.gvk)
 
+	if a.opts.UniqueApplyForResourceVersion {
+		a.seen.Delete(key)
+	}
+
 	return nil, generic.ConfigureApplyForObject(a.apply, obj, &a.opts).
 		WithOwner(obj).
 		WithSetID(a.name).
 		ApplyObjects()
 }
 
+// Handle executes the configured ClusterGroupGeneratingHandler and pass the resulting objects to apply.Apply, finally returning the new status of the resource
 func (a *clusterGroupGeneratingHandler) Handle(obj *v1alpha1.ClusterGroup, status v1alpha1.ClusterGroupStatus) (v1alpha1.ClusterGroupStatus, error) {
 	if !obj.DeletionTimestamp.IsZero() {
 		return status, nil
@@ -368,9 +383,41 @@ func (a *clusterGroupGeneratingHandler) Handle(obj *v1alpha1.ClusterGroup, statu
 	if err != nil {
 		return newStatus, err
 	}
+	if !a.isNewResourceVersion(obj) {
+		return newStatus, nil
+	}
 
-	return newStatus, generic.ConfigureApplyForObject(a.apply, obj, &a.opts).
+	err = generic.ConfigureApplyForObject(a.apply, obj, &a.opts).
 		WithOwner(obj).
 		WithSetID(a.name).
 		ApplyObjects(objs...)
+	if err != nil {
+		return newStatus, err
+	}
+	a.storeResourceVersion(obj)
+	return newStatus, nil
+}
+
+// isNewResourceVersion detects if a specific resource version was already successfully processed.
+// Only used if UniqueApplyForResourceVersion is set in generic.GeneratingHandlerOptions
+func (a *clusterGroupGeneratingHandler) isNewResourceVersion(obj *v1alpha1.ClusterGroup) bool {
+	if !a.opts.UniqueApplyForResourceVersion {
+		return true
+	}
+
+	// Apply once per resource version
+	key := obj.Namespace + "/" + obj.Name
+	previous, ok := a.seen.Load(key)
+	return !ok || previous != obj.ResourceVersion
+}
+
+// storeResourceVersion keeps track of the latest resource version of an object for which Apply was executed
+// Only used if UniqueApplyForResourceVersion is set in generic.GeneratingHandlerOptions
+func (a *clusterGroupGeneratingHandler) storeResourceVersion(obj *v1alpha1.ClusterGroup) {
+	if !a.opts.UniqueApplyForResourceVersion {
+		return
+	}
+
+	key := obj.Namespace + "/" + obj.Name
+	a.seen.Store(key, obj.ResourceVersion)
 }

--- a/pkg/generated/controllers/fleet.cattle.io/v1alpha1/clusterregistration.go
+++ b/pkg/generated/controllers/fleet.cattle.io/v1alpha1/clusterregistration.go
@@ -20,6 +20,7 @@ package v1alpha1
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	v1alpha1 "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
@@ -263,10 +264,14 @@ func (c *clusterRegistrationCache) GetByIndex(indexName, key string) (result []*
 	return result, nil
 }
 
+// ClusterRegistrationStatusHandler is executed for every added or modified ClusterRegistration. Should return the new status to be updated
 type ClusterRegistrationStatusHandler func(obj *v1alpha1.ClusterRegistration, status v1alpha1.ClusterRegistrationStatus) (v1alpha1.ClusterRegistrationStatus, error)
 
+// ClusterRegistrationGeneratingHandler is the top-level handler that is executed for every ClusterRegistration event. It extends ClusterRegistrationStatusHandler by a returning a slice of child objects to be passed to apply.Apply
 type ClusterRegistrationGeneratingHandler func(obj *v1alpha1.ClusterRegistration, status v1alpha1.ClusterRegistrationStatus) ([]runtime.Object, v1alpha1.ClusterRegistrationStatus, error)
 
+// RegisterClusterRegistrationStatusHandler configures a ClusterRegistrationController to execute a ClusterRegistrationStatusHandler for every events observed.
+// If a non-empty condition is provided, it will be updated in the status conditions for every handler execution
 func RegisterClusterRegistrationStatusHandler(ctx context.Context, controller ClusterRegistrationController, condition condition.Cond, name string, handler ClusterRegistrationStatusHandler) {
 	statusHandler := &clusterRegistrationStatusHandler{
 		client:    controller,
@@ -276,6 +281,8 @@ func RegisterClusterRegistrationStatusHandler(ctx context.Context, controller Cl
 	controller.AddGenericHandler(ctx, name, FromClusterRegistrationHandlerToHandler(statusHandler.sync))
 }
 
+// RegisterClusterRegistrationGeneratingHandler configures a ClusterRegistrationController to execute a ClusterRegistrationGeneratingHandler for every events observed, passing the returned objects to the provided apply.Apply.
+// If a non-empty condition is provided, it will be updated in the status conditions for every handler execution
 func RegisterClusterRegistrationGeneratingHandler(ctx context.Context, controller ClusterRegistrationController, apply apply.Apply,
 	condition condition.Cond, name string, handler ClusterRegistrationGeneratingHandler, opts *generic.GeneratingHandlerOptions) {
 	statusHandler := &clusterRegistrationGeneratingHandler{
@@ -297,6 +304,7 @@ type clusterRegistrationStatusHandler struct {
 	handler   ClusterRegistrationStatusHandler
 }
 
+// sync is executed on every resource addition or modification. Executes the configured handlers and sends the updated status to the Kubernetes API
 func (a *clusterRegistrationStatusHandler) sync(key string, obj *v1alpha1.ClusterRegistration) (*v1alpha1.ClusterRegistration, error) {
 	if obj == nil {
 		return obj, nil
@@ -342,8 +350,10 @@ type clusterRegistrationGeneratingHandler struct {
 	opts  generic.GeneratingHandlerOptions
 	gvk   schema.GroupVersionKind
 	name  string
+	seen  sync.Map
 }
 
+// Remove handles the observed deletion of a resource, cascade deleting every associated resource previously applied
 func (a *clusterRegistrationGeneratingHandler) Remove(key string, obj *v1alpha1.ClusterRegistration) (*v1alpha1.ClusterRegistration, error) {
 	if obj != nil {
 		return obj, nil
@@ -353,12 +363,17 @@ func (a *clusterRegistrationGeneratingHandler) Remove(key string, obj *v1alpha1.
 	obj.Namespace, obj.Name = kv.RSplit(key, "/")
 	obj.SetGroupVersionKind(a.gvk)
 
+	if a.opts.UniqueApplyForResourceVersion {
+		a.seen.Delete(key)
+	}
+
 	return nil, generic.ConfigureApplyForObject(a.apply, obj, &a.opts).
 		WithOwner(obj).
 		WithSetID(a.name).
 		ApplyObjects()
 }
 
+// Handle executes the configured ClusterRegistrationGeneratingHandler and pass the resulting objects to apply.Apply, finally returning the new status of the resource
 func (a *clusterRegistrationGeneratingHandler) Handle(obj *v1alpha1.ClusterRegistration, status v1alpha1.ClusterRegistrationStatus) (v1alpha1.ClusterRegistrationStatus, error) {
 	if !obj.DeletionTimestamp.IsZero() {
 		return status, nil
@@ -368,9 +383,41 @@ func (a *clusterRegistrationGeneratingHandler) Handle(obj *v1alpha1.ClusterRegis
 	if err != nil {
 		return newStatus, err
 	}
+	if !a.isNewResourceVersion(obj) {
+		return newStatus, nil
+	}
 
-	return newStatus, generic.ConfigureApplyForObject(a.apply, obj, &a.opts).
+	err = generic.ConfigureApplyForObject(a.apply, obj, &a.opts).
 		WithOwner(obj).
 		WithSetID(a.name).
 		ApplyObjects(objs...)
+	if err != nil {
+		return newStatus, err
+	}
+	a.storeResourceVersion(obj)
+	return newStatus, nil
+}
+
+// isNewResourceVersion detects if a specific resource version was already successfully processed.
+// Only used if UniqueApplyForResourceVersion is set in generic.GeneratingHandlerOptions
+func (a *clusterRegistrationGeneratingHandler) isNewResourceVersion(obj *v1alpha1.ClusterRegistration) bool {
+	if !a.opts.UniqueApplyForResourceVersion {
+		return true
+	}
+
+	// Apply once per resource version
+	key := obj.Namespace + "/" + obj.Name
+	previous, ok := a.seen.Load(key)
+	return !ok || previous != obj.ResourceVersion
+}
+
+// storeResourceVersion keeps track of the latest resource version of an object for which Apply was executed
+// Only used if UniqueApplyForResourceVersion is set in generic.GeneratingHandlerOptions
+func (a *clusterRegistrationGeneratingHandler) storeResourceVersion(obj *v1alpha1.ClusterRegistration) {
+	if !a.opts.UniqueApplyForResourceVersion {
+		return
+	}
+
+	key := obj.Namespace + "/" + obj.Name
+	a.seen.Store(key, obj.ResourceVersion)
 }

--- a/pkg/generated/controllers/fleet.cattle.io/v1alpha1/clusterregistrationtoken.go
+++ b/pkg/generated/controllers/fleet.cattle.io/v1alpha1/clusterregistrationtoken.go
@@ -20,6 +20,7 @@ package v1alpha1
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	v1alpha1 "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
@@ -263,10 +264,14 @@ func (c *clusterRegistrationTokenCache) GetByIndex(indexName, key string) (resul
 	return result, nil
 }
 
+// ClusterRegistrationTokenStatusHandler is executed for every added or modified ClusterRegistrationToken. Should return the new status to be updated
 type ClusterRegistrationTokenStatusHandler func(obj *v1alpha1.ClusterRegistrationToken, status v1alpha1.ClusterRegistrationTokenStatus) (v1alpha1.ClusterRegistrationTokenStatus, error)
 
+// ClusterRegistrationTokenGeneratingHandler is the top-level handler that is executed for every ClusterRegistrationToken event. It extends ClusterRegistrationTokenStatusHandler by a returning a slice of child objects to be passed to apply.Apply
 type ClusterRegistrationTokenGeneratingHandler func(obj *v1alpha1.ClusterRegistrationToken, status v1alpha1.ClusterRegistrationTokenStatus) ([]runtime.Object, v1alpha1.ClusterRegistrationTokenStatus, error)
 
+// RegisterClusterRegistrationTokenStatusHandler configures a ClusterRegistrationTokenController to execute a ClusterRegistrationTokenStatusHandler for every events observed.
+// If a non-empty condition is provided, it will be updated in the status conditions for every handler execution
 func RegisterClusterRegistrationTokenStatusHandler(ctx context.Context, controller ClusterRegistrationTokenController, condition condition.Cond, name string, handler ClusterRegistrationTokenStatusHandler) {
 	statusHandler := &clusterRegistrationTokenStatusHandler{
 		client:    controller,
@@ -276,6 +281,8 @@ func RegisterClusterRegistrationTokenStatusHandler(ctx context.Context, controll
 	controller.AddGenericHandler(ctx, name, FromClusterRegistrationTokenHandlerToHandler(statusHandler.sync))
 }
 
+// RegisterClusterRegistrationTokenGeneratingHandler configures a ClusterRegistrationTokenController to execute a ClusterRegistrationTokenGeneratingHandler for every events observed, passing the returned objects to the provided apply.Apply.
+// If a non-empty condition is provided, it will be updated in the status conditions for every handler execution
 func RegisterClusterRegistrationTokenGeneratingHandler(ctx context.Context, controller ClusterRegistrationTokenController, apply apply.Apply,
 	condition condition.Cond, name string, handler ClusterRegistrationTokenGeneratingHandler, opts *generic.GeneratingHandlerOptions) {
 	statusHandler := &clusterRegistrationTokenGeneratingHandler{
@@ -297,6 +304,7 @@ type clusterRegistrationTokenStatusHandler struct {
 	handler   ClusterRegistrationTokenStatusHandler
 }
 
+// sync is executed on every resource addition or modification. Executes the configured handlers and sends the updated status to the Kubernetes API
 func (a *clusterRegistrationTokenStatusHandler) sync(key string, obj *v1alpha1.ClusterRegistrationToken) (*v1alpha1.ClusterRegistrationToken, error) {
 	if obj == nil {
 		return obj, nil
@@ -342,8 +350,10 @@ type clusterRegistrationTokenGeneratingHandler struct {
 	opts  generic.GeneratingHandlerOptions
 	gvk   schema.GroupVersionKind
 	name  string
+	seen  sync.Map
 }
 
+// Remove handles the observed deletion of a resource, cascade deleting every associated resource previously applied
 func (a *clusterRegistrationTokenGeneratingHandler) Remove(key string, obj *v1alpha1.ClusterRegistrationToken) (*v1alpha1.ClusterRegistrationToken, error) {
 	if obj != nil {
 		return obj, nil
@@ -353,12 +363,17 @@ func (a *clusterRegistrationTokenGeneratingHandler) Remove(key string, obj *v1al
 	obj.Namespace, obj.Name = kv.RSplit(key, "/")
 	obj.SetGroupVersionKind(a.gvk)
 
+	if a.opts.UniqueApplyForResourceVersion {
+		a.seen.Delete(key)
+	}
+
 	return nil, generic.ConfigureApplyForObject(a.apply, obj, &a.opts).
 		WithOwner(obj).
 		WithSetID(a.name).
 		ApplyObjects()
 }
 
+// Handle executes the configured ClusterRegistrationTokenGeneratingHandler and pass the resulting objects to apply.Apply, finally returning the new status of the resource
 func (a *clusterRegistrationTokenGeneratingHandler) Handle(obj *v1alpha1.ClusterRegistrationToken, status v1alpha1.ClusterRegistrationTokenStatus) (v1alpha1.ClusterRegistrationTokenStatus, error) {
 	if !obj.DeletionTimestamp.IsZero() {
 		return status, nil
@@ -368,9 +383,41 @@ func (a *clusterRegistrationTokenGeneratingHandler) Handle(obj *v1alpha1.Cluster
 	if err != nil {
 		return newStatus, err
 	}
+	if !a.isNewResourceVersion(obj) {
+		return newStatus, nil
+	}
 
-	return newStatus, generic.ConfigureApplyForObject(a.apply, obj, &a.opts).
+	err = generic.ConfigureApplyForObject(a.apply, obj, &a.opts).
 		WithOwner(obj).
 		WithSetID(a.name).
 		ApplyObjects(objs...)
+	if err != nil {
+		return newStatus, err
+	}
+	a.storeResourceVersion(obj)
+	return newStatus, nil
+}
+
+// isNewResourceVersion detects if a specific resource version was already successfully processed.
+// Only used if UniqueApplyForResourceVersion is set in generic.GeneratingHandlerOptions
+func (a *clusterRegistrationTokenGeneratingHandler) isNewResourceVersion(obj *v1alpha1.ClusterRegistrationToken) bool {
+	if !a.opts.UniqueApplyForResourceVersion {
+		return true
+	}
+
+	// Apply once per resource version
+	key := obj.Namespace + "/" + obj.Name
+	previous, ok := a.seen.Load(key)
+	return !ok || previous != obj.ResourceVersion
+}
+
+// storeResourceVersion keeps track of the latest resource version of an object for which Apply was executed
+// Only used if UniqueApplyForResourceVersion is set in generic.GeneratingHandlerOptions
+func (a *clusterRegistrationTokenGeneratingHandler) storeResourceVersion(obj *v1alpha1.ClusterRegistrationToken) {
+	if !a.opts.UniqueApplyForResourceVersion {
+		return
+	}
+
+	key := obj.Namespace + "/" + obj.Name
+	a.seen.Store(key, obj.ResourceVersion)
 }

--- a/pkg/generated/controllers/fleet.cattle.io/v1alpha1/gitrepo.go
+++ b/pkg/generated/controllers/fleet.cattle.io/v1alpha1/gitrepo.go
@@ -20,6 +20,7 @@ package v1alpha1
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	v1alpha1 "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
@@ -263,10 +264,14 @@ func (c *gitRepoCache) GetByIndex(indexName, key string) (result []*v1alpha1.Git
 	return result, nil
 }
 
+// GitRepoStatusHandler is executed for every added or modified GitRepo. Should return the new status to be updated
 type GitRepoStatusHandler func(obj *v1alpha1.GitRepo, status v1alpha1.GitRepoStatus) (v1alpha1.GitRepoStatus, error)
 
+// GitRepoGeneratingHandler is the top-level handler that is executed for every GitRepo event. It extends GitRepoStatusHandler by a returning a slice of child objects to be passed to apply.Apply
 type GitRepoGeneratingHandler func(obj *v1alpha1.GitRepo, status v1alpha1.GitRepoStatus) ([]runtime.Object, v1alpha1.GitRepoStatus, error)
 
+// RegisterGitRepoStatusHandler configures a GitRepoController to execute a GitRepoStatusHandler for every events observed.
+// If a non-empty condition is provided, it will be updated in the status conditions for every handler execution
 func RegisterGitRepoStatusHandler(ctx context.Context, controller GitRepoController, condition condition.Cond, name string, handler GitRepoStatusHandler) {
 	statusHandler := &gitRepoStatusHandler{
 		client:    controller,
@@ -276,6 +281,8 @@ func RegisterGitRepoStatusHandler(ctx context.Context, controller GitRepoControl
 	controller.AddGenericHandler(ctx, name, FromGitRepoHandlerToHandler(statusHandler.sync))
 }
 
+// RegisterGitRepoGeneratingHandler configures a GitRepoController to execute a GitRepoGeneratingHandler for every events observed, passing the returned objects to the provided apply.Apply.
+// If a non-empty condition is provided, it will be updated in the status conditions for every handler execution
 func RegisterGitRepoGeneratingHandler(ctx context.Context, controller GitRepoController, apply apply.Apply,
 	condition condition.Cond, name string, handler GitRepoGeneratingHandler, opts *generic.GeneratingHandlerOptions) {
 	statusHandler := &gitRepoGeneratingHandler{
@@ -297,6 +304,7 @@ type gitRepoStatusHandler struct {
 	handler   GitRepoStatusHandler
 }
 
+// sync is executed on every resource addition or modification. Executes the configured handlers and sends the updated status to the Kubernetes API
 func (a *gitRepoStatusHandler) sync(key string, obj *v1alpha1.GitRepo) (*v1alpha1.GitRepo, error) {
 	if obj == nil {
 		return obj, nil
@@ -342,8 +350,10 @@ type gitRepoGeneratingHandler struct {
 	opts  generic.GeneratingHandlerOptions
 	gvk   schema.GroupVersionKind
 	name  string
+	seen  sync.Map
 }
 
+// Remove handles the observed deletion of a resource, cascade deleting every associated resource previously applied
 func (a *gitRepoGeneratingHandler) Remove(key string, obj *v1alpha1.GitRepo) (*v1alpha1.GitRepo, error) {
 	if obj != nil {
 		return obj, nil
@@ -353,12 +363,17 @@ func (a *gitRepoGeneratingHandler) Remove(key string, obj *v1alpha1.GitRepo) (*v
 	obj.Namespace, obj.Name = kv.RSplit(key, "/")
 	obj.SetGroupVersionKind(a.gvk)
 
+	if a.opts.UniqueApplyForResourceVersion {
+		a.seen.Delete(key)
+	}
+
 	return nil, generic.ConfigureApplyForObject(a.apply, obj, &a.opts).
 		WithOwner(obj).
 		WithSetID(a.name).
 		ApplyObjects()
 }
 
+// Handle executes the configured GitRepoGeneratingHandler and pass the resulting objects to apply.Apply, finally returning the new status of the resource
 func (a *gitRepoGeneratingHandler) Handle(obj *v1alpha1.GitRepo, status v1alpha1.GitRepoStatus) (v1alpha1.GitRepoStatus, error) {
 	if !obj.DeletionTimestamp.IsZero() {
 		return status, nil
@@ -368,9 +383,41 @@ func (a *gitRepoGeneratingHandler) Handle(obj *v1alpha1.GitRepo, status v1alpha1
 	if err != nil {
 		return newStatus, err
 	}
+	if !a.isNewResourceVersion(obj) {
+		return newStatus, nil
+	}
 
-	return newStatus, generic.ConfigureApplyForObject(a.apply, obj, &a.opts).
+	err = generic.ConfigureApplyForObject(a.apply, obj, &a.opts).
 		WithOwner(obj).
 		WithSetID(a.name).
 		ApplyObjects(objs...)
+	if err != nil {
+		return newStatus, err
+	}
+	a.storeResourceVersion(obj)
+	return newStatus, nil
+}
+
+// isNewResourceVersion detects if a specific resource version was already successfully processed.
+// Only used if UniqueApplyForResourceVersion is set in generic.GeneratingHandlerOptions
+func (a *gitRepoGeneratingHandler) isNewResourceVersion(obj *v1alpha1.GitRepo) bool {
+	if !a.opts.UniqueApplyForResourceVersion {
+		return true
+	}
+
+	// Apply once per resource version
+	key := obj.Namespace + "/" + obj.Name
+	previous, ok := a.seen.Load(key)
+	return !ok || previous != obj.ResourceVersion
+}
+
+// storeResourceVersion keeps track of the latest resource version of an object for which Apply was executed
+// Only used if UniqueApplyForResourceVersion is set in generic.GeneratingHandlerOptions
+func (a *gitRepoGeneratingHandler) storeResourceVersion(obj *v1alpha1.GitRepo) {
+	if !a.opts.UniqueApplyForResourceVersion {
+		return
+	}
+
+	key := obj.Namespace + "/" + obj.Name
+	a.seen.Store(key, obj.ResourceVersion)
 }

--- a/pkg/generated/controllers/fleet.cattle.io/v1alpha1/imagescan.go
+++ b/pkg/generated/controllers/fleet.cattle.io/v1alpha1/imagescan.go
@@ -20,6 +20,7 @@ package v1alpha1
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	v1alpha1 "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
@@ -263,10 +264,14 @@ func (c *imageScanCache) GetByIndex(indexName, key string) (result []*v1alpha1.I
 	return result, nil
 }
 
+// ImageScanStatusHandler is executed for every added or modified ImageScan. Should return the new status to be updated
 type ImageScanStatusHandler func(obj *v1alpha1.ImageScan, status v1alpha1.ImageScanStatus) (v1alpha1.ImageScanStatus, error)
 
+// ImageScanGeneratingHandler is the top-level handler that is executed for every ImageScan event. It extends ImageScanStatusHandler by a returning a slice of child objects to be passed to apply.Apply
 type ImageScanGeneratingHandler func(obj *v1alpha1.ImageScan, status v1alpha1.ImageScanStatus) ([]runtime.Object, v1alpha1.ImageScanStatus, error)
 
+// RegisterImageScanStatusHandler configures a ImageScanController to execute a ImageScanStatusHandler for every events observed.
+// If a non-empty condition is provided, it will be updated in the status conditions for every handler execution
 func RegisterImageScanStatusHandler(ctx context.Context, controller ImageScanController, condition condition.Cond, name string, handler ImageScanStatusHandler) {
 	statusHandler := &imageScanStatusHandler{
 		client:    controller,
@@ -276,6 +281,8 @@ func RegisterImageScanStatusHandler(ctx context.Context, controller ImageScanCon
 	controller.AddGenericHandler(ctx, name, FromImageScanHandlerToHandler(statusHandler.sync))
 }
 
+// RegisterImageScanGeneratingHandler configures a ImageScanController to execute a ImageScanGeneratingHandler for every events observed, passing the returned objects to the provided apply.Apply.
+// If a non-empty condition is provided, it will be updated in the status conditions for every handler execution
 func RegisterImageScanGeneratingHandler(ctx context.Context, controller ImageScanController, apply apply.Apply,
 	condition condition.Cond, name string, handler ImageScanGeneratingHandler, opts *generic.GeneratingHandlerOptions) {
 	statusHandler := &imageScanGeneratingHandler{
@@ -297,6 +304,7 @@ type imageScanStatusHandler struct {
 	handler   ImageScanStatusHandler
 }
 
+// sync is executed on every resource addition or modification. Executes the configured handlers and sends the updated status to the Kubernetes API
 func (a *imageScanStatusHandler) sync(key string, obj *v1alpha1.ImageScan) (*v1alpha1.ImageScan, error) {
 	if obj == nil {
 		return obj, nil
@@ -342,8 +350,10 @@ type imageScanGeneratingHandler struct {
 	opts  generic.GeneratingHandlerOptions
 	gvk   schema.GroupVersionKind
 	name  string
+	seen  sync.Map
 }
 
+// Remove handles the observed deletion of a resource, cascade deleting every associated resource previously applied
 func (a *imageScanGeneratingHandler) Remove(key string, obj *v1alpha1.ImageScan) (*v1alpha1.ImageScan, error) {
 	if obj != nil {
 		return obj, nil
@@ -353,12 +363,17 @@ func (a *imageScanGeneratingHandler) Remove(key string, obj *v1alpha1.ImageScan)
 	obj.Namespace, obj.Name = kv.RSplit(key, "/")
 	obj.SetGroupVersionKind(a.gvk)
 
+	if a.opts.UniqueApplyForResourceVersion {
+		a.seen.Delete(key)
+	}
+
 	return nil, generic.ConfigureApplyForObject(a.apply, obj, &a.opts).
 		WithOwner(obj).
 		WithSetID(a.name).
 		ApplyObjects()
 }
 
+// Handle executes the configured ImageScanGeneratingHandler and pass the resulting objects to apply.Apply, finally returning the new status of the resource
 func (a *imageScanGeneratingHandler) Handle(obj *v1alpha1.ImageScan, status v1alpha1.ImageScanStatus) (v1alpha1.ImageScanStatus, error) {
 	if !obj.DeletionTimestamp.IsZero() {
 		return status, nil
@@ -368,9 +383,41 @@ func (a *imageScanGeneratingHandler) Handle(obj *v1alpha1.ImageScan, status v1al
 	if err != nil {
 		return newStatus, err
 	}
+	if !a.isNewResourceVersion(obj) {
+		return newStatus, nil
+	}
 
-	return newStatus, generic.ConfigureApplyForObject(a.apply, obj, &a.opts).
+	err = generic.ConfigureApplyForObject(a.apply, obj, &a.opts).
 		WithOwner(obj).
 		WithSetID(a.name).
 		ApplyObjects(objs...)
+	if err != nil {
+		return newStatus, err
+	}
+	a.storeResourceVersion(obj)
+	return newStatus, nil
+}
+
+// isNewResourceVersion detects if a specific resource version was already successfully processed.
+// Only used if UniqueApplyForResourceVersion is set in generic.GeneratingHandlerOptions
+func (a *imageScanGeneratingHandler) isNewResourceVersion(obj *v1alpha1.ImageScan) bool {
+	if !a.opts.UniqueApplyForResourceVersion {
+		return true
+	}
+
+	// Apply once per resource version
+	key := obj.Namespace + "/" + obj.Name
+	previous, ok := a.seen.Load(key)
+	return !ok || previous != obj.ResourceVersion
+}
+
+// storeResourceVersion keeps track of the latest resource version of an object for which Apply was executed
+// Only used if UniqueApplyForResourceVersion is set in generic.GeneratingHandlerOptions
+func (a *imageScanGeneratingHandler) storeResourceVersion(obj *v1alpha1.ImageScan) {
+	if !a.opts.UniqueApplyForResourceVersion {
+		return
+	}
+
+	key := obj.Namespace + "/" + obj.Name
+	a.seen.Store(key, obj.ResourceVersion)
 }


### PR DESCRIPTION
Refers to #2054

CPU improvements were merged into a new wrangler v1 version. Upgrade and also reduce the number of Apply calls from the `Bundle` and `GitRepo` handlers.