### PR TITLE
Rename gitjob image

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -113,7 +113,7 @@ steps:
     dockerfile: package/Dockerfile.gitjob
     password:
       from_secret: docker_password
-    repo: "rancher/fleet-gitjob"
+    repo: "rancher/gitjob"
     tag: "${DRONE_TAG}-linux-amd64"
     username:
       from_secret: docker_username
@@ -217,7 +217,7 @@ steps:
     dockerfile: package/Dockerfile.gitjob
     password:
       from_secret: docker_password
-    repo: "rancher/fleet-gitjob"
+    repo: "rancher/gitjob"
     tag: "${DRONE_TAG}-linux-arm64"
     username:
       from_secret: docker_username

--- a/.github/scripts/build-fleet-images.sh
+++ b/.github/scripts/build-fleet-images.sh
@@ -2,4 +2,4 @@ export GOARCH="${GOARCH:-amd64}"
 
 docker build -f package/Dockerfile -t rancher/fleet:dev --build-arg="ARCH=$GOARCH"  .
 docker build -f package/Dockerfile.agent -t rancher/fleet-agent:dev --build-arg="ARCH=$GOARCH" .
-docker build -f package/Dockerfile.gitjob -t rancher/fleet-gitjob:dev --build-arg="ARCH=$GOARCH" .
+docker build -f package/Dockerfile.gitjob -t rancher/gitjob:dev --build-arg="ARCH=$GOARCH" .

--- a/.github/scripts/deploy-fleet.sh
+++ b/.github/scripts/deploy-fleet.sh
@@ -22,7 +22,7 @@ else
   fleetTag="dev"
   agentRepo="rancher/fleet-agent"
   agentTag="dev"
-  gitjobRepo="rancher/fleet-gitjob"
+  gitjobRepo="rancher/gitjob"
   gitjobTag="dev"
 fi
 

--- a/.github/workflows/aks.yml
+++ b/.github/workflows/aks.yml
@@ -122,11 +122,11 @@ jobs:
           tags: ${{ steps.meta-fleet-agent.outputs.tags }}
           labels: ${{ steps.meta-fleet-agent.outputs.labels }}
       -
-        id: meta-fleet-gitjob
+        id: meta-gitjob
         uses: docker/metadata-action@v5
         with:
           images: |
-            ttl.sh/rancher/fleet-gitjob-${{ steps.uuid.outputs.uuid }}
+            ttl.sh/rancher/gitjob-${{ steps.uuid.outputs.uuid }}
           tags: type=raw,value=1h
       -
         uses: docker/build-push-action@v5
@@ -136,14 +136,14 @@ jobs:
           build-args: |
             ARCH=${{ env.GOARCH }}
           push: true
-          tags: ${{ steps.meta-fleet-gitjob.outputs.tags }}
-          labels: ${{ steps.meta-fleet-gitjob.outputs.labels }}
+          tags: ${{ steps.meta-gitjob.outputs.tags }}
+          labels: ${{ steps.meta-gitjob.outputs.labels }}
       -
         name: Deploy Fleet
         run: |
           export KUBECONFIG="$GITHUB_WORKSPACE/kubeconfig-fleet-ci"
           echo "${{ steps.meta-fleet.outputs.tags }} ${{ steps.meta-fleet-agent.outputs.tags }}"
-          ./.github/scripts/deploy-fleet.sh ${{ steps.meta-fleet.outputs.tags }} ${{ steps.meta-fleet-agent.outputs.tags }} ${{ steps.meta-fleet-gitjob.outputs.tags }}
+          ./.github/scripts/deploy-fleet.sh ${{ steps.meta-fleet.outputs.tags }} ${{ steps.meta-fleet-agent.outputs.tags }} ${{ steps.meta-gitjob.outputs.tags }}
       -
         name: Fleet E2E Tests
         env:

--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -71,7 +71,7 @@ jobs:
       -
         name: Import Images Into k3d
         run: |
