### PR TITLE
Fix helm deployer ignoring kubeconfig CLI arg

### DIFF
--- a/internal/cmd/agent/operator.go
+++ b/internal/cmd/agent/operator.go
@@ -152,10 +152,9 @@ func newReconciler(ctx, localCtx context.Context, mgr manager.Manager, localConf
 	}
 	localClient := localCluster.GetClient()
 
-	kubeconfig := flag.Lookup("kubeconfig").Value.String()
-	if kubeconfig != "" {
+	if kubeconfig := flag.Lookup("kubeconfig").Value.String(); kubeconfig != "" {
 		// set KUBECONFIG env var so helm can find it
-		os.Setenv("KUBECONFIG", flag.Lookup("kubeconfig").Value.String())
+		os.Setenv("KUBECONFIG", kubeconfig)
 	}
 
 	// Build the helm deployer, which uses a getter for local cluster's client-go client for helm SDK

--- a/internal/cmd/agent/operator.go
+++ b/internal/cmd/agent/operator.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"flag"
 	"os"
 
 	"github.com/rancher/fleet/internal/cmd/agent/controller"
@@ -150,6 +151,12 @@ func newReconciler(ctx, localCtx context.Context, mgr manager.Manager, localConf
 		return nil, err
 	}
 	localClient := localCluster.GetClient()
+
+	kubeconfig := flag.Lookup("kubeconfig").Value.String()
+	if kubeconfig != "" {
+		// set KUBECONFIG env var so helm can find it
+		os.Setenv("KUBECONFIG", flag.Lookup("kubeconfig").Value.String())
+	}
 
 	// Build the helm deployer, which uses a getter for local cluster's client-go client for helm SDK
 	helmDeployer := helmdeployer.New(

--- a/internal/helmdeployer/deployer.go
+++ b/internal/helmdeployer/deployer.go
@@ -68,11 +68,11 @@ type DeployedBundle struct {
 }
 
 // New returns a new helm deployer
-// * namespace is the system namespace, which is the namespace the agent is running in, e.g. cattle-fleet-system
-func New(namespace, defaultNamespace, labelPrefix, labelSuffix string) *Helm {
+// * agentNamespace is the system namespace, which is the namespace the agent is running in, e.g. cattle-fleet-system
+func New(agentNamespace, defaultNamespace, labelPrefix, labelSuffix string) *Helm {
 	return &Helm{
+		agentNamespace:   agentNamespace,
 		defaultNamespace: defaultNamespace,
-		agentNamespace:   namespace,
 		labelPrefix:      labelPrefix,
 		labelSuffix:      labelSuffix,
 	}


### PR DESCRIPTION
Noticed during https://github.com/rancher/fleet/issues/2110

The helmdeployer does not consider `--kubeconfig`.  We don't seem to use the flag, except in upcoming CLI tests to target the testenv cluster.