### PR TITLE
Add a Parameter to Configure Worker count for fleet-controller

### DIFF
--- a/charts/fleet/templates/deployment.yaml
+++ b/charts/fleet/templates/deployment.yaml
@@ -65,15 +65,15 @@ spec:
           value: "true"
         {{- end }}
         {{- if $.Values.controller.reconciler.workers.gitrepo }}
-        - name: CONTROLLER_GITREPO_RECONCILER_WORKERS
+        - name: GITREPO_RECONCILER_WORKERS
           value: {{ quote $.Values.controller.reconciler.workers.gitrepo }}
         {{- end }}
         {{- if $.Values.controller.reconciler.workers.bundle }}
-        - name: CONTROLLER_BUNDLE_RECONCILER_WORKERS
+        - name: BUNDLE_RECONCILER_WORKERS
           value: {{ quote $.Values.controller.reconciler.workers.bundle }}
         {{- end }}
         {{- if $.Values.controller.reconciler.workers.bundledeployment }}
-        - name: CONTROLLER_BUNDLEDEPLOYMENT_RECONCILER_WORKERS
+        - name: BUNDLEDEPLOYMENT_RECONCILER_WORKERS
           value: {{ quote $.Values.controller.reconciler.workers.bundledeployment }}
         {{- end }}
         image: '{{ template "system_default_registry" $ }}{{ $.Values.image.repository }}:{{ $.Values.image.tag }}'
@@ -139,15 +139,15 @@ spec:
           value: {{$.Values.leaderElection.renewDeadline}}
         {{- end }}
         {{- if $.Values.controller.reconciler.workers.gitrepo }}
-        - name: CONTROLLER_GITREPO_RECONCILER_WORKERS
+        - name: GITREPO_RECONCILER_WORKERS
           value: {{ quote $.Values.controller.reconciler.workers.gitrepo }}
         {{- end }}
         {{- if $.Values.controller.reconciler.workers.bundle }}
-        - name: CONTROLLER_BUNDLE_RECONCILER_WORKERS
+        - name: BUNDLE_RECONCILER_WORKERS
           value: {{ quote $.Values.controller.reconciler.workers.bundle }}
         {{- end }}
         {{- if $.Values.controller.reconciler.workers.bundledeployment }}
-        - name: CONTROLLER_BUNDLEDEPLOYMENT_RECONCILER_WORKERS
+        - name: BUNDLEDEPLOYMENT_RECONCILER_WORKERS
           value: {{ quote $.Values.controller.reconciler.workers.bundledeployment }}
         {{- end }}
         image: '{{ template "system_default_registry" $ }}{{ $.Values.image.repository }}:{{ $.Values.image.tag }}'

--- a/charts/fleet/templates/deployment.yaml
+++ b/charts/fleet/templates/deployment.yaml
@@ -64,6 +64,18 @@ spec:
         - name: CATTLE_DEV_MODE
           value: "true"
         {{- end }}
+        {{- if $.Values.controller.reconciler.workers.gitrepo }}
+        - name: CONTROLLER_GITREPO_RECONCILER_WORKERS
+          value: {{ quote $.Values.controller.reconciler.workers.gitrepo }}
+        {{- end }}
+        {{- if $.Values.controller.reconciler.workers.bundle }}
+        - name: CONTROLLER_BUNDLE_RECONCILER_WORKERS
+          value: {{ quote $.Values.controller.reconciler.workers.bundle }}
+        {{- end }}
+        {{- if $.Values.controller.reconciler.workers.bundledeployment }}
+        - name: CONTROLLER_BUNDLEDEPLOYMENT_RECONCILER_WORKERS
+          value: {{ quote $.Values.controller.reconciler.workers.bundledeployment }}
+        {{- end }}
         image: '{{ template "system_default_registry" $ }}{{ $.Values.image.repository }}:{{ $.Values.image.tag }}'
         name: fleet-controller
         imagePullPolicy: "{{ $.Values.image.imagePullPolicy }}"
@@ -125,6 +137,18 @@ spec:
         {{- if $.Values.leaderElection.renewDeadline }}
         - name: CATTLE_ELECTION_RENEW_DEADLINE
           value: {{$.Values.leaderElection.renewDeadline}}
