### PR TITLE
Use curl for downloading Windows Git in Dapper

### DIFF
--- a/package/Dockerfile-windows.agent
+++ b/package/Dockerfile-windows.agent
@@ -10,8 +10,7 @@ RUN pushd c:\; \
     $URL = 'https://github.com/git-for-windows/git/releases/download/v2.42.0.windows.2/MinGit-2.42.0.2-64-bit.zip'; \
     \
     Write-Host ('Downloading git from {0} ...' -f $URL); \
-    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-    Invoke-WebRequest -UseBasicParsing -OutFile c:\git.zip -Uri $URL; \
+    curl.exe -sfL $URL -o c:\git.zip; \
     \
     Write-Host 'Expanding ...'; \
     Expand-Archive -Force -Path c:\git.zip -DestinationPath c:\git\.; \


### PR DESCRIPTION
the same way Rancher does it.

This should prevent the following Drone Windows error when building Docker images:
Invoke-WebRequest : Access to the path 'C:\git.zip' is denied.

e.g. https://drone-publish.rancher.io/rancher/fleet/3178/3/2