### PR TITLE
Build for gitjob binaries supports multiple archs

### DIFF
--- a/.github/scripts/build-fleet-binaries.sh
+++ b/.github/scripts/build-fleet-binaries.sh
@@ -15,5 +15,5 @@ go build -gcflags='all=-N -l' -o "bin/fleet-linux-$GOARCH" ./cmd/fleetcli
 go build -gcflags='all=-N -l' -o "bin/fleetagent-linux-$GOARCH" ./cmd/fleetagent
 
 # gitjob
-go build -gcflags='all=-N -l' -o "bin/gitcloner" ./cmd/gitcloner
-go build -gcflags='all=-N -l' -o "bin/gitjob" ./cmd/gitjob
+go build -gcflags='all=-N -l' -o "bin/gitcloner-linux-$GOARCH" ./cmd/gitcloner
+go build -gcflags='all=-N -l' -o "bin/gitjob-linux-$GOARCH" ./cmd/gitjob

--- a/dev/build-fleet
+++ b/dev/build-fleet
@@ -27,7 +27,7 @@ go build -gcflags='all=-N -l' -o "bin/fleetagent-linux-$GOARCH" ./cmd/fleetagent
 docker build -f package/Dockerfile.agent -t rancher/fleet-agent:dev --build-arg="ARCH=$GOARCH" .
 
 # gitjob
-go build -gcflags='all=-N -l' -o "bin/gitcloner" ./cmd/gitcloner
-go build -gcflags='all=-N -l' -o "bin/gitjob" ./cmd/gitjob
+go build -gcflags='all=-N -l' -o "bin/gitcloner-linux-$GOARCH" ./cmd/gitcloner
+go build -gcflags='all=-N -l' -o "bin/gitjob-linux-$GOARCH" ./cmd/gitjob
 
 docker build -f package/Dockerfile.gitjob -t rancher/fleet-gitjob:dev --build-arg="ARCH=$GOARCH" .

--- a/package/Dockerfile.gitjob
+++ b/package/Dockerfile.gitjob
@@ -1,10 +1,22 @@
-FROM registry.suse.com/bci/bci-base:15.5
+ARG BUILD_ENV=dapper
+
+FROM registry.suse.com/bci/bci-base:15.5 AS base
 RUN zypper -n update && \
     zypper -n install openssh catatonit git-core && \
     zypper -n clean -a
 RUN useradd -u 1000 -U -m gitjob
-COPY bin/gitjob /usr/bin/
-COPY bin/gitcloner /usr/bin
+
+FROM base AS copy_dapper
+ONBUILD ARG ARCH
+ONBUILD COPY bin/gitjob-linux-$ARCH /usr/bin/gitjob
+ONBUILD COPY bin/gitcloner-linux-$ARCH /usr/bin/gitcloner
+
+FROM base AS copy_buildx
+ONBUILD ARG TARGETARCH
+ONBUILD COPY bin/gitjob-linux-$TARGETARCH /usr/bin/gitjob
+ONBUILD COPY bin/gitcloner-linux-$TARGETARCH /usr/bin/gitcloner
+
+FROM copy_${BUILD_ENV}
 USER 1000
 ENTRYPOINT ["catatonit", "--"]
 CMD ["gitjob"]

--- a/scripts/package
+++ b/scripts/package
@@ -22,5 +22,6 @@ function build-image() {
 
 build-image fleet
 build-image fleet-agent .agent
+build-image gitjob .gitjob
 
 ./scripts/package-helm


### PR DESCRIPTION
refers to https://github.com/rancher/fleet/issues/2151
follow up for https://github.com/rancher/fleet/pull/2152

This also adds TARGETARCH support for buildx based builders, like goreleaser

 