+        {{- end }}
+        {{- if $.Values.controller.reconciler.workers.gitrepo }}
+        - name: CONTROLLER_GITREPO_RECONCILER_WORKERS
+          value: {{ quote $.Values.controller.reconciler.workers.gitrepo }}
+        {{- end }}
+        {{- if $.Values.controller.reconciler.workers.bundle }}
+        - name: CONTROLLER_BUNDLE_RECONCILER_WORKERS
+          value: {{ quote $.Values.controller.reconciler.workers.bundle }}
+        {{- end }}
+        {{- if $.Values.controller.reconciler.workers.bundledeployment }}
+        - name: CONTROLLER_BUNDLEDEPLOYMENT_RECONCILER_WORKERS
+          value: {{ quote $.Values.controller.reconciler.workers.bundledeployment }}
         {{- end }}
         image: '{{ template "system_default_registry" $ }}{{ $.Values.image.repository }}:{{ $.Values.image.tag }}'
         name: fleet-cleanup

--- a/charts/fleet/values.yaml
+++ b/charts/fleet/values.yaml
@@ -97,5 +97,5 @@ controller:
     # The number of workers that are allowed to each type of reconciler
     workers:
       gitrepo: "1"
-      bundle: "2"
-      bundledeployment: "3"
+      bundle: "1"
+      bundledeployment: "1"

--- a/charts/fleet/values.yaml
+++ b/charts/fleet/values.yaml
@@ -90,3 +90,12 @@ leaderElection:
   leaseDuration: 30s
   retryPeriod: 10s
   renewDeadline: 25s
+
+## Fleet controller configuration
+controller:
+  reconciler:
+    # The number of workers that are allowed to each type of reconciler
+    workers:
+      gitrepo: "1"
+      bundle: "2"
+      bundledeployment: "3"

--- a/internal/cmd/controller/operator.go
+++ b/internal/cmd/controller/operator.go
@@ -129,7 +129,7 @@ func start(
 			Scheduler: sched,
 			ShardID:   shardID,
 
-			Workers: workersOpts.Gitrepo,
+			Workers: workersOpts.GitRepo,
 		}).SetupWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "GitRepo")
 			return err
@@ -151,7 +151,7 @@ func start(
 		Scheme:  mgr.GetScheme(),
 		ShardID: shardID,
 
-		Workers: workersOpts.Bundledeployment,
+		Workers: workersOpts.BundleDeployment,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "BundleDeployment")
 		return err

--- a/internal/cmd/controller/operator.go
+++ b/internal/cmd/controller/operator.go
@@ -36,6 +36,7 @@ func start(
 	systemNamespace string,
 	config *rest.Config,
 	leaderOpts LeaderElectionOptions,
+	workersOpts ControllerReconcilerWorkers,
 	bindAddresses BindAddresses,
 	disableGitops bool,
 	disableMetrics bool,
@@ -111,6 +112,8 @@ func start(
 		Store:   store,
 		Query:   builder,
 		ShardID: shardID,
+
+		Workers: workersOpts.Bundle,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Bundle")
 		return err
@@ -125,6 +128,8 @@ func start(
 
 			Scheduler: sched,
 			ShardID:   shardID,
+
+			Workers: workersOpts.Gitrepo,
 		}).SetupWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "GitRepo")
 			return err
@@ -145,6 +150,8 @@ func start(
 		Client:  mgr.GetClient(),
 		Scheme:  mgr.GetScheme(),
 		ShardID: shardID,
+
+		Workers: workersOpts.Bundledeployment,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "BundleDeployment")
 		return err

--- a/internal/cmd/controller/reconciler/bundle_controller.go
+++ b/internal/cmd/controller/reconciler/bundle_controller.go
@@ -210,8 +210,6 @@ func upper(op controllerutil.OperationResult) string {
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *BundleReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	logger := log.FromContext(context.Background()).WithName("bundle")
-	logger.Info("Setting up BundleReconciler with workers", "workers", r.Workers)
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&fleet.Bundle{}).
 		// Note: Maybe improve with WatchesMetadata, does it have access to labels?

--- a/internal/cmd/controller/reconciler/bundle_controller.go
+++ b/internal/cmd/controller/reconciler/bundle_controller.go
@@ -21,6 +21,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -49,6 +50,8 @@ type BundleReconciler struct {
 	Store   Store
 	Query   BundleQuery
 	ShardID string
+
+	Workers int
 }
 
 //+kubebuilder:rbac:groups=fleet.cattle.io,resources=bundles,verbs=get;list;watch;create;update;patch;delete
