### PR TITLE
Fix Existing Namespace Not Found By Label

### DIFF
--- a/internal/cmd/agent/controllers/bundledeployment/controller.go
+++ b/internal/cmd/agent/controllers/bundledeployment/controller.go
@@ -198,18 +198,13 @@ func (h *handler) updateNamespace(ns *corev1.Namespace) error {
 func (h *handler) fetchNamespace(releaseID string) (*corev1.Namespace, error) {
 	// releaseID is composed of release.Namespace/release.Name/release.Version
 	namespace := strings.Split(releaseID, "/")[0]
-	list, err := h.dynamic.Resource(nsResource).List(h.ctx, metav1.ListOptions{
-		LabelSelector: corev1.LabelMetadataName + "=" + namespace,
-	})
+	res, err := h.dynamic.Resource(nsResource).Get(h.ctx, namespace, metav1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}
-	if len(list.Items) == 0 {
-		return nil, fmt.Errorf("namespace %s not found", namespace)
-	}
 	var ns corev1.Namespace
 	err = runtime.DefaultUnstructuredConverter.
-		FromUnstructured(list.Items[0].Object, &ns)
+		FromUnstructured(res.Object, &ns)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/cmd/agent/controllers/bundledeployment/controller.go
+++ b/internal/cmd/agent/controllers/bundledeployment/controller.go
@@ -199,7 +199,7 @@ func (h *handler) fetchNamespace(releaseID string) (*corev1.Namespace, error) {
 	// releaseID is composed of release.Namespace/release.Name/release.Version
 	namespace := strings.Split(releaseID, "/")[0]
 	list, err := h.dynamic.Resource(nsResource).List(h.ctx, metav1.ListOptions{
-		LabelSelector: "name=" + namespace,
+		LabelSelector: corev1.LabelMetadataName + "=" + namespace,
 	})
 	if err != nil {
 		return nil, err
@@ -217,16 +217,18 @@ func (h *handler) fetchNamespace(releaseID string) (*corev1.Namespace, error) {
 	return &ns, nil
 }
 
-// addLabelsFromOptions updates nsLabels so that it only contains all labels specified in optLabels, plus the `name` labels added by Helm when creating the namespace.
+// addLabelsFromOptions updates nsLabels so that it only contains all labels
+// specified in optLabels, plus the `kubernetes.io/metadata.name` labels added
+// by kubernetes when creating the namespace.
 func addLabelsFromOptions(nsLabels map[string]string, optLabels map[string]string) {
 	for k, v := range optLabels {
 		nsLabels[k] = v
 	}
 
 	// Delete labels not defined in the options.
-	// Keep the name label as it is added by helm when creating the namespace.
+	// Keep the `kubernetes.io/metadata.name` label as it is added by kubernetes when creating the namespace.
 	for k := range nsLabels {
-		if _, ok := optLabels[k]; k != "name" && !ok {
+		if _, ok := optLabels[k]; k != corev1.LabelMetadataName && !ok {
 			delete(nsLabels, k)
 		}
 	}

--- a/internal/cmd/agent/controllers/bundledeployment/controller_test.go
+++ b/internal/cmd/agent/controllers/bundledeployment/controller_test.go
@@ -33,13 +33,14 @@ func TestSetNamespaceLabelsAndAnnotations(t *testing.T) {
 			}},
 			ns: corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{"name": "test"},
+					Name:   "namespace1234",
+					Labels: map[string]string{"kubernetes.io/metadata.name": "namespace"},
 				},
 			},
 			release: "namespace/foo/bar",
 			expectedNs: corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels:      map[string]string{"name": "test", "optLabel1": "optValue1", "optLabel2": "optValue2"},
+					Labels:      map[string]string{"kubernetes.io/metadata.name": "namespace", "optLabel1": "optValue1", "optLabel2": "optValue2"},
 					Annotations: map[string]string{"optAnn1": "optValue1"},
 				},
 			},
@@ -54,14 +55,15 @@ func TestSetNamespaceLabelsAndAnnotations(t *testing.T) {
 			}},
 			ns: corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels:      map[string]string{"nsLabel": "nsValue", "name": "test"},
