### PR TITLE
Add sharding to Fleet deployments in CI workflows running end-to-end tests

### DIFF
--- a/.github/workflows/aks.yml
+++ b/.github/workflows/aks.yml
@@ -126,7 +126,9 @@ jobs:
         run: |
           export KUBECONFIG="$GITHUB_WORKSPACE/kubeconfig-fleet-ci"
           echo "${{ steps.meta-fleet.outputs.tags }} ${{ steps.meta-fleet-agent.outputs.tags }}"
-          ./.github/scripts/deploy-fleet.sh ${{ steps.meta-fleet.outputs.tags }} ${{ steps.meta-fleet-agent.outputs.tags }}
+          SHARDS="shard1,shard2,shard3" ./.github/scripts/deploy-fleet.sh \
+                                       ${{ steps.meta-fleet.outputs.tags }} \
+                                       ${{ steps.meta-fleet-agent.outputs.tags }}
       -
         name: Fleet E2E Tests
         env:

--- a/.github/workflows/gke.yml
+++ b/.github/workflows/gke.yml
@@ -130,7 +130,9 @@ jobs:
         name: Deploy Fleet
         run: |
           echo "${{ steps.meta-fleet.outputs.tags }} ${{ steps.meta-fleet-agent.outputs.tags }}"
-          ./.github/scripts/deploy-fleet.sh ${{ steps.meta-fleet.outputs.tags }} ${{ steps.meta-fleet-agent.outputs.tags }}
+          SHARDS="shard1,shard2,shard3" ./.github/scripts/deploy-fleet.sh \
+                                       ${{ steps.meta-fleet.outputs.tags }} \
+                                       ${{ steps.meta-fleet-agent.outputs.tags }}
       -
         name: Fleet E2E Tests
         env:

--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -83,7 +83,7 @@ jobs:
       -
         name: Deploy Fleet
         run: |
-          ./.github/scripts/deploy-fleet.sh
+          SHARDS="shard1,shard2,shard3" ./.github/scripts/deploy-fleet.sh
       -
         name: Create Zot certificates for OCI tests
         if: ${{ matrix.test_type == 'e2e-nosecrets' }}
@@ -109,21 +109,24 @@ jobs:
           # 1. Run test cases not needing infra
           ginkgo --label-filter='!infra-setup' e2e/single-cluster e2e/keep-resources
 
-          # 2. Run tests requiring only the git server
+          # 2. Run tests for metrics
+          ginkgo e2e/metrics
+
+          # 3. Run tests requiring only the git server
           e2e/testenv/infra/infra setup --git-server=true
           ginkgo --label-filter='infra-setup && !helm-registry && !oci-registry' e2e/single-cluster/
 
-          # 3. Run tests requiring a Helm registry
+          # 4. Run tests requiring a Helm registry
           e2e/testenv/infra/infra setup --helm-registry=true
           ginkgo --label-filter='helm-registry' e2e/single-cluster
 
           e2e/testenv/infra/infra teardown --helm-registry=true
 
-          # 4. Run tests requiring an OCI registry
+          # 5. Run tests requiring an OCI registry
           e2e/testenv/infra/infra setup --oci-registry=true
           ginkgo --label-filter='oci-registry' e2e/single-cluster
 
-          # 5. Tear down all infra
+          # 6. Tear down all infra
           e2e/testenv/infra/infra teardown
       -
         name: Acceptance Tests for Examples


### PR DESCRIPTION
With sharding end-to-end tests now running without needing test infra (see #2396), those tests will run in AKS and GKE workflows, where Fleet deployments need sharding enabled to allow those tests to pass.
This PR also fixes Fleet deployments in a similar way for the nightly CI workflow.

This should fix CI failures such as [this one](https://github.com/rancher/fleet/actions/runs/8935401076/job/24543850540) (nightly) and [that one](https://github.com/rancher/fleet/actions/runs/8937525971/job/24549947791) (AKS).