@@ -207,6 +210,8 @@ func upper(op controllerutil.OperationResult) string {
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *BundleReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	logger := log.FromContext(context.Background()).WithName("bundle")
+	logger.Info("Setting up BundleReconciler with workers", "workers", r.Workers)
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&fleet.Bundle{}).
 		// Note: Maybe improve with WatchesMetadata, does it have access to labels?
@@ -258,5 +263,6 @@ func (r *BundleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			builder.WithPredicates(predicate.ResourceVersionChangedPredicate{}),
 		).
 		WithEventFilter(sharding.FilterByShardID(r.ShardID)).
+		WithOptions(controller.Options{MaxConcurrentReconciles: r.Workers}).
 		Complete(r)
 }

--- a/internal/cmd/controller/reconciler/bundledeployment_controller.go
+++ b/internal/cmd/controller/reconciler/bundledeployment_controller.go
@@ -108,8 +108,6 @@ func bundleDeploymentStatusChangedPredicate() predicate.Funcs {
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *BundleDeploymentReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	logger := log.FromContext(context.Background()).WithName("bundledeployment")
-	logger.Info("Setting up BundleReconciler with workers", "workers", r.Workers)
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&fleet.BundleDeployment{}, builder.WithPredicates(
 			bundleDeploymentStatusChangedPredicate(),

--- a/internal/cmd/controller/reconciler/gitrepo_controller.go
+++ b/internal/cmd/controller/reconciler/gitrepo_controller.go
@@ -242,8 +242,6 @@ func (r *GitRepoReconciler) updateStatus(ctx context.Context, req types.Namespac
 // SetupWithManager sets up the controller with the Manager.
 func (r *GitRepoReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	// Note: Maybe use mgr.GetFieldIndexer().IndexField for better performance?
-	logger := log.FromContext(context.Background()).WithName("gitrepo")
-	logger.Info("Setting up BundleReconciler with workers", "workers", r.Workers)
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&fleet.GitRepo{},
 			builder.WithPredicates(

--- a/internal/cmd/controller/root.go
+++ b/internal/cmd/controller/root.go
@@ -54,6 +54,12 @@ type LeaderElectionOptions struct {
 	RetryPeriod *time.Duration
 }
 
+type ControllerReconcilerWorkers struct {
+	Gitrepo          int
+	Bundle           int
+	Bundledeployment int
+}
+
 type BindAddresses struct {
 	Metrics     string
 	HealthProbe string
@@ -90,6 +96,9 @@ func (f *FleetManager) Run(cmd *cobra.Command, args []string) error {
 	kubeconfig := ctrl.GetConfigOrDie()
 
 	leaderOpts := LeaderElectionOptions{}
+
+	workersOpts := ControllerReconcilerWorkers{}
+
 	if d := os.Getenv("CATTLE_ELECTION_LEASE_DURATION"); d != "" {
 		v, err := time.ParseDuration(d)
 		if err != nil {
@@ -127,6 +136,28 @@ func (f *FleetManager) Run(cmd *cobra.Command, args []string) error {
 		bindAddresses.HealthProbe = d
 	}
 
+	if d := os.Getenv("CONTROLLER_GITREPO_RECONCILER_WORKERS"); d != "" {
+		w, err := strconv.Atoi(d)
+		if err != nil {
+			setupLog.Error(err, "failed to parse CONTROLLER_GITREPO_RECONCILER_WORKERS", "value", d)
+		}
+		workersOpts.Gitrepo = w
+	}
+	if d := os.Getenv("CONTROLLER_BUNDLE_RECONCILER_WORKERS"); d != "" {
+		w, err := strconv.Atoi(d)
+		if err != nil {
+			setupLog.Error(err, "failed to parse CONTROLLER_BUNDLE_RECONCILER_WORKERS", "value", d)
+		}
+		workersOpts.Bundle = w
+	}
+	if d := os.Getenv("CONTROLLER_BUNDLEDEPLOYMENT_RECONCILER_WORKERS"); d != "" {
+		w, err := strconv.Atoi(d)
+		if err != nil {
+			setupLog.Error(err, "failed to parse CONTROLLER_BUNDLEDEPLOYMENT_RECONCILER_WORKERS", "value", d)
+		}
+		workersOpts.Bundledeployment = w
+	}
+
 	setupCpuPprof(ctx)
 	go func() {
 		log.Println(http.ListenAndServe("localhost:6060", nil)) // nolint:gosec // Debugging only
@@ -136,6 +167,7 @@ func (f *FleetManager) Run(cmd *cobra.Command, args []string) error {
 		f.Namespace,
 		kubeconfig,
 		leaderOpts,
+		workersOpts,
 		bindAddresses,
 		f.DisableGitops,
 		f.DisableMetrics,

--- a/internal/cmd/controller/root.go
+++ b/internal/cmd/controller/root.go
@@ -136,24 +136,24 @@ func (f *FleetManager) Run(cmd *cobra.Command, args []string) error {
 		bindAddresses.HealthProbe = d
 	}
 
-	if d := os.Getenv("CONTROLLER_GITREPO_RECONCILER_WORKERS"); d != "" {
+	if d := os.Getenv("GITREPO_RECONCILER_WORKERS"); d != "" {
 		w, err := strconv.Atoi(d)
 		if err != nil {
-			setupLog.Error(err, "failed to parse CONTROLLER_GITREPO_RECONCILER_WORKERS", "value", d)
+			setupLog.Error(err, "failed to parse GITREPO_RECONCILER_WORKERS", "value", d)
 		}
 		workersOpts.Gitrepo = w
 	}
-	if d := os.Getenv("CONTROLLER_BUNDLE_RECONCILER_WORKERS"); d != "" {
+	if d := os.Getenv("BUNDLE_RECONCILER_WORKERS"); d != "" {
 		w, err := strconv.Atoi(d)
 		if err != nil {
-			setupLog.Error(err, "failed to parse CONTROLLER_BUNDLE_RECONCILER_WORKERS", "value", d)
+			setupLog.Error(err, "failed to parse BUNDLE_RECONCILER_WORKERS", "value", d)
 		}
 		workersOpts.Bundle = w
 	}
-	if d := os.Getenv("CONTROLLER_BUNDLEDEPLOYMENT_RECONCILER_WORKERS"); d != "" {
+	if d := os.Getenv("BUNDLEDEPLOYMENT_RECONCILER_WORKERS"); d != "" {
 		w, err := strconv.Atoi(d)
 		if err != nil {
-			setupLog.Error(err, "failed to parse CONTROLLER_BUNDLEDEPLOYMENT_RECONCILER_WORKERS", "value", d)
+			setupLog.Error(err, "failed to parse BUNDLEDEPLOYMENT_RECONCILER_WORKERS", "value", d)
 		}
 		workersOpts.Bundledeployment = w
 	}

--- a/internal/cmd/controller/root.go
+++ b/internal/cmd/controller/root.go
@@ -55,9 +55,9 @@ type LeaderElectionOptions struct {
 }
 
 type ControllerReconcilerWorkers struct {
-	Gitrepo          int
+	GitRepo          int
 	Bundle           int
-	Bundledeployment int
+	BundleDeployment int
 }
 
 type BindAddresses struct {
@@ -141,7 +141,7 @@ func (f *FleetManager) Run(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			setupLog.Error(err, "failed to parse GITREPO_RECONCILER_WORKERS", "value", d)
 		}
-		workersOpts.Gitrepo = w
+		workersOpts.GitRepo = w
 	}
 	if d := os.Getenv("BUNDLE_RECONCILER_WORKERS"); d != "" {
 		w, err := strconv.Atoi(d)
@@ -155,7 +155,7 @@ func (f *FleetManager) Run(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			setupLog.Error(err, "failed to parse BUNDLEDEPLOYMENT_RECONCILER_WORKERS", "value", d)
 		}
-		workersOpts.Bundledeployment = w
+		workersOpts.BundleDeployment = w
 	}
 
 	setupCpuPprof(ctx)


### PR DESCRIPTION
Refers to https://github.com/rancher/fleet/issues/2415

Added a new environment var for each type of reconciler (gitrepo, bundle, bundledeployment) to configure their worker count (in values.yaml)

No test for this, we need a large scale fleet to test to test it