### PR TITLE
Delete namespace when a gitRepo is deleted

### DIFF
--- a/charts/fleet-crd/templates/crds.yaml
+++ b/charts/fleet-crd/templates/crds.yaml
@@ -195,6 +195,10 @@ spec:
                       description: DeleteCRDResources deletes CRDs. Warning! this
                         will also delete all your Custom Resources.
                       type: boolean
+                    deleteNamespace:
+                      description: DeleteNamespace can be used to delete the deployed
+                        namespace when removing the bundle
+                      type: boolean
                     diff:
                       description: Diff can be used to ignore the modified state of
                         objects which are amended at runtime.
@@ -537,6 +541,10 @@ spec:
                     deleteCRDResources:
                       description: DeleteCRDResources deletes CRDs. Warning! this
                         will also delete all your Custom Resources.
+                      type: boolean
+                    deleteNamespace:
+                      description: DeleteNamespace can be used to delete the deployed
+                        namespace when removing the bundle
                       type: boolean
                     diff:
                       description: Diff can be used to ignore the modified state of
@@ -1283,6 +1291,10 @@ spec:
                 deleteCRDResources:
                   description: DeleteCRDResources deletes CRDs. Warning! this will
                     also delete all your Custom Resources.
+                  type: boolean
+                deleteNamespace:
+                  description: DeleteNamespace can be used to delete the deployed
+                    namespace when removing the bundle
                   type: boolean
                 dependsOn:
                   description: DependsOn refers to the bundles which must be ready
@@ -2166,6 +2178,10 @@ spec:
                       deleteCRDResources:
                         description: DeleteCRDResources deletes CRDs. Warning! this
                           will also delete all your Custom Resources.
+                        type: boolean
+                      deleteNamespace:
+                        description: DeleteNamespace can be used to delete the deployed
+                          namespace when removing the bundle
                         type: boolean
                       diff:
                         description: Diff can be used to ignore the modified state
@@ -5737,6 +5753,10 @@ spec:
                         in the helm history.
                       type: boolean
                   type: object
+                deleteNamespace:
+                  description: DeleteNamespace specifies if the namespace created
+                    must be deleted after deleting the GitRepo.
+                  type: boolean
                 disablePolling:
                   description: Disables git polling. When enabled only webhooks will
                     be used.

--- a/e2e/assets/single-cluster/delete-namespace/gitrepo.yaml
+++ b/e2e/assets/single-cluster/delete-namespace/gitrepo.yaml
@@ -1,0 +1,11 @@
+kind: GitRepo
+apiVersion: fleet.cattle.io/v1alpha1
+metadata:
+  name: my-gitrepo
+spec:
+  repo: https://github.com/rancher/fleet-test-data
+  branch: master
+  paths:
+  - helm-verify
+  targetNamespace: {{.TargetNamespace}}
+  deleteNamespace: {{.DeleteNamespace}}

