### PR TITLE
Do not mess up go toolchain during release

### DIFF
--- a/.github/workflows/release-against-rancher.yml
+++ b/.github/workflows/release-against-rancher.yml
@@ -22,11 +22,15 @@ on:
         description: "Should the Fleet api be bumped in the Rancher repo? (In most cases true unless there are incompatibilities.)"
         required: true
         default: "true"
+      go_version:
+        description: "Go version used for bumping the api. This should be the same version as in the go.mod file of the project."
+        required: true
+        default: '1.21.*'
 
 env:
   GOARCH: amd64
   CGO_ENABLED: 0
-  SETUP_GO_VERSION: '1.22.*'
+  SETUP_GO_VERSION: ${{github.event.inputs.go_version}}
 
 jobs:
   create-rancher-pr:


### PR DESCRIPTION
by making the go version of the Github release action for Rancher configurable.

Test run against this branch: https://github.com/rancher/fleet/actions/runs/8157486317