### PR TITLE
Add static sharding support

### DIFF
--- a/.github/scripts/deploy-fleet.sh
+++ b/.github/scripts/deploy-fleet.sh
@@ -2,6 +2,8 @@
 
 set -euxo pipefail
 
+shards=${SHARDS-""}
+
 function eventually {
   for _ in $(seq 1 3); do
     "$@" && return 0
@@ -35,6 +37,8 @@ eventually helm upgrade --install fleet charts/fleet \
   --set agentImage.repository="$agentRepo" \
   --set agentImage.tag="$agentTag" \
   --set agentImage.imagePullPolicy=IfNotPresent \
+  --set shards="{$shards}" \
+  --set debug=true --set debugLevel=1
 
 # wait for controller and agent rollout
 kubectl -n cattle-fleet-system rollout status deploy/fleet-controller

--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -82,7 +82,7 @@ jobs:
       -
         name: Deploy Fleet
         run: |
-          ./.github/scripts/deploy-fleet.sh
+          SHARDS="shard1,shard2,shard3" ./.github/scripts/deploy-fleet.sh
       -
         name: Create Zot certificates for OCI tests
         env:

--- a/charts/fleet/templates/deployment.yaml
+++ b/charts/fleet/templates/deployment.yaml
@@ -15,6 +15,7 @@ spec:
     metadata:
       labels:
         app: fleet-controller
+        shard: "{{ . }}"
     spec:
       containers:
       - env:

--- a/charts/fleet/templates/deployment.yaml
+++ b/charts/fleet/templates/deployment.yaml
@@ -6,7 +6,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: "fleet-controller{{if . }}-shard-{{ . }}{{end}}" # TODO normalise strings or use indexes!
+  name: "fleet-controller{{if . }}-shard-{{ . }}{{end}}"
 spec:
   selector:
     matchLabels:

--- a/charts/fleet/templates/deployment.yaml
+++ b/charts/fleet/templates/deployment.yaml
@@ -71,7 +71,7 @@ spec:
         {{- end }}
         {{- if . }}
         - --shard-id
-        - {{ . }}
+        - {{ quote . }}
         {{- end }}
         {{- if $.Values.debug }}
         - --debug

--- a/charts/fleet/templates/deployment.yaml
+++ b/charts/fleet/templates/deployment.yaml
@@ -1,7 +1,12 @@
+{{ $shards := list "" }}
+{{ if len .Values.shards }}
+{{ $shards = concat $shards .Values.shards | uniq }}
+{{ end }}
+{{ range $shards }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: fleet-controller
+  name: "fleet-controller{{if . }}-shard-{{ . }}{{end}}" # TODO normalise strings or use indexes!
 spec:
   selector:
     matchLabels:
@@ -18,55 +23,59 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         - name: FLEET_PROPAGATE_DEBUG_SETTINGS_TO_AGENTS
-          value: {{ quote .Values.propagateDebugSettingsToAgents }}
-        {{- if .Values.clusterEnqueueDelay }}
+          value: {{ quote $.Values.propagateDebugSettingsToAgents }}
+        {{- if $.Values.clusterEnqueueDelay }}
         - name: FLEET_CLUSTER_ENQUEUE_DELAY
-          value: {{ .Values.clusterEnqueueDelay }}
+          value: {{ $.Values.clusterEnqueueDelay }}
         {{- end }}
-        {{- if .Values.proxy }}
+        {{- if $.Values.proxy }}
         - name: HTTP_PROXY
-          value: {{ .Values.proxy }}
+          value: {{ $.Values.proxy }}
         - name: HTTPS_PROXY
-          value: {{ .Values.proxy }}
+          value: {{ $.Values.proxy }}
         - name: NO_PROXY
-          value: {{ .Values.noProxy }}
+          value: {{ $.Values.noProxy }}
         {{- end }}
-        {{- if .Values.cpuPprof }}
+        {{- if $.Values.cpuPprof }}
         - name: FLEET_CPU_PPROF_DIR
           value: /tmp/pprof/
         {{- end }}
-        {{- if .Values.cpuPprof }}
+        {{- if $.Values.cpuPprof }}
         - name: FLEET_CPU_PPROF_PERIOD
-          value: {{ quote .Values.cpuPprof.period }}
+          value: {{ quote $.Values.cpuPprof.period }}
         {{- end }}
-        {{- if .Values.leaderElection.leaseDuration }}
+        {{- if $.Values.leaderElection.leaseDuration }}
         - name: CATTLE_ELECTION_LEASE_DURATION
-          value: {{.Values.leaderElection.leaseDuration}}
+          value: {{$.Values.leaderElection.leaseDuration}}
         {{- end }}
-        {{- if .Values.leaderElection.retryPeriod }}
+        {{- if $.Values.leaderElection.retryPeriod }}
         - name: CATTLE_ELECTION_RETRY_PERIOD
-          value: {{.Values.leaderElection.retryPeriod}}
+          value: {{$.Values.leaderElection.retryPeriod}}
         {{- end }}
-        {{- if .Values.leaderElection.renewDeadline }}
+        {{- if $.Values.leaderElection.renewDeadline }}
         - name: CATTLE_ELECTION_RENEW_DEADLINE
-          value: {{.Values.leaderElection.renewDeadline}}
+          value: {{$.Values.leaderElection.renewDeadline}}
         {{- end }}
-        {{- if .Values.debug }}
+        {{- if $.Values.debug }}
         - name: CATTLE_DEV_MODE
           value: "true"
         {{- end }}
-        image: '{{ template "system_default_registry" . }}{{ .Values.image.repository }}:{{ .Values.image.tag }}'
+        image: '{{ template "system_default_registry" $ }}{{ $.Values.image.repository }}:{{ $.Values.image.tag }}'
         name: fleet-controller
-        imagePullPolicy: "{{ .Values.image.imagePullPolicy }}"
+        imagePullPolicy: "{{ $.Values.image.imagePullPolicy }}"
         command:
         - fleetcontroller
-        {{- if not .Values.gitops.enabled }}
+        {{- if not $.Values.gitops.enabled }}
         - --disable-gitops
         {{- end }}
-        {{- if .Values.debug }}
+        {{- if . }}
+        - --shard-id
+        - {{ . }}
+        {{- end }}
+        {{- if $.Values.debug }}
         - --debug
         - --debug-level
-        - {{ quote .Values.debugLevel }}
+        - {{ quote $.Values.debugLevel }}
         {{- else }}
         securityContext:
           allowPrivilegeEscalation: false
@@ -79,41 +88,42 @@ spec:
         volumeMounts:
           - mountPath: /tmp
             name: tmp
-        {{- if .Values.cpuPprof }}
+        {{- if $.Values.cpuPprof }}
           - mountPath: /tmp/pprof
             name: pprof
         {{- end }}
+      {{- if not . }} # Only deploy cleanup and agent management through sharding-less deployment
       - env:
         - name: NAMESPACE
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        {{- if .Values.debug }}
+        {{- if $.Values.debug }}
         - name: CATTLE_DEV_MODE
           value: "true"
         {{- end }}
-        {{- if .Values.leaderElection.leaseDuration }}
+        {{- if $.Values.leaderElection.leaseDuration }}
         - name: CATTLE_ELECTION_LEASE_DURATION
-          value: {{.Values.leaderElection.leaseDuration}}
+          value: {{$.Values.leaderElection.leaseDuration}}
         {{- end }}
-        {{- if .Values.leaderElection.retryPeriod }}
+        {{- if $.Values.leaderElection.retryPeriod }}
         - name: CATTLE_ELECTION_RETRY_PERIOD
-          value: {{.Values.leaderElection.retryPeriod}}
+          value: {{$.Values.leaderElection.retryPeriod}}
         {{- end }}
-        {{- if .Values.leaderElection.renewDeadline }}
+        {{- if $.Values.leaderElection.renewDeadline }}
         - name: CATTLE_ELECTION_RENEW_DEADLINE
-          value: {{.Values.leaderElection.renewDeadline}}
+          value: {{$.Values.leaderElection.renewDeadline}}
         {{- end }}
-        image: '{{ template "system_default_registry" . }}{{ .Values.image.repository }}:{{ .Values.image.tag }}'
+        image: '{{ template "system_default_registry" $ }}{{ $.Values.image.repository }}:{{ $.Values.image.tag }}'
         name: fleet-cleanup
-        imagePullPolicy: "{{ .Values.image.imagePullPolicy }}"
+        imagePullPolicy: "{{ $.Values.image.imagePullPolicy }}"
         command:
         - fleetcontroller
         - cleanup
-        {{- if .Values.debug }}
+        {{- if $.Values.debug }}
         - --debug
         - --debug-level
-        - {{ quote .Values.debugLevel }}
+        - {{ quote $.Values.debugLevel }}
         {{- else }}
         securityContext:
           allowPrivilegeEscalation: false
@@ -128,35 +138,35 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        {{- if .Values.debug }}
+        {{- if $.Values.debug }}
         - name: CATTLE_DEV_MODE
           value: "true"
         {{- end }}
-        {{- if .Values.leaderElection.leaseDuration }}
+        {{- if $.Values.leaderElection.leaseDuration }}
         - name: CATTLE_ELECTION_LEASE_DURATION
-          value: {{.Values.leaderElection.leaseDuration}}
+          value: {{$.Values.leaderElection.leaseDuration}}
         {{- end }}
-        {{- if .Values.leaderElection.retryPeriod }}
+        {{- if $.Values.leaderElection.retryPeriod }}
         - name: CATTLE_ELECTION_RETRY_PERIOD
-          value: {{.Values.leaderElection.retryPeriod}}
+          value: {{$.Values.leaderElection.retryPeriod}}
         {{- end }}
-        {{- if .Values.leaderElection.renewDeadline }}
+        {{- if $.Values.leaderElection.renewDeadline }}
         - name: CATTLE_ELECTION_RENEW_DEADLINE
-          value: {{.Values.leaderElection.renewDeadline}}
+          value: {{$.Values.leaderElection.renewDeadline}}
         {{- end }}
-        image: '{{ template "system_default_registry" . }}{{ .Values.image.repository }}:{{ .Values.image.tag }}'
+        image: '{{ template "system_default_registry" $ }}{{ $.Values.image.repository }}:{{ $.Values.image.tag }}'
         name: fleet-agentmanagement
-        imagePullPolicy: "{{ .Values.image.imagePullPolicy }}"
+        imagePullPolicy: "{{ $.Values.image.imagePullPolicy }}"
         command:
         - fleetcontroller
         - agentmanagement
-        {{- if not .Values.bootstrap.enabled }}
+        {{- if not $.Values.bootstrap.enabled }}
         - --disable-bootstrap
         {{- end }}
-        {{- if .Values.debug }}
+        {{- if $.Values.debug }}
         - --debug
         - --debug-level
-        - {{ quote .Values.debugLevel }}
+        - {{ quote $.Values.debugLevel }}
         {{- else }}
         securityContext:
           allowPrivilegeEscalation: false
@@ -166,29 +176,32 @@ spec:
             drop:
             - ALL
         {{- end }}
+      {{- end }}
       volumes:
         - name: tmp
           emptyDir: {}
-      {{- if .Values.cpuPprof }}
-        - name: pprof {{ toYaml .Values.cpuPprof.volumeConfiguration | nindent 10 }}
+      {{- if $.Values.cpuPprof }}
+        - name: pprof {{ toYaml $.Values.cpuPprof.volumeConfiguration | nindent 10 }}
       {{- end }}
 
       serviceAccountName: fleet-controller
       nodeSelector: {{ include "linux-node-selector" . | nindent 8 }}
-{{- if .Values.nodeSelector }}
-{{ toYaml .Values.nodeSelector | indent 8 }}
+{{- if $.Values.nodeSelector }}
+{{ toYaml $.Values.nodeSelector | indent 8 }}
 {{- end }}
       tolerations: {{ include "linux-node-tolerations" . | nindent 8 }}
-{{- if .Values.tolerations }}
-{{ toYaml .Values.tolerations | indent 8 }}
+{{- if $.Values.tolerations }}
+{{ toYaml $.Values.tolerations | indent 8 }}
 {{- end }}
-      {{- if .Values.priorityClassName }}
-      priorityClassName: "{{.Values.priorityClassName}}"
+      {{- if $.Values.priorityClassName }}
+      priorityClassName: "{{$.Values.priorityClassName}}"
       {{- end }}
 
-{{- if not .Values.debug }}
+{{- if not $.Values.debug }}
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000
         runAsGroup: 1000
+{{- end }}
+---
 {{- end }}

--- a/dev/setup-fleet
+++ b/dev/setup-fleet
@@ -4,6 +4,7 @@
 set -euxo pipefail
 
 cluster_name=${1-upstream}
+shards=${2-""}
 
 if [ ! -d ./charts/fleet ]; then
   echo "please change the current directory to the fleet repo checkout"
@@ -18,6 +19,7 @@ helm -n cattle-fleet-system upgrade --install --create-namespace --wait fleet-cr
 helm -n cattle-fleet-system upgrade --install --create-namespace --wait --reset-values \
   --set apiServerCA="$ca" \
   --set apiServerURL="$server" \
+  --set shards="{$shards}" \
   --set debug=true --set debugLevel=1 fleet charts/fleet
 
 # wait for controller and agent rollout

--- a/dev/setup-single-cluster
+++ b/dev/setup-single-cluster
@@ -12,7 +12,7 @@ source ./dev/setup-cluster-config
 ./dev/setup-k3d
 ./dev/build-fleet
 ./dev/import-images-k3d
-./dev/setup-fleet
+./dev/setup-fleet upstream shard1,shard2,shard3
 
 # needed for gitrepo tests
 ./dev/import-images-tests-k3d

--- a/e2e/assets/gitrepo/gitrepo_sharded.yaml
+++ b/e2e/assets/gitrepo/gitrepo_sharded.yaml
@@ -1,0 +1,13 @@
+kind: GitRepo
+apiVersion: fleet.cattle.io/v1alpha1
+metadata:
+  name: {{.Name}}
+  labels:
+    fleet.cattle.io/shard: {{.ShardID}}
+spec:
+  repo: {{.Repo}}
+  branch: {{.Branch}}
+  pollingInterval: {{.PollingInterval}}
+  targetNamespace: {{.TargetNamespace}}
+  paths:
+  - examples

--- a/e2e/single-cluster/imagescan_test.go
+++ b/e2e/single-cluster/imagescan_test.go
@@ -189,7 +189,7 @@ var _ = Describe("Image Scan dynamic tests pushing to ttl.sh", Label("infra-setu
 })
 
 func getFleetControllerRestarts(k kubectl.Command, index int) int {
-	out, err := k.Namespace("cattle-fleet-system").Get("pods", "-l", "app=fleet-controller",
+	out, err := k.Namespace("cattle-fleet-system").Get("pods", "-l", "app=fleet-controller", "-l", "shard=",
 		"--no-headers",
 		"-o", fmt.Sprintf("custom-columns=RESTARTS:.status.containerStatuses[%d].restartCount", index))
 	Expect(err).NotTo(HaveOccurred())
@@ -200,7 +200,7 @@ func getFleetControllerRestarts(k kubectl.Command, index int) int {
 }
 
 func getFleetControllerReady(k kubectl.Command, index int) bool {
-	out, err := k.Namespace("cattle-fleet-system").Get("pods", "-l", "app=fleet-controller",
+	out, err := k.Namespace("cattle-fleet-system").Get("pods", "-l", "app=fleet-controller", "-l", "shard=",
 		"--no-headers",
 		"-o", fmt.Sprintf("custom-columns=RESTARTS:.status.containerStatuses[%d].ready", index))
 	Expect(err).NotTo(HaveOccurred())
@@ -214,7 +214,7 @@ func getFleetControllerContainerIndexInPod(k kubectl.Command, container string) 
 	// the fleet controller pod runs 3 containers.
 	// we need to know the index of the fleet-controller container inside the pod.
 	// get all the container names, and return the index of the given container name
-	out, err := k.Namespace("cattle-fleet-system").Get("pods", "-l", "app=fleet-controller",
+	out, err := k.Namespace("cattle-fleet-system").Get("pods", "-l", "app=fleet-controller", "-l", "shard=",
 		"--no-headers", "-o", "custom-columns=RESTARTS:.status.containerStatuses[*].name")
 	Expect(err).NotTo(HaveOccurred())
 	out = strings.TrimSuffix(out, "\n")

--- a/e2e/single-cluster/sharding_test.go
+++ b/e2e/single-cluster/sharding_test.go
@@ -1,0 +1,202 @@
+package singlecluster_test
+
+import (
+	"fmt"
+	"math/rand"
+	"os"
+	"path"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/matchers"
+	"github.com/rancher/fleet/e2e/testenv"
+	"github.com/rancher/fleet/e2e/testenv/githelper"
+	"github.com/rancher/fleet/e2e/testenv/kubectl"
+)
+
+var shards = []string{"shard1", "shard2", "shard3"}
+
+var _ = Describe("Filtering events by shard", Label("infra-setup"), Ordered, func() {
+	var (
+		tmpDir           string
+		clonedir         string
+		k                kubectl.Command
+		gh               *githelper.Git
+		inClusterRepoURL string
+		gitrepoName      string
+		r                = rand.New(rand.NewSource(GinkgoRandomSeed()))
+		targetNamespace  string
+	)
+
+	BeforeAll(func() {
+		// No sharded controller should have reconciled any GitRepo until this point.
+		for _, shard := range shards {
+			logs, err := k.Namespace("cattle-fleet-system").Logs(
+				"-l",
+				"app=fleet-controller",
+				"-l",
+				fmt.Sprintf("shard=%s", shard),
+			)
+			Expect(err).ToNot(HaveOccurred())
+			regexMatcher := matchers.MatchRegexpMatcher{Regexp: "Reconciling GitRepo.*"}
+			hasReconciledGitRepos, err := regexMatcher.Match(logs)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(hasReconciledGitRepos).To(BeFalse())
+		}
+
+		// Build git repo URL reachable _within_ the cluster, for the GitRepo
+		host, err := githelper.BuildGitHostname(env.Namespace)
+		Expect(err).ToNot(HaveOccurred())
+
+		addr, err := githelper.GetExternalRepoAddr(env, port, repoName)
+		Expect(err).ToNot(HaveOccurred())
+		gh = githelper.NewHTTP(addr)
+
+		inClusterRepoURL = gh.GetInClusterURL(host, port, repoName)
+
+		tmpDir, _ = os.MkdirTemp("", "fleet-")
+		clonedir = path.Join(tmpDir, repoName)
+
+		gitrepoName = testenv.RandomFilename("sharding-test", r)
+
+		_, err = gh.Create(clonedir, testenv.AssetPath("gitrepo/sleeper-chart"), "examples")
+		Expect(err).ToNot(HaveOccurred())
+
+		k = env.Kubectl.Namespace(env.Namespace)
+	})
+
+	for _, shard := range shards {
+		When(fmt.Sprintf("deploying a gitrepo labeled with shard ID %s", shard), func() {
+			JustBeforeEach(func() {
+				targetNamespace = testenv.NewNamespaceName("target", r)
+
+				err := testenv.ApplyTemplate(k, testenv.AssetPath("gitrepo/gitrepo_sharded.yaml"), struct {
+					Name            string
+					Repo            string
+					Branch          string
+					PollingInterval string
+					TargetNamespace string
+					ShardID         string
+				}{
+					gitrepoName,
+					inClusterRepoURL,
+					gh.Branch,
+					"15s",           // default
+					targetNamespace, // to avoid conflicts with other tests
+					shard,
+				})
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It(fmt.Sprintf("deploys the gitrepo via the controller labeled with shard ID %s", shard), func() {
+				By("checking the pod exists")
+				Eventually(func() string {
+					out, _ := k.Namespace(targetNamespace).Get("pods")
+					return out
+				}).Should(ContainSubstring("sleeper-"))
+
+				for _, s := range shards {
+					logs, err := k.Namespace("cattle-fleet-system").Logs(
+						"-l",
+						"app=fleet-controller",
+						"-l",
+						fmt.Sprintf("shard=%s", s),
+					)
+					Expect(err).ToNot(HaveOccurred())
+					regexMatcher := matchers.MatchRegexpMatcher{
+						Regexp: fmt.Sprintf(
+							`Reconciling GitRepo.*"GitRepo": {"name":"%s","namespace":"%s"}`,
+							gitrepoName,
+							env.Namespace,
+						),
+					}
+					hasReconciledGitRepos, err := regexMatcher.Match(logs)
+					Expect(err).ToNot(HaveOccurred())
+					if s == shard {
+						Expect(hasReconciledGitRepos).To(BeTrueBecause(
+							"GitRepo %s labeled with shard %q should have been deployed by"+
+								" controller for shard %q in namespace %s",
+							gitrepoName,
+							shard,
+							shard,
+							env.Namespace,
+						))
+					} else {
+						Expect(hasReconciledGitRepos).To(BeFalseBecause(
+							"GitRepo labeled with shard %q should not have been deployed by"+
+								" controller for shard %q",
+							shard,
+							s,
+						))
+					}
+				}
+			})
+
+			AfterEach(func() {
+				_ = os.RemoveAll(tmpDir)
+				_, _ = k.Delete("gitrepo", gitrepoName)
+			})
+		})
+	}
+
+	When("deploying a gitrepo labeled with an unknown shard ID", func() {
+		JustBeforeEach(func() {
+			targetNamespace = testenv.NewNamespaceName("target", r)
+
+			err := testenv.ApplyTemplate(k, testenv.AssetPath("gitrepo/gitrepo_sharded.yaml"), struct {
+				Name            string
+				Repo            string
+				Branch          string
+				PollingInterval string
+				TargetNamespace string
+				ShardID         string
+			}{
+				gitrepoName,
+				inClusterRepoURL,
+				gh.Branch,
+				"15s",           // default
+				targetNamespace, // to avoid conflicts with other tests
+				"unknown",
+			})
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("does not deploy the gitrepo", func() {
+			By("checking the pod does not exist")
+			Eventually(func() string {
+				out, _ := k.Namespace(targetNamespace).Get("pods")
+				return out
+			}).ShouldNot(ContainSubstring("sleeper-"))
+
+			for _, s := range shards {
+				logs, err := k.Namespace("cattle-fleet-system").Logs(
+					"-l",
+					"app=fleet-controller",
+					"-l",
+					fmt.Sprintf("shard=%s", s),
+				)
+				Expect(err).ToNot(HaveOccurred())
+				regexMatcher := matchers.MatchRegexpMatcher{
+					Regexp: fmt.Sprintf(
+						`Reconciling GitRepo.*"GitRepo": {"name":"%s","namespace":"%s"}`,
+						gitrepoName,
+						env.Namespace,
+					),
+				}
+				hasReconciledGitRepos, err := regexMatcher.Match(logs)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(hasReconciledGitRepos).To(BeFalseBecause(
+					"GitRepo labeled with shard %q should not have been deployed by"+
+						" controller for shard %q",
+					"unknown",
+					s,
+				))
+			}
+		})
+
+		AfterEach(func() {
+			_ = os.RemoveAll(tmpDir)
+			_, _ = k.Delete("gitrepo", gitrepoName)
+		})
+	})
+})

--- a/internal/cmd/controller/operator.go
+++ b/internal/cmd/controller/operator.go
@@ -63,6 +63,7 @@ func start(
 		Scheme: mgr.GetScheme(),
 
 		SystemNamespace: systemNamespace,
+		ShardID:         shardID,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ConfigMap")
 		return err
@@ -76,7 +77,8 @@ func start(
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
 
-		Query: builder,
+		Query:   builder,
+		ShardID: shardID,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Cluster")
 		return err
@@ -112,8 +114,9 @@ func start(
 
 	// controllers that update status.display
 	if err = (&reconciler.ClusterGroupReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
+		Client:  mgr.GetClient(),
+		Scheme:  mgr.GetScheme(),
+		ShardID: shardID,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ClusterGroup")
 		return err

--- a/internal/cmd/controller/operator.go
+++ b/internal/cmd/controller/operator.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/reugn/go-quartz/quartz"
 
@@ -40,13 +41,18 @@ func start(
 ) error {
 	setupLog.Info("listening for changes on local cluster", "disableGitops", disableGitops)
 
+	var leaderElectionSuffix string
+	if shardID != "" {
+		leaderElectionSuffix = fmt.Sprintf("-%s", shardID)
+	}
+
 	mgr, err := ctrl.NewManager(config, ctrl.Options{
 		Scheme:                 scheme,
 		Metrics:                metricsserver.Options{BindAddress: bindAddresses.Metrics},
 		HealthProbeBindAddress: bindAddresses.HealthProbe,
 
-		LeaderElection:          shardID == "",
-		LeaderElectionID:        "fleet-controller-leader-election",
+		LeaderElection:          true,
+		LeaderElectionID:        fmt.Sprintf("fleet-controller-leader-election-shard%s", leaderElectionSuffix),
 		LeaderElectionNamespace: systemNamespace,
 		LeaseDuration:           leaderOpts.LeaseDuration,
 		RenewDeadline:           leaderOpts.RenewDeadline,

--- a/internal/cmd/controller/operator.go
+++ b/internal/cmd/controller/operator.go
@@ -29,9 +29,18 @@ func init() {
 	//+kubebuilder:scaffold:scheme
 }
 
-func start(ctx context.Context, systemNamespace string, config *rest.Config, leaderOpts LeaderElectionOptions, bindAddresses BindAddresses, disableGitops bool) error {
+func start(
+	ctx context.Context,
+	systemNamespace string,
+	config *rest.Config,
+	leaderOpts LeaderElectionOptions,
+	bindAddresses BindAddresses,
+	disableGitops bool,
+	shardID string,
+) error {
 	setupLog.Info("listening for changes on local cluster", "disableGitops", disableGitops)
 
+	// TODO figure out here how to use shardID
 	mgr, err := ctrl.NewManager(config, ctrl.Options{
 		Scheme:                 scheme,
 		Metrics:                metricsserver.Options{BindAddress: bindAddresses.Metrics},

--- a/internal/cmd/controller/operator.go
+++ b/internal/cmd/controller/operator.go
@@ -134,6 +134,7 @@ func start(
 		Scheme: mgr.GetScheme(),
 
 		Scheduler: sched,
+		ShardID:   shardID,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ImageScan")
 		return err

--- a/internal/cmd/controller/reconciler/bundle_controller.go
+++ b/internal/cmd/controller/reconciler/bundle_controller.go
@@ -9,6 +9,7 @@ import (
 	"github.com/rancher/fleet/internal/cmd/controller/target"
 	"github.com/rancher/fleet/internal/manifest"
 	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
+	"github.com/rancher/fleet/pkg/sharding"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -46,6 +47,7 @@ type BundleReconciler struct {
 	Builder TargetBuilder
 	Store   Store
 	Query   BundleQuery
+	ShardID string
 }
 
 //+kubebuilder:rbac:groups=fleet.cattle.io,resources=bundles,verbs=get;list;watch;create;update;patch;delete
@@ -252,5 +254,6 @@ func (r *BundleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			}),
 			builder.WithPredicates(predicate.ResourceVersionChangedPredicate{}),
 		).
+		WithEventFilter(sharding.FilterByShardID(r.ShardID)).
 		Complete(r)
 }

--- a/internal/cmd/controller/reconciler/config_controller.go
+++ b/internal/cmd/controller/reconciler/config_controller.go
@@ -5,6 +5,7 @@ import (
 	"context"
 
 	"github.com/rancher/fleet/internal/config"
+	"github.com/rancher/fleet/pkg/sharding"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -22,6 +23,7 @@ type ConfigReconciler struct {
 	Scheme *runtime.Scheme
 
 	SystemNamespace string
+	ShardID         string
 }
 
 // Load the config from the configmap and set it in the config package.
@@ -73,6 +75,7 @@ func (r *ConfigReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		WithEventFilter(
 			// we do not trigger for status changes
 			predicate.And(
+				sharding.FilterByShardID(r.ShardID),
 				predicate.NewPredicateFuncs(func(object client.Object) bool {
 					return object.GetNamespace() == r.SystemNamespace &&
 						object.GetName() == config.ManagerConfigName

--- a/internal/cmd/controller/root.go
+++ b/internal/cmd/controller/root.go
@@ -34,6 +34,7 @@ type FleetManager struct {
 	Kubeconfig    string `usage:"Kubeconfig file"`
 	Namespace     string `usage:"namespace to watch" default:"cattle-fleet-system" env:"NAMESPACE"`
 	DisableGitops bool   `usage:"disable gitops components" name:"disable-gitops"`
+	ShardID       string `usage:"only manage resources labeled with a specific shard ID" name:"shard-id"`
 }
 
 type LeaderElectionOptions struct {
@@ -128,7 +129,15 @@ func (f *FleetManager) Run(cmd *cobra.Command, args []string) error {
 	go func() {
 		log.Println(http.ListenAndServe("localhost:6060", nil)) // nolint:gosec // Debugging only
 	}()
-	if err := start(ctx, f.Namespace, kubeconfig, leaderOpts, bindAddresses, f.DisableGitops); err != nil {
+	if err := start(
+		ctx,
+		f.Namespace,
+		kubeconfig,
+		leaderOpts,
+		bindAddresses,
+		f.DisableGitops,
+		f.ShardID,
+	); err != nil {
 		return err
 	}
 

--- a/pkg/sharding/sharding.go
+++ b/pkg/sharding/sharding.go
@@ -1,0 +1,33 @@
+package sharding
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+const ShardingLabel string = "fleet.cattle.io/shard"
+
+func FilterByShardID(shardID string) predicate.Funcs {
+	matchesLabel := func(o client.Object) bool {
+		label, hasLabel := o.GetLabels()[ShardingLabel]
+
+		if shardID == "" {
+			return !hasLabel
+		}
+
+		return label == shardID
+	}
+
+	return predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			return matchesLabel(e.Object)
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			return matchesLabel(e.ObjectNew)
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			return matchesLabel(e.Object)
+		},
+	}
+}


### PR DESCRIPTION
This adds support for static sharding to Fleet controllers, as follows:
* Fleet can be deployed with `--set shards="<comma-separated IDs>"`, which will create one controller per shard, named after that shard, plus the usual (unsharded) Fleet controller
* Each sharded Fleet controller is labeled with `shard=<shard ID>`
* Any invalid shard ID, which would not fit in a k8s resource name, will lead to the corresponding Fleet controller not being deployed

Then, a `GitRepo` can be deployed with label `fleet.cattle.io/shard: <shard ID>`, meaning that only the Fleet controller with that label will reconcile it and its children (bundles, bundle deployments). This is end-to-end tested with `GitRepo` creation, but should also work when creating bundles directly.

Any unsharded resource will be processed by the unsharded controller.
Any resource with an unknown shard ID, ie not configured at Fleet deployment time, will not be reconciled.

A controller's leader election ID now contains its shard ID. This prevents controllers from stepping on each other's toes and, while leader election itself is not of much use for as long as each shard ID only maps to a single Fleet controller, this configuration should enable enhancements relying on multiple controllers per shard ID.

Refers to #1740.