### PR TITLE
Release scripts chart dir var

### DIFF
--- a/.github/scripts/release-against-charts.sh
+++ b/.github/scripts/release-against-charts.sh
@@ -10,11 +10,7 @@ PREV_CHART_VERSION="$3"   # e.g. 101.2.0
 NEW_CHART_VERSION="$4"
 REPLACE="$5"              # remove previous version if `true`, otherwise add new
 
-if [ -z "${GITHUB_WORKSPACE:-}" ]; then
-    CHARTS_DIR="$(dirname -- "$0")/../../../charts"
-else
-    CHARTS_DIR="${GITHUB_WORKSPACE}/charts"
-fi
+CHARTS_DIR=${CHARTS_DIR-"$(dirname -- "$0")/../../../charts"}
 
 pushd "${CHARTS_DIR}" > /dev/null
 

--- a/.github/scripts/release-against-rancher.sh
+++ b/.github/scripts/release-against-rancher.sh
@@ -15,11 +15,7 @@ bump_fleet_api() {
     go mod tidy
 }
 
-if [ -z "${GITHUB_WORKSPACE:-}" ]; then
-    CHARTS_DIR="$(dirname -- "$0")/../../../rancher"
-else
-    CHARTS_DIR="${GITHUB_WORKSPACE}/rancher"
-fi
+CHARTS_DIR=${CHARTS_DIR-"$(dirname -- "$0")/../../../rancher"}
 
 pushd "${CHARTS_DIR}" > /dev/null
 

--- a/.github/workflows/release-against-charts.yml
+++ b/.github/workflows/release-against-charts.yml
@@ -50,7 +50,9 @@ jobs:
       - name: Install dependencies
         run: sudo snap install yq --channel=v4/stable
       - name: Run release script
-        run: ./fleet/.github/scripts/release-against-charts.sh ${{github.event.inputs.prev_fleet}} ${{github.event.inputs.new_fleet}} ${{github.event.inputs.prev_chart}}  ${{github.event.inputs.new_chart}}  ${{github.event.inputs.should_replace}}
+        run: |
+          export CHARTS_DIR="${GITHUB_WORKSPACE}/charts"
+          ./fleet/.github/scripts/release-against-charts.sh ${{github.event.inputs.prev_fleet}} ${{github.event.inputs.new_fleet}} ${{github.event.inputs.prev_chart}}  ${{github.event.inputs.new_chart}}  ${{github.event.inputs.should_replace}}
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v5
         with:

--- a/.github/workflows/release-against-rancher.yml
+++ b/.github/workflows/release-against-rancher.yml
@@ -48,7 +48,9 @@ jobs:
         with:
           go-version: ${{ env.SETUP_GO_VERSION }}
       - name: Run release script
-        run: ./fleet/.github/scripts/release-against-rancher.sh ${{github.event.inputs.new_fleet}} ${{github.event.inputs.new_chart}} ${{github.event.inputs.should_bump_api}}
+        run: |
+          export CHARTS_DIR="${GITHUB_WORKSPACE}/rancher"
+          ./fleet/.github/scripts/release-against-rancher.sh ${{github.event.inputs.new_fleet}} ${{github.event.inputs.new_chart}} ${{github.event.inputs.should_bump_api}}
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v5
         with:


### PR DESCRIPTION
Ideally the `.github/scripts` don't contain much configuration complexity and tailored to the CI.
However, we do execute this locally and duping it into dev seems unnecessary, when I can just remove a variable and an if condition instead.

This also allows me to use any charts dir, like `charts-2.7`.