### PR TITLE
Update gitjob base image

### DIFF
--- a/package/Dockerfile.gitjob
+++ b/package/Dockerfile.gitjob
@@ -1,4 +1,4 @@
-FROM registry.suse.com/bci/bci-base:15.5.36.5.68
+FROM registry.suse.com/bci/bci-base:15.5
 RUN zypper -n update && \
     zypper -n install openssh catatonit git && \
     zypper -n clean -a


### PR DESCRIPTION
Follow-up to #2098, refers to #2008.
[Original PR](https://github.com/rancher/gitjob/pull/421) submitted to `rancher/gitjob` by @macedogm, with the following description (verbatim):
1. Use `major:minor` version for base image`registry.suse.com/bci/bci-base:15.5` instead of `registry.suse.com/bci/bci-base:15.5.36.5.68`, which is already a month old.

~2. Patch bump of `github.com/cloudflare/circl` to `v1.3.7` to fix advisory GHSA-9763-4f94-gfch.~ → already applied to `master` via #2098, removed from this PR.