-          ./.github/scripts/k3d-import-retry.sh rancher/fleet:dev rancher/fleet-agent:dev rancher/fleet-gitjob:dev nginx-git:test
+          ./.github/scripts/k3d-import-retry.sh rancher/fleet:dev rancher/fleet-agent:dev rancher/gitjob:dev nginx-git:test
       -
         name: Set Up Tmate Debug Session
         if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.enable_tmate == 'true' }}

--- a/.github/workflows/e2e-multicluster-ci.yml
+++ b/.github/workflows/e2e-multicluster-ci.yml
@@ -72,7 +72,7 @@ jobs:
       -
         name: Import Images Into k3d
         run: |
-          ./.github/scripts/k3d-import-retry.sh rancher/fleet:dev rancher/fleet-agent:dev rancher/fleet-gitjob:dev -c upstream
+          ./.github/scripts/k3d-import-retry.sh rancher/fleet:dev rancher/fleet-agent:dev rancher/gitjob:dev -c upstream
           ./.github/scripts/k3d-import-retry.sh rancher/fleet-agent:dev -c downstream
       -
         name: Set Up Tmate Debug Session

--- a/.github/workflows/fleet-upgrade.yml
+++ b/.github/workflows/fleet-upgrade.yml
@@ -74,7 +74,7 @@ jobs:
       -
         name: Import Images Into k3d
         run: |
-          ./.github/scripts/k3d-import-retry.sh rancher/fleet:dev rancher/fleet-agent:dev rancher/fleet-gitjob:dev -c upstream
+          ./.github/scripts/k3d-import-retry.sh rancher/fleet:dev rancher/fleet-agent:dev rancher/gitjob:dev -c upstream
       -
         name: Verify Example Workload
         run: |

--- a/.github/workflows/gke.yml
+++ b/.github/workflows/gke.yml
@@ -127,11 +127,11 @@ jobs:
           tags: ${{ steps.meta-fleet-agent.outputs.tags }}
           labels: ${{ steps.meta-fleet-agent.outputs.labels }}
       -
-        id: meta-fleet-gitjob
+        id: meta-gitjob
         uses: docker/metadata-action@v5
         with:
           images: |
-            ttl.sh/rancher/fleet-gitjob-${{ steps.uuid.outputs.uuid }}
+            ttl.sh/rancher/gitjob-${{ steps.uuid.outputs.uuid }}
           tags: type=raw,value=1h
       -
         uses: docker/build-push-action@v5
@@ -141,13 +141,13 @@ jobs:
           build-args: |
             ARCH=${{ env.GOARCH }}
           push: true
-          tags: ${{ steps.meta-fleet-gitjob.outputs.tags }}
-          labels: ${{ steps.meta-fleet-gitjob.outputs.labels }}
+          tags: ${{ steps.meta-gitjob.outputs.tags }}
+          labels: ${{ steps.meta-gitjob.outputs.labels }}
       -
         name: Deploy Fleet
         run: |
           echo "${{ steps.meta-fleet.outputs.tags }} ${{ steps.meta-fleet-agent.outputs.tags }}"
-          ./.github/scripts/deploy-fleet.sh ${{ steps.meta-fleet.outputs.tags }} ${{ steps.meta-fleet-agent.outputs.tags }} ${{ steps.meta-fleet-gitjob.outputs.tags }}
+          ./.github/scripts/deploy-fleet.sh ${{ steps.meta-fleet.outputs.tags }} ${{ steps.meta-fleet-agent.outputs.tags }} ${{ steps.meta-gitjob.outputs.tags }}
       -
         name: Fleet E2E Tests
         env:

--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -72,7 +72,7 @@ jobs:
       -
         name: Import Images Into k3d
         run: |
-          ./.github/scripts/k3d-import-retry.sh rancher/fleet:dev rancher/fleet-agent:dev rancher/fleet-gitjob:dev nginx-git:test
+          ./.github/scripts/k3d-import-retry.sh rancher/fleet:dev rancher/fleet-agent:dev rancher/gitjob:dev nginx-git:test
       -
         name: Set Up Tmate Debug Session
         if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.enable_tmate == 'true' }}

