### PR TITLE
Fixes panic when imagescan uses prereleases and *

### DIFF
--- a/e2e/assets/imagescan/pre-releases-ignored/deployment.yaml
+++ b/e2e/assets/imagescan/pre-releases-ignored/deployment.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pause-prerelease
+  labels:
+    app: pause
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: pause
+  template:
+    metadata:
+      labels:
+        app: pause
+    spec:
+      containers:
+      - name: pause
+        image: {{.ImageWithTag}} # {"$imagescan": "test-scan"}
+        ports:
+        - containerPort: 80

--- a/e2e/assets/imagescan/pre-releases-ignored/fleet.yaml
+++ b/e2e/assets/imagescan/pre-releases-ignored/fleet.yaml
@@ -1,0 +1,21 @@
+imageScans:
+# specify the policy to retrieve images, can be semver or alphabetical order
+- policy:
+    # if range is specified, it will take the latest image according to semver order in the range
+    # for more details on how to use semver, see https://github.com/Masterminds/semver
+    # in this test case we're going to use prerelease versions.
+    # as we're specifying * semver will ignore new tags but should not crash the fleet controller
+    semver:
+      range: "*"
+    # can use ascending or descending order
+    alphabetical:
+      order: asc
+
+  # specify images to scan
+  image: {{.Image}}
+
+  # Specify the tag name, it has to be unique in the same bundle
+  tagName: test-scan
+
+  # Specify the scan interval
+  interval: 5s

--- a/e2e/assets/imagescan/pre-releases-ok/deployment.yaml
+++ b/e2e/assets/imagescan/pre-releases-ok/deployment.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pause-prerelease
+  labels:
+    app: pause
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: pause
+  template:
+    metadata:
+      labels:
+        app: pause
+    spec:
+      containers:
+      - name: pause
+        image: {{.ImageWithTag}} # {"$imagescan": "test-scan"}
+        ports:
+        - containerPort: 80

--- a/e2e/assets/imagescan/pre-releases-ok/fleet.yaml
+++ b/e2e/assets/imagescan/pre-releases-ok/fleet.yaml
@@ -1,0 +1,19 @@
+imageScans:
+# specify the policy to retrieve images, can be semver or alphabetical order
+- policy:
+    # if range is specified, it will take the latest image according to semver order in the range
+    # for more details on how to use semver, see https://github.com/Masterminds/semver
+    semver:
+      range: ">= 0.0.0-40"
+    # can use ascending or descending order
+    alphabetical:
+      order: asc
+
+  # specify images to scan
+  image: {{.Image}}
+
+  # Specify the tag name, it has to be unique in the same bundle
+  tagName: test-scan
+
+  # Specify the scan interval
+  interval: 5s

