### PR TITLE
Gitjob controller updates GitRepo with generation it is reconciling

### DIFF
--- a/.golangci.json
+++ b/.golangci.json
@@ -68,6 +68,12 @@
           "dupl",
           "gosec"
         ]
+      },
+      {
+        "path": "e2e",
+        "linters": [
+          "gosec"
+        ]
       }
     ]
   }

--- a/dev/update-controller-k3d
+++ b/dev/update-controller-k3d
@@ -18,3 +18,4 @@ docker build -f package/Dockerfile -t rancher/fleet:dev --build-arg="ARCH=$GOARC
 fleet_ctx=$(kubectl config current-context)
 k3d image import rancher/fleet:dev -m direct -c "${fleet_ctx#k3d-}"
 kubectl delete pod -l app=fleet-controller -n cattle-fleet-system
+kubectl delete pod -l app=gitjob -n cattle-fleet-system

--- a/e2e/metrics/bundle_test.go
+++ b/e2e/metrics/bundle_test.go
@@ -142,6 +142,8 @@ var _ = Describe("Bundle Metrics", Label("bundle"), func() {
 		out, err := k.Create("ns", namespace)
 		Expect(err).ToNot(HaveOccurred(), out)
 
+		// This GitRepo will not create any workload, since it is in a
+		// random namespace, which lacks a cluster
 		err = testenv.CreateGitRepo(
 			kw,
 			namespace,
@@ -151,6 +153,8 @@ var _ = Describe("Bundle Metrics", Label("bundle"), func() {
 			"simple-manifest",
 		)
 		Expect(err).ToNot(HaveOccurred())
+
+		Eventually(metricsExist(gitRepoName+"-simple-manifest", nil)).ShouldNot(HaveOccurred())
 
 		DeferCleanup(func() {
 			out, err = k.Delete("ns", namespace)

--- a/e2e/multi-cluster/bundle_namespace_mapping_test.go
+++ b/e2e/multi-cluster/bundle_namespace_mapping_test.go
@@ -22,6 +22,8 @@ var _ = Describe("Bundle Namespace Mapping", Label("difficult"), func() {
 
 		interval = 2 * time.Second
 		duration = 30 * time.Second
+
+		r = rand.New(rand.NewSource(GinkgoRandomSeed()))
 	)
 
 	type TemplateData struct {
@@ -50,7 +52,7 @@ var _ = Describe("Bundle Namespace Mapping", Label("difficult"), func() {
 	Context("with bundlenamespacemapping", func() {
 		When("bundle selector does not match", func() {
 			BeforeEach(func() {
-				namespace = testenv.NewNamespaceName("bnm-nomatch", rand.New(rand.NewSource(GinkgoRandomSeed())))
+				namespace = testenv.NewNamespaceName("bnm-nomatch", r)
 				asset = "multi-cluster/bundle-namespace-mapping.yaml"
 				data = TemplateData{env.ClusterRegistrationNamespace, namespace, "", "mismatch", false}
 			})

--- a/e2e/multi-cluster/depends_on_test.go
+++ b/e2e/multi-cluster/depends_on_test.go
@@ -25,6 +25,8 @@ var _ = Describe("Bundle Depends On", Label("difficult"), func() {
 
 		interval = 2 * time.Second
 		duration = 30 * time.Second
+
+		r = rand.New(rand.NewSource(GinkgoRandomSeed()))
 	)
 
 	type TemplateData struct {
@@ -68,7 +70,7 @@ var _ = Describe("Bundle Depends On", Label("difficult"), func() {
 		BeforeEach(func() {
 			required = "required"
 			dependsOn = "depends-on"
-			namespace = testenv.NewNamespaceName("bnm-nomatch", rand.New(rand.NewSource(GinkgoRandomSeed())))
+			namespace = testenv.NewNamespaceName("bnm-nomatch", r)
 			asset = "multi-cluster/bundle-depends-on.yaml"
 			data = TemplateData{dependsOn, env.Namespace, namespace}
 		})

--- a/e2e/single-cluster/values_from_test.go
+++ b/e2e/single-cluster/values_from_test.go
@@ -18,11 +18,12 @@ var _ = Describe("ValuesFrom", func() {
 		// kw is the kubectl command for namespace the workload is deployed to
 		kw        kubectl.Command
 		namespace string
+		r         = rand.New(rand.NewSource(GinkgoRandomSeed()))
 	)
 
 	BeforeEach(func() {
 		k = env.Kubectl.Namespace(env.Namespace)
-		namespace = testenv.NewNamespaceName("values-from", rand.New(rand.NewSource(GinkgoRandomSeed())))
+		namespace = testenv.NewNamespaceName("values-from", r)
 		kw = k.Namespace(namespace)
 
 		out, err := k.Create("ns", namespace)

--- a/e2e/testenv/template.go
+++ b/e2e/testenv/template.go
@@ -18,6 +18,8 @@ const gitrepoTemplate = "gitrepo-template.yaml"
 const clusterTemplate = "cluster-template.yaml"
 const clustergroupTemplate = "clustergroup-template.yaml"
 
+var r = rand.New(rand.NewSource(ginkgo.GinkgoRandomSeed()))
+
 // GitRepoData can be used with the gitrepo-template.yaml asset when no custom
 // GitRepo properties are required. All fields except Shard are required.
 type GitRepoData struct {
@@ -86,7 +88,7 @@ func ApplyTemplate(k kubectl.Command, asset string, data interface{}) error {
 	output := path.Join(
 		tmpdir, RandomFilename(
 			asset,
-			rand.New(rand.NewSource(ginkgo.GinkgoRandomSeed())), // nolint:gosec // test code
+			r,
 		),
 	)
 	if err := Template(output, AssetPath(asset), data); err != nil {

--- a/internal/cmd/controller/summary/summary.go
+++ b/internal/cmd/controller/summary/summary.go
@@ -13,6 +13,7 @@ import (
 	"github.com/rancher/wrangler/v2/pkg/genericcondition"
 )
 
+// IncrementState increments counters in the BundleSummary. We store up to 10 non ready resources in the summary, with the bundldedeployment's state.
 func IncrementState(summary *fleet.BundleSummary, name string, state fleet.BundleState, message string, modified []fleet.ModifiedStatus, nonReady []fleet.NonReadyStatus) {
 	switch state {
 	case fleet.Modified:


### PR DESCRIPTION
The gitjob reconciler updates the gitrepo resource with information it was acting on.
* ObservedGeneration, this is also updated in the gitrepo reconciler. However the gitjob reconciler updates the status and should note the generation it worked on.
* Job termination message, if the gitrepo reconciler is conflicting with the gitjob reconciler while trying to update the status, the gitjob reconciler will store the message as it was when it triggered.


Also fixes several tests that were not waiting for setup to be complete, or trying to update outdated resources.


Refers to #2435