### PR TITLE
Replace Drone pipeline with Github actions

### DIFF
--- a/.github/workflows/release-fleet.yml
+++ b/.github/workflows/release-fleet.yml
@@ -1,0 +1,110 @@
+# Fleet release workflow
+name: Fleet release
+
+on:
+  push:
+    tags:
+      - v**
+
+permissions:
+  contents: write
+  packages: write
+
+env:
+  GOARCH: amd64
+  CGO_ENABLED: 0
+  SETUP_K3D_VERSION: 'v5.5.1'
+
+jobs:
+  build-fleet:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out Fleet
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+          check-latest: true
+
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v4.0.0
+        with:
+          # Required: the version of golangci-lint is required and must be specified without patch version: we always
+          # use the latest patch version.
+          version: v1.55
+          args: --timeout=10m --config=.golangci.json
+
+      - name: Run FOSSA scan
+        uses: fossas/fossa-action@v1.3.1
+        with:
+          api-key: ${{ secrets.FOSSA_API_KEY }}
+
+      - name: Run FOSSA tests
+        uses: fossas/fossa-action@v1.3.1
+        with:
+          api-key: ${{ secrets.FOSSA_API_KEY }}
+          run-tests: true
+
+      - name: Check for code changes
+        run: |
+          ./.github/scripts/check-for-auto-generated-changes.sh
+          go mod verify
+
+      - name: Run unit tests
+        run: go test -cover -tags=test $(go list ./... | grep -v -e /e2e -e /integrationtests)
+
+      - name: Run integration tests
+        env:
+          SETUP_ENVTEST_VER: v0.0.0-20240115093953-9e6e3b144a69
+          ENVTEST_K8S_VERSION: 1.28
+        run: ./.github/scripts/run-integration-tests.sh
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log into Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v5
+        with:
+          distribution: goreleaser
+          version: v1.24.0
+          args: release --clean --verbose
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload charts to release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          repo: "ghcr.io/rancher/fleet"
+          tag: "${GITHUB_REF_NAME}"
+        run: |
+          sed -i \
+              -e "s@repository:.*@repository: $repo@" \
+              -e "s/tag:.*/tag: ${VERSION}/" \
+              charts/fleet/values.yaml
+
+          sed -i \
+              -e "s@repository:.*@repository: $repo@" \
+              -e "s/tag: dev/tag: ${VERSION}/" \
+              charts/fleet-agent/values.yaml
+
+          helm package --version="$VERSION" --app-version="$VERSION" -d ./dist ./charts/fleet
+          helm package --version="$VERSION" --app-version="$VERSION" -d ./dist ./charts/fleet-crd
+          helm package --version="$VERSION" --app-version="$VERSION" -d ./dist ./charts/fleet-agent
+
+          for f in $(find dist/artifacts/ -name '*.tgz'); do
+            gh release upload $tag $f
+          done

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,268 @@
+---
+project_name: fleet
+
+before:
+  hooks:
+    - go mod download
+
+archives:
+  - id: fleet-controller
+    format: binary
+    name_template: "{{ .Binary }}"
+    builds:
+      - fleet-controller
+
+  - id: fleet-agent
+    format: binary
+    name_template: "{{ .Binary }}"
+    builds:
+      - fleet-agent
+
+  - id: fleet-gitcloner
+    format: binary
+    name_template: "{{ .Binary }}"
+    builds:
+      - fleet-gitcloner
+
+  - id: fleet-gitjob
+    format: binary
+    name_template: "{{ .Binary }}"
+    builds:
+      - fleet-gitjob
+
+  - id: fleet-cli
+    format: binary
+    name_template: "{{ .Binary }}"
+    builds:
+      - fleet-cli
+
+builds:
+  -
+    id: fleet-controller
+    main: ./cmd/fleetcontroller
+    binary: fleetcontroller-{{ .Os }}-{{ .Arch }}{{ if .Arm }}64{{ end }}
+    no_unique_dist_dir: true
+    # gcflags:
+    #   - all="-N -l"
+    ldflags:
+      - -w -s
+      - -X github.com/rancher/fleet/pkg/version.GitCommit={{ .Commit }}
+      - -X github.com/rancher/fleet/pkg/version.Version={{ .Tag }}
+    targets:
+    - linux_amd64_v1
+    - linux_arm64
+  -
+    id: fleet-agent
+    main: ./cmd/fleetagent
+    binary: fleetagent-{{ .Os }}-{{ .Arch }}{{ if .Arm }}64{{ end }}
+    no_unique_dist_dir: true
+    ldflags:
+      - -w -s
+      - -X github.com/rancher/fleet/pkg/version.GitCommit={{ .Commit }}
+      - -X github.com/rancher/fleet/pkg/version.Version={{ .Tag }}
+    targets:
+    - linux_amd64_v1
+    - linux_arm64
+    - windows_amd64
+  -
+    id: fleet-gitcloner
+    main: ./cmd/gitcloner
+    binary: gitcloner-{{ .Os }}-{{ .Arch }}{{ if .Arm }}64{{ end }}
+    no_unique_dist_dir: true
+    ldflags:
+      - -w -s
+      - -X github.com/rancher/fleet/pkg/version.GitCommit={{ .Commit }}
+      - -X github.com/rancher/fleet/pkg/version.Version={{ .Tag }}
+    targets:
+    - linux_amd64_v1
+    - linux_arm64
+  -
+    id: fleet-gitjob
+    main: ./cmd/gitjob
+    binary: gitjob-{{ .Os }}-{{ .Arch }}{{ if .Arm }}64{{ end }}
+    no_unique_dist_dir: true
+    ldflags:
+      - -w -s
+      - -X github.com/rancher/fleet/pkg/version.GitCommit={{ .Commit }}
+      - -X github.com/rancher/fleet/pkg/version.Version={{ .Tag }}
+    targets:
+    - linux_amd64_v1
+    - linux_arm64
+  -
+    id: fleet-cli
+    main: ./cmd/fleetcli
+    binary: fleet-{{ .Os }}-{{ .Arch }}{{ if .Arm }}64{{ end }}
+    no_unique_dist_dir: true
+    ldflags:
+      - -w -s
+      - -X github.com/rancher/fleet/pkg/version.GitCommit={{ .Commit }}
+      - -X github.com/rancher/fleet/pkg/version.Version={{ .Tag }}
+    targets:
+    - linux_amd64_v1
+    - linux_arm64
+    - windows_amd64
+
+changelog:
+  ## Delegate Changelog to release-drafter
+  disable: false
+  use: github
+
+env:
+  - CGO_ENABLED=0
+
+snapshot:
+  name_template: "{{ .Tag }}-next"
+
+dockers:
+  # fleet-controller images
+  -
+    use: buildx
+
+    # GOOS of the built binaries/packages that should be used.
+    goos: linux
+
+    # GOARCH of the built binaries/packages that should be used.
+    goarch: amd64
+
+    # IDs to filter the binaries/packages.
+    ids:
+    - fleet-controller
+
+    # Templates of the Docker image names.
+    image_templates:
+    - "ghcr.io/rancher/fleet:{{ .Tag }}-linux-amd64"
+
+    # Path to the Dockerfile (from the project root).
+    dockerfile: package/Dockerfile
+
+    # Template of the docker build flags.
+    build_flag_templates:
+    - "--pull"
+    - "--label=org.opencontainers.image.created={{.Date}}"
+    - "--label=org.opencontainers.image.title={{.ProjectName}}"
+    - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+    - "--label=org.opencontainers.image.version={{.Version}}"
+    - "--label=org.opencontainers.image.source=https://github.com/rancher/fleet"
+    - "--build-arg=ARCH=amd64"
+    - "--build-arg=BUILD_ENV=goreleaser"
+    - "--platform=linux/amd64"
+  -
+    use: buildx
+    goos: linux
+    goarch: arm64
+    ids:
+    - fleet-controller
+    image_templates:
+    - "ghcr.io/rancher/fleet:{{ .Tag }}-linux-arm64"
+    dockerfile: package/Dockerfile
+    build_flag_templates:
+    - "--pull"
+    - "--label=org.opencontainers.image.created={{.Date}}"
+    - "--label=org.opencontainers.image.title={{.ProjectName}}"
+    - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+    - "--label=org.opencontainers.image.version={{.Version}}"
+    - "--label=org.opencontainers.image.source=https://github.com/rancher/fleet"
+    - "--build-arg=ARCH=arm64"
+    - "--build-arg=BUILD_ENV=goreleaser"
+    - "--platform=linux/arm64/v8"
+  # fleet-agent images
+  -
+    use: buildx
+    goos: linux
+    goarch: amd64
+    ids:
+    - fleet-agent
+    - fleet-cli
+    image_templates:
+    - "ghcr.io/rancher/fleet-agent:{{ .Tag }}-linux-amd64"
+    dockerfile: package/Dockerfile.agent
+    build_flag_templates:
+    - "--pull"
+    - "--label=org.opencontainers.image.created={{.Date}}"
+    - "--label=org.opencontainers.image.title={{.ProjectName}}"
+    - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+    - "--label=org.opencontainers.image.version={{.Version}}"
+    - "--label=org.opencontainers.image.source=https://github.com/rancher/fleet"
+    - "--build-arg=ARCH=amd64"
+    - "--build-arg=BUILD_ENV=goreleaser"
+    - "--platform=linux/amd64"
+    extra_files: [ "package/log.sh" ]
+  -
+    use: buildx
+    goos: linux
+    goarch: arm64
+    ids:
+    - fleet-agent
+    - fleet-cli
+    image_templates:
+    - "ghcr.io/rancher/fleet-agent:{{ .Tag }}-linux-arm64"
+    dockerfile: package/Dockerfile.agent
+    build_flag_templates:
+    - "--pull"
+    - "--label=org.opencontainers.image.created={{.Date}}"
+    - "--label=org.opencontainers.image.title={{.ProjectName}}"
+    - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+    - "--label=org.opencontainers.image.version={{.Version}}"
+    - "--label=org.opencontainers.image.source=https://github.com/rancher/fleet"
+    - "--build-arg=ARCH=arm64"
+    - "--build-arg=BUILD_ENV=goreleaser"
+    - "--platform=linux/arm64/v8"
+    extra_files: [ "package/log.sh" ]
+  # fleet-gitjob images
+  -
+    use: buildx
+    goos: linux
+    goarch: amd64
+    ids:
+    - fleet-gitcloner
+    - fleet-gitjob
+    image_templates:
+    - "ghcr.io/rancher/fleet-gitjob:{{ .Tag }}-linux-amd64"
+    dockerfile: package/Dockerfile.gitjob
+    build_flag_templates:
+    - "--pull"
+    - "--label=org.opencontainers.image.created={{.Date}}"
+    - "--label=org.opencontainers.image.title={{.ProjectName}}"
+    - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+    - "--label=org.opencontainers.image.version={{.Version}}"
+    - "--label=org.opencontainers.image.source=https://github.com/rancher/fleet"
+    - "--build-arg=ARCH=amd64"
+    - "--build-arg=BUILD_ENV=goreleaser"
+    - "--platform=linux/amd64"
+  -
+    use: buildx
+    goos: linux
+    goarch: arm64
+    ids:
+    - fleet-gitcloner
+    - fleet-gitjob
+    image_templates:
+    - "ghcr.io/rancher/fleet-gitjob:{{ .Tag }}-linux-arm64"
+    dockerfile: package/Dockerfile.gitjob
+    build_flag_templates:
+    - "--pull"
+    - "--label=org.opencontainers.image.created={{.Date}}"
+    - "--label=org.opencontainers.image.title={{.ProjectName}}"
+    - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+    - "--label=org.opencontainers.image.version={{.Version}}"
+    - "--label=org.opencontainers.image.source=https://github.com/rancher/fleet"
+    - "--build-arg=ARCH=arm64"
+    - "--build-arg=BUILD_ENV=goreleaser"
+    - "--platform=linux/arm64/v8"
+
+docker_manifests:
+  # https://goreleaser.com/customization/docker_manifest/
+  - name_template: "ghcr.io/rancher/fleet:{{ .Tag }}"
+    image_templates:
+    - "ghcr.io/rancher/fleet:{{ .Tag }}-linux-amd64"
+    - "ghcr.io/rancher/fleet:{{ .Tag }}-linux-arm64"
+
+  - name_template: "ghcr.io/rancher/fleet-agent:{{ .Tag }}"
+    image_templates:
+    - "ghcr.io/rancher/fleet-agent:{{ .Tag }}-linux-amd64"
+    - "ghcr.io/rancher/fleet-agent:{{ .Tag }}-linux-arm64"
+
+  - name_template: "ghcr.io/rancher/fleet-gitjob:{{ .Tag }}"
+    image_templates:
+    - "ghcr.io/rancher/fleet-gitjob:{{ .Tag }}-linux-amd64"
+    - "ghcr.io/rancher/fleet-gitjob:{{ .Tag }}-linux-arm64"

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,6 +1,7 @@
 ARG BUILD_ENV=dapper
