### PR TITLE
Fixes for image reference and CI

### DIFF
--- a/charts/fleet/templates/deployment_gitjob.yaml
+++ b/charts/fleet/templates/deployment_gitjob.yaml
@@ -40,15 +40,22 @@ spec:
             - name: CATTLE_DEV_MODE
               value: "true"
           {{- end }}
-      {{- with .Values.tolerations }}
-      tolerations:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.nodeSelector }}
-      nodeSelector:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+      nodeSelector: {{ include "linux-node-selector" . | nindent 8 }}
+{{- if .Values.nodeSelector }}
+{{ toYaml .Values.nodeSelector | indent 8 }}
+{{- end }}
+      tolerations: {{ include "linux-node-tolerations" . | nindent 8 }}
+{{- if .Values.tolerations }}
+{{ toYaml .Values.tolerations | indent 8 }}
+{{- end }}
       {{- if .Values.priorityClassName }}
       priorityClassName: "{{.Values.priorityClassName}}"
       {{- end }}
+{{- end }}
+
+{{- if not .Values.debug }}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
 {{- end }}

--- a/dev/build-fleet
+++ b/dev/build-fleet
@@ -22,10 +22,10 @@ go build -gcflags='all=-N -l' -o "bin/gitcloner-linux-$GOARCH" ./cmd/gitcloner
 go build -gcflags='all=-N -l' -o "bin/gitjob-linux-$GOARCH" ./cmd/gitjob
 
 # fleet
+go build -gcflags='all=-N -l' -o "bin/fleet-linux-$GOARCH" ./cmd/fleetcli
 go build -gcflags='all=-N -l' -o bin/fleetcontroller-linux-"$GOARCH" ./cmd/fleetcontroller
 docker build -f package/Dockerfile -t rancher/fleet:dev --build-arg="ARCH=$GOARCH"  .
 
 # fleet agent
-go build -gcflags='all=-N -l' -o "bin/fleet-linux-$GOARCH" ./cmd/fleetcli
 go build -gcflags='all=-N -l' -o "bin/fleetagent-linux-$GOARCH" ./cmd/fleetagent
 docker build -f package/Dockerfile.agent -t rancher/fleet-agent:dev --build-arg="ARCH=$GOARCH" .

--- a/internal/cmd/gitjob/gitjob.go
+++ b/internal/cmd/gitjob/gitjob.go
@@ -13,7 +13,6 @@ import (
 	"github.com/sirupsen/logrus"
 
 	grutil "github.com/rancher/fleet/internal/cmd/controller/gitrepo"
-	"github.com/rancher/fleet/internal/config"
 	v1alpha1 "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
 	"github.com/rancher/wrangler/v2/pkg/condition"
 	"github.com/rancher/wrangler/v2/pkg/kstatus"
@@ -51,7 +50,7 @@ type GitPoller interface {
 	CleanUpGitRepoPollJobs(ctx context.Context)
 }
 
-// CronJobReconciler reconciles a GitJob object
+// CronJobReconciler reconciles a GitRepo resource to create a git cloning k8s job
 type GitJobReconciler struct {
 	client.Client
 	Scheme    *runtime.Scheme
@@ -380,7 +379,7 @@ func (r *GitJobReconciler) computeJobSpec(ctx context.Context, gitrepo *v1alpha1
 				Containers: []corev1.Container{
 					{
 						Name:         "fleet",
-						Image:        config.DefaultManagerImage,
+						Image:        r.Image,
 						Command:      []string{"log.sh"},
 						Args:         append(args, paths...),
 						WorkingDir:   "/workspace/source",

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -6,8 +6,6 @@ COPY package/log.sh /usr/bin/
 RUN zypper -n update && \
     zypper -n install openssh catatonit git-core && \
     zypper -n clean -a
-RUN groupadd -g 1000 fleet-apply
-RUN useradd -u 1000 -U -m gitjob
 
 FROM base AS copy_dapper
 ONBUILD ARG ARCH
@@ -31,7 +29,6 @@ ONBUILD COPY gitjob-linux-$ARCH /usr/bin/gitjob
 ONBUILD COPY gitcloner-linux-$ARCH /usr/bin/gitcloner
 
 FROM copy_${BUILD_ENV}
-RUN useradd fleet-apply -u 1001 -G fleet-apply
 USER 1000
 ENTRYPOINT ["catatonit", "--"]
 CMD ["fleetcontroller"]

--- a/package/Dockerfile.agent
+++ b/package/Dockerfile.agent
@@ -2,11 +2,6 @@ ARG BUILD_ENV=dapper
 ARG ARCH
 
 FROM --platform=linux/$ARCH registry.suse.com/bci/bci-busybox:15.5 AS base
-# Create non-root user and group
-RUN echo "fleet-apply:x:1000:1000::/home/fleet-apply:/bin/bash" >> /etc/passwd && \
-    echo "fleet-apply:x:1000:" >> /etc/group && \
-    mkdir /home/fleet-apply && \
-    chown -R fleet-apply:fleet-apply /home/fleet-apply
 
 FROM base AS copy_dapper
 ONBUILD ARG ARCH
@@ -19,7 +14,6 @@ ONBUILD COPY bin/fleetagent-linux-$TARGETARCH /usr/bin/fleetagent
 FROM base AS copy_goreleaser
 ONBUILD ARG ARCH
 ONBUILD COPY fleetagent-linux-$ARCH /usr/bin/fleetagent
-ONBUILD COPY fleet-linux-$ARCH /usr/bin/fleet
 
 FROM copy_${BUILD_ENV}
 USER 1000


### PR DESCRIPTION

Gitjob deployment uses same fields as in the other deployments.
* nodeSelector for linux
* securityContext for uid
* tolerations for linux

Fixed dev script error, tried to copy binary that wasn't build.

Fleet CLI is now on the fleet controller image, update git job to use the new image.


Refers to https://github.com/rancher/fleet/issues/2184