### PR TITLE
Add status reconcile tests

### DIFF
--- a/integrationtests/controller/bundle/bundle_labels_test.go
+++ b/integrationtests/controller/bundle/bundle_labels_test.go
@@ -9,7 +9,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -93,13 +92,3 @@ var _ = Describe("Bundle labels", func() {
 		})
 	})
 })
-
-func expectedLabelValue(bdLabels map[string]string, key, value string) (*v1alpha1.BundleDeployment, bool) {
-	list := &v1alpha1.BundleDeploymentList{}
-	err := k8sClient.List(ctx, list, client.MatchingLabelsSelector{Selector: labels.SelectorFromSet(bdLabels)})
-	Expect(err).NotTo(HaveOccurred())
-	if len(list.Items) == 1 {
-		return &list.Items[0], list.Items[0].Labels[key] == value
-	}
-	return nil, false
-}

--- a/integrationtests/controller/bundle/bundle_labels_test.go
+++ b/integrationtests/controller/bundle/bundle_labels_test.go
@@ -30,7 +30,7 @@ var _ = Describe("Bundle labels", func() {
 
 	When("BundleDeployment labels are updated", func() {
 		BeforeEach(func() {
-			cluster, err := createCluster("cluster", namespace, nil, namespace)
+			cluster, err := utils.CreateCluster(ctx, k8sClient, "cluster", namespace, nil, namespace)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(cluster).To(Not(BeNil()))
 			targets := []v1alpha1.BundleTarget{
@@ -42,7 +42,7 @@ var _ = Describe("Bundle labels", func() {
 					ClusterName: "cluster",
 				},
 			}
-			bundle, err := createBundle("name", namespace, targets, targets)
+			bundle, err := utils.CreateBundle(ctx, k8sClient, "name", namespace, targets, targets)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(bundle).To(Not(BeNil()))
 		})

--- a/integrationtests/controller/bundle/bundle_targets_test.go
+++ b/integrationtests/controller/bundle/bundle_targets_test.go
@@ -41,7 +41,7 @@ var _ = Describe("Bundle targets", Ordered, func() {
 	)
 
 	JustBeforeEach(func() {
-		bundle, err := createBundle(bundleName, namespace, targets, targetRestrictions)
+		bundle, err := utils.CreateBundle(ctx, k8sClient, bundleName, namespace, targets, targetRestrictions)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(bundle).To(Not(BeNil()))
 	})
@@ -443,7 +443,7 @@ func createClustersAndClusterGroups() {
 			Expect(k8sClient.Delete(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: clusterNs}})).ToNot(HaveOccurred())
 		})
 
-		clusterOne, err := createCluster(cn, namespace, map[string]string{"cluster": cn, "env": "test"}, clusterNs)
+		clusterOne, err := utils.CreateCluster(ctx, k8sClient, cn, namespace, map[string]string{"cluster": cn, "env": "test"}, clusterNs)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(clusterOne).To(Not(BeNil()))
 

--- a/integrationtests/controller/bundle/status_test.go
+++ b/integrationtests/controller/bundle/status_test.go
@@ -29,7 +29,7 @@ var _ = Describe("Bundle Status Fields", func() {
 
 	When("BundleDeployment changes", func() {
 		BeforeEach(func() {
-			cluster, err := createCluster("cluster", namespace, nil, namespace)
+			cluster, err := utils.CreateCluster(ctx, k8sClient, "cluster", namespace, nil, namespace)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(cluster).To(Not(BeNil()))
 			targets := []v1alpha1.BundleTarget{
@@ -41,7 +41,7 @@ var _ = Describe("Bundle Status Fields", func() {
 					ClusterName: "cluster",
 				},
 			}
-			bundle, err := createBundle("name", namespace, targets, targets)
+			bundle, err := utils.CreateBundle(ctx, k8sClient, "name", namespace, targets, targets)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(bundle).To(Not(BeNil()))
 		})
@@ -94,7 +94,7 @@ var _ = Describe("Bundle Status Fields", func() {
 
 	When("Cluster changes", func() {
 		BeforeEach(func() {
-			cluster, err := createCluster("cluster", namespace, nil, namespace)
+			cluster, err := utils.CreateCluster(ctx, k8sClient, "cluster", namespace, nil, namespace)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(cluster).To(Not(BeNil()))
 			targets := []v1alpha1.BundleTarget{
@@ -106,7 +106,7 @@ var _ = Describe("Bundle Status Fields", func() {
 					ClusterName: "cluster",
 				},
 			}
-			bundle, err := createBundle("name", namespace, targets, targets)
+			bundle, err := utils.CreateBundle(ctx, k8sClient, "name", namespace, targets, targets)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(bundle).To(Not(BeNil()))
 		})

--- a/integrationtests/controller/bundle/status_test.go
+++ b/integrationtests/controller/bundle/status_test.go
@@ -124,7 +124,6 @@ var _ = Describe("Bundle Status Fields", func() {
 			err := k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "cluster"}, cluster)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(cluster.Status.Summary.Ready).To(Equal(0))
-			Expect(cluster.Status.Display.ReadyBundles).To(Equal("0/0"))
 
 			bundle := &v1alpha1.Bundle{}
 			Eventually(func() bool {
@@ -164,7 +163,7 @@ var _ = Describe("Bundle Status Fields", func() {
 				return cluster.Status.Summary.Ready == 1
 			}).Should(BeTrue())
 			Expect(cluster.Status.Summary.Pending).To(Equal(0))
-			Expect(cluster.Status.Display.ReadyBundles).To(Equal("1/2"))
+			Expect(cluster.Status.Display.ReadyBundles).To(Equal("1/1"))
 
 			// resourceVersion := cluster.ResourceVersion
 			By("Modifying labels will change cluster state")

--- a/integrationtests/controller/bundle/status_test.go
+++ b/integrationtests/controller/bundle/status_test.go
@@ -5,9 +5,11 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/rancher/fleet/integrationtests/utils"
+	"github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 var _ = Describe("Bundle Status Fields", func() {
@@ -27,17 +29,162 @@ var _ = Describe("Bundle Status Fields", func() {
 
 	When("BundleDeployment changes", func() {
 		BeforeEach(func() {
+			cluster, err := createCluster("cluster", namespace, nil, namespace)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cluster).To(Not(BeNil()))
+			targets := []v1alpha1.BundleTarget{
+				{
+					BundleDeploymentOptions: v1alpha1.BundleDeploymentOptions{
+						TargetNamespace: "targetNs",
+					},
+					Name:        "cluster",
+					ClusterName: "cluster",
+				},
+			}
+			bundle, err := createBundle("name", namespace, targets, targets)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(bundle).To(Not(BeNil()))
+		})
+
+		AfterEach(func() {
+			Expect(k8sClient.Delete(ctx, &v1alpha1.Bundle{ObjectMeta: metav1.ObjectMeta{
+				Name:      "name",
+				Namespace: namespace,
+			}})).NotTo(HaveOccurred())
+
 		})
 
 		It("updates the status fields", func() {
+			bundle := &v1alpha1.Bundle{}
+			err := k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "name"}, bundle)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(bundle).To(Not(BeNil()))
+			Expect(bundle.Status.Summary.Ready).To(Equal(0))
+			Expect(bundle.Status.Summary.DesiredReady).To(Equal(0))
+			Expect(bundle.Status.Display.ReadyClusters).To(Equal(""))
+
+			By("To reflect the 'Ready' status in bundle, bundleDeployment needs below mentioned status fields.")
+			bd := &v1alpha1.BundleDeployment{}
+			Eventually(func() error {
+				err = k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "name"}, bd)
+				if err != nil {
+					return err
+				}
+				bd.Status.Display.State = "Ready"
+				bd.Status.AppliedDeploymentID = bd.Spec.DeploymentID
+				bd.Status.Ready = true
+				bd.Status.NonModified = true
+				return k8sClient.Status().Update(ctx, bd)
+			}).ShouldNot(HaveOccurred())
+
+			err = k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "name"}, bd)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(bd.Status.Display.State).To(Equal("Ready"))
+			Expect(bd.Status.AppliedDeploymentID).To(Equal(bd.Spec.DeploymentID))
+
+			Eventually(func() bool {
+				err = k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "name"}, bundle)
+				Expect(err).NotTo(HaveOccurred())
+				return bundle.Status.Summary.Ready == 1
+			}).Should(BeTrue())
+			Expect(bundle.Status.Summary.DesiredReady).To(Equal(1))
+			Expect(bundle.Status.Display.ReadyClusters).To(Equal("1/1"))
 		})
 	})
 
 	When("Cluster changes", func() {
 		BeforeEach(func() {
+			cluster, err := createCluster("cluster", namespace, nil, namespace)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cluster).To(Not(BeNil()))
+			targets := []v1alpha1.BundleTarget{
+				{
+					BundleDeploymentOptions: v1alpha1.BundleDeploymentOptions{
+						TargetNamespace: "targetNs",
+					},
+					Name:        "cluster",
+					ClusterName: "cluster",
+				},
+			}
+			bundle, err := createBundle("name", namespace, targets, targets)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(bundle).To(Not(BeNil()))
+		})
+
+		AfterEach(func() {
+			Expect(k8sClient.Delete(ctx, &v1alpha1.Bundle{ObjectMeta: metav1.ObjectMeta{
+				Name:      "name",
+				Namespace: namespace,
+			}})).NotTo(HaveOccurred())
+
 		})
 
 		It("updates the status fields", func() {
+			cluster := &v1alpha1.Cluster{}
+			err := k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "cluster"}, cluster)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cluster.Status.Summary.Ready).To(Equal(0))
+			Expect(cluster.Status.Display.ReadyBundles).To(Equal("0/0"))
+
+			bundle := &v1alpha1.Bundle{}
+			Eventually(func() bool {
+				err = k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "name"}, bundle)
+				Expect(err).NotTo(HaveOccurred())
+				return bundle.Status.Summary.Ready == 0
+			}).Should(BeTrue())
+
+			// prepare bundle deployment so it satisfies the status change
+			bd := &v1alpha1.BundleDeployment{}
+			Eventually(func() error {
+				err = k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "name"}, bd)
+				if err != nil {
+					return err
+				}
+				bd.Status.Display.State = "Ready"
+				bd.Status.AppliedDeploymentID = bd.Spec.DeploymentID
+				bd.Status.Ready = true
+				bd.Status.NonModified = true
+				return k8sClient.Status().Update(ctx, bd)
+			}).ShouldNot(HaveOccurred())
+
+			err = k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "name"}, bd)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(bd.Status.Display.State).To(Equal("Ready"))
+			Expect(bd.Status.AppliedDeploymentID).To(Equal(bd.Spec.DeploymentID))
+
+			Eventually(func() bool {
+				err = k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "name"}, bundle)
+				Expect(err).NotTo(HaveOccurred())
+				return bundle.Status.Summary.Ready == 1
+			}).Should(BeTrue())
+
+			Eventually(func() bool {
+				err = k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "cluster"}, cluster)
+				Expect(err).NotTo(HaveOccurred())
+				return cluster.Status.Summary.Ready == 1
+			}).Should(BeTrue())
+			Expect(cluster.Status.Summary.Pending).To(Equal(0))
+			Expect(cluster.Status.Display.ReadyBundles).To(Equal("1/2"))
+
+			// resourceVersion := cluster.ResourceVersion
+			By("Modifying labels will change cluster state")
+			modifiedLabels := map[string]string{"foo": "bar"}
+			Eventually(func() error {
+				err = k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "cluster"}, cluster)
+				Expect(err).NotTo(HaveOccurred())
+				cluster.Labels = modifiedLabels
+				return k8sClient.Update(ctx, cluster)
+			}).ShouldNot(HaveOccurred())
+
+			// Change in cluster state reflects a change in bundle state
+			Eventually(func() bool {
+				err = k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "name"}, bundle)
+				Expect(err).NotTo(HaveOccurred())
+				return bundle.Status.Summary.Ready == 0
+			}).Should(BeTrue())
+			Expect(bundle.Status.Summary.WaitApplied).To(Equal(1))
+			Expect(bundle.Status.Display.ReadyClusters).To(Equal("0/1"))
+			Expect(bundle.Status.Display.State).To(Equal("WaitApplied"))
 		})
 	})
 })

