### PR TITLE
Infra e2e command uses a published fleet module

### DIFF
--- a/e2e/testenv/infra/go.mod
+++ b/e2e/testenv/infra/go.mod
@@ -4,14 +4,10 @@ go 1.21
 
 toolchain go1.21.0
 
-replace github.com/rancher/fleet => ../../../
-
-replace github.com/rancher/fleet/pkg/apis => ../../../pkg/apis
-
 replace k8s.io/client-go => k8s.io/client-go v0.29.0
 
 require (
-	github.com/rancher/fleet v0.0.0
+	github.com/rancher/fleet v0.9.0-rc.4.0.20240208111910-ad2d2d829a12
 	github.com/spf13/cobra v1.8.0
 	golang.org/x/crypto v0.18.0
 	helm.sh/helm/v3 v3.14.0

--- a/e2e/testenv/infra/go.sum
+++ b/e2e/testenv/infra/go.sum
@@ -168,6 +168,8 @@ github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsT
 github.com/prometheus/procfs v0.0.3/go.mod h1:4A/X28fw3Fc593LaREMrKMqOKvUAntwMDaekg4FpcdQ=
 github.com/prometheus/procfs v0.12.0 h1:jluTpSng7V9hY0O2R9DzzJHYb2xULk9VTR1V1R/k6Bo=
 github.com/prometheus/procfs v0.12.0/go.mod h1:pcuDEFsWDnvcgNzo4EEweacyhjeA9Zk3cnaOZAZEfOo=
+github.com/rancher/fleet v0.9.0-rc.4.0.20240208111910-ad2d2d829a12 h1:kJlKRwgNieVmem+yzeGr6ZgIS98Udh7Oou3ZRao/FtM=
+github.com/rancher/fleet v0.9.0-rc.4.0.20240208111910-ad2d2d829a12/go.mod h1:QU6g1mmw3RIELU2LwB7d703tw+SZjumrQNt7w3lbGak=
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=


### PR DESCRIPTION
We have trouble updating our `go.mod`. Often, we need to update `e2e/testenv/infra/go.mod` when the main `go.mod` updates.

That's because the infra module imports the local fleet module via `replace github.com/rancher/fleet => ../../../`.

This PR imports a published go.mod instead, since the infra command only uses the testenv helpers from e2e, the dependency does not have to be updated often.

When making changes to the infra command, one might want to edit and use the helpers directly. Without the need to tag a version for every change. Go workspaces can help:

```
cd e2e/testenv/infra
go work init
go work use ../../../
go work use .
```

This is similar to a replace statement. Never commit the `go.work` file, though.
It might still be necessary split the PR into two, one for the helpers and a second to update the infra command and switch infra's go.mod to the commit of the first PR.


