### PR TITLE
Deprecate "fleet test" command, previously used to debug chart

### DIFF
--- a/internal/cmd/cli/test.go
+++ b/internal/cmd/cli/test.go
@@ -11,8 +11,9 @@ import (
 
 func NewTest() *cobra.Command {
 	return command.Command(&Test{}, cobra.Command{
-		Args:  cobra.MaximumNArgs(1),
-		Short: "Match a bundle to a target and render the output",
+		Args:       cobra.MaximumNArgs(1),
+		Deprecated: "use target and deploy sub-commands instead.",
+		Short:      "Match a bundle to a target and render the output (deprecated)",
 	})
 }
 


### PR DESCRIPTION
Will be replaced by https://github.com/rancher/fleet/issues/2110

The `fleet test` command, `match.Matcher` in the code, seems to be mostly useless. See discussion in https://github.com/rancher/fleet/issues/1385#issuecomment-1527758555