### PR TITLE
CI bumps golangci-lint and uses typos 1.19.0

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -27,13 +27,15 @@ jobs:
           export PATH=$PATH:/home/runner/go/bin/
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3.7.0
+        uses: golangci/golangci-lint-action@v4.0.0
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.56
+          version: v1.57.2
 
           args: --timeout=10m --config=.golangci.json
 
           # Optional: show only new issues if it's a pull request. The default value is `false`.
           # The condition sets this to true for PR events.
           only-new-issues: "${{ github.event_name == 'pull_request'}}"
+
+          skip-pkg-cache: true

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -30,7 +30,7 @@ jobs:
         uses: golangci/golangci-lint-action@v4.0.0
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.57.2
+          version: v1.57
 
           args: --timeout=10m --config=.golangci.json
 

--- a/.github/workflows/typos.yaml
+++ b/.github/workflows/typos.yaml
@@ -10,5 +10,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Check spelling of file.txt
-      uses: crate-ci/typos@master
+      # Using v1.19.0 as v1.20.1 introduced a new false positive.
+      # 'ro' in ${PWD}:${PWD}:ro was identified as a typo for 'to'
+      uses: crate-ci/typos@v1.19.0
 

--- a/.golangci.json
+++ b/.golangci.json
@@ -1,9 +1,6 @@
 {
   "run": {
-    "deadline": "20s",
-    "skip-files": [
-      "/zz_generated_"
-    ]
+    "timeout": "20s"
   },
   "linters-settings": {
     "revive": {


### PR DESCRIPTION
Bumping `goglangci-lint` to 4.0.0 and 1.57.2 and adding `skip-pkg-cache: true`

Using `typos` 1.19.0 as 1.20.0 and 1.20.1 introduced false errors.
False positive introduced in 1.20.1 is:
```
error: `ro` should be `to`
  --> ./fleet/cmd/codegen/hack/patch_crd_descriptions.sh:27:59
   |
27 |     container_id=$(docker create --rm -i -v ${PWD}:${PWD}:ro -w ${PWD} -v ${tmpdir}:${tmpdir} ${image} yq $@ )
   |                                                           ^^
   |
 ```
