### PR TITLE
Remove unused update status code from bundle reconciler

### DIFF
--- a/internal/cmd/controller/reconciler/bundle_controller.go
+++ b/internal/cmd/controller/reconciler/bundle_controller.go
@@ -112,19 +112,16 @@ func (r *BundleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	}
 
 	if err := resetStatus(&bundle.Status, matchedTargets); err != nil {
-		updateDisplay(&bundle.Status)
 		return ctrl.Result{}, err
 	}
 
 	// this will add the defaults for a new bundledeployment
 	if err := target.UpdatePartitions(&bundle.Status, matchedTargets); err != nil {
-		updateDisplay(&bundle.Status)
 		return ctrl.Result{}, err
 	}
 
 	if bundle.Status.ObservedGeneration != bundle.Generation {
 		if err := setResourceKey(context.Background(), &bundle.Status, bundle, manifest, r.isNamespaced); err != nil {
-			updateDisplay(&bundle.Status)
 			return ctrl.Result{}, err
 		}
 	}


### PR DESCRIPTION

Refers to https://github.com/rancher/fleet/issues/1972


The status was not updated in the cluster, we just trigger another reconcile.

