### PR TITLE
Add gitjob end-to-end tests with SSH key

### DIFF
--- a/.github/scripts/deploy-fleet.sh
+++ b/.github/scripts/deploy-fleet.sh
@@ -10,16 +10,20 @@ function eventually {
 }
 
 # usage: ./deploy-fleet.sh ghcr.io/rancher/fleet:sha-49f6f81 ghcr.io/rancher/fleet-agent:1h
-if [ $# -ge 2 ] && [ -n "$1" ] && [ -n "$2" ]; then
+if [ $# -ge 3 ] && [ -n "$1" ] && [ -n "$2" ] && [ -n "$3" ]; then
   fleetRepo="${1%:*}"
   fleetTag="${1#*:}"
   agentRepo="${2%:*}"
   agentTag="${2#*:}"
+  gitjobRepo="${3%:*}"
+  gitjobTag="${3#*:}"
 else
   fleetRepo="rancher/fleet"
   fleetTag="dev"
   agentRepo="rancher/fleet-agent"
   agentTag="dev"
+  gitjobRepo="rancher/fleet-gitjob"
+  gitjobTag="dev"
 fi
 
 eventually helm upgrade --install fleet-crd charts/fleet-crd \
@@ -34,7 +38,9 @@ eventually helm upgrade --install fleet charts/fleet \
   --set image.tag="$fleetTag" \
   --set agentImage.repository="$agentRepo" \
   --set agentImage.tag="$agentTag" \
-  --set agentImage.imagePullPolicy=IfNotPresent
+  --set agentImage.imagePullPolicy=IfNotPresent \
+  --set gitjob.repository="$gitjobRepo" \
+  --set gitjob.tag="$gitjobTag"
 
 # wait for controller and agent rollout
 kubectl -n cattle-fleet-system rollout status deploy/fleet-controller

--- a/.github/workflows/aks.yml
+++ b/.github/workflows/aks.yml
@@ -159,6 +159,13 @@ jobs:
           echo "${{ secrets.CI_AKS_SSH_PUBKEY }}" > "$GIT_SSH_PUBKEY"
 
           ginkgo e2e/require-secrets
+
+          export GIT_GITJOB_SSH_KEY="$GITHUB_WORKSPACE/id_ed25519"
+          export GIT_GITJOB_SSH_PUBKEY="$GITHUB_WORKSPACE/id_ed25519.pub"
+          echo "${{ secrets.CI_GITJOB_SSH_KEY }}" > "$GIT_GITJOB_SSH_KEY"
+          echo "${{ secrets.CI_GITJOB_SSH_PUBKEY }}" > "$GIT_GITJOB_SSH_PUBKEY"
+
+          ginkgo e2e/gitjob
       -
         name: Delete AKS cluster
         # We always tear down the cluster, to avoid costs. Except when running

--- a/.github/workflows/aks.yml
+++ b/.github/workflows/aks.yml
@@ -122,11 +122,28 @@ jobs:
           tags: ${{ steps.meta-fleet-agent.outputs.tags }}
           labels: ${{ steps.meta-fleet-agent.outputs.labels }}
       -
+        id: meta-fleet-gitjob
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ttl.sh/rancher/fleet-gitjob-${{ steps.uuid.outputs.uuid }}
+          tags: type=raw,value=1h
+      -
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: package/Dockerfile.gitjob
+          build-args: |
+            ARCH=${{ env.GOARCH }}
+          push: true
+          tags: ${{ steps.meta-fleet-gitjob.outputs.tags }}
+          labels: ${{ steps.meta-fleet-gitjob.outputs.labels }}
+      -
         name: Deploy Fleet
         run: |
           export KUBECONFIG="$GITHUB_WORKSPACE/kubeconfig-fleet-ci"
           echo "${{ steps.meta-fleet.outputs.tags }} ${{ steps.meta-fleet-agent.outputs.tags }}"
-          ./.github/scripts/deploy-fleet.sh ${{ steps.meta-fleet.outputs.tags }} ${{ steps.meta-fleet-agent.outputs.tags }}
+          ./.github/scripts/deploy-fleet.sh ${{ steps.meta-fleet.outputs.tags }} ${{ steps.meta-fleet-agent.outputs.tags }} ${{ steps.meta-fleet-gitjob.outputs.tags }}
       -
         name: Fleet E2E Tests
         env:

--- a/.github/workflows/gke.yml
+++ b/.github/workflows/gke.yml
@@ -127,10 +127,27 @@ jobs:
           tags: ${{ steps.meta-fleet-agent.outputs.tags }}
           labels: ${{ steps.meta-fleet-agent.outputs.labels }}
       -
+        id: meta-fleet-gitjob
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ttl.sh/rancher/fleet-gitjob-${{ steps.uuid.outputs.uuid }}
+          tags: type=raw,value=1h
+      -
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: package/Dockerfile.gitjob
+          build-args: |
+            ARCH=${{ env.GOARCH }}
+          push: true
+          tags: ${{ steps.meta-fleet-gitjob.outputs.tags }}
+          labels: ${{ steps.meta-fleet-gitjob.outputs.labels }}
+      -
         name: Deploy Fleet
         run: |
           echo "${{ steps.meta-fleet.outputs.tags }} ${{ steps.meta-fleet-agent.outputs.tags }}"
-          ./.github/scripts/deploy-fleet.sh ${{ steps.meta-fleet.outputs.tags }} ${{ steps.meta-fleet-agent.outputs.tags }}
+          ./.github/scripts/deploy-fleet.sh ${{ steps.meta-fleet.outputs.tags }} ${{ steps.meta-fleet-agent.outputs.tags }} ${{ steps.meta-fleet-gitjob.outputs.tags }}
       -
         name: Fleet E2E Tests
         env:

--- a/.github/workflows/gke.yml
+++ b/.github/workflows/gke.yml
@@ -160,6 +160,13 @@ jobs:
           echo "${{ secrets.CI_GKE_SSH_PUBKEY }}" > "$GIT_SSH_PUBKEY"
 
           ginkgo e2e/require-secrets
+
+          export GIT_GITJOB_SSH_KEY="$GITHUB_WORKSPACE/id_ed25519"
+          export GIT_GITJOB_SSH_PUBKEY="$GITHUB_WORKSPACE/id_ed25519.pub"
+          echo "${{ secrets.CI_GITJOB_SSH_KEY }}" > "$GIT_GITJOB_SSH_KEY"
+          echo "${{ secrets.CI_GITJOB_SSH_PUBKEY }}" > "$GIT_GITJOB_SSH_PUBKEY"
+
+          ginkgo e2e/gitjob
       -
         name: Delete GKE cluster
         if: ${{ always() && github.event.inputs.keep_cluster != 'yes' }}

--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -150,6 +150,12 @@ jobs:
           echo "${{ secrets.CI_SSH_PUBKEY }}" > "$GIT_SSH_PUBKEY"
 
           ginkgo e2e/require-secrets
+
+          export GIT_GITJOB_SSH_KEY="$GITHUB_WORKSPACE/id_ed25519"
+          export GIT_GITJOB_SSH_PUBKEY="$GITHUB_WORKSPACE/id_ed25519.pub"
+          echo "${{ secrets.CI_GITJOB_SSH_KEY }}" > "$GIT_GITJOB_SSH_KEY"
+          echo "${{ secrets.CI_GITJOB_SSH_PUBKEY }}" > "$GIT_GITJOB_SSH_PUBKEY"
+
           ginkgo e2e/gitjob
       -
         name: Dump Failed Environment


### PR DESCRIPTION
This commit ensures that gitjob end-to-end tests run in all CI workflows which run end-to-end tests requiring secrets. This entails setting the gitjob-specific SSH key in all such workflows.

This fixes failures for:
- Nighly E2E Fleet ([before](https://github.com/rancher/fleet/actions/runs/7722443912/job/21050630477)/[after](https://github.com/rancher/fleet/actions/runs/7723663716/job/21054482926))
- CI GKE ([before](https://github.com/rancher/fleet/actions/runs/7719988713/job/21044174369)/[after](https://github.com/rancher/fleet/actions/runs/7724550665/job/21056923633))
- CI AKS ([before](https://github.com/rancher/fleet/actions/runs/7709609929/job/21011176521)/[after](https://github.com/rancher/fleet/actions/runs/7724557547/job/21056942936))

Refers to #2008