--- a/integrationtests/controller/bundle/status_test.go
+++ b/integrationtests/controller/bundle/status_test.go
@@ -165,7 +165,6 @@ var _ = Describe("Bundle Status Fields", func() {
 			Expect(cluster.Status.Summary.Pending).To(Equal(0))
 			Expect(cluster.Status.Display.ReadyBundles).To(Equal("1/1"))
 
-			// resourceVersion := cluster.ResourceVersion
 			By("Modifying labels will change cluster state")
 			modifiedLabels := map[string]string{"foo": "bar"}
 			Eventually(func() error {

--- a/integrationtests/controller/bundle/status_test.go
+++ b/integrationtests/controller/bundle/status_test.go
@@ -1,0 +1,43 @@
+package bundle
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/rancher/fleet/integrationtests/utils"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("Bundle Status Fields", func() {
+
+	BeforeEach(func() {
+		var err error
+		namespace, err = utils.NewNamespaceName()
+		Expect(err).ToNot(HaveOccurred())
+
+		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}
+		Expect(k8sClient.Create(ctx, ns)).ToNot(HaveOccurred())
+
+		DeferCleanup(func() {
+			Expect(k8sClient.Delete(ctx, ns)).ToNot(HaveOccurred())
+		})
+	})
+
+	When("BundleDeployment changes", func() {
+		BeforeEach(func() {
+		})
+
+		It("updates the status fields", func() {
+		})
+	})
+
+	When("Cluster changes", func() {
+		BeforeEach(func() {
+		})
+
+		It("updates the status fields", func() {
+		})
+	})
+})

--- a/integrationtests/controller/bundle/suite_test.go
+++ b/integrationtests/controller/bundle/suite_test.go
@@ -44,7 +44,6 @@ var _ = BeforeSuite(func() {
 	ctx, cancel = context.WithCancel(context.TODO())
 	testenv = utils.NewEnvTest()
 	testEnvBool = true
-	testenv.UseExistingCluster = &testEnvBool
 
 	var err error
 	cfg, err = testenv.Start()
@@ -80,7 +79,7 @@ var _ = BeforeSuite(func() {
 	err = (&reconciler.ClusterReconciler{
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
-		Query:  &FakeQuery{},
+		Query:  builder,
 	}).SetupWithManager(mgr)
 	Expect(err).ToNot(HaveOccurred(), "failed to set up manager")
 
@@ -95,9 +94,6 @@ var _ = AfterSuite(func() {
 	cancel()
 	Expect(testenv.Stop()).ToNot(HaveOccurred())
 })
-
-type FakeQuery struct {
-}
 
 func createClusterGroup(name, namespace string, selector *metav1.LabelSelector) (*v1alpha1.ClusterGroup, error) {
 	cg := &v1alpha1.ClusterGroup{
@@ -121,9 +117,4 @@ func expectedLabelValue(bdLabels map[string]string, key, value string) (*v1alpha
 		return &list.Items[0], list.Items[0].Labels[key] == value
 	}
 	return nil, false
-}
-
-// BundlesForCluster returns empty list, so no cleanup is needed
-func (q *FakeQuery) BundlesForCluster(context.Context, *v1alpha1.Cluster) ([]*v1alpha1.Bundle, []*v1alpha1.Bundle, error) {
-	return nil, nil, nil
 }

--- a/integrationtests/controller/bundledeployment/status_test.go
+++ b/integrationtests/controller/bundledeployment/status_test.go
@@ -5,9 +5,11 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/rancher/fleet/integrationtests/utils"
+	"github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 var _ = Describe("BundleDeployment Status Fields", func() {
@@ -27,9 +29,69 @@ var _ = Describe("BundleDeployment Status Fields", func() {
 
 	When("BundleDeployment changes", func() {
 		BeforeEach(func() {
+			options := v1alpha1.BundleDeploymentOptions{
+				TargetNamespace: "targetNs",
+			}
+			bd, err := createBundleDeployment("name", namespace, options)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(bd).To(Not(BeNil()))
+		})
+
+		AfterEach(func() {
+			Expect(k8sClient.Delete(ctx, &v1alpha1.BundleDeployment{ObjectMeta: metav1.ObjectMeta{
+				Name:      "name",
+				Namespace: namespace,
+			}})).NotTo(HaveOccurred())
+
 		})
 
 		It("updates the status fields", func() {
+			bd := &v1alpha1.BundleDeployment{}
+			Eventually(func() error {
+				err := k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "name"}, bd)
+				if err != nil {
+					return err
+				}
+				bd.Status.AppliedDeploymentID = bd.Spec.DeploymentID
+				bd.Status.Ready = true
+				bd.Status.NonModified = true
+				return k8sClient.Status().Update(ctx, bd)
+			}).ShouldNot(HaveOccurred())
+
+			Eventually(func() error {
+				err := k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "name"}, bd)
+				Expect(err).ToNot(HaveOccurred())
+				bd.Spec.StagedDeploymentID = bd.Spec.DeploymentID
+				err = k8sClient.Update(ctx, bd)
+				return err
+			}).ShouldNot(HaveOccurred())
+			Expect(bd.Status.Display.State).To(Equal("Ready"))
+			Expect(bd.Spec.StagedDeploymentID).To(Equal(bd.Spec.DeploymentID))
+
+			By("Updating the bundledeployment spec, updates status fields")
+			Expect(bd.Spec.Options.DeleteNamespace).ToNot(BeTrue())
+
+			err := k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "name"}, bd)
+			Expect(err).NotTo(HaveOccurred())
+			bd.Status.NonModified = false
+			err = k8sClient.Status().Update(ctx, bd)
+			Expect(err).NotTo(HaveOccurred())
+
+			err = k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "name"}, bd)
+			Expect(bd.Status.NonModified).To(BeFalse())
+			Expect(bd.Status.Ready).To(BeTrue())
+			Expect(bd.Status.Display.State).To(Equal("Ready"))
+
+			Eventually(func() error {
+				err = k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "name"}, bd)
+				Expect(err).NotTo(HaveOccurred())
+				bd.Spec.Options.DeleteNamespace = true
+				return k8sClient.Update(ctx, bd)
+			}).ShouldNot(HaveOccurred())
+
+			err = k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "name"}, bd)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(bd.Status.Display.State).To(Equal("Modified"))
 		})
 	})
 })

