### PR TITLE
Use apimachinery yaml package directly

### DIFF
--- a/integrationtests/cli/helpers.go
+++ b/integrationtests/cli/helpers.go
@@ -1,13 +1,15 @@
 package cli
 
 import (
+	"bytes"
 	"errors"
 	"io"
 	"os"
 	"strings"
 
 	"github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
-	"github.com/rancher/wrangler/v2/pkg/yaml"
+
+	"k8s.io/apimachinery/pkg/util/yaml"
 
 	"github.com/onsi/gomega/gbytes"
 )
@@ -24,7 +26,7 @@ func GetBundleFromOutput(w io.Writer) (*v1alpha1.Bundle, error) {
 		return nil, errors.New("can't convert to gbytes.Buffer")
 	}
 	bundle := &v1alpha1.Bundle{}
-	err := yaml.Unmarshal(buf.Contents(), bundle)
+	err := yaml.NewYAMLToJSONDecoder(bytes.NewBuffer(buf.Contents())).Decode(bundle)
 	if err != nil {
 		return nil, err
 	}
@@ -43,7 +45,7 @@ func GetBundleListFromOutput(w io.Writer) ([]*v1alpha1.Bundle, error) {
 	for _, bundleStr := range bundlesStr {
 		if bundleStr != "" {
 			bundle := &v1alpha1.Bundle{}
-			err := yaml.Unmarshal([]byte(bundleStr), bundle)
+			err := yaml.NewYAMLToJSONDecoder(bytes.NewBufferString(bundleStr)).Decode(bundle)
 			if err != nil {
 				return nil, err
 			}

--- a/internal/bundlereader/resources_test.go
+++ b/internal/bundlereader/resources_test.go
@@ -1,10 +1,12 @@
 package bundlereader
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
-	"github.com/rancher/wrangler/v2/pkg/yaml"
+
+	"k8s.io/apimachinery/pkg/util/yaml"
 )
 
 const (
@@ -36,12 +38,12 @@ func TestValueMerge(t *testing.T) {
 	first := &v1alpha1.GenericMap{}
 	second := &v1alpha1.GenericMap{}
 
-	err := yaml.Unmarshal([]byte(valuesOneYaml), first)
+	err := yaml.NewYAMLToJSONDecoder(bytes.NewBufferString(valuesOneYaml)).Decode(first)
 	if err != nil {
 		t.Fatalf("error during valuesOneYaml parsing %v", err)
 	}
 
-	err = yaml.Unmarshal([]byte(valuesTwoYaml), second)
+	err = yaml.NewYAMLToJSONDecoder(bytes.NewBufferString(valuesTwoYaml)).Decode(second)
 	if err != nil {
 		t.Fatalf("error during valuesTwoYaml parsing %v", err)
 	}

--- a/internal/cmd/cli/apply.go
+++ b/internal/cmd/cli/apply.go
@@ -7,13 +7,14 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/rancher/wrangler/v2/pkg/yaml"
 	"github.com/spf13/cobra"
 
 	"github.com/rancher/fleet/internal/bundlereader"
 	command "github.com/rancher/fleet/internal/cmd"
 	"github.com/rancher/fleet/internal/cmd/cli/apply"
 	"github.com/rancher/fleet/internal/cmd/cli/writer"
+
+	"k8s.io/apimachinery/pkg/util/yaml"
 )
 
 type readFile func(name string) ([]byte, error)
@@ -118,7 +119,7 @@ func (a *Apply) addAuthToOpts(opts *apply.Options, readFile readFile) error {
 			return err
 		}
 		var authByPath map[string]bundlereader.Auth
-		err = yaml.Unmarshal(file, &authByPath)
+		err = yaml.NewYAMLToJSONDecoder(bytes.NewBuffer(file)).Decode(&authByPath)
 		if err != nil {
 			return err
 		}

--- a/internal/cmd/controller/agentmanagement/agent/agent.go
+++ b/internal/cmd/controller/agentmanagement/agent/agent.go
@@ -2,6 +2,7 @@
 package agent
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"time"
@@ -13,11 +14,10 @@ import (
 	"github.com/rancher/fleet/pkg/durations"
 	fleetcontrollers "github.com/rancher/fleet/pkg/generated/controllers/fleet.cattle.io/v1alpha1"
 
-	"github.com/rancher/wrangler/v2/pkg/yaml"
-
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/apimachinery/pkg/watch"
 )
 
@@ -123,7 +123,7 @@ func getToken(ctx context.Context, controllerNamespace, tokenName string, client
 	}
 
 	data := map[string]interface{}{}
-	if err := yaml.Unmarshal(values, &data); err != nil {
+	if err := yaml.NewYAMLToJSONDecoder(bytes.NewBuffer(values)).Decode(&data); err != nil {
 		return nil, err
 	}
 

--- a/internal/cmd/controller/target/target_test.go
+++ b/internal/cmd/controller/target/target_test.go
@@ -1,12 +1,12 @@
 package target
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/pkg/errors"
 
-	"github.com/rancher/wrangler/v2/pkg/yaml"
-
+	"k8s.io/apimachinery/pkg/util/yaml"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	"github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
@@ -42,7 +42,7 @@ func TestProcessLabelValues(t *testing.T) {
 	clusterLabels["name"] = "local"
 	clusterLabels["envType"] = "dev"
 
-	err := yaml.Unmarshal([]byte(bundleYaml), bundle)
+	err := yaml.NewYAMLToJSONDecoder(bytes.NewBufferString(bundleYaml)).Decode(bundle)
 	if err != nil {
 		t.Fatalf("error during yaml parsing %v", err)
 	}
@@ -180,7 +180,7 @@ func TestProcessTemplateValues(t *testing.T) {
 	}
 
 	bundle := &v1alpha1.BundleSpec{}
-	err := yaml.Unmarshal([]byte(bundleYamlWithTemplate), bundle)
+	err := yaml.NewYAMLToJSONDecoder(bytes.NewBufferString(bundleYamlWithTemplate)).Decode(bundle)
 	if err != nil {
 		t.Fatalf("error during yaml parsing %v", err)
 	}
@@ -330,13 +330,13 @@ spec:
 
 func getClusterAndBundle(bundleYaml string) (*v1alpha1.Cluster, *v1alpha1.BundleDeploymentOptions, error) {
 	cluster := &v1alpha1.Cluster{}
-	err := yaml.Unmarshal([]byte(clusterYamlWithTemplateValues), cluster)
+	err := yaml.NewYAMLToJSONDecoder(bytes.NewBufferString(clusterYamlWithTemplateValues)).Decode(cluster)
 	if err != nil {
 		return nil, nil, errors.Wrapf(err, "error during cluster yaml parsing")
 	}
 
 	bundle := &v1alpha1.BundleDeploymentOptions{}
-	err = yaml.Unmarshal([]byte(bundleYaml), bundle)
+	err = yaml.NewYAMLToJSONDecoder(bytes.NewBufferString(bundleYaml)).Decode(bundle)
 	if err != nil {
 		return nil, nil, errors.Wrapf(err, "error during bundle yaml parsing")
 	}

--- a/internal/helmdeployer/install.go
+++ b/internal/helmdeployer/install.go
@@ -1,6 +1,7 @@
 package helmdeployer
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"strconv"
@@ -15,10 +16,9 @@ import (
 	"github.com/rancher/fleet/internal/manifest"
 	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
 
-	"github.com/rancher/wrangler/v2/pkg/yaml"
-
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/yaml"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -287,7 +287,7 @@ func valuesFromSecret(name, namespace, key string, secret *corev1.Secret) (map[s
 	if !ok {
 		return nil, fmt.Errorf("key %s is missing from secret %s/%s, can't use it in valuesFrom", key, namespace, name)
 	}
-	if err := yaml.Unmarshal(values, &m); err != nil {
+	if err := yaml.NewYAMLToJSONDecoder(bytes.NewBuffer(values)).Decode(&m); err != nil {
 		return nil, err
 	}
 	return m, nil
@@ -303,7 +303,7 @@ func valuesFromConfigMap(name, namespace, key string, configMap *corev1.ConfigMa
 	if !ok {
 		return nil, fmt.Errorf("key %s is missing from configmap %s/%s, can't use it in valuesFrom", key, namespace, name)
 	}
-	if err := yaml.Unmarshal([]byte(values), &m); err != nil {
+	if err := yaml.NewYAMLToJSONDecoder(bytes.NewBufferString(values)).Decode(&m); err != nil {
 		return nil, err
 	}
 	return m, nil


### PR DESCRIPTION
Wrangler would just call
	`yamlDecoder.NewYAMLToJSONDecoder(bytes.NewBuffer(data)).Decode(v)`




Wrangler `yaml` uses https://github.com/ghodss/yaml and https://github.com/kubernetes/apimachinery/blob/master/pkg/util/yaml/decoder.go. The first is old, while apimachinery wraps "sigs.k8s.io/yaml", which uses 
	"sigs.k8s.io/yaml/goyaml.v2".

