### PR TITLE
Duplicate integrationtests scripts for devs

### DIFF
--- a/.github/scripts/run-integration-tests.sh
+++ b/.github/scripts/run-integration-tests.sh
@@ -6,11 +6,8 @@ SETUP_ENVTEST_VER=${SETUP_ENVTEST_VER-v0.0.0-20221214170741-69f093833822}
 ENVTEST_K8S_VERSION=${ENVTEST_K8S_VERSION-1.25}
 
 # install and prepare setup-envtest
-if ! command -v setup-envtest &> /dev/null
-then
-    go install sigs.k8s.io/controller-runtime/tools/setup-envtest@$SETUP_ENVTEST_VER
-fi
-KUBEBUILDER_ASSETS=$(setup-envtest use --use-env -p path $ENVTEST_K8S_VERSION)
+go install sigs.k8s.io/controller-runtime/tools/setup-envtest@"$SETUP_ENVTEST_VER"
+KUBEBUILDER_ASSETS=$(setup-envtest use --use-env -p path "$ENVTEST_K8S_VERSION")
 export KUBEBUILDER_ASSETS
 
 # run integration tests

--- a/dev/run-integration-tests.sh
+++ b/dev/run-integration-tests.sh
@@ -2,4 +2,16 @@
 
 set -euxo pipefail
 
-./.github/scripts/run-integration-tests.sh
+SETUP_ENVTEST_VER=${SETUP_ENVTEST_VER-v0.0.0-20240115093953-9e6e3b144a69}
+ENVTEST_K8S_VERSION=${ENVTEST_K8S_VERSION-1.28}
+
+# install and prepare setup-envtest
+if ! command -v setup-envtest &> /dev/null
+then
+    go install sigs.k8s.io/controller-runtime/tools/setup-envtest@"$SETUP_ENVTEST_VER"
+fi
+KUBEBUILDER_ASSETS=$(setup-envtest use --use-env -p path "$ENVTEST_K8S_VERSION")
+export KUBEBUILDER_ASSETS
+
+# run integration tests
+go test ./integrationtests/...


### PR DESCRIPTION
Devs modify these scripts to run tests locally. Protect the CI scripts from accidential changes, as these are overlooked easily in PR reviews.
