### PR TITLE
metrics: Add E2E test for cluster deletion

### DIFF
--- a/e2e/assets/cluster-template.yaml
+++ b/e2e/assets/cluster-template.yaml
@@ -1,0 +1,19 @@
+apiVersion: fleet.cattle.io/v1alpha1
+kind: Cluster
+metadata:
+  name: {{ .Name }}
+  namespace: {{ .Namespace }}
+  {{- if .Labels}}
+  labels:
+    {{- range $key, $value := .Labels}}
+    {{$key}}: {{$value}}
+    {{- end}}
+  {{- end}}
+{{- if .Spec }}
+spec:
+  {{- range $key, $value := .Spec}}
+  {{$key}}: {{$value}}
+  {{- end}}
+{{- end}}
+
+

--- a/e2e/metrics/bundle_test.go
+++ b/e2e/metrics/bundle_test.go
@@ -53,7 +53,6 @@ var _ = Describe("Bundle Metrics", Label("bundle"), func() {
 	// the value of the metrics.
 	metricsExist := func(gitRepoName string, check func(metric *metrics.Metric) error) func() error {
 		return func() error {
-			et := metrics.NewExporterTest(metricsURL)
 			metrics, err := et.Get()
 			Expect(err).ToNot(HaveOccurred())
 
@@ -100,7 +99,6 @@ var _ = Describe("Bundle Metrics", Label("bundle"), func() {
 	// metricsMissing checks that the metrics do not exist.
 	metricsMissing := func(gitRepoName string) func() error {
 		return func() error {
-			et := metrics.NewExporterTest(metricsURL)
 			metrics, err := et.Get()
 			Expect(err).ToNot(HaveOccurred())
 
@@ -173,7 +171,6 @@ var _ = Describe("Bundle Metrics", Label("bundle"), func() {
 
 		When("the GitRepo (and therefore Bundle) is changed", Label("bundle-modified"), func() {
 			It("should not duplicate metrics if Bundle is updated", Label("bundle-update"), func() {
-				// et := metrics.NewExporterTest(metricsURL)
 				out, err := kw.Patch(
 					"gitrepo", gitRepoName,
 					"--type=json",

--- a/e2e/metrics/bundledeployment_test.go
+++ b/e2e/metrics/bundledeployment_test.go
@@ -8,7 +8,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/rancher/fleet/e2e/metrics"
 	"github.com/rancher/fleet/e2e/testenv"
 	"github.com/rancher/fleet/e2e/testenv/kubectl"
 )
@@ -64,7 +63,6 @@ var _ = Describe("BundleDeployment Metrics", Label("bundledeployment"), func() {
 	}
 
 	It("should have exactly one metric for the BundleDeployment", func() {
-		et := metrics.NewExporterTest(metricsURL)
 		Eventually(func() error {
 			metrics, err := et.Get()
 			Expect(err).ToNot(HaveOccurred())
@@ -90,7 +88,6 @@ var _ = Describe("BundleDeployment Metrics", Label("bundledeployment"), func() {
 
 	When("the GitRepo (and therefore Bundle) is changed", Label("bundle-altered"), func() {
 		It("should not duplicate metrics if Bundle is updated", Label("bundle-update"), func() {
-			et := metrics.NewExporterTest(metricsURL)
 			out, err := kw.Patch(
 				"gitrepo", objName,
 				"--type=json",
@@ -130,8 +127,6 @@ var _ = Describe("BundleDeployment Metrics", Label("bundledeployment"), func() {
 		})
 
 		It("should not keep metrics if Bundle is deleted", Label("bundle-delete"), func() {
-			et := metrics.NewExporterTest(metricsURL)
-
 			objName := objName + "-simple-manifest"
 
 			Eventually(func() (string, error) {

--- a/e2e/metrics/cluster_test.go
+++ b/e2e/metrics/cluster_test.go
@@ -6,7 +6,49 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/rancher/fleet/e2e/testenv"
 )
+
+var (
+	expectedMetricsNotExist = map[string]bool{
+		"fleet_cluster_desired_ready_git_repos":      false,
+		"fleet_cluster_ready_git_repos":              false,
+		"fleet_cluster_resources_count_desiredready": false,
+		"fleet_cluster_resources_count_missing":      false,
+		"fleet_cluster_resources_count_modified":     false,
+		"fleet_cluster_resources_count_notready":     false,
+		"fleet_cluster_resources_count_orphaned":     false,
+		"fleet_cluster_resources_count_ready":        false,
+		"fleet_cluster_resources_count_unknown":      false,
+		"fleet_cluster_resources_count_waitapplied":  false,
+		"fleet_cluster_state":                        false,
+	}
+)
+
+func eventuallyExpectMetrics(namespace, name string, expectedMetrics map[string]bool) {
+	Eventually(func() error {
+		return expectMetrics(namespace, name, expectedMetrics)
+	}).ShouldNot(HaveOccurred())
+}
+
+func expectMetrics(namespace, name string, expectedMetrics map[string]bool) error {
+	metrics, err := et.Get()
+	if err != nil {
+		return err
+	}
+	for expectedMetric, expectedExist := range expectedMetrics {
+		metric, err := et.FindOneMetric(metrics, expectedMetric, map[string]string{
+			"namespace": namespace,
+			"name":      name,
+		})
+		if expectedExist && err != nil {
+			return err
+		} else if !expectedExist && err == nil {
+			return fmt.Errorf("metric found but not expected: %v", metric)
+		}
+	}
+	return nil
+}
 
 type cluster struct {
 	Name      string `json:"name"`
@@ -74,31 +116,99 @@ var _ = Describe("Cluster Metrics", Label("cluster"), func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(len(existingClusters)).ToNot(BeZero())
 
-			metrics, err := et.Get()
 			Expect(err).ToNot(HaveOccurred())
 
 			for _, cluster := range existingClusters {
-				for name, expectedExist := range expectedMetricsExist {
-					_, err := et.FindOneMetric(
-						metrics,
-						name,
-						map[string]string{
-							"name":      cluster.Name,
-							"namespace": cluster.Namespace,
-						},
-					)
-					if expectedExist && err != nil {
-						return err
-					} else if !expectedExist && err == nil {
-						return fmt.Errorf(
-							"expected metric %s not to exist, but it exists",
-							name,
-						)
-					}
-				}
+				eventuallyExpectMetrics(cluster.Namespace, cluster.Name, expectedMetricsExist)
 			}
 			return nil
 		}).ShouldNot(HaveOccurred())
 	},
 	)
+
+	When("the initial cluster object has changed in any way", func() {
+		It(
+			"should not have duplicated metrics after a cluster has been changed",
+			Label("modified"),
+			func() {
+				name := "testing-modification"
+				ns := "fleet-local"
+				kw := k.Namespace(ns)
+
+				err := testenv.CreateCluster(
+					k,
+					ns,
+					name,
+					map[string]string{
+						"management.cattle.io/cluster-display-name": "testing",
+						"name": "testing",
+					},
+					map[string]string{
+						"clientID": "testing",
+					},
+				)
+				Expect(err).ToNot(HaveOccurred())
+
+				Eventually(func() (string, error) {
+					return kw.Get("clusters.fleet.cattle.io", name)
+				}).Should(ContainSubstring(name))
+
+				eventuallyExpectMetrics(ns, name, expectedMetricsExist)
+
+				Expect(kw.Patch(
+					"cluster", name,
+					"--type=json",
+					"-p", `[
+						{
+							"op": "replace",
+							"path": "/spec/clientID",
+							"value": "changed"
+						}
+					]`,
+				)).To(ContainSubstring(name))
+
+				eventuallyExpectMetrics(ns, name, expectedMetricsExist)
+
+				DeferCleanup(func() {
+					_, _ = kw.Delete("cluster", name)
+				})
+			},
+		)
+		It(
+			"should not have metrics for a deleted cluster",
+			Label("deleted"),
+			func() {
+				name := "testing-deletion"
+				ns := "fleet-local"
+				kw := k.Namespace(ns)
+
+				Expect(testenv.CreateCluster(
+					k,
+					ns,
+					name,
+					map[string]string{
+						"management.cattle.io/cluster-display-name": "testing",
+						"name": "testing",
+					},
+					nil,
+				)).ToNot(HaveOccurred())
+
+				Eventually(func() (string, error) {
+					return kw.Get("clusters.fleet.cattle.io", name)
+				}).Should(ContainSubstring(name))
+
+				eventuallyExpectMetrics(ns, name, expectedMetricsExist)
+
+				Eventually(func() (string, error) {
+					return kw.Delete("cluster", name)
+				}).Should(ContainSubstring(name))
+
+				eventuallyExpectMetrics(ns, name, expectedMetricsNotExist)
+
+				DeferCleanup(func() {
+					_, _ = kw.Delete("cluster", name)
+				})
+			},
+		)
+	})
 })

--- a/e2e/metrics/cluster_test.go
+++ b/e2e/metrics/cluster_test.go
@@ -6,7 +6,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/rancher/fleet/e2e/metrics"
 )
 
 type cluster struct {
@@ -75,7 +74,6 @@ var _ = Describe("Cluster Metrics", Label("cluster"), func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(len(existingClusters)).ToNot(BeZero())
 
-			et := metrics.NewExporterTest(metricsURL)
 			metrics, err := et.Get()
 			Expect(err).ToNot(HaveOccurred())
 

--- a/e2e/metrics/clustergroup_test.go
+++ b/e2e/metrics/clustergroup_test.go
@@ -7,7 +7,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/rancher/fleet/e2e/metrics"
 	"github.com/rancher/fleet/e2e/testenv"
 )
 
@@ -81,8 +80,6 @@ var _ = Describe("Cluster Metrics", Label("clustergroup"), func() {
 				"-o", "jsonpath=.metadata.name",
 			)
 		}).ShouldNot(ContainSubstring("not found"))
-
-		et := metrics.NewExporterTest(metricsURL)
 
 		identityLabels := map[string]string{
 			"name":      clusterGroupName,

--- a/e2e/metrics/exporter.go
+++ b/e2e/metrics/exporter.go
@@ -13,8 +13,8 @@ type ExporterTest struct {
 	url string
 }
 
-func NewExporterTest(url string) *ExporterTest {
-	return &ExporterTest{
+func NewExporterTest(url string) ExporterTest {
+	return ExporterTest{
 		url: url,
 	}
 }

--- a/e2e/metrics/exporter.go
+++ b/e2e/metrics/exporter.go
@@ -112,30 +112,3 @@ func (m *Metric) LabelValue(name string) string {
 	}
 	return ""
 }
-
-func (m *Metric) MatchLabelValue(name, value string) error {
-	for _, label := range m.Label {
-		if *label.Name == name {
-			if *label.Value == value {
-				return nil
-			} else {
-				return fmt.Errorf(
-					"expected label %q to have value %q, got %q",
-					name,
-					value,
-					*label.Value,
-				)
-			}
-		}
-	}
-	return fmt.Errorf("label %q not found", name)
-}
-
-func (m *Metric) HasLabel(name string) bool {
-	for _, label := range m.Label {
-		if *label.Name == name {
-			return true
-		}
-	}
-	return false
-}

--- a/e2e/metrics/gitrepo_test.go
+++ b/e2e/metrics/gitrepo_test.go
@@ -66,7 +66,6 @@ var _ = Describe("GitRepo Metrics", Label("gitrepo"), func() {
 		}
 
 		It("should have exactly one metric of each type for the gitrepo", func() {
-			et := metrics.NewExporterTest(metricsURL)
 			Eventually(func() error {
 				metrics, err := et.Get()
 				Expect(err).ToNot(HaveOccurred())
@@ -90,7 +89,6 @@ var _ = Describe("GitRepo Metrics", Label("gitrepo"), func() {
 
 		Context("when the GitRepo is changed", func() {
 			It("it should not duplicate metrics if GitRepo is updated", func() {
-				et := metrics.NewExporterTest(metricsURL)
 				out, err := kw.Patch(
 					"gitrepo", objName,
 					"--type=json",
@@ -130,8 +128,6 @@ var _ = Describe("GitRepo Metrics", Label("gitrepo"), func() {
 			})
 
 			It("should not keep metrics if GitRepo is deleted", Label("gitrepo-delete"), func() {
-				et := metrics.NewExporterTest(metricsURL)
-
 				out, err := kw.Delete("gitrepo", objName)
 				Expect(err).ToNot(HaveOccurred(), out)
 

--- a/e2e/metrics/suite_test.go
+++ b/e2e/metrics/suite_test.go
@@ -58,8 +58,7 @@ func setupLoadBalancer() (metricsURL string) {
 
 func tearDownLoadBalancer() {
 	ks := k.Namespace("cattle-fleet-system")
-	out, err := ks.Delete("service", loadBalancerName)
-	Expect(err).ToNot(HaveOccurred(), out)
+	_, _ = ks.Delete("service", loadBalancerName)
 }
 
 var _ = BeforeSuite(func() {

--- a/e2e/metrics/suite_test.go
+++ b/e2e/metrics/suite_test.go
@@ -62,7 +62,7 @@ func tearDownLoadBalancer() {
 }
 
 var _ = BeforeSuite(func() {
-	SetDefaultEventuallyTimeout(time.Minute)
+	SetDefaultEventuallyTimeout(testenv.Timeout)
 	SetDefaultEventuallyPollingInterval(time.Second)
 	testenv.SetRoot("../..")
 

--- a/e2e/testenv/template.go
+++ b/e2e/testenv/template.go
@@ -15,6 +15,7 @@ import (
 )
 
 const gitrepoTemplate = "gitrepo-template.yaml"
+const clusterTemplate = "cluster-template.yaml"
 const clustergroupTemplate = "clustergroup-template.yaml"
 
 // GitRepoData can be used with the gitrepo-template.yaml asset when no custom
@@ -33,6 +34,21 @@ func CreateGitRepo(k kubectl.Command, namespace string, name string, branch stri
 		Name:            name,
 		Branch:          branch,
 		Paths:           paths,
+	})
+}
+
+func CreateCluster(
+	k kubectl.Command,
+	namespace,
+	name string,
+	labels map[string]string,
+	spec map[string]string,
+) error {
+	return ApplyTemplate(k, AssetPath(clusterTemplate), map[string]interface{}{
+		"Name":      name,
+		"Namespace": namespace,
+		"Labels":    labels,
+		"Spec":      spec,
 	})
 }
 


### PR DESCRIPTION
- **e2e/metrics: use a single instance of ExporterTest**
- **e2e/metrics: remove unused functions**
- **e2e/metrics: add E2E test for cluster deletion and modifications**
- **e2e/metrics: simplify testing cluster resources**
- **e2e/metrics: properly test fleet_cluster_state metric**

Refers to #2315
<!-- Specify the issue ID that this pull request is solving -->

<!-- Make sure that the referenced issue provides steps to reproduce it -->

<!-- Describe the changes introduced by this pull request -->

<!--
  Please provide a unit, integration (`./integrationtests/`) or e2e (`./e2e/`) test if possible.
-->
