### PR TITLE
Add git/ssh binaries to images

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,6 +1,7 @@
 ARG BUILD_ENV=dapper
 
-FROM registry.suse.com/bci/bci-busybox:15.5 AS base
+FROM registry.suse.com/bci/bci-base:15.5 AS base
+RUN zypper in --no-recommends -y git-core openssh; rm -fr /var/cache/* /var/log/*log
 
 FROM base AS copy_dapper
 ONBUILD ARG ARCH

--- a/package/Dockerfile.agent
+++ b/package/Dockerfile.agent
@@ -1,6 +1,7 @@
 ARG BUILD_ENV=dapper
 
-FROM registry.suse.com/suse/git:2.35 AS base
+FROM registry.suse.com/bci/bci-base:15.5 AS base
+RUN zypper in --no-recommends -y git-core openssh; rm -fr /var/cache/* /var/log/*log
 COPY package/log.sh /usr/bin/
 
 FROM base AS copy_dapper


### PR DESCRIPTION
Partially reverts https://github.com/rancher/fleet/pull/2125

The go-getter library used in the fleet apply command [uses the git CLI](https://github.com/hashicorp/go-getter/issues/99). Since git uses the ssh binary, both the git-core and openssh packages are needed.

The go-git library, used in the fleetcontroller (imagescan) needs git and probably ssh. Though the [file:// protocol](https://github.com/go-git/go-git/blob/master/COMPATIBILITY.md#transport-schemes) is not used, they give  [misleading error messages](https://github.com/rancher/gitjob/pull/362) if git is missing.