--- a/e2e/single-cluster/imagescan_test.go
+++ b/e2e/single-cluster/imagescan_test.go
@@ -1,12 +1,20 @@
 package singlecluster_test
 
 import (
+	"fmt"
 	"os"
+	"os/exec"
 	"path"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
 
+	"github.com/go-git/go-git/v5"
 	"github.com/rancher/fleet/e2e/testenv"
 	"github.com/rancher/fleet/e2e/testenv/githelper"
 	"github.com/rancher/fleet/e2e/testenv/kubectl"
+	"k8s.io/apimachinery/pkg/util/uuid"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -14,60 +22,28 @@ import (
 
 var _ = Describe("Image Scan", Label("infra-setup"), func() {
 	var (
-		tmpdir   string
 		clonedir string
 		k        kubectl.Command
-		gh       *githelper.Git
+		assetdir string
 	)
 
-	BeforeEach(func() {
+	JustBeforeEach(func() {
 		k = env.Kubectl.Namespace(env.Namespace)
 
-		// Create git secret
-		out, err := k.Create(
-			"secret", "generic", "git-auth", "--type", "kubernetes.io/basic-auth",
-			"--from-literal=username="+os.Getenv("GIT_HTTP_USER"),
-			"--from-literal=password="+os.Getenv("GIT_HTTP_PASSWORD"),
-		)
-		Expect(err).ToNot(HaveOccurred(), out)
-
-		addr, err := githelper.GetExternalRepoAddr(env, port, repoName)
-		Expect(err).ToNot(HaveOccurred())
-		gh = githelper.NewHTTP(addr)
-		gh.Branch = "imagescan"
-
-		tmpdir, _ = os.MkdirTemp("", "fleet-")
+		tmpdir := GinkgoT().TempDir()
 		clonedir = path.Join(tmpdir, "clone")
-		_, err = gh.Create(clonedir, testenv.AssetPath("imagescan/repo"), "examples")
-		Expect(err).ToNot(HaveOccurred())
-
-		// Build git repo URL reachable _within_ the cluster, for the GitRepo
-		host, err := githelper.BuildGitHostname(env.Namespace)
-		Expect(err).ToNot(HaveOccurred())
-
-		inClusterRepoURL := gh.GetInClusterURL(host, port, repoName)
-
-		gitrepo := path.Join(tmpdir, "gitrepo.yaml")
-		err = testenv.Template(gitrepo, testenv.AssetPath("imagescan/imagescan.yaml"), struct {
-			Repo   string
-			Branch string
-		}{
-			inClusterRepoURL,
-			gh.Branch,
-		})
-		Expect(err).ToNot(HaveOccurred())
-
-		out, err = k.Apply("-f", gitrepo)
-		Expect(err).ToNot(HaveOccurred(), out)
+		setupRepo(k, tmpdir, clonedir, testenv.AssetPath(assetdir))
 	})
 
 	AfterEach(func() {
-		os.RemoveAll(tmpdir)
 		_, _ = k.Delete("gitrepo", "imagescan")
 		_, _ = k.Delete("secret", "git-auth")
 	})
 
 	When("update docker reference in git via image scan", func() {
+		BeforeEach(func() {
+			assetdir = "imagescan/repo"
+		})
 		It("updates the docker reference", func() {
 			By("checking the deployment exists")
 			Eventually(func() string {
@@ -92,3 +68,244 @@ var _ = Describe("Image Scan", Label("infra-setup"), func() {
 		})
 	})
 })
+
+var _ = Describe("Image Scan dynamic tests pushing to ttl.sh", Label("infra-setup"), func() {
+	var (
+		clonedir   string
+		k          kubectl.Command
+		gh         *githelper.Git
+		repository *git.Repository
+		assetdir   string
+		tmpRepoDir string
+		image      string
+		imageTag   string
+	)
+
+	JustBeforeEach(func() {
+		k = env.Kubectl.Namespace(env.Namespace)
+		tmpdir := GinkgoT().TempDir()
+		clonedir = path.Join(tmpdir, "clone")
+		repository = setupRepo(k, tmpdir, clonedir, tmpRepoDir)
+	})
+
+	AfterEach(func() {
+		_, _ = k.Delete("gitrepo", "imagescan")
+		_, _ = k.Delete("secret", "git-auth")
+	})
+	When("deploying imagescan setup with pre-release images", func() {
+		BeforeEach(func() {
+			assetdir = "imagescan/pre-releases-ok"
+			tmpRepoDir = GinkgoT().TempDir()
+			image, imageTag = initRegistryWithImageAndTag("k8s.gcr.io/pause", "0.0.0-40")
+			applyTemplateValues(assetdir, tmpRepoDir, image, imageTag)
+		})
+		It("updates the docker reference", func() {
+			By("checking the deployment exists")
+			Eventually(func() string {
+				out, _ := k.Namespace("default").Get("pods")
+				return out
+			}).Should(ContainSubstring("pause-prerelease-"))
+
+			By("checking the bundle has the original image tag")
+			Eventually(func() string {
+				out, _ := k.Get("bundles", "imagescan-examples", "-o", "yaml")
+				return out
+			}).Should(
+				MatchRegexp(fmt.Sprintf(`image: %s # {"\$imagescan": "test-scan"}`, imageTag)))
+
+			By("pushing a new tag to the registry and checking the new image tag is found in the bundle")
+			newTag := "0.0.0-50"
+			imageTag = tagAndPushImage("k8s.gcr.io/pause", image, newTag)
+			Eventually(func() string {
+				out, _ := k.Get("bundles", "imagescan-examples", "-o", "yaml")
+				return out
+			}).Should(
+				MatchRegexp(fmt.Sprintf(`image: %s # {"\$imagescan": "test-scan"}`, imageTag)))
+
+			By("checking that the new tag is pushed in the git repository")
+			err := gh.CheckoutRemote(repository, "imagescan")
+			Expect(err).NotTo(HaveOccurred())
+			basedir := filepath.Join(clonedir, "examples")
+			b, err := os.ReadFile(filepath.Join(basedir, "deployment.yaml"))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(b)).Should(ContainSubstring(newTag))
+		})
+	})
+
+	// this test didn't pass before adding fix for issue #2096
+	When("deploy imagescan setup with pre-release images and * semver range", func() {
+		BeforeEach(func() {
+			assetdir = "imagescan/pre-releases-ignored"
+			tmpRepoDir = GinkgoT().TempDir()
+			image, imageTag = initRegistryWithImageAndTag("k8s.gcr.io/pause", "0.0.0-40")
+			applyTemplateValues(assetdir, tmpRepoDir, image, imageTag)
+		})
+		It("updates the image reference", func() {
+			By("checking the deployment exists")
+			Eventually(func() string {
+				out, _ := k.Namespace("default").Get("pods")
+				return out
+			}).Should(ContainSubstring("pause-prerelease-"))
+
+			By("checking the bundle has the original image tag")
+			Eventually(func() string {
+				out, _ := k.Get("bundles", "imagescan-examples", "-o", "yaml")
+				return out
+			}).Should(
+				MatchRegexp(fmt.Sprintf(`image: %s # {"\$imagescan": "test-scan"}`, imageTag)))
+
+			By("pushing a new tag to the registry and checking the fleet controller does not crash")
+			// store number of fleet controller restarts to compare later
+			index, ok := getFleetControllerContainerIndexInPod(k, "fleet-controller")
+			Expect(ok).To(BeTrue())
+			fleetControllerInitialRestarts := getFleetControllerRestarts(k, index)
+			newTag := "0.0.0-50"
+			previousImageTag := imageTag
+			imageTag = tagAndPushImage("k8s.gcr.io/pause", image, newTag)
+
+			// the scan time interval is 5 seconds.
+			// we check for 10 seconds so we're sure that the image has been scanned and the controller didn't crash
+			// Checks for number of restarts and also to the status.ready property to be more robust
+			Consistently(func() bool {
+				indexNow, ok := getFleetControllerContainerIndexInPod(k, "fleet-controller")
+				Expect(ok).To(BeTrue())
+				restarts := getFleetControllerRestarts(k, indexNow)
+				ready := getFleetControllerReady(k, indexNow)
+				return (restarts == fleetControllerInitialRestarts) && ready
+			}, 10*time.Second, 1*time.Second).Should(BeTrue())
+
+			By("checking the bundle has the original image tag")
+			Eventually(func() string {
+				out, _ := k.Get("bundles", "imagescan-examples", "-o", "yaml")
+				return out
+			}).Should(
+				MatchRegexp(fmt.Sprintf(`image: %s # {"\$imagescan": "test-scan"}`, previousImageTag)))
+		})
+	})
+	AfterEach(func() {
+		_, _ = k.Delete("gitrepo", "imagescan")
+		_, _ = k.Delete("secret", "git-auth")
+	})
+})
+
+func getFleetControllerRestarts(k kubectl.Command, index int) int {
+	out, err := k.Namespace("cattle-fleet-system").Get("pods", "-l", "app=fleet-controller",
+		"--no-headers",
+		"-o", fmt.Sprintf("custom-columns=RESTARTS:.status.containerStatuses[%d].restartCount", index))
+	Expect(err).NotTo(HaveOccurred())
+	out = strings.TrimSuffix(out, "\n")
+	n, err := strconv.Atoi(out)
+	Expect(err).NotTo(HaveOccurred())
+	return n
+}
+
+func getFleetControllerReady(k kubectl.Command, index int) bool {
+	out, err := k.Namespace("cattle-fleet-system").Get("pods", "-l", "app=fleet-controller",
+		"--no-headers",
+		"-o", fmt.Sprintf("custom-columns=RESTARTS:.status.containerStatuses[%d].ready", index))
+	Expect(err).NotTo(HaveOccurred())
+	out = strings.TrimSuffix(out, "\n")
+	boolValue, err := strconv.ParseBool(out)
+	Expect(err).NotTo(HaveOccurred())
+	return boolValue
+}
+
+func getFleetControllerContainerIndexInPod(k kubectl.Command, container string) (int, bool) {
+	// the fleet controller pod runs 3 containers.
+	// we need to know the index of the fleet-controller container inside the pod.
+	// get all the container names, and return the index of the given container name
+	out, err := k.Namespace("cattle-fleet-system").Get("pods", "-l", "app=fleet-controller",
+		"--no-headers", "-o", "custom-columns=RESTARTS:.status.containerStatuses[*].name")
+	Expect(err).NotTo(HaveOccurred())
+	out = strings.TrimSuffix(out, "\n")
+	containers := strings.Split(out, ",")
+	for i, n := range containers {
+		if container == n {
+			return i, true
+		}
+	}
+	return -1, false
+}
+
+func setupRepo(k kubectl.Command, tmpdir, clonedir, repoDir string) *git.Repository {
+	// Create git secret
+	out, err := k.Create(
+		"secret", "generic", "git-auth", "--type", "kubernetes.io/basic-auth",
+		"--from-literal=username="+os.Getenv("GIT_HTTP_USER"),
+		"--from-literal=password="+os.Getenv("GIT_HTTP_PASSWORD"),
+	)
+	Expect(err).ToNot(HaveOccurred(), out)
+
+	addr, err := githelper.GetExternalRepoAddr(env, port, repoName)
+	Expect(err).ToNot(HaveOccurred())
+	gh := githelper.NewHTTP(addr)
+	gh.Branch = "imagescan"
+
+	repo, err := gh.Create(clonedir, repoDir, "examples")
+	Expect(err).ToNot(HaveOccurred())
+
+	// Build git repo URL reachable _within_ the cluster, for the GitRepo
+	host, err := githelper.BuildGitHostname(env.Namespace)
+	Expect(err).ToNot(HaveOccurred())
+
+	inClusterRepoURL := gh.GetInClusterURL(host, port, repoName)
+
+	gitrepo := path.Join(tmpdir, "gitrepo.yaml")
+	err = testenv.Template(gitrepo, testenv.AssetPath("imagescan/imagescan.yaml"), struct {
+		Repo   string
+		Branch string
+	}{
+		inClusterRepoURL,
+		gh.Branch,
+	})
+	Expect(err).ToNot(HaveOccurred())
+
+	out, err = k.Apply("-f", gitrepo)
+	Expect(err).ToNot(HaveOccurred(), out)
+	return repo
+}
+
+func tagAndPushImage(baseImage, image, tag string) string {
+	imageTag := fmt.Sprintf("%s:%s", image, tag)
+	// tag the image and push it to ttl.sh
+	cmd := exec.Command("docker", "tag", baseImage, imageTag)
+	err := cmd.Run()
+	Expect(err).ToNot(HaveOccurred())
+	// push the image to ttl.sh
+	cmd = exec.Command("docker", "push", imageTag)
+	err = cmd.Run()
+	Expect(err).ToNot(HaveOccurred())
+	return imageTag
+}
+
+func initRegistryWithImageAndTag(baseImage string, tag string) (string, string) {
+	cmd := exec.Command("docker", "pull", baseImage)
+	err := cmd.Run()
+	Expect(err).ToNot(HaveOccurred())
+	// generate a new uuid for this test
+	uuid := uuid.NewUUID()
+	image := fmt.Sprintf("ttl.sh/%s-fleet-test", uuid)
+	imageTag := tagAndPushImage(baseImage, image, tag)
+
+	return image, imageTag
+}
+
+func applyTemplateValues(assetdir, tmpRepoDir, image, imageTag string) {
+	in := filepath.Join(testenv.AssetPath(assetdir), "fleet.yaml")
+	out := filepath.Join(tmpRepoDir, "fleet.yaml")
+	err := testenv.Template(out, in, struct {
+		Image string
+	}{
+		image,
+	})
+	Expect(err).ToNot(HaveOccurred())
+
+	in = filepath.Join(testenv.AssetPath(assetdir), "deployment.yaml")
+	out = filepath.Join(tmpRepoDir, "deployment.yaml")
+	err = testenv.Template(out, in, struct {
+		ImageWithTag string
+	}{
+		imageTag,
+	})
+	Expect(err).ToNot(HaveOccurred())
+}

--- a/e2e/testenv/githelper/git.go
+++ b/e2e/testenv/githelper/git.go
@@ -13,6 +13,7 @@ import (
 	"github.com/go-git/go-billy/v5/osfs"
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/config"
+	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/cache"
 	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/go-git/go-git/v5/plumbing/transport"
@@ -256,6 +257,19 @@ func (g *Git) Update(repo *git.Repository) (string, error) {
 	}
 
 	return h.String(), repo.Push(&po)
+}
+
+// Checkouts the specified remote branch from the given repository
+func (g *Git) CheckoutRemote(repo *git.Repository, branch string) error {
+	w, err := repo.Worktree()
+	if err != nil {
+		return err
+	}
+	_ = repo.Fetch(&git.FetchOptions{RefSpecs: []config.RefSpec{"refs/*:refs/*"}})
+	if err := w.Checkout(&git.CheckoutOptions{Branch: plumbing.NewBranchReferenceName(branch)}); err != nil {
+		return err
+	}
+	return nil
 }
 
 func author() *object.Signature {

--- a/internal/cmd/controller/imagescan/tagscan_job.go
+++ b/internal/cmd/controller/imagescan/tagscan_job.go
@@ -303,5 +303,8 @@ func semverLatest(r string, versions []string) (string, error) {
 			}
 		}
 	}
+	if latestVersion == nil {
+		return "", fmt.Errorf("no available version matching %s", r)
+	}
 	return latestVersion.Original(), nil
 }


### PR DESCRIPTION
When using pre-releases in imagescan combined with
```yaml
semver:
  range: *
```
it failed because `semver` ignores pre-releases unless they're explicitly described in the `semver.range`.

For example:
```yaml
semver:
  range: ">= 0.0.0-40"
```
works fine because it is explicitly using a pre-release.

This fixes the `*` case by checking if there's any version found (lastVersion != nil)

It also adds `e2e` tests for the following imagescans cases:

* Deploy gitrepo with imagescan using `semver.range = ">= 0.0.0-40"` deploying image `0.0.0-40` and after that pushing image `0.0.0-50`
* Same as above but for the case that whis branch fixed (using `semver.range = "*"` with pre-releases.

Refers to: https://github.com/rancher/fleet/issues/2096