--- a/integrationtests/controller/bundledeployment/status_test.go
+++ b/integrationtests/controller/bundledeployment/status_test.go
@@ -1,0 +1,35 @@
+package bundledeployment
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/rancher/fleet/integrationtests/utils"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("BundleDeployment Status Fields", func() {
+
+	BeforeEach(func() {
+		var err error
+		namespace, err = utils.NewNamespaceName()
+		Expect(err).ToNot(HaveOccurred())
+
+		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}
+		Expect(k8sClient.Create(ctx, ns)).ToNot(HaveOccurred())
+
+		DeferCleanup(func() {
+			Expect(k8sClient.Delete(ctx, ns)).ToNot(HaveOccurred())
+		})
+	})
+
+	When("BundleDeployment changes", func() {
+		BeforeEach(func() {
+		})
+
+		It("updates the status fields", func() {
+		})
+	})
+})

--- a/integrationtests/controller/bundledeployment/status_test.go
+++ b/integrationtests/controller/bundledeployment/status_test.go
@@ -1,6 +1,8 @@
 package bundledeployment
 
 import (
+	"errors"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -63,7 +65,13 @@ var _ = Describe("BundleDeployment Status Fields", func() {
 				Expect(err).ToNot(HaveOccurred())
 				bd.Spec.StagedDeploymentID = bd.Spec.DeploymentID
 				err = k8sClient.Update(ctx, bd)
-				return err
+				if err != nil {
+					return err
+				}
+				if bd.Status.Display.State != "Ready" {
+					return errors.New("bundle deployment not ready")
+				}
+				return nil
 			}).ShouldNot(HaveOccurred())
 			Expect(bd.Status.Display.State).To(Equal("Ready"))
 			Expect(bd.Spec.StagedDeploymentID).To(Equal(bd.Spec.DeploymentID))

--- a/integrationtests/controller/bundledeployment/suite_test.go
+++ b/integrationtests/controller/bundledeployment/suite_test.go
@@ -9,7 +9,9 @@ import (
 
 	"github.com/rancher/fleet/integrationtests/utils"
 	"github.com/rancher/fleet/internal/cmd/controller/reconciler"
+	"github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -66,3 +68,18 @@ var _ = AfterSuite(func() {
 	cancel()
 	Expect(testenv.Stop()).ToNot(HaveOccurred())
 })
+
+func createBundleDeployment(name, namespace string, options v1alpha1.BundleDeploymentOptions) (*v1alpha1.BundleDeployment, error) {
+	bundleDeployment := v1alpha1.BundleDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    map[string]string{"foo": "bar"},
+		},
+		Spec: v1alpha1.BundleDeploymentSpec{
+			Options: options,
+		},
+	}
+
+	return &bundleDeployment, k8sClient.Create(ctx, &bundleDeployment)
+}