--- a/e2e/single-cluster/delete_namespaces_test.go
+++ b/e2e/single-cluster/delete_namespaces_test.go
@@ -1,0 +1,110 @@
+package singlecluster_test
+
+import (
+	"errors"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/rancher/fleet/e2e/testenv"
+	"github.com/rancher/fleet/e2e/testenv/kubectl"
+)
+
+var _ = Describe("delete namespaces", func() {
+	var (
+		k               kubectl.Command
+		targetNamespace string
+		deleteNamespace bool
+		interval        = 100 * time.Millisecond
+		duration        = 2 * time.Second
+	)
+
+	type TemplateData struct {
+		TargetNamespace string
+		DeleteNamespace bool
+	}
+
+	BeforeEach(func() {
+		k = env.Kubectl.Namespace(env.Namespace)
+		deleteNamespace = false
+
+		DeferCleanup(func() {
+			_, _ = k.Delete("ns", "my-custom-namespace", "--wait=false")
+		})
+	})
+
+	JustBeforeEach(func() {
+		err := testenv.ApplyTemplate(k, testenv.AssetPath("single-cluster/delete-namespace/gitrepo.yaml"),
+			TemplateData{targetNamespace, deleteNamespace})
+
+		Expect(err).ToNot(HaveOccurred())
+		Eventually(func() error {
+			out, err := k.Namespace(targetNamespace).Get("configmaps")
+			if err != nil {
+				return err
+			}
+
+			if !strings.Contains(out, "app-config") {
+				return errors.New("expected configmap is not found")
+			}
+
+			return nil
+		}).ShouldNot(HaveOccurred())
+	})
+
+	When("delete namespaces is false", func() {
+		BeforeEach(func() {
+			targetNamespace = "my-custom-namespace"
+		})
+
+		It("preserves targetNamespace when GitRepo is deleted", func() {
+			out, err := k.Delete("gitrepo", "my-gitrepo", "-n", "fleet-local")
+			Expect(err).ToNot(HaveOccurred(), out)
+
+			Consistently(func() error {
+				_, err := k.Get("namespaces", targetNamespace)
+				return err
+			}, duration, interval).ShouldNot(HaveOccurred())
+		})
+	})
+
+	When("delete namespaces is true", func() {
+		BeforeEach(func() {
+			deleteNamespace = true
+		})
+
+		It("targetNamespace is deleted after deleting gitRepo", func() {
+			_, err := k.Get("namespaces", targetNamespace)
+			Expect(err).To(BeNil())
+
+			out, err := k.Delete("gitrepo", "my-gitrepo", "-n", "fleet-local")
+			Expect(err).ToNot(HaveOccurred(), out)
+
+			Eventually(func() error {
+				_, err = k.Get("namespaces", targetNamespace)
+				return err
+			}).ShouldNot(BeNil())
+		})
+	})
+
+	When("delete namespaces is true but resources are deployed in default namespace", func() {
+		BeforeEach(func() {
+			deleteNamespace = true
+			targetNamespace = "default"
+		})
+
+		It("default namespace exists", func() {
+			out, err := k.Delete("gitrepo", "my-gitrepo", "-n", "fleet-local")
+			Expect(err).ToNot(HaveOccurred(), out)
+
+			Eventually(func() string {
+				out, _ = k.Namespace(targetNamespace).Get("configmap", "app-config", "-o", "yaml")
+				return out
+			}).Should(ContainSubstring("Error from server (NotFound)"))
+
+			_, err = k.Get("namespaces", targetNamespace)
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+})

--- a/internal/bundlereader/read.go
+++ b/internal/bundlereader/read.go
@@ -34,6 +34,7 @@ type Options struct {
 	Auth             Auth
 	HelmRepoURLRegex string
 	KeepResources    bool
+	DeleteNamespace  bool
 	CorrectDrift     *fleet.CorrectDrift
 }
 
@@ -259,6 +260,10 @@ func read(ctx context.Context, name, baseDir string, bundleSpecReader io.Reader,
 
 	if opts.KeepResources {
 		bundle.Spec.KeepResources = opts.KeepResources
+	}
+
+	if opts.DeleteNamespace {
+		bundle.Spec.DeleteNamespace = opts.DeleteNamespace
 	}
 
 	if opts.CorrectDrift != nil && opts.CorrectDrift.Enabled {

--- a/internal/cmd/cli/apply.go
+++ b/internal/cmd/cli/apply.go
@@ -46,6 +46,7 @@ type Apply struct {
 	SSHPrivateKeyFile           string            `usage:"Path of ssh-private-key for helm repo" name:"ssh-privatekey-file"`
 	HelmRepoURLRegex            string            `usage:"Helm credentials will be used if the helm repo matches this regex. Credentials will always be used if this is empty or not provided" name:"helm-repo-url-regex"`
 	KeepResources               bool              `usage:"Keep resources created after the GitRepo or Bundle is deleted" name:"keep-resources"`
+	DeleteNamespace             bool              `usage:"Delete GitRepo target namespace after the GitRepo or Bundle is deleted" name:"delete-namespace"`
 	HelmCredentialsByPathFile   string            `usage:"Path of file containing helm credentials for paths" name:"helm-credentials-by-path-file"`
 	CorrectDrift                bool              `usage:"Rollback any change made from outside of Fleet" name:"correct-drift"`
 	CorrectDriftForce           bool              `usage:"Use --force when correcting drift. Resources can be deleted and recreated" name:"correct-drift-force"`
@@ -85,6 +86,7 @@ func (a *Apply) Run(cmd *cobra.Command, args []string) error {
 		SyncGeneration:              int64(a.SyncGeneration),
 		HelmRepoURLRegex:            a.HelmRepoURLRegex,
 		KeepResources:               a.KeepResources,
+		DeleteNamespace:             a.DeleteNamespace,
 		CorrectDrift:                a.CorrectDrift,
 		CorrectDriftForce:           a.CorrectDriftForce,
 		CorrectDriftKeepFailHistory: a.CorrectDriftKeepFailHistory,

--- a/internal/cmd/cli/apply/apply.go
+++ b/internal/cmd/cli/apply/apply.go
@@ -50,6 +50,7 @@ type Options struct {
 	Auth                        bundlereader.Auth
 	HelmRepoURLRegex            string
 	KeepResources               bool
+	DeleteNamespace             bool
 	AuthByPath                  map[string]bundlereader.Auth
 	CorrectDrift                bool
 	CorrectDriftForce           bool
@@ -181,6 +182,7 @@ func readBundle(ctx context.Context, name, baseDir string, opts *Options) (*flee
 		Auth:             opts.Auth,
 		HelmRepoURLRegex: opts.HelmRepoURLRegex,
 		KeepResources:    opts.KeepResources,
+		DeleteNamespace:  opts.DeleteNamespace,
 		CorrectDrift: &fleet.CorrectDrift{
 			Enabled:         opts.CorrectDrift,
 			Force:           opts.CorrectDriftForce,

--- a/internal/cmd/controller/gitops/reconciler/gitjob_controller.go
+++ b/internal/cmd/controller/gitops/reconciler/gitjob_controller.go
@@ -445,6 +445,10 @@ func argsAndEnvs(gitrepo *v1alpha1.GitRepo, debug bool) ([]string, []corev1.EnvV
 		args = append(args, "--keep-resources")
 	}
 
+	if gitrepo.Spec.DeleteNamespace {
+		args = append(args, "--delete-namespace")
+	}
+
 	if gitrepo.Spec.CorrectDrift != nil && gitrepo.Spec.CorrectDrift.Enabled {
 		args = append(args, "--correct-drift")
 		if gitrepo.Spec.CorrectDrift.Force {

--- a/pkg/apis/fleet.cattle.io/v1alpha1/bundledeployment_types.go
+++ b/pkg/apis/fleet.cattle.io/v1alpha1/bundledeployment_types.go
@@ -92,6 +92,9 @@ type BundleDeploymentOptions struct {
 	// KeepResources can be used to keep the deployed resources when removing the bundle
 	KeepResources bool `json:"keepResources,omitempty"`
 
+	// DeleteNamespace can be used to delete the deployed namespace when removing the bundle
+	DeleteNamespace bool `json:"deleteNamespace,omitempty"`
+
 	//IgnoreOptions can be used to ignore fields when monitoring the bundle.
 	IgnoreOptions `json:"ignore,omitempty"`
 

--- a/pkg/apis/fleet.cattle.io/v1alpha1/gitrepo_types.go
+++ b/pkg/apis/fleet.cattle.io/v1alpha1/gitrepo_types.go
@@ -127,6 +127,9 @@ type GitRepoSpec struct {
 	// KeepResources specifies if the resources created must be kept after deleting the GitRepo.
 	KeepResources bool `json:"keepResources,omitempty"`
 
+	// DeleteNamespace specifies if the namespace created must be deleted after deleting the GitRepo.
+	DeleteNamespace bool `json:"deleteNamespace,omitempty"`
+
 	// CorrectDrift specifies how drift correction should work.
 	CorrectDrift *CorrectDrift `json:"correctDrift,omitempty"`
 


### PR DESCRIPTION
<!-- Specify the issue ID that this pull request is solving -->
Refers to #1564
<!-- Make sure that the referenced issue provides steps to reproduce it -->

<!-- Describe the changes introduced by this pull request -->
This PR introduces a new attribute `spec.deleteNamespace: boolean` in gitRepo to delete the namespace when gitRepo is deleted. This namespace is created by fleet to deploy the services. 
<!--
  Please provide a unit, integration (`./integrationtests/`) or e2e (`./e2e/`) test if possible.
-->

Thanks @weyfonk :heart: 