+ARG ARCH
 
-FROM registry.suse.com/bci/bci-busybox:15.5 AS base
+FROM --platform=linux/$ARCH registry.suse.com/bci/bci-busybox:15.5 AS base
 
 FROM base AS copy_dapper
 ONBUILD ARG ARCH
@@ -9,6 +10,10 @@ ONBUILD COPY bin/fleetcontroller-linux-${ARCH} /usr/bin/fleetcontroller
 FROM base AS copy_buildx
 ONBUILD ARG TARGETARCH
 ONBUILD COPY bin/fleetcontroller-linux-${TARGETARCH} /usr/bin/fleetcontroller
+
+FROM base AS copy_goreleaser
+ONBUILD ARG ARCH
+ONBUILD COPY fleetcontroller-linux-${ARCH} /usr/bin/fleetcontroller
 
 FROM copy_${BUILD_ENV}
 RUN addgroup -g 1000 fleet-apply && adduser -u 1000 -G fleet-apply -D fleet-apply

--- a/package/Dockerfile.agent
+++ b/package/Dockerfile.agent
@@ -1,6 +1,7 @@
 ARG BUILD_ENV=dapper
+ARG ARCH
 
-FROM registry.suse.com/suse/git:2.35 AS base
+FROM --platform=linux/$ARCH registry.suse.com/suse/git:2.35 AS base
 COPY package/log.sh /usr/bin/
 # Create non-root user and group
 RUN echo "fleet-apply:x:1000:1000::/home/fleet-apply:/bin/bash" >> /etc/passwd && \