--- a/integrationtests/controller/bundledeployment/suite_test.go
+++ b/integrationtests/controller/bundledeployment/suite_test.go
@@ -1,4 +1,4 @@
-package gitrepo
+package bundledeployment
 
 import (
 	"context"
@@ -6,11 +6,9 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/reugn/go-quartz/quartz"
 
 	"github.com/rancher/fleet/integrationtests/utils"
 	"github.com/rancher/fleet/internal/cmd/controller/reconciler"
-	"github.com/rancher/fleet/internal/config"
 
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -31,7 +29,7 @@ var (
 
 func TestFleet(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Fleet GitRepo Suite")
+	RunSpecs(t, "Fleet BundleDeployment Suite")
 }
 
 var _ = BeforeSuite(func() {
@@ -50,24 +48,12 @@ var _ = BeforeSuite(func() {
 	mgr, err := utils.NewManager(cfg)
 	Expect(err).ToNot(HaveOccurred())
 
-	// Set up the gitrepo reconciler
-	config.Set(config.DefaultConfig())
-
-	sched := quartz.NewStdScheduler()
-	Expect(sched).ToNot(BeNil())
-
-	err = (&reconciler.GitRepoReconciler{
+	// Set up the clustergroup reconciler
+	err = (&reconciler.BundleDeploymentReconciler{
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
-
-		Scheduler: sched,
 	}).SetupWithManager(mgr)
 	Expect(err).ToNot(HaveOccurred(), "failed to set up manager")
-
-	sched.Start(ctx)
-	DeferCleanup(func() {
-		sched.Stop()
-	})
 
 	go func() {
 		defer GinkgoRecover()

--- a/integrationtests/controller/cluster/status_test.go
+++ b/integrationtests/controller/cluster/status_test.go
@@ -1,0 +1,143 @@
+package cluster
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/rancher/fleet/integrationtests/utils"
+	"github.com/rancher/fleet/internal/cmd/controller/summary"
+	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
+
+	"github.com/rancher/wrangler/v2/pkg/condition"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+var _ = Describe("Cluster Status Fields", func() {
+
+	var (
+		gitrepo *fleet.GitRepo
+		bd      *fleet.BundleDeployment
+	)
+	const deploymentID = "test123"
+
+	BeforeEach(func() {
+		var err error
+		namespace, err = utils.NewNamespaceName()
+		Expect(err).ToNot(HaveOccurred())
+
+		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}
+		Expect(k8sClient.Create(ctx, ns)).ToNot(HaveOccurred())
+
+		DeferCleanup(func() {
+			Expect(k8sClient.Delete(ctx, ns)).ToNot(HaveOccurred())
+		})
+	})
+
+	When("Bundledeployment is added", func() {
+		BeforeEach(func() {
+			cluster := &fleet.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: namespace,
+				},
+				Spec: fleet.ClusterSpec{},
+			}
+
+			err := k8sClient.Create(ctx, cluster)
+			Expect(err).NotTo(HaveOccurred())
+
+			// simulate agentmanagement updating the status to set the namespace
+			cluster.Status.Agent.LastSeen = metav1.Now()
+			cluster.Status.Namespace = namespace
+			err = k8sClient.Status().Update(ctx, cluster)
+			Expect(err).NotTo(HaveOccurred())
+
+			gitrepo = &fleet.GitRepo{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-gitrepo",
+					Namespace: namespace,
+				},
+				Spec: fleet.GitRepoSpec{},
+			}
+			err = k8sClient.Create(ctx, gitrepo)
+			Expect(err).NotTo(HaveOccurred())
+
+			bd = &fleet.BundleDeployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-bd",
+					Namespace: namespace,
+					Labels: map[string]string{
+						"fleet.cattle.io/repo-name":        "test-gitrepo",
+						"fleet.cattle.io/bundle-namespace": namespace,
+					},
+				},
+				Spec: fleet.BundleDeploymentSpec{
+					DeploymentID:       deploymentID,
+					StagedDeploymentID: deploymentID,
+				},
+			}
+			err = k8sClient.Create(ctx, bd)
+			Expect(err).NotTo(HaveOccurred())
+
+		})
+
+		It("updates the status fields", func() {
+			cluster := &fleet.Cluster{}
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: "test-cluster", Namespace: namespace}, cluster)
+				Expect(err).NotTo(HaveOccurred())
+
+				return cluster.Status.Summary.DesiredReady == 1
+			}).Should(BeTrue())
+
+			fmt.Printf("### cluster: %#v\n", cluster.Status)
+			Expect(cluster.Status.Summary.Ready).To(Equal(0))
+			Expect(cluster.Status.Summary.NonReadyResources).To(HaveLen(1))
+
+			Expect(cluster.Status.Display.ReadyBundles).To(Equal("0/1"))
+			Expect(cluster.Status.Display.State).To(Equal("WaitApplied"))
+
+			Expect(cluster.Status.DesiredReadyGitRepos).To(Equal(1))
+			Expect(cluster.Status.ReadyGitRepos).To(Equal(0))
+
+			Expect(condition.Cond(fleet.ClusterConditionReady).IsFalse(cluster)).To(BeTrue())
+			// Was `NotReady(1) [Bundle test-bd]`
+			Expect(condition.Cond(fleet.ClusterConditionReady).GetMessage(cluster)).To(Equal("WaitApplied(1) [Bundle test-bd]"))
+			Expect(condition.Cond(fleet.ClusterConditionProcessed).IsTrue(cluster)).To(BeTrue())
+
+			By("updating the bundledeployment to be ready")
+			bd.Status.AppliedDeploymentID = deploymentID
+			bd.Status.Ready = true
+			bd.Status.NonModified = true
+			err := k8sClient.Status().Update(ctx, bd)
+			Expect(err).NotTo(HaveOccurred())
+			fmt.Printf("### bd: %#v, %v\n", bd.Status, summary.GetDeploymentState(bd))
+
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: "test-cluster", Namespace: namespace}, cluster)
+				Expect(err).NotTo(HaveOccurred())
+
+				fmt.Printf("### cluster: %#v\n", cluster.Status)
+
+				return cluster.Status.Summary.Ready == 1
+			}).Should(BeTrue())
+
+			// Expect(cluster.Status.DesiredReadyGitRepos).To(Equal(0))
+			// Expect(cluster.Status.ReadyGitRepos).To(Equal(0))
+
+			// Expect(cluster.Status.Summary.ErrApplied).To(Equal(0))
+
+			// Expect(cluster.Status.ResourceCounts).To(HaveLen(1))
+			// Expect(cluster.Status.ResourceCounts).To(ContainElement(fleet.GitRepoResourceCounts{}))
+
+			// Expect(cluster.Status.Display.ReadyBundles).To(Equal("1/1"))
+			// Expect(cluster.Status.Display.State).To(Equal(fleet.Ready))
+			By("deleting the bundledeployment")
+		})
+	})
+})

