### PR TITLE
Make pre-release detection automatic

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,7 @@
 ---
 project_name: fleet
+release:
+  prerelease: auto
 
 before:
   hooks:


### PR DESCRIPTION
This adds field `prerelease` with value `auto` to Github releases for Fleet, which according to GoReleaser documentation [1] works as follows:
>  If set to auto, will mark the release as not ready for production
>  in case there is an indicator for this in the tag e.g. v1.0.0-rc1
>  If set to true, will mark the release as not ready for production.
>  Default is false.

Relates to #2121.

[1]: https://goreleaser.com/customization/release/#github