### PR TITLE
Make AlphabeticalPolicy string check case insensitive

### DIFF
--- a/internal/cmd/controller/imagescan/tagscan_job.go
+++ b/internal/cmd/controller/imagescan/tagscan_job.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/Masterminds/semver/v3"
@@ -265,7 +266,7 @@ func latestTag(policy fleet.ImagePolicyChoice, versions []string) (string, error
 		if policy.Alphabetical.Order == "" {
 			des = true
 		} else {
-			des = policy.Alphabetical.Order == AlphabeticalOrderDesc
+			des = strings.ToUpper(policy.Alphabetical.Order) == AlphabeticalOrderDesc
 		}
 		var latest string
 		for _, version := range versions {

--- a/internal/cmd/controller/imagescan/tagscan_job_test.go
+++ b/internal/cmd/controller/imagescan/tagscan_job_test.go
@@ -1,0 +1,48 @@
+package imagescan
+
+import (
+	"fmt"
+	"testing"
+
+	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
+)
+
+var alphabeticalVersions = []string{"a", "b", "c"}
+func TestLatestTag(t *testing.T) {
+	alphabeticalAscPolicyLowercase := fleet.ImagePolicyChoice{
+		Alphabetical: &fleet.AlphabeticalPolicy{Order: "asc"},
+	}
+	alphabeticalAscPolicyUppercase := fleet.ImagePolicyChoice{
+		Alphabetical: &fleet.AlphabeticalPolicy{Order: "ASC"},
+	}
+	alphabeticalDescPolicyLowercase := fleet.ImagePolicyChoice{
+		Alphabetical: &fleet.AlphabeticalPolicy{Order: "desc"},
+	}
+	alphabeticalDescPolicyUppercase := fleet.ImagePolicyChoice{
+		Alphabetical: &fleet.AlphabeticalPolicy{Order: "DESC"},
+	}
+
+	out, err := latestTag(alphabeticalAscPolicyLowercase, alphabeticalVersions)
+	if err != nil {
+		t.Fatalf("Error getting latest tag: %v", err)
+	}
+	fmt.Println(out)
+
+	out, err = latestTag(alphabeticalAscPolicyUppercase, alphabeticalVersions)
+	if err != nil {
+		t.Fatalf("Error getting latest tag: %v", err)
+	}
+	fmt.Println(out)
+
+	out, err = latestTag(alphabeticalDescPolicyLowercase, alphabeticalVersions)
+	if err != nil {
+		t.Fatalf("Error getting latest tag: %v", err)
+	}
+	fmt.Println(out)
+	
+	out, err = latestTag(alphabeticalDescPolicyUppercase, alphabeticalVersions)
+	if err != nil {
+		t.Fatalf("Error getting latest tag: %v", err)
+	}
+	fmt.Println(out)
+}

--- a/internal/cmd/controller/imagescan/tagscan_job_test.go
+++ b/internal/cmd/controller/imagescan/tagscan_job_test.go
@@ -1,48 +1,58 @@
 package imagescan
 
 import (
-	"fmt"
 	"testing"
 
 	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
 )
 
 var alphabeticalVersions = []string{"a", "b", "c"}
+
 func TestLatestTag(t *testing.T) {
-	alphabeticalAscPolicyLowercase := fleet.ImagePolicyChoice{
-		Alphabetical: &fleet.AlphabeticalPolicy{Order: "asc"},
-	}
-	alphabeticalAscPolicyUppercase := fleet.ImagePolicyChoice{
-		Alphabetical: &fleet.AlphabeticalPolicy{Order: "ASC"},
-	}
-	alphabeticalDescPolicyLowercase := fleet.ImagePolicyChoice{
-		Alphabetical: &fleet.AlphabeticalPolicy{Order: "desc"},
-	}
-	alphabeticalDescPolicyUppercase := fleet.ImagePolicyChoice{
-		Alphabetical: &fleet.AlphabeticalPolicy{Order: "DESC"},
+	tests := []struct{
+		name, want string
+		policy fleet.ImagePolicyChoice
+	}{
+		{
+			name: "alphabetical asc lowercase",
+			policy: fleet.ImagePolicyChoice{
+				Alphabetical: &fleet.AlphabeticalPolicy{Order: "asc"},
+			},
+			want: "a",
+		}, 
+		{
+			name: "alphabetical asc uppercase",
+			policy: fleet.ImagePolicyChoice{
+				Alphabetical: &fleet.AlphabeticalPolicy{Order: "ASC"},
+			},
+			want: "a",
+		}, 
+		{
+			name: "alphabetical desc lowercase",
+			policy: fleet.ImagePolicyChoice{
+				Alphabetical: &fleet.AlphabeticalPolicy{Order: "desc"},
+			},
+			want: "c",
+		}, 
+		{
+			name: "alphabetical desc uppercase",
+			policy: fleet.ImagePolicyChoice{
+				Alphabetical: &fleet.AlphabeticalPolicy{Order: "DESC"},
+			},
+			want: "c",
+		},
 	}
 
-	out, err := latestTag(alphabeticalAscPolicyLowercase, alphabeticalVersions)
-	if err != nil {
-		t.Fatalf("Error getting latest tag: %v", err)
-	}
-	fmt.Println(out)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := latestTag(tt.policy, alphabeticalVersions)
+			if err != nil {
+				t.Errorf("Error calling latestTag: %v", err)
+			}
 
-	out, err = latestTag(alphabeticalAscPolicyUppercase, alphabeticalVersions)
-	if err != nil {
-		t.Fatalf("Error getting latest tag: %v", err)
+			if got != tt.want {
+				t.Errorf("latestTag() = %v, want %v", got, tt.want)
+			}
+		})
 	}
-	fmt.Println(out)
-
-	out, err = latestTag(alphabeticalDescPolicyLowercase, alphabeticalVersions)
-	if err != nil {
-		t.Fatalf("Error getting latest tag: %v", err)
-	}
-	fmt.Println(out)
-	
-	out, err = latestTag(alphabeticalDescPolicyUppercase, alphabeticalVersions)
-	if err != nil {
-		t.Fatalf("Error getting latest tag: %v", err)
-	}
-	fmt.Println(out)
 }

--- a/internal/cmd/controller/imagescan/tagscan_job_test.go
+++ b/internal/cmd/controller/imagescan/tagscan_job_test.go
@@ -6,9 +6,10 @@ import (
 	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
 )
 
-var alphabeticalVersions = []string{"a", "b", "c"}
 
 func TestLatestTag(t *testing.T) {
+	var alphabeticalVersions = []string{"a", "b", "c"}
+
 	tests := []struct{
 		name, want string
 		policy fleet.ImagePolicyChoice
@@ -47,7 +48,7 @@ func TestLatestTag(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := latestTag(tt.policy, alphabeticalVersions)
 			if err != nil {
-				t.Errorf("Error calling latestTag: %v", err)
+				t.Fatalf("Error calling latestTag: %v", err)
 			}
 
 			if got != tt.want {

--- a/internal/cmd/controller/imagescan/tagscan_job_test.go
+++ b/internal/cmd/controller/imagescan/tagscan_job_test.go
@@ -6,13 +6,12 @@ import (
 	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
 )
 
-
 func TestLatestTag(t *testing.T) {
 	var alphabeticalVersions = []string{"a", "b", "c"}
 
-	tests := []struct{
+	tests := []struct {
 		name, want string
-		policy fleet.ImagePolicyChoice
+		policy     fleet.ImagePolicyChoice
 	}{
 		{
 			name: "alphabetical asc lowercase",
@@ -20,21 +19,21 @@ func TestLatestTag(t *testing.T) {
 				Alphabetical: &fleet.AlphabeticalPolicy{Order: "asc"},
 			},
 			want: "a",
-		}, 
+		},
 		{
 			name: "alphabetical asc uppercase",
 			policy: fleet.ImagePolicyChoice{
 				Alphabetical: &fleet.AlphabeticalPolicy{Order: "ASC"},
 			},
 			want: "a",
-		}, 
+		},
 		{
 			name: "alphabetical desc lowercase",
 			policy: fleet.ImagePolicyChoice{
 				Alphabetical: &fleet.AlphabeticalPolicy{Order: "desc"},
 			},
 			want: "c",
-		}, 
+		},
 		{
 			name: "alphabetical desc uppercase",
 			policy: fleet.ImagePolicyChoice{


### PR DESCRIPTION

<!-- Make sure that the referenced issue provides steps to reproduce it -->

<!-- Describe the changes introduced by this pull request -->
Previously if users wanted to use image scan with descending alphabetical policy, they had to use uppercase `DESC`, as shown below:
```yaml
imageScans:
# specify the policy to retrieve images, can be semver or alphabetical order
- policy:
    # can use ascending or descending order
    alphabetical:
      order: DESC
```
This is not very intuitive, because the [documentation](https://fleet.rancher.io/imagescan) gives an example in lowercase:
```yaml
imageScans:
# specify the policy to retrieve images, can be semver or alphabetical order
- policy:
    # if range is specified, it will take the latest image according to semver order in the range
    # for more details on how to use semver, see https://github.com/Masterminds/semver
    semver:
      range: "*"
    # can use ascending or descending order
    alphabetical:
      order: asc
```
This PR makes the string check case insensitive, removing the need to use uppercase `DESC` in the `fleet.yaml`
<!--
  Please provide a unit, integration (`./integrationtests/`) or e2e (`./e2e/`) test if possible.
-->