### PR TITLE
Optimize renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,5 +8,9 @@
   "prHourlyLimit": 2,
   "ignorePaths": [
     "**/assets/**"
-  ]
+  ],
+  "force": {
+    "constraints": {
+    }
+  }
 }


### PR DESCRIPTION
There were two issues with renovate so far, both are fixed in this pr.

1. The first is that the renovate action fails with the helmv3 manager. The issue seems to be that we have two `Chart.yaml` files which have template variables, which are not helm compatible, when directly parsed.
To prevent future issues like these all assets directories are added to `ignorePaths`.
2. The default renovate config in our rancher repo has an [exception](https://github.com/rancher/renovate-config/blob/release/default.json#L11-L16) for go 1.22, which disables the run of go mod tidy for it.
I have tested to override this constraint without issues.


