### PR TITLE
Simplify shards configuration detection

### DIFF
--- a/charts/fleet/templates/deployment.yaml
+++ b/charts/fleet/templates/deployment.yaml
@@ -1,5 +1,5 @@
 {{ $shards := list "" }}
-{{ if len .Values.shards }}
+{{ if .Values.shards }}
 {{ $shards = concat $shards .Values.shards | uniq }}
 {{ end }}
 {{ range $shards }}


### PR DESCRIPTION
This prevents nil pointer errors when deploying Fleet without any `shards` Helm value, in which case a single controller should and now will be deployed.

It should fix [this CI failure](https://github.com/rancher/fleet/actions/runs/8784583508/job/24103116168).

<!-- Specify the issue ID that this pull request is solving -->
Refers to #1740
<!-- Make sure that the referenced issue provides steps to reproduce it -->

<!-- Describe the changes introduced by this pull request -->

<!--
  Please provide a unit, integration (`./integrationtests/`) or e2e (`./e2e/`) test if possible.
-->