@@ -17,6 +18,11 @@ FROM base AS copy_buildx
 ONBUILD ARG TARGETARCH
 ONBUILD COPY bin/fleetagent-linux-$TARGETARCH /usr/bin/fleetagent
 ONBUILD COPY bin/fleet-linux-$TARGETARCH /usr/bin/fleet
+
+FROM base AS copy_goreleaser
+ONBUILD ARG ARCH
+ONBUILD COPY fleetagent-linux-$ARCH /usr/bin/fleetagent
+ONBUILD COPY fleet-linux-$ARCH /usr/bin/fleet
 
 FROM copy_${BUILD_ENV}
 USER 1000

--- a/package/Dockerfile.gitjob
+++ b/package/Dockerfile.gitjob
@@ -1,6 +1,7 @@
 ARG BUILD_ENV=dapper
+ARG ARCH
 
-FROM registry.suse.com/bci/bci-base:15.5 AS base
+FROM --platform=linux/$ARCH registry.suse.com/bci/bci-base:15.5 AS base
 RUN zypper -n update && \
     zypper -n install openssh catatonit git-core && \
     zypper -n clean -a
@@ -15,6 +16,11 @@ FROM base AS copy_buildx
 ONBUILD ARG TARGETARCH
 ONBUILD COPY bin/gitjob-linux-$TARGETARCH /usr/bin/gitjob
 ONBUILD COPY bin/gitcloner-linux-$TARGETARCH /usr/bin/gitcloner
