### PR TITLE
Controller image only install ssh clients

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -4,7 +4,7 @@ ARG ARCH
 FROM --platform=linux/$ARCH registry.suse.com/bci/bci-base:15.5 AS base
 COPY package/log.sh /usr/bin/
 RUN zypper -n update && \
-    zypper -n install openssh catatonit git-core && \
+    zypper -n install openssh-clients catatonit git-core && \
     zypper -n clean -a
 
 FROM base AS copy_dapper


### PR DESCRIPTION
We don't need the server

```
> rpm -ql openssh-server
/etc/pam.d/sshd
/etc/slp.reg.d
/etc/slp.reg.d/ssh.reg
/etc/ssh/sshd_config
/etc/sysconfig/SuSEfirewall2.d
/etc/sysconfig/SuSEfirewall2.d/services
/etc/sysconfig/SuSEfirewall2.d/services/sshd
/usr/lib/ssh/sftp-server
/usr/lib/systemd/system/sshd.service
/usr/lib/sysusers.d/sshd.conf
/usr/sbin/rcsshd
/usr/sbin/sshd
/usr/sbin/sshd-gen-keys-start
/usr/share/fillup-templates/sysconfig.ssh
/usr/share/man/man5/sshd_config.5.gz
/usr/share/man/man8/sftp-server.8.gz
/usr/share/man/man8/sshd.8.gz
/var/lib/sshd
```