--- a/integrationtests/controller/cluster/status_test.go
+++ b/integrationtests/controller/cluster/status_test.go
@@ -29,7 +29,7 @@ var _ = Describe("Cluster Status Fields", func() {
 
 	When("Bundledeployment is added", func() {
 		BeforeEach(func() {
-			cluster, err := createCluster("cluster", namespace, nil, namespace)
+			cluster, err := utils.CreateCluster(ctx, k8sClient, "cluster", namespace, nil, namespace)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(cluster).To(Not(BeNil()))
 
@@ -54,7 +54,7 @@ var _ = Describe("Cluster Status Fields", func() {
 					ClusterName: "cluster",
 				},
 			}
-			bundle, err := createBundle("name", namespace, targets, targets)
+			bundle, err := utils.CreateBundle(ctx, k8sClient, "name", namespace, targets, targets)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(bundle).To(Not(BeNil()))
 		})

--- a/integrationtests/controller/cluster/suite_test.go
+++ b/integrationtests/controller/cluster/suite_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/rancher/fleet/internal/manifest"
 	"github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -110,49 +109,4 @@ type FakeQuery struct {
 // BundlesForCluster returns empty list, so no cleanup is needed
 func (q *FakeQuery) BundlesForCluster(context.Context, *v1alpha1.Cluster) ([]*v1alpha1.Bundle, []*v1alpha1.Bundle, error) {
 	return nil, nil, nil
-}
-
-func createBundle(name, namespace string, targets []v1alpha1.BundleTarget, targetRestrictions []v1alpha1.BundleTarget) (*v1alpha1.Bundle, error) {
-	restrictions := []v1alpha1.BundleTargetRestriction{}
-	for _, r := range targetRestrictions {
-		restrictions = append(restrictions, v1alpha1.BundleTargetRestriction{
-			Name:                 r.Name,
-			ClusterName:          r.ClusterName,
-			ClusterSelector:      r.ClusterSelector,
-			ClusterGroup:         r.ClusterGroup,
-			ClusterGroupSelector: r.ClusterGroupSelector,
-		})
-	}
-	bundle := v1alpha1.Bundle{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
-			Labels:    map[string]string{"foo": "bar"},
-		},
-		Spec: v1alpha1.BundleSpec{
-			Targets:            targets,
-			TargetRestrictions: restrictions,
-		},
-	}
-
-	return &bundle, k8sClient.Create(ctx, &bundle)
-}
-
-func createCluster(name, controllerNs string, labels map[string]string, clusterNs string) (*v1alpha1.Cluster, error) {
-	cluster := &v1alpha1.Cluster{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: controllerNs,
-			Labels:    labels,
-		},
-	}
-	err := k8sClient.Create(ctx, cluster)
-	if err != nil {
-		return nil, err
-	}
-	// Need to set the status.Namespace as it is needed to create a BundleDeployment.
-	// Namespace is set by the Cluster controller. We need to do it manually because we are running just the Bundle controller.
-	cluster.Status.Namespace = clusterNs
-	err = k8sClient.Status().Update(ctx, cluster)
-	return cluster, err
 }

--- a/integrationtests/controller/cluster/suite_test.go
+++ b/integrationtests/controller/cluster/suite_test.go
@@ -6,11 +6,15 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/reugn/go-quartz/quartz"
 
 	"github.com/rancher/fleet/integrationtests/utils"
 	"github.com/rancher/fleet/internal/cmd/controller/reconciler"
-	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
+	"github.com/rancher/fleet/internal/cmd/controller/target"
+	"github.com/rancher/fleet/internal/manifest"
+	"github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -59,6 +63,35 @@ var _ = BeforeSuite(func() {
 	}).SetupWithManager(mgr)
 	Expect(err).ToNot(HaveOccurred(), "failed to set up manager")
 
+	store := manifest.NewStore(mgr.GetClient())
+	builder := target.New(mgr.GetClient())
+
+	err = (&reconciler.BundleReconciler{
+		Client:  mgr.GetClient(),
+		Scheme:  mgr.GetScheme(),
+		Builder: builder,
+		Store:   store,
+		Query:   builder,
+	}).SetupWithManager(mgr)
+	Expect(err).ToNot(HaveOccurred(), "failed to set up manager")
+
+	err = (&reconciler.BundleDeploymentReconciler{
+		Client: mgr.GetClient(),
+		Scheme: mgr.GetScheme(),
+	}).SetupWithManager(mgr)
+	Expect(err).ToNot(HaveOccurred(), "failed to set up manager")
+
+	sched := quartz.NewStdScheduler()
+	Expect(sched).ToNot(BeNil())
+
+	err = (&reconciler.GitRepoReconciler{
+		Client: mgr.GetClient(),
+		Scheme: mgr.GetScheme(),
+
+		Scheduler: sched,
+	}).SetupWithManager(mgr)
+	Expect(err).ToNot(HaveOccurred(), "failed to set up manager")
+
 	go func() {
 		defer GinkgoRecover()
 		err = mgr.Start(ctx)
@@ -75,6 +108,51 @@ type FakeQuery struct {
 }
 
 // BundlesForCluster returns empty list, so no cleanup is needed
-func (q *FakeQuery) BundlesForCluster(context.Context, *fleet.Cluster) ([]*fleet.Bundle, []*fleet.Bundle, error) {
+func (q *FakeQuery) BundlesForCluster(context.Context, *v1alpha1.Cluster) ([]*v1alpha1.Bundle, []*v1alpha1.Bundle, error) {
 	return nil, nil, nil
+}
+
+func createBundle(name, namespace string, targets []v1alpha1.BundleTarget, targetRestrictions []v1alpha1.BundleTarget) (*v1alpha1.Bundle, error) {
+	restrictions := []v1alpha1.BundleTargetRestriction{}
+	for _, r := range targetRestrictions {
+		restrictions = append(restrictions, v1alpha1.BundleTargetRestriction{
+			Name:                 r.Name,
+			ClusterName:          r.ClusterName,
+			ClusterSelector:      r.ClusterSelector,
+			ClusterGroup:         r.ClusterGroup,
+			ClusterGroupSelector: r.ClusterGroupSelector,
+		})
+	}
+	bundle := v1alpha1.Bundle{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    map[string]string{"foo": "bar"},
+		},
+		Spec: v1alpha1.BundleSpec{
+			Targets:            targets,
+			TargetRestrictions: restrictions,
+		},
+	}
+
+	return &bundle, k8sClient.Create(ctx, &bundle)
+}
+
+func createCluster(name, controllerNs string, labels map[string]string, clusterNs string) (*v1alpha1.Cluster, error) {
+	cluster := &v1alpha1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: controllerNs,
+			Labels:    labels,
+		},
+	}
+	err := k8sClient.Create(ctx, cluster)
+	if err != nil {
+		return nil, err
+	}
+	// Need to set the status.Namespace as it is needed to create a BundleDeployment.
+	// Namespace is set by the Cluster controller. We need to do it manually because we are running just the Bundle controller.
+	cluster.Status.Namespace = clusterNs
+	err = k8sClient.Status().Update(ctx, cluster)
+	return cluster, err
 }

--- a/integrationtests/controller/clustergroup/status_test.go
+++ b/integrationtests/controller/clustergroup/status_test.go
@@ -5,12 +5,19 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/rancher/fleet/integrationtests/utils"
+	"github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 var _ = Describe("ClusterGroup Status Fields", func() {
+
+	var (
+		clusterName = "test-cluster"
+		groupName   = "test-cluster-group"
+	)
 
 	BeforeEach(func() {
 		var err error
@@ -27,9 +34,35 @@ var _ = Describe("ClusterGroup Status Fields", func() {
 
 	When("Cluster is added", func() {
 		BeforeEach(func() {
+			clusterGroup, err := createClusterGroup(groupName, namespace, &metav1.LabelSelector{
+				MatchLabels: map[string]string{},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(clusterGroup).To(Not(BeNil()))
 		})
 
 		It("updates the status fields", func() {
+			clusterGroup := &v1alpha1.ClusterGroup{}
+			err := k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: groupName}, clusterGroup)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(clusterGroup).To(Not(BeNil()))
+			Expect(clusterGroup.Status.ClusterCount).To(Equal(0))
+			Expect(clusterGroup.Status.Display.ReadyClusters).To(Equal(""))
+
+			cluster, err := createCluster(clusterName, namespace, nil, namespace)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cluster).To(Not(BeNil()))
+
+			Eventually(func() error {
+				err := k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: groupName}, clusterGroup)
+				Expect(err).NotTo(HaveOccurred())
+				clusterGroup.Spec.Selector.MatchLabels = map[string]string{
+					"Name": clusterName,
+				}
+				return k8sClient.Update(ctx, clusterGroup)
+			}).ShouldNot(HaveOccurred())
+			Expect(clusterGroup.Status.ClusterCount).To(Equal(1))
+			Expect(clusterGroup.Status.Display.ReadyClusters).To(Equal("1/1"))
 		})
 	})
 })

