### PR TITLE
[v0.9] BCI base version

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,6 +1,6 @@
 ARG BUILD_ENV=dapper
 
-FROM registry.suse.com/bci/bci-base:15.5.36.5.34 AS base
+FROM registry.suse.com/bci/bci-base:15.5 AS base
 USER 1000
 
 FROM base AS copy_dapper

--- a/package/Dockerfile.agent
+++ b/package/Dockerfile.agent
@@ -1,6 +1,6 @@
 ARG BUILD_ENV=dapper
 
-FROM registry.suse.com/bci/bci-base:15.5.36.5.34 AS base
+FROM registry.suse.com/bci/bci-base:15.5 AS base
 RUN zypper in --no-recommends -y git bash openssh && groupadd -g 1000 fleet-apply && useradd -u 1000 -g 1000 -m fleet-apply; rm -fr /var/cache/* /var/log/*log
 COPY package/log.sh /usr/bin/
 


### PR DESCRIPTION
BCI images are stable, specifying minor will allow us to pull in the latest image shortly before the actual release.
