### PR TITLE
CI: Revert typos back to master

### DIFF
--- a/.github/workflows/typos.yaml
+++ b/.github/workflows/typos.yaml
@@ -10,7 +10,5 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Check spelling of file.txt
-      # Using v1.19.0 as v1.20.1 introduced a new false positive.
-      # 'ro' in ${PWD}:${PWD}:ro was identified as a typo for 'to'
-      uses: crate-ci/typos@v1.19.0
+      uses: crate-ci/typos@master
 

--- a/_typos.toml
+++ b/_typos.toml
@@ -4,3 +4,4 @@ extend-exclude = ["go.mod","ssh_host_ecdsa_key","cloner_test.go"]
 [default.extend-identifiers]
 "passin" = "passin"
 "ANDed" = "ANDed"
+"HoTWPQxTJ5dIY31" = "HoTWPQxTJ5dIY31"


### PR DESCRIPTION
The false positive issue we had with 1.20.0 and 1.20.1 has been fixed. 

We can get back to master to run the latest.