--- a/integrationtests/controller/clustergroup/status_test.go
+++ b/integrationtests/controller/clustergroup/status_test.go
@@ -49,7 +49,7 @@ var _ = Describe("ClusterGroup Status Fields", func() {
 			Expect(clusterGroup.Status.ClusterCount).To(Equal(0))
 			Expect(clusterGroup.Status.Display.ReadyClusters).To(Equal(""))
 
-			cluster, err := createCluster(clusterName, namespace, nil, namespace)
+			cluster, err := utils.CreateCluster(ctx, k8sClient, clusterName, namespace, nil, namespace)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(cluster).To(Not(BeNil()))
 

--- a/integrationtests/controller/clustergroup/status_test.go
+++ b/integrationtests/controller/clustergroup/status_test.go
@@ -1,0 +1,35 @@
+package clustergroup
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/rancher/fleet/integrationtests/utils"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("ClusterGroup Status Fields", func() {
+
+	BeforeEach(func() {
+		var err error
+		namespace, err = utils.NewNamespaceName()
+		Expect(err).ToNot(HaveOccurred())
+
+		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}
+		Expect(k8sClient.Create(ctx, ns)).ToNot(HaveOccurred())
+
+		DeferCleanup(func() {
+			Expect(k8sClient.Delete(ctx, ns)).ToNot(HaveOccurred())
+		})
+	})
+
+	When("Cluster is added", func() {
+		BeforeEach(func() {
+		})
+
+		It("updates the status fields", func() {
+		})
+	})
+})

--- a/integrationtests/controller/clustergroup/suite_test.go
+++ b/integrationtests/controller/clustergroup/suite_test.go
@@ -85,25 +85,6 @@ func (q *FakeQuery) BundlesForCluster(context.Context, *v1alpha1.Cluster) ([]*v1
 	return nil, nil, nil
 }
 
