### PR TITLE
Use portable API for bind mounts in integration tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/Masterminds/sprig/v3 v3.2.3
 	github.com/cheggaaa/pb v1.0.29
 	github.com/davecgh/go-spew v1.1.1
+	github.com/docker/docker v25.0.3+incompatible
 	github.com/evanphx/json-patch v5.7.0+incompatible
 	github.com/go-git/go-billy/v5 v5.5.0
 	github.com/go-git/go-git/v5 v5.11.0
@@ -97,7 +98,6 @@ require (
 	github.com/distribution/reference v0.5.0 // indirect
 	github.com/docker/cli v25.0.1+incompatible // indirect
 	github.com/docker/distribution v2.8.3+incompatible // indirect
-	github.com/docker/docker v25.0.3+incompatible // indirect
 	github.com/docker/docker-credential-helpers v0.7.0 // indirect
 	github.com/docker/go-connections v0.5.0 // indirect
 	github.com/docker/go-metrics v0.0.1 // indirect

--- a/integrationtests/gitcloner/clone_test.go
+++ b/integrationtests/gitcloner/clone_test.go
@@ -17,6 +17,8 @@ import (
 	"github.com/rancher/fleet/cmd/gitcloner/cmd"
 	"github.com/rancher/fleet/cmd/gitcloner/gogit"
 
+	dockercontainer "github.com/docker/docker/api/types/container"
+	dockermount "github.com/docker/docker/api/types/mount"
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing/object"
@@ -286,11 +288,15 @@ func createGogsContainerWithHTTPS() (testcontainers.Container, error) {
 	req := testcontainers.ContainerRequest{
 		Image:        "gogs/gogs:0.13",
 		ExposedPorts: []string{gogsHTTPSPort + "/tcp", gogsSSHPort + "/tcp"},
-		Mounts: testcontainers.ContainerMounts{
-			{
-				Source: testcontainers.GenericBindMountSource{HostPath: tmpDir},
-				Target: "/data",
-			},
+		HostConfigModifier: func(hostConfig *dockercontainer.HostConfig) {
+			hostConfig.Mounts = []dockermount.Mount{
+				{
+					Type:   dockermount.TypeBind,
+					Source: tmpDir,
+					Target: "/data",
+				},
+			}
+
 		},
 	}
 	container, err := testcontainers.GenericContainer(context.Background(), testcontainers.GenericContainerRequest{

--- a/integrationtests/gitjob/git/git_test.go
+++ b/integrationtests/gitjob/git/git_test.go
@@ -13,6 +13,8 @@ import (
 	"testing"
 	"time"
 
+	dockercontainer "github.com/docker/docker/api/types/container"
+	dockermount "github.com/docker/docker/api/types/mount"
 	gogit "github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing/object"
@@ -286,11 +288,15 @@ func createGogsContainer(ctx context.Context, tmpDir string) (testcontainers.Con
 			wait.ForHTTP("/").WithPort("3000/tcp").WithStartupTimeout(startupTimeout),
 			wait.ForListeningPort("22/tcp").WithStartupTimeout(startupTimeout),
 		),
-		Mounts: testcontainers.ContainerMounts{
-			{
-				Source: testcontainers.GenericBindMountSource{HostPath: tmpDir},
-				Target: "/data",
-			},
+		HostConfigModifier: func(hostConfig *dockercontainer.HostConfig) {
+			hostConfig.Mounts = []dockermount.Mount{
+				{
+					Type:   dockermount.TypeBind,
+					Source: tmpDir,
+					Target: "/data",
+				},
+			}
+
 		},
 	}
 	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{


### PR DESCRIPTION
This eliminates linter [errors](https://github.com/rancher/fleet/actions/runs/8291590248/job/22691555805).
Those were not caught when bumping `testcontainers/testcontainers-go` because when running against pull requests, `golangci-lint` only runs against the diff which in that case only affected the go mod and sum files.