### PR TITLE
dev: Make setup-single-cluster capable of setting up multiple clusters

### DIFF
--- a/dev/build-fleet
+++ b/dev/build-fleet
@@ -18,6 +18,17 @@ fi
 
 export GOOS=linux
 
+# The name of the container image created here is a potential source of conflict
+# when fleet is set up simultaneously in multiple sets (i.e. 1 upstream + 0 to n
+# downstream). build-fleet always creates a container image with the same name
+# (`rancher/fleet`, rancher/fleet-agent`) and tag (`dev`). Conflicts can simply
+# be avoided by making sure that the images `rancher/fleet:dev` and
+# `rancher/fleet-agent:dev` are rebuilt from the right context (e.g. git clone,
+# checkout or worktree) before being imported into clusters created for testing
+# that context.  This can be easily achieved by ensuring that, for instance, at
+# most one instance of `./dev/setup-single-cluster` or
+# `./dev/setup-multi-cluster` runs at any given point in time.
+
 # fleet
 go build -gcflags='all=-N -l' -o "bin/fleet-linux-$GOARCH" ./cmd/fleetcli
 go build -gcflags='all=-N -l' -o bin/fleetcontroller-linux-"$GOARCH" ./cmd/fleetcontroller
@@ -25,8 +36,4 @@ docker build -f package/Dockerfile -t rancher/fleet:dev --build-arg="ARCH=$GOARC
 
 # fleet agent
 go build -gcflags='all=-N -l' -o "bin/fleetagent-linux-$GOARCH" ./cmd/fleetagent
-
-# The name of the container image created here is a potential source of
-# conflicts when the clusters are created simultaneously. It might be worth thinking about
-# how to make the image name unique for each test run.
 docker build -f package/Dockerfile.agent -t rancher/fleet-agent:dev --build-arg="ARCH=$GOARCH" .

--- a/dev/build-fleet
+++ b/dev/build-fleet
@@ -25,4 +25,8 @@ docker build -f package/Dockerfile -t rancher/fleet:dev --build-arg="ARCH=$GOARC
 
 # fleet agent
 go build -gcflags='all=-N -l' -o "bin/fleetagent-linux-$GOARCH" ./cmd/fleetagent
+
+# The name of the container image created here is a potential source of
+# conflicts when the clusters are created simultaneously. It might be worth thinking about
+# how to make the image name unique for each test run.
 docker build -f package/Dockerfile.agent -t rancher/fleet-agent:dev --build-arg="ARCH=$GOARCH" .

--- a/dev/k3d-act-clean
+++ b/dev/k3d-act-clean
@@ -15,14 +15,17 @@ function docker-clean-by-name {
         return
     fi
 
-    ids=$(docker ps -a --filter name="$1" --format "{{.ID}}")
-    if [ -z "$ids" ]; then
-        return
-    fi
+    # only delete `-server` and `-agent` suffixed containers.
+    for suffix in server agent; do
+        ids=$(docker ps -a --filter name="$1-$suffix" --format "{{.ID}}")
+        if [ -z "$ids" ]; then
+            continue
+        fi
 
-    for id in $ids; do
-        docker stop "$id"
-        docker rm "$id"
+        for id in $ids; do
+            docker stop "$id"
+            docker rm "$id"
+        done
     done
 }
 

--- a/dev/setup-single-cluster
+++ b/dev/setup-single-cluster
@@ -9,10 +9,10 @@ source ./dev/setup-cluster-config
 # Cleans with settings sourced, so it should be rather selective.
 ./dev/k3d-act-clean
 
-./dev/setup-k3d
+./dev/setup-k3d "${FLEET_E2E_CLUSTER#k3d-}"
 ./dev/build-fleet
 ./dev/import-images-k3d
-./dev/setup-fleet upstream '[
+./dev/setup-fleet "${FLEET_E2E_CLUSTER#k3d-}" '[
     {
         "id": "shard0",
         "nodeSelector": {

--- a/dev/setup-single-cluster
+++ b/dev/setup-single-cluster
@@ -9,7 +9,7 @@ source ./dev/setup-cluster-config
 # Cleans with settings sourced, so it should be rather selective.
 ./dev/k3d-act-clean
 
-./dev/setup-k3d "${FLEET_E2E_CLUSTER#k3d-}"
+./dev/setup-k3d "${FLEET_E2E_CLUSTER#k3d-}" $(( RANDOM % 10001 ))
 ./dev/build-fleet
 ./dev/import-images-k3d
 ./dev/setup-fleet "${FLEET_E2E_CLUSTER#k3d-}" '[


### PR DESCRIPTION
By using different git worktrees with different environment variables for configuring the single-cluster environment, specifically the `FLEET_E2E_CLUSTER` variable, you can use `./dev/setup-single-cluster` to start independent k3d clusters next to each other.

Please note that, at the time of creating a cluster, there is a possibility of a conflict still. While clusters can be run at the same time with `dev/setup-single-cluster`, they cannot be created simultaneously (yet).

- [ ] Perhaps add a entry in dev/README.