### PR TITLE
Update helm fork, rename ForceAdopt/Adopt to TakeOwnership

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.21
 
 replace (
 	github.com/rancher/fleet/pkg/apis => ./pkg/apis
-	helm.sh/helm/v3 => github.com/rancher/helm/v3 v3.14.0-fleet1
+	helm.sh/helm/v3 => github.com/rancher/helm/v3 v3.14.0-fleet2
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -747,8 +747,8 @@ github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsT
 github.com/prometheus/procfs v0.0.3/go.mod h1:4A/X28fw3Fc593LaREMrKMqOKvUAntwMDaekg4FpcdQ=
 github.com/prometheus/procfs v0.12.0 h1:jluTpSng7V9hY0O2R9DzzJHYb2xULk9VTR1V1R/k6Bo=
 github.com/prometheus/procfs v0.12.0/go.mod h1:pcuDEFsWDnvcgNzo4EEweacyhjeA9Zk3cnaOZAZEfOo=
-github.com/rancher/helm/v3 v3.14.0-fleet1 h1:a5/spqTA536u4xTRmNBaIYm4atpBNb9UTK2+Ct0httE=
-github.com/rancher/helm/v3 v3.14.0-fleet1/go.mod h1:2itvvDv2WSZXTllknfQo6j7u3VVgMAvm8POCDgYH424=
+github.com/rancher/helm/v3 v3.14.0-fleet2 h1:DpduV+vYN1u8VnoH0wvVfgLm1BEsjvg6/FIBOh8bRvw=
+github.com/rancher/helm/v3 v3.14.0-fleet2/go.mod h1:2itvvDv2WSZXTllknfQo6j7u3VVgMAvm8POCDgYH424=
 github.com/rancher/lasso v0.0.0-20230830164424-d684fdeb6f29 h1:+kige/h8/LnzWgPjB5NUIHz/pWiW/lFpqcTUkN5uulY=
 github.com/rancher/lasso v0.0.0-20230830164424-d684fdeb6f29/go.mod h1:kgk9kJVMj9FIrrXU0iyM6u/9Je4bEjPImqswkTVaKsQ=
 github.com/rancher/wrangler/v2 v2.1.2 h1:XAiReB3caOAepsTHs12AwKVv4vBJkjLosZPXbbj/85E=

--- a/internal/helmdeployer/install.go
+++ b/internal/helmdeployer/install.go
@@ -136,7 +136,7 @@ func (h *Helm) install(ctx context.Context, bundleID string, manifest *manifest.
 				u.APIVersions = cfg.Capabilities.APIVersions
 			}
 		}
-		u.ForceAdopt = options.Helm.TakeOwnership
+		u.TakeOwnership = options.Helm.TakeOwnership
 		u.EnableDNS = !options.Helm.DisableDNS
 		u.Replace = true
 		u.ReleaseName = releaseName
@@ -156,7 +156,7 @@ func (h *Helm) install(ctx context.Context, bundleID string, manifest *manifest.
 	}
 
 	u := action.NewUpgrade(&cfg)
-	u.Adopt = true
+	u.TakeOwnership = true
 	u.EnableDNS = !options.Helm.DisableDNS
 	u.Force = options.Helm.Force
 	u.Atomic = options.Helm.Atomic


### PR DESCRIPTION
In tag `v3.14.0-fleet2`, `rancher/helm` replaces `ForceAdopt` with `TakeOwnership` to clarify the purpose of that feature.