### PR TITLE
Hide global CLI flags on sub commands

### DIFF
--- a/internal/cmd/agent/clusterstatus.go
+++ b/internal/cmd/agent/clusterstatus.go
@@ -49,6 +49,12 @@ type ClusterStatus struct {
 	CheckinInterval string `usage:"How often to post cluster status" env:"CHECKIN_INTERVAL"`
 }
 
+// HelpFunc hides the global agent-scope flag from the help output
+func (c *ClusterStatus) HelpFunc(cmd *cobra.Command, strings []string) {
+	_ = cmd.Flags().MarkHidden("agent-scope")
+	cmd.Parent().HelpFunc()(cmd, strings)
+}
+
 func (cs *ClusterStatus) PersistentPre(cmd *cobra.Command, _ []string) error {
 	if err := cs.SetupDebug(); err != nil {
 		return fmt.Errorf("failed to setup debug logging: %w", err)

--- a/internal/cmd/agent/register.go
+++ b/internal/cmd/agent/register.go
@@ -29,6 +29,12 @@ type Register struct {
 	UpstreamOptions
 }
 
+// HelpFunc hides the global agent-scope flag from the help output
+func (c *Register) HelpFunc(cmd *cobra.Command, strings []string) {
+	_ = cmd.Flags().MarkHidden("agent-scope")
+	cmd.Parent().HelpFunc()(cmd, strings)
+}
+
 func (r *Register) PersistentPre(cmd *cobra.Command, _ []string) error {
 	if err := r.SetupDebug(); err != nil {
 		return fmt.Errorf("failed to setup debug logging: %w", err)

--- a/internal/cmd/agent/root.go
+++ b/internal/cmd/agent/root.go
@@ -75,7 +75,9 @@ func App() *cobra.Command {
 	ctrl.RegisterFlags(fs)
 	root.Flags().AddGoFlagSet(fs)
 
-	root.AddCommand(NewClusterStatus())
-	root.AddCommand(NewRegister())
+	root.AddCommand(
+		NewClusterStatus(),
+		NewRegister(),
+	)
 	return root
 }

--- a/internal/cmd/builder.go
+++ b/internal/cmd/builder.go
@@ -25,6 +25,10 @@ type PreRunnable interface {
 	Pre(cmd *cobra.Command, args []string) error
 }
 
+type HasHelpFunc interface {
+	HelpFunc(command *cobra.Command, strings []string)
+}
+
 type Runnable interface {
 	Run(cmd *cobra.Command, args []string) error
 }
@@ -145,6 +149,10 @@ func Command(obj Runnable, cmd cobra.Command) *cobra.Command {
 
 	if p, ok := obj.(PreRunnable); ok {
 		c.PreRunE = p.Pre
+	}
+
+	if p, ok := obj.(HasHelpFunc); ok {
+		c.SetHelpFunc(p.HelpFunc)
 	}
 
 	c.RunE = obj.Run

--- a/internal/cmd/controller/agentmanagement/root.go
+++ b/internal/cmd/controller/agentmanagement/root.go
@@ -14,6 +14,14 @@ type AgentManagement struct {
 	DisableBootstrap bool   `usage:"disable local cluster components" name:"disable-bootstrap"`
 }
 
+// HelpFunc hides the global flag from the help output
+func (c *AgentManagement) HelpFunc(cmd *cobra.Command, strings []string) {
+	_ = cmd.Flags().MarkHidden("disable-gitops")
+	_ = cmd.Flags().MarkHidden("disable-metrics")
+	_ = cmd.Flags().MarkHidden("shard-id")
+	cmd.Parent().HelpFunc()(cmd, strings)
+}
+
 func (a *AgentManagement) Run(cmd *cobra.Command, args []string) error {
 	if a.Namespace == "" {
 		return fmt.Errorf("--namespace or env NAMESPACE is required to be set")

--- a/internal/cmd/controller/cleanup/root.go
+++ b/internal/cmd/controller/cleanup/root.go
@@ -13,6 +13,14 @@ type CleanUp struct {
 	Namespace  string `usage:"namespace to watch" env:"NAMESPACE"`
 }
 
+// HelpFunc hides the global flags from the help output
+func (c *CleanUp) HelpFunc(cmd *cobra.Command, strings []string) {
+	_ = cmd.Flags().MarkHidden("disable-gitops")
+	_ = cmd.Flags().MarkHidden("disable-metrics")
+	_ = cmd.Flags().MarkHidden("shard-id")
+	cmd.Parent().HelpFunc()(cmd, strings)
+}
+
 func (c *CleanUp) Run(cmd *cobra.Command, args []string) error {
 	if c.Namespace == "" {
 		return fmt.Errorf("--namespace or env NAMESPACE is required to be set")

--- a/internal/cmd/controller/gitops/operator.go
+++ b/internal/cmd/controller/gitops/operator.go
@@ -56,6 +56,14 @@ func App(zo *zap.Options) *cobra.Command {
 	})
 }
 
+// HelpFunc hides the global flag from the help output
+func (c *GitOperator) HelpFunc(cmd *cobra.Command, strings []string) {
+	_ = cmd.Flags().MarkHidden("disable-gitops")
+	_ = cmd.Flags().MarkHidden("disable-metrics")
+	_ = cmd.Flags().MarkHidden("shard-id")
+	cmd.Parent().HelpFunc()(cmd, strings)
+}
+
 func (g *GitOperator) PersistentPre(_ *cobra.Command, _ []string) error {
 	if err := g.SetupDebug(); err != nil {
 		return fmt.Errorf("failed to setup debug logging: %w", err)
@@ -65,10 +73,10 @@ func (g *GitOperator) PersistentPre(_ *cobra.Command, _ []string) error {
 }
 
 func (g *GitOperator) Run(cmd *cobra.Command, args []string) error {
-	ctx := clog.IntoContext(cmd.Context(), ctrl.Log.WithName("gitjob-reconciler"))
 	// TODO for compatibility, override zap opts with legacy debug opts. remove once manifests are updated.
 	zopts.Development = g.Debug
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(zopts)))
+	ctx := clog.IntoContext(cmd.Context(), ctrl.Log.WithName("gitjob-reconciler"))
 
 	namespace := g.Namespace
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{

--- a/internal/cmd/controller/root.go
+++ b/internal/cmd/controller/root.go
@@ -82,10 +82,10 @@ func (r *FleetManager) PersistentPre(_ *cobra.Command, _ []string) error {
 }
 
 func (f *FleetManager) Run(cmd *cobra.Command, args []string) error {
-	ctx := clog.IntoContext(cmd.Context(), ctrl.Log)
 	// for compatibility, override zap opts with legacy debug opts. remove once manifests are updated.
 	zopts.Development = f.Debug
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&zopts)))
+	ctx := clog.IntoContext(cmd.Context(), ctrl.Log)
 
 	kubeconfig := ctrl.GetConfigOrDie()
 


### PR DESCRIPTION
The binaries run a default action if no sub command is given. The flags of the default action, e.g. running the main fleet controller, aka manager, are inherited by the sub commands as global flags.

This is a easy fix to hide the unsupported flags. We could turn all parent commands into sub commands one day, but it seems low priority.


This does not seem to affect doc generation with `go run cmd/docs/generate-cli-docs.go ../docs/docs/cli/`, so we still need to look out for the options in docs: https://github.com/rancher/fleet-docs/pull/128

Refers to https://github.com/rancher/fleet/issues/2342
