### PR TITLE
Disable cache in golangci-lint action

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -20,6 +20,7 @@ jobs:
         with:
           go-version-file: 'go.mod'
           check-latest: true
+          cache: false
 
       - name: Generate Golang
         run: |


### PR DESCRIPTION
According to the [README](https://github.com/golangci/golangci-lint-action) we should disable the setup-go cache.

Maybe this helps with the cache errors/warnings?