### PR TITLE
Simplify sharding end-to-end tests

### DIFF
--- a/e2e/assets/gitrepo/gitrepo_sharded.yaml
+++ b/e2e/assets/gitrepo/gitrepo_sharded.yaml
@@ -10,4 +10,4 @@ spec:
   pollingInterval: {{.PollingInterval}}
   targetNamespace: {{.TargetNamespace}}
   paths:
-  - examples
+  - simple-chart


### PR DESCRIPTION
This makes sharding end-to-end tests more lightweight by relying on `GitRepo`s pointing to an external repository. Relying on test infrastructure and creating git repositories on-the-fly is not necessary, because sharding tests don't need to push any commit.

Checks on Fleet controller logs are now more reliable, by consistently tailing the last 100 log entries.