### PR TITLE
CI script to update fleet reset values

### DIFF
--- a/.github/scripts/upgrade-rancher-fleet-to-dev-fleet.sh
+++ b/.github/scripts/upgrade-rancher-fleet-to-dev-fleet.sh
@@ -29,6 +29,7 @@ until helm -n cattle-fleet-system status fleet | grep -q "STATUS: deployed"; do 
 sed -i 's/^version: 0/version: 9000/' charts/fleet/Chart.yaml
 
 helm upgrade fleet charts/fleet \
+  --reset-then-reuse-values \
   --wait -n cattle-fleet-system \
   --create-namespace \
   --set image.repository="$fleetRepo" \


### PR DESCRIPTION
Values handling changed in recent Helm versions, maybe that's related. Using the new switch `--reset-then-reuse-values`:

> when upgrading, reset the values to the ones built into the chart, apply the last release's values and merge in any overrides from the command line via --set and -f. If '--reset-values' or '--reuse-values' is specified, this is ignored
