### PR TITLE
[v0.9] Switch base images to smaller images [SURE-7269]

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,7 +1,6 @@
 ARG BUILD_ENV=dapper
 
-FROM registry.suse.com/bci/bci-base:15.5 AS base
-USER 1000
+FROM registry.suse.com/bci/bci-busybox:15.5 AS base
 
 FROM base AS copy_dapper
 ONBUILD ARG ARCH
@@ -12,4 +11,5 @@ ONBUILD ARG TARGETARCH
 ONBUILD COPY bin/fleetcontroller-linux-${TARGETARCH} /usr/bin/fleetcontroller
 
 FROM copy_${BUILD_ENV}
+USER 1000
 CMD ["fleetcontroller"]

--- a/package/Dockerfile.agent
+++ b/package/Dockerfile.agent
@@ -1,7 +1,6 @@
 ARG BUILD_ENV=dapper
 
-FROM registry.suse.com/bci/bci-base:15.5 AS base
-RUN zypper in --no-recommends -y git bash openssh && groupadd -g 1000 fleet-apply && useradd -u 1000 -g 1000 -m fleet-apply; rm -fr /var/cache/* /var/log/*log
+FROM registry.suse.com/suse/git:2.35 AS base
 COPY package/log.sh /usr/bin/
 
 FROM base AS copy_dapper
@@ -15,4 +14,5 @@ ONBUILD COPY bin/fleetagent-linux-$TARGETARCH /usr/bin/fleetagent
 ONBUILD COPY bin/fleet-linux-$TARGETARCH /usr/bin/fleet
 
 FROM copy_${BUILD_ENV}
+USER 1000
 CMD ["fleetagent"]


### PR DESCRIPTION
Also moving the USER statement to the bottom. Experiments show it works
in any place, but it's confusing to read. Note, the USER statement is
the default UID if no securityContext is used. However, Fleet uses a
securityContext/RunAsUser, but scanners complain when USER is missing.
This is probably because scanners don't distinguish between the docker
container runtime and the container runtime used in k8s.