### PR TITLE
Adds extra e2e test to check status display

### DIFF
--- a/e2e/assets/single-cluster/helm-status-check.yaml
+++ b/e2e/assets/single-cluster/helm-status-check.yaml
@@ -1,0 +1,10 @@
+apiVersion: fleet.cattle.io/v1alpha1
+kind: GitRepo
+metadata:
+  name: sample
+  namespace: fleet-local
+spec:
+  repo: "https://github.com/rancher/fleet-test-data"
+  branch: master
+  paths:
+  - helm-deployment-status


### PR DESCRIPTION
Adding an extra test that deploys a bit more complex scenario so it exercises the Watcher area and events that were filtered in PR: https://github.com/rancher/fleet/pull/2031 

This test should fail from `v0.9.1-rc.2` to `v0.9.1-rc.6` and was fixed after reverting the above PR in `v0.9.2-rc.1`

It also introduces the following changes in CI:
* ~bumps `golangci-lint` to the last version~
* ~adds the `skip-pkg-cache: true` to `golangci-lint`~
* ~Uses typos `v1.19.0` as latest version (v1.20.1) adds false positives~ → see #2269 and #2273 

Related to: https://github.com/rancher/fleet/issues/2128