-func createCluster(name, controllerNs string, labels map[string]string, clusterNs string) (*v1alpha1.Cluster, error) {
-	cluster := &v1alpha1.Cluster{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: controllerNs,
-			Labels:    labels,
-		},
-	}
-	err := k8sClient.Create(ctx, cluster)
-	if err != nil {
-		return nil, err
-	}
-	// Need to set the status.Namespace as it is needed to create a BundleDeployment.
-	// Namespace is set by the Cluster controller. We need to do it manually because we are running just the Bundle controller.
-	cluster.Status.Namespace = clusterNs
-	err = k8sClient.Status().Update(ctx, cluster)
-	return cluster, err
-}
-
 func createClusterGroup(name, namespace string, selector *metav1.LabelSelector) (*v1alpha1.ClusterGroup, error) {
 	cg := &v1alpha1.ClusterGroup{
 		ObjectMeta: metav1.ObjectMeta{

--- a/integrationtests/controller/clustergroup/suite_test.go
+++ b/integrationtests/controller/clustergroup/suite_test.go
@@ -1,4 +1,4 @@
-package gitrepo
+package clustergroup
 
 import (
 	"context"
@@ -6,11 +6,9 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/reugn/go-quartz/quartz"
 
 	"github.com/rancher/fleet/integrationtests/utils"
 	"github.com/rancher/fleet/internal/cmd/controller/reconciler"
-	"github.com/rancher/fleet/internal/config"
 
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -31,7 +29,7 @@ var (
 
 func TestFleet(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Fleet GitRepo Suite")
+	RunSpecs(t, "Fleet ClusterGroup Suite")
 }
 
 var _ = BeforeSuite(func() {
@@ -50,24 +48,12 @@ var _ = BeforeSuite(func() {
 	mgr, err := utils.NewManager(cfg)
 	Expect(err).ToNot(HaveOccurred())
 
-	// Set up the gitrepo reconciler
-	config.Set(config.DefaultConfig())
-
-	sched := quartz.NewStdScheduler()
-	Expect(sched).ToNot(BeNil())
-
-	err = (&reconciler.GitRepoReconciler{
+	// Set up the clustergroup reconciler
+	err = (&reconciler.ClusterGroupReconciler{
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
-
-		Scheduler: sched,
 	}).SetupWithManager(mgr)
 	Expect(err).ToNot(HaveOccurred(), "failed to set up manager")
-
-	sched.Start(ctx)
-	DeferCleanup(func() {
-		sched.Stop()
-	})
 
 	go func() {
 		defer GinkgoRecover()

--- a/integrationtests/controller/clustergroup/suite_test.go
+++ b/integrationtests/controller/clustergroup/suite_test.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/rancher/fleet/integrationtests/utils"
 	"github.com/rancher/fleet/internal/cmd/controller/reconciler"
+	"github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -55,6 +57,14 @@ var _ = BeforeSuite(func() {
 	}).SetupWithManager(mgr)
 	Expect(err).ToNot(HaveOccurred(), "failed to set up manager")
 
+	err = (&reconciler.ClusterReconciler{
+		Client: mgr.GetClient(),
+		Scheme: mgr.GetScheme(),
+
+		Query: &FakeQuery{},
+	}).SetupWithManager(mgr)
+	Expect(err).ToNot(HaveOccurred(), "failed to set up manager")
+
 	go func() {
 		defer GinkgoRecover()
 		err = mgr.Start(ctx)
@@ -66,3 +76,44 @@ var _ = AfterSuite(func() {
 	cancel()
 	Expect(testenv.Stop()).ToNot(HaveOccurred())
 })
+
+type FakeQuery struct {
+}
+
+// BundlesForCluster returns empty list, so no cleanup is needed
+func (q *FakeQuery) BundlesForCluster(context.Context, *v1alpha1.Cluster) ([]*v1alpha1.Bundle, []*v1alpha1.Bundle, error) {
+	return nil, nil, nil
+}
+
+func createCluster(name, controllerNs string, labels map[string]string, clusterNs string) (*v1alpha1.Cluster, error) {
+	cluster := &v1alpha1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: controllerNs,
+			Labels:    labels,
+		},
+	}
+	err := k8sClient.Create(ctx, cluster)
+	if err != nil {
+		return nil, err
+	}
+	// Need to set the status.Namespace as it is needed to create a BundleDeployment.
+	// Namespace is set by the Cluster controller. We need to do it manually because we are running just the Bundle controller.
+	cluster.Status.Namespace = clusterNs
+	err = k8sClient.Status().Update(ctx, cluster)
+	return cluster, err
+}
+
+func createClusterGroup(name, namespace string, selector *metav1.LabelSelector) (*v1alpha1.ClusterGroup, error) {
+	cg := &v1alpha1.ClusterGroup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: v1alpha1.ClusterGroupSpec{
+			Selector: selector,
+		},
+	}
+	err := k8sClient.Create(ctx, cg)
+	return cg, err
+}

--- a/integrationtests/controller/gitrepo/status_test.go
+++ b/integrationtests/controller/gitrepo/status_test.go
@@ -34,7 +34,7 @@ var _ = Describe("GitRepo Status Fields", func() {
 
 	When("Bundle changes", func() {
 		BeforeEach(func() {
-			cluster, err := createCluster("cluster", namespace, nil, namespace)
+			cluster, err := utils.CreateCluster(ctx, k8sClient, "cluster", namespace, nil, namespace)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(cluster).To(Not(BeNil()))
 			targets := []v1alpha1.BundleTarget{
@@ -46,7 +46,7 @@ var _ = Describe("GitRepo Status Fields", func() {
 					ClusterName: "cluster",
 				},
 			}
-			bundle, err := createBundle("name", namespace, targets, targets)
+			bundle, err := utils.CreateBundle(ctx, k8sClient, "name", namespace, targets, targets)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(bundle).To(Not(BeNil()))
 

--- a/integrationtests/controller/gitrepo/status_test.go
+++ b/integrationtests/controller/gitrepo/status_test.go
@@ -1,0 +1,35 @@
+package gitrepo
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/rancher/fleet/integrationtests/utils"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("GitRepo Status Fields", func() {
+
+	BeforeEach(func() {
+		var err error
+		namespace, err = utils.NewNamespaceName()
+		Expect(err).ToNot(HaveOccurred())
+
+		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}
+		Expect(k8sClient.Create(ctx, ns)).ToNot(HaveOccurred())
+
+		DeferCleanup(func() {
+			Expect(k8sClient.Delete(ctx, ns)).ToNot(HaveOccurred())
+		})
+	})
+
+	When("Bundle changes", func() {
+		BeforeEach(func() {
+		})
+
+		It("updates the status fields", func() {
+		})
+	})
+})

--- a/integrationtests/controller/gitrepo/status_test.go
+++ b/integrationtests/controller/gitrepo/status_test.go
@@ -5,12 +5,19 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/rancher/fleet/integrationtests/utils"
+	"github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 var _ = Describe("GitRepo Status Fields", func() {
+
+	var (
+		gitrepo *v1alpha1.GitRepo
+		bd      *v1alpha1.BundleDeployment
+	)
 
 	BeforeEach(func() {
 		var err error
@@ -27,9 +34,76 @@ var _ = Describe("GitRepo Status Fields", func() {
 
 	When("Bundle changes", func() {
 		BeforeEach(func() {
+			cluster, err := createCluster("cluster", namespace, nil, namespace)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cluster).To(Not(BeNil()))
+			targets := []v1alpha1.BundleTarget{
+				{
+					BundleDeploymentOptions: v1alpha1.BundleDeploymentOptions{
+						TargetNamespace: "targetNs",
+					},
+					Name:        "cluster",
+					ClusterName: "cluster",
+				},
+			}
+			bundle, err := createBundle("name", namespace, targets, targets)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(bundle).To(Not(BeNil()))
+
+			gitrepo = &v1alpha1.GitRepo{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-gitrepo",
+					Namespace: namespace,
+				},
+				Spec: v1alpha1.GitRepoSpec{
+					Repo: "https://github.com/rancher/fleet-test-data/not-found",
+				},
+			}
+			err = k8sClient.Create(ctx, gitrepo)
+			Expect(err).NotTo(HaveOccurred())
+
+			bd = &v1alpha1.BundleDeployment{}
+			Eventually(func() bool {
+				err = k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "name"}, bd)
+				return err == nil
+			}).Should(BeTrue())
 		})
 
 		It("updates the status fields", func() {
+			bundle := &v1alpha1.Bundle{}
+			Eventually(func() error {
+				err := k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "name"}, bundle)
+				Expect(err).ToNot(HaveOccurred())
+				bundle.Labels["fleet.cattle.io/repo-name"] = gitrepo.Name
+				return k8sClient.Update(ctx, bundle)
+			}).ShouldNot(HaveOccurred())
+			Expect(bundle.Status.Summary.Ready).ToNot(Equal(1))
+
+			err := k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: gitrepo.Name}, gitrepo)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(gitrepo.Status.Summary.Ready).To(Equal(0))
+
+			bd := &v1alpha1.BundleDeployment{}
+			Eventually(func() error {
+				err := k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "name"}, bd)
+				if err != nil {
+					return err
+				}
+				bd.Status.Display.State = "Ready"
+				bd.Status.AppliedDeploymentID = bd.Spec.DeploymentID
+				bd.Status.Ready = true
+				bd.Status.NonModified = true
+				return k8sClient.Status().Update(ctx, bd)
+			}).ShouldNot(HaveOccurred())
+
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "name"}, bundle)
+				Expect(err).NotTo(HaveOccurred())
+				return bundle.Status.Summary.Ready == 1
+			}).Should(BeTrue())
+			err = k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: gitrepo.Name}, gitrepo)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(gitrepo.Status.Summary.Ready).To(Equal(1))
 		})
 	})
 })

--- a/integrationtests/controller/gitrepo/suite_test.go
+++ b/integrationtests/controller/gitrepo/suite_test.go
@@ -13,9 +13,7 @@ import (
 	"github.com/rancher/fleet/internal/cmd/controller/target"
 	"github.com/rancher/fleet/internal/config"
 	"github.com/rancher/fleet/internal/manifest"
-	"github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -96,46 +94,3 @@ var _ = AfterSuite(func() {
 	cancel()
 	Expect(testenv.Stop()).ToNot(HaveOccurred())
 })
-
-func createBundle(name, namespace string, targets []v1alpha1.BundleTarget, targetRestrictions []v1alpha1.BundleTarget) (*v1alpha1.Bundle, error) {
-	restrictions := []v1alpha1.BundleTargetRestriction{}
-	for _, r := range targetRestrictions {
-		restrictions = append(restrictions, v1alpha1.BundleTargetRestriction{
-			Name:                 r.Name,
-			ClusterName:          r.ClusterName,
-			ClusterSelector:      r.ClusterSelector,
-			ClusterGroup:         r.ClusterGroup,
-			ClusterGroupSelector: r.ClusterGroupSelector,
-		})
-	}
-	bundle := v1alpha1.Bundle{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
-			Labels:    map[string]string{"foo": "bar"},
-		},
-		Spec: v1alpha1.BundleSpec{
-			Targets:            targets,
-			TargetRestrictions: restrictions,
-		},
-	}
-
-	return &bundle, k8sClient.Create(ctx, &bundle)
-}
-
-func createCluster(name, controllerNs string, labels map[string]string, clusterNs string) (*v1alpha1.Cluster, error) {
-	cluster := &v1alpha1.Cluster{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: controllerNs,
-			Labels:    labels,
-		},
-	}
-	err := k8sClient.Create(ctx, cluster)
-	if err != nil {
-		return nil, err
-	}
-	cluster.Status.Namespace = clusterNs
-	err = k8sClient.Status().Update(ctx, cluster)
-	return cluster, err
-}