+
+FROM base AS copy_goreleaser
+ONBUILD ARG ARCH
+ONBUILD COPY gitjob-linux-$ARCH /usr/bin/gitjob
+ONBUILD COPY gitcloner-linux-$ARCH /usr/bin/gitcloner
 
 FROM copy_${BUILD_ENV}
 USER 1000


### PR DESCRIPTION
This provides a new `release-fleet.yaml` CI workflow to replace our `.drone.yml` pipelines.
[Here](https://github.com/weyfonk/fleet/releases/tag/v42.0.26-test) is an example of a release generated by this new workflow.

Refers to #2121

## Additions
* Linting
* Integration tests
* `gitjob` and `gitcloner` binaries

## Limitations/Possible improvements
* Single checksum file, as per GoReleaser limitation (this may change [soon](https://github.com/goreleaser/goreleaser/issues/4618)); could be mitigated by using a separate workflow step to compute checksums by target arch
* [No Windows-based images](https://github.com/orgs/goreleaser/discussions/2440) for now, although there may be a way (see [experimental branch](https://github.com/weyfonk/fleet/tree/2121-build-windows-images)) involving a patch to GoReleaser
    * Further discussion suggested that we may not actually _need_ Windows images, because we require at least one Linux node in each cluster, and the agent is not scheduled to run on Windows nodes anyway.
* Fleet binaries are built _twice_ for the Github runner platform: once to run the tests, then again by GoReleaser to prepare a release.

## Doubts
* How much value is there in releasing `gitjob` and `gitcloner` binaries on their own? Would having them in `rancher/gitjob` images be enough?

## Left to do
* Remove `.drone.yml` and Dapper `./scripts/`