### PR TITLE
Switch fetchNamespace to Get instead of list

### DIFF
--- a/internal/cmd/agent/deployer/deployer.go
+++ b/internal/cmd/agent/deployer/deployer.go
@@ -16,6 +16,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
@@ -161,20 +162,15 @@ func (d *Deployer) updateNamespace(ctx context.Context, ns *corev1.Namespace) er
 }
 
 // fetchNamespace gets the namespace matching the release ID. Returns an error if none is found.
+// releaseID is composed of release.Namespace/release.Name/release.Version
 func (d *Deployer) fetchNamespace(ctx context.Context, releaseID string) (*corev1.Namespace, error) {
-	// releaseID is composed of release.Namespace/release.Name/release.Version
 	namespace := strings.Split(releaseID, "/")[0]
-	list := &corev1.NamespaceList{}
-	err := d.client.List(ctx, list, client.MatchingLabels{
-		corev1.LabelMetadataName: namespace,
-	})
+	ns := &corev1.Namespace{}
+	err := d.client.Get(ctx, types.NamespacedName{Name: namespace}, ns)
 	if err != nil {
 		return nil, err
 	}
-	if len(list.Items) == 0 {
-		return nil, fmt.Errorf("namespace %s not found", namespace)
-	}
-	return &list.Items[0], nil
+	return ns, nil
 }
 
 // addLabelsFromOptions updates nsLabels so that it only contains all labels specified in optLabels, plus the `kubernetes.io/metadata.name` labels added by kubernetes when creating the namespace.


### PR DESCRIPTION
Was using List with a label, that's set by k8s to the name of the namespace. Only returned the first result.
Testdata assumed label and namespace name could be different.

<!-- Specify the issue ID that this pull request is solving -->
Follow up to #1994