+					Name:        "namespace1234",
+					Labels:      map[string]string{"nsLabel": "nsValue", "kubernetes.io/metadata.name": "namespace"},
 					Annotations: map[string]string{"nsAnn": "nsValue"},
 				},
 			},
 			release: "namespace/foo/bar",
 			expectedNs: corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels:      map[string]string{"optLabel": "optValue", "name": "test"},
+					Labels:      map[string]string{"optLabel": "optValue", "kubernetes.io/metadata.name": "namespace"},
 					Annotations: map[string]string{},
 				},
 			},
@@ -76,14 +78,15 @@ func TestSetNamespaceLabelsAndAnnotations(t *testing.T) {
 			}},
 			ns: corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels:      map[string]string{"bdLabel": "nsValue"},
+					Name:        "namespace1234",
+					Labels:      map[string]string{"bdLabel": "nsValue", "kubernetes.io/metadata.name": "namespace"},
 					Annotations: map[string]string{"bdAnn": "nsValue"},
 				},
 			},
 			release: "namespace/foo/bar",
 			expectedNs: corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels:      map[string]string{"bdLabel": "labelUpdated"},
+					Labels:      map[string]string{"bdLabel": "labelUpdated", "kubernetes.io/metadata.name": "namespace"},
 					Annotations: map[string]string{"bdAnn": "annUpdated"},
 				},
 			},

--- a/internal/cmd/agent/controllers/bundledeployment/controller_test.go
+++ b/internal/cmd/agent/controllers/bundledeployment/controller_test.go
@@ -104,7 +104,7 @@ func TestSetNamespaceLabelsAndAnnotations(t *testing.T) {
 			mockDynamic := mocks.NewMockInterface(ctrl)
 			mockNamespaceableResourceInterface := mocks.NewMockNamespaceableResourceInterface(ctrl)
 			u, _ := runtime.DefaultUnstructuredConverter.ToUnstructured(&test.ns)
-			// Resource will be called twice, one time for UPDATE and another time for LIST
+			// Resource will be called twice, one time for UPDATE and another time for GET
 			mockDynamic.EXPECT().Resource(gomock.Any()).Return(mockNamespaceableResourceInterface).Times(2)
 			mockNamespaceableResourceInterface.EXPECT().Get(gomock.Any(), "namespace", metav1.GetOptions{}).
 				Return(&unstructured.Unstructured{Object: u}, nil).Times(1)

--- a/internal/cmd/agent/controllers/bundledeployment/controller_test.go
+++ b/internal/cmd/agent/controllers/bundledeployment/controller_test.go
@@ -3,7 +3,6 @@ package bundledeployment
 //go:generate mockgen --build_flags=--mod=mod -destination=../../../controller/mocks/dynamic_mock.go -package mocks k8s.io/client-go/dynamic Interface,NamespaceableResourceInterface
 
 import (
-	"errors"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -12,6 +11,7 @@ import (
 	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -33,13 +33,14 @@ func TestSetNamespaceLabelsAndAnnotations(t *testing.T) {
 			}},
 			ns: corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:   "namespace1234",
+					Name:   "namespace",
 					Labels: map[string]string{"kubernetes.io/metadata.name": "namespace"},
 				},
 			},
 			release: "namespace/foo/bar",
 			expectedNs: corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
+					Name:        "namespace",
 					Labels:      map[string]string{"kubernetes.io/metadata.name": "namespace", "optLabel1": "optValue1", "optLabel2": "optValue2"},
 					Annotations: map[string]string{"optAnn1": "optValue1"},
 				},
@@ -55,7 +56,7 @@ func TestSetNamespaceLabelsAndAnnotations(t *testing.T) {
 			}},
 			ns: corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:        "namespace1234",
+					Name:        "namespace",
 					Labels:      map[string]string{"nsLabel": "nsValue", "kubernetes.io/metadata.name": "namespace"},
 					Annotations: map[string]string{"nsAnn": "nsValue"},
 				},
@@ -63,6 +64,7 @@ func TestSetNamespaceLabelsAndAnnotations(t *testing.T) {
 			release: "namespace/foo/bar",
 			expectedNs: corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
+					Name:        "namespace",
 					Labels:      map[string]string{"optLabel": "optValue", "kubernetes.io/metadata.name": "namespace"},
 					Annotations: map[string]string{},
 				},