--- a/integrationtests/controller/gitrepo/suite_test.go
+++ b/integrationtests/controller/gitrepo/suite_test.go
@@ -10,8 +10,12 @@ import (
 
 	"github.com/rancher/fleet/integrationtests/utils"
 	"github.com/rancher/fleet/internal/cmd/controller/reconciler"
+	"github.com/rancher/fleet/internal/cmd/controller/target"
 	"github.com/rancher/fleet/internal/config"
+	"github.com/rancher/fleet/internal/manifest"
+	"github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -64,6 +68,18 @@ var _ = BeforeSuite(func() {
 	}).SetupWithManager(mgr)
 	Expect(err).ToNot(HaveOccurred(), "failed to set up manager")
 
+	store := manifest.NewStore(mgr.GetClient())
+	builder := target.New(mgr.GetClient())
+
+	err = (&reconciler.BundleReconciler{
+		Client:  mgr.GetClient(),
+		Scheme:  mgr.GetScheme(),
+		Builder: builder,
+		Store:   store,
+		Query:   builder,
+	}).SetupWithManager(mgr)
+	Expect(err).ToNot(HaveOccurred(), "failed to set up manager")
+
 	sched.Start(ctx)
 	DeferCleanup(func() {
 		sched.Stop()
@@ -80,3 +96,46 @@ var _ = AfterSuite(func() {
 	cancel()
 	Expect(testenv.Stop()).ToNot(HaveOccurred())
 })
+
+func createBundle(name, namespace string, targets []v1alpha1.BundleTarget, targetRestrictions []v1alpha1.BundleTarget) (*v1alpha1.Bundle, error) {
+	restrictions := []v1alpha1.BundleTargetRestriction{}
+	for _, r := range targetRestrictions {
+		restrictions = append(restrictions, v1alpha1.BundleTargetRestriction{
+			Name:                 r.Name,
+			ClusterName:          r.ClusterName,
+			ClusterSelector:      r.ClusterSelector,
+			ClusterGroup:         r.ClusterGroup,
+			ClusterGroupSelector: r.ClusterGroupSelector,
+		})
+	}
+	bundle := v1alpha1.Bundle{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    map[string]string{"foo": "bar"},
+		},
+		Spec: v1alpha1.BundleSpec{
+			Targets:            targets,
+			TargetRestrictions: restrictions,
+		},
+	}
+
+	return &bundle, k8sClient.Create(ctx, &bundle)
+}
+
+func createCluster(name, controllerNs string, labels map[string]string, clusterNs string) (*v1alpha1.Cluster, error) {
+	cluster := &v1alpha1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: controllerNs,
+			Labels:    labels,
+		},
+	}
+	err := k8sClient.Create(ctx, cluster)
+	if err != nil {
+		return nil, err
+	}
+	cluster.Status.Namespace = clusterNs
+	err = k8sClient.Status().Update(ctx, cluster)
+	return cluster, err
+}

--- a/integrationtests/utils/envtest.go
+++ b/integrationtests/utils/envtest.go
@@ -1,0 +1,53 @@
+package utils
+
+import (
+	"path/filepath"
+	"time"
+
+	"github.com/onsi/gomega"
+
+	"github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
+
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/rest"
+	"k8s.io/kubectl/pkg/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+)
+
+const (
+	Timeout         = 30 * time.Second
+	PollingInterval = 3 * time.Second
+)
+
+func init() {
+	gomega.SetDefaultEventuallyTimeout(Timeout)
+	gomega.SetDefaultEventuallyPollingInterval(PollingInterval)
+}
+
+// NewEnvTest returns a new envtest with the Fleet CRDs loaded.
+func NewEnvTest() *envtest.Environment {
+	return &envtest.Environment{
+		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "charts", "fleet-crd", "templates", "crds.yaml")},
+		ErrorIfCRDPathMissing: true,
+	}
+}
+
+// NewClient returns a new controller-runtime client.
+func NewClient(cfg *rest.Config) (client.Client, error) {
+	utilruntime.Must(v1alpha1.AddToScheme(scheme.Scheme))
+	//+kubebuilder:scaffold:scheme
+
+	return client.New(cfg, client.Options{Scheme: scheme.Scheme})
+}
+
+// NewManager returns a new controller-runtime manager suitable for testing.
+func NewManager(cfg *rest.Config) (ctrl.Manager, error) {
+	return ctrl.NewManager(cfg, ctrl.Options{
+		Scheme:         scheme.Scheme,
+		LeaderElection: false,
+		Metrics:        metricsserver.Options{BindAddress: "0"},
+	})
+}

--- a/integrationtests/utils/helpers.go
+++ b/integrationtests/utils/helpers.go
@@ -1,0 +1,52 @@
+package utils
+
+import (
+	"context"
+
+	"github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func CreateBundle(ctx context.Context, k8sClient client.Client, name, namespace string, targets []v1alpha1.BundleTarget, targetRestrictions []v1alpha1.BundleTarget) (*v1alpha1.Bundle, error) {
+	restrictions := []v1alpha1.BundleTargetRestriction{}
+	for _, r := range targetRestrictions {
+		restrictions = append(restrictions, v1alpha1.BundleTargetRestriction{
+			Name:                 r.Name,
+			ClusterName:          r.ClusterName,
+			ClusterSelector:      r.ClusterSelector,
+			ClusterGroup:         r.ClusterGroup,
+			ClusterGroupSelector: r.ClusterGroupSelector,
+		})
+	}
+	bundle := v1alpha1.Bundle{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    map[string]string{"foo": "bar"},
+		},
+		Spec: v1alpha1.BundleSpec{
+			Targets:            targets,
+			TargetRestrictions: restrictions,
+		},
+	}
+
+	return &bundle, k8sClient.Create(ctx, &bundle)
+}
+
+func CreateCluster(ctx context.Context, k8sClient client.Client, name, controllerNs string, labels map[string]string, clusterNs string) (*v1alpha1.Cluster, error) {
+	cluster := &v1alpha1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: controllerNs,
+			Labels:    labels,
+		},
+	}
+	err := k8sClient.Create(ctx, cluster)
+	if err != nil {
+		return nil, err
+	}
+	cluster.Status.Namespace = clusterNs
+	err = k8sClient.Status().Update(ctx, cluster)
+	return cluster, err
+}

--- a/internal/cmd/controller/reconciler/cluster_controller.go
+++ b/internal/cmd/controller/reconciler/cluster_controller.go
@@ -135,10 +135,12 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		repo := bd.Labels[fleet.RepoLabel]
 		ns := bd.Labels[fleet.BundleNamespaceLabel]
 		if repo != "" && ns != "" {
+			// a gitrepo is ready if its bundledeployments are ready, take previous state into account
 			repos[repoKey{repo: repo, ns: ns}] = (state == fleet.Ready) || repos[repoKey{repo: repo, ns: ns}]
 		}
 	}
 
+	// a cluster is ready if all its gitrepos are ready and the resources are ready too
 	allReady := true
 	for repo, ready := range repos {
 		gitrepo := &fleet.GitRepo{}


### PR DESCRIPTION
Refers to https://github.com/rancher/fleet/pull/2400


Add integration tests to check status reconciles

* BundleDeployment triggers Bundle
* Bundle triggers GitRepo
* BundleDeployment triggers Cluster
  * uses BundleDeployment and GitRepo for update
* Cluster triggers ClusterGroup

