### PR TITLE
[Backport 0.9] CI: Revert typos back to master

### DIFF
--- a/.github/workflows/typos.yaml
+++ b/.github/workflows/typos.yaml
@@ -10,5 +10,4 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Check spelling of file.txt
-      uses: crate-ci/typos@v1.19.0
-
+      uses: crate-ci/typos@master


### PR DESCRIPTION
The false positive issue we had with 1.20.0 and 1.20.1 has been fixed. 

We can get back to master to run the latest.