@@ -78,7 +80,7 @@ func TestSetNamespaceLabelsAndAnnotations(t *testing.T) {
 			}},
 			ns: corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:        "namespace1234",
+					Name:        "namespace",
 					Labels:      map[string]string{"bdLabel": "nsValue", "kubernetes.io/metadata.name": "namespace"},
 					Annotations: map[string]string{"bdAnn": "nsValue"},
 				},
@@ -86,6 +88,7 @@ func TestSetNamespaceLabelsAndAnnotations(t *testing.T) {
 			release: "namespace/foo/bar",
 			expectedNs: corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
+					Name:        "namespace",
 					Labels:      map[string]string{"bdLabel": "labelUpdated", "kubernetes.io/metadata.name": "namespace"},
 					Annotations: map[string]string{"bdAnn": "annUpdated"},
 				},
@@ -103,11 +106,8 @@ func TestSetNamespaceLabelsAndAnnotations(t *testing.T) {
 			u, _ := runtime.DefaultUnstructuredConverter.ToUnstructured(&test.ns)
 			// Resource will be called twice, one time for UPDATE and another time for LIST
 			mockDynamic.EXPECT().Resource(gomock.Any()).Return(mockNamespaceableResourceInterface).Times(2)
-			mockNamespaceableResourceInterface.EXPECT().List(gomock.Any(), metav1.ListOptions{
-				LabelSelector: "name=namespace",
-			}).Return(&unstructured.UnstructuredList{
-				Items: []unstructured.Unstructured{{Object: u}},
-			}, nil).Times(1)
+			mockNamespaceableResourceInterface.EXPECT().Get(gomock.Any(), "namespace", metav1.GetOptions{}).
+				Return(&unstructured.Unstructured{Object: u}, nil).Times(1)
 			uns, _ := runtime.DefaultUnstructuredConverter.ToUnstructured(&test.expectedNs)
 			mockNamespaceableResourceInterface.EXPECT().Update(gomock.Any(), &unstructured.Unstructured{Object: uns}, gomock.Any()).Times(1)
 
@@ -131,24 +131,20 @@ func TestSetNamespaceLabelsAndAnnotationsError(t *testing.T) {
 		},
 	}}
 	release := "test/foo/bar"
-	expectedErr := errors.New("namespace test not found")
 
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	mockDynamic := mocks.NewMockInterface(ctrl)
 	mockNamespaceableResourceInterface := mocks.NewMockNamespaceableResourceInterface(ctrl)
 	mockDynamic.EXPECT().Resource(gomock.Any()).Return(mockNamespaceableResourceInterface).Times(1)
-	mockNamespaceableResourceInterface.EXPECT().List(gomock.Any(), metav1.ListOptions{
-		LabelSelector: "name=test",
-	}).Return(&unstructured.UnstructuredList{
-		Items: []unstructured.Unstructured{},
-	}, nil).Times(1)
+	mockNamespaceableResourceInterface.EXPECT().Get(gomock.Any(), "test", metav1.GetOptions{}).
+		Return(nil, apierrors.NewNotFound(corev1.Resource("namespace"), "test")).Times(1)
 	h := handler{
 		dynamic: mockDynamic,
 	}
 	err := h.setNamespaceLabelsAndAnnotations(bd, release)
 
-	if err.Error() != expectedErr.Error() {
-		t.Errorf("expected error %v: got %v", expectedErr, err)
+	if !apierrors.IsNotFound(err) {
+		t.Errorf("expected not found error: got %v", err)
 	}
 }


### PR DESCRIPTION
Refers to #2195 

Filter by `kubernetes.io/metadata.name` label

Use the label `kubernetes.io/metadata.name`, which is added by k8s to all
namespaces, instead of the helm "name" label. The helm "name" label
might be missing from pre-existing namespaces.

Switch `fetchNamespace` to Get instead of list

Was using List with a label, that's set by k8s to the name of the
namespace. Only returned the first result.
Testdata assumed label and namespace name could be different.
