### PR TITLE
Remove trailing comma from bootstrap template

### DIFF
--- a/charts/fleet/templates/configmap.yaml
+++ b/charts/fleet/templates/configmap.yaml
@@ -18,7 +18,7 @@ data:
         "secret": "{{.Values.bootstrap.secret}}",
         "branch":  "{{.Values.bootstrap.branch}}",
         "namespace": "{{.Values.bootstrap.namespace}}",
-        "agentNamespace": "{{.Values.bootstrap.agentNamespace}}",
+        "agentNamespace": "{{.Values.bootstrap.agentNamespace}}"
       },
       "webhookReceiverURL": "{{.Values.webhookReceiverURL}}",
       "githubURLPrefix": "{{.Values.githubURLPrefix}}"


### PR DESCRIPTION
<!-- Specify the issue ID that this pull request is solving -->
Refers to #XXX
<!-- Make sure that the referenced issue provides steps to reproduce it -->

<!-- Describe the changes introduced by this pull request -->

This causes `Error("trailing comma", line: 16, column: 13)` when using serde_json to deserialize the value and do something with apiServerURL and apiServerCA. Unfortunately this rust framework does not tolerate invalid json content.

<!--
  Please provide a unit, integration (`./integrationtests/`) or e2e (`./e2e/`) test if possible.
-->