### PR TITLE
Bump fleet-agent chart's kubectl to 1.29

### DIFF
--- a/charts/fleet-agent/values.yaml
+++ b/charts/fleet-agent/values.yaml
@@ -57,7 +57,7 @@ global:
     systemDefaultRegistry: ""
   kubectl:
     repository: rancher/kubectl
-    tag: v1.21.5
+    tag: v1.29.0
 
 debug: false
 debugLevel: 0


### PR DESCRIPTION
This kubectl is only used by the standalone chart.


Maybe this should be same image as the one used by Rancher to limit downloads?