--- a/charts/fleet/values.yaml
+++ b/charts/fleet/values.yaml
@@ -89,7 +89,7 @@ leaderElection:
   renewDeadline: 25s
 
 gitjob:
-  repository: rancher/fleet-gitjob
+  repository: rancher/gitjob
   tag: dev
   imagePullPolicy: IfNotPresent
   nodeSelector:

--- a/cmd/gitjob/main.go
+++ b/cmd/gitjob/main.go
@@ -102,7 +102,7 @@ func bindFlags() flags {
 	flag.StringVar(
 		&image,
 		"gitjob-image",
-		"rancher/fleet-gitjob:dev",
+		"rancher/gitjob:dev",
 		"The gitjob image that will be used in the generated job.",
 	)
 	flag.StringVar(&listen, "listen", ":8080", "The port the webhook listens.")

--- a/dev/build-fleet
+++ b/dev/build-fleet
@@ -30,4 +30,4 @@ docker build -f package/Dockerfile.agent -t rancher/fleet-agent:dev --build-arg=
 go build -gcflags='all=-N -l' -o "bin/gitcloner-linux-$GOARCH" ./cmd/gitcloner
 go build -gcflags='all=-N -l' -o "bin/gitjob-linux-$GOARCH" ./cmd/gitjob
 
-docker build -f package/Dockerfile.gitjob -t rancher/fleet-gitjob:dev --build-arg="ARCH=$GOARCH" .
+docker build -f package/Dockerfile.gitjob -t rancher/gitjob:dev --build-arg="ARCH=$GOARCH" .

--- a/dev/import-images-k3d
+++ b/dev/import-images-k3d
@@ -5,7 +5,7 @@ set -euxo pipefail
 upstream_ctx="${FLEET_E2E_CLUSTER-k3d-upstream}"
 downstream_ctx="${FLEET_E2E_CLUSTER_DOWNSTREAM-k3d-downstream}"
 
-k3d image import rancher/fleet:dev rancher/fleet-agent:dev rancher/fleet-gitjob:dev -m direct -c "${upstream_ctx#k3d-}"
+k3d image import rancher/fleet:dev rancher/fleet-agent:dev rancher/gitjob:dev -m direct -c "${upstream_ctx#k3d-}"
 
 if [ "$upstream_ctx" != "$downstream_ctx" ]; then
   k3d image import rancher/fleet-agent:dev -m direct -c "${downstream_ctx#k3d-}"

--- a/manifest-gitjob.tmpl
+++ b/manifest-gitjob.tmpl
@@ -1,12 +1,12 @@
-image: rancher/fleet-gitjob:{{#if build.tag}}{{build.tag}}{{else}}{{replace "release/" "" build.branch }}-head{{/if}}
+image: rancher/gitjob:{{#if build.tag}}{{build.tag}}{{else}}{{replace "release/" "" build.branch }}-head{{/if}}
 manifests:
   -
-    image: rancher/fleet-gitjob:{{#if build.tag}}{{build.tag}}{{else}}{{replace "release/" "" build.branch }}-head{{/if}}-linux-amd64
+    image: rancher/gitjob:{{#if build.tag}}{{build.tag}}{{else}}{{replace "release/" "" build.branch }}-head{{/if}}-linux-amd64
     platform:
       architecture: amd64
       os: linux
   -
-    image: rancher/fleet-gitjob:{{#if build.tag}}{{build.tag}}{{else}}{{replace "release/" "" build.branch }}-head{{/if}}-linux-arm64
+    image: rancher/gitjob:{{#if build.tag}}{{build.tag}}{{else}}{{replace "release/" "" build.branch }}-head{{/if}}-linux-arm64
     platform:
       architecture: arm64
       os: linux


### PR DESCRIPTION
Naming that image `rancher/gitjob` instead of `rancher/fleet-gitjob` should allow us to keep releasing it with existing permissions.

The risk of confusion for `rancher/gitjob` users is minimal, given that only Fleet is expected to use that repository and its images.

<!-- Specify the issue ID that this pull request is solving -->
Follow-up to #2008
Also relevant to #2151