### PR TITLE
Moves functionality from gitrepo to gitjob controller

### DIFF
--- a/charts/fleet/templates/rbac_gitjob.yaml
+++ b/charts/fleet/templates/rbac_gitjob.yaml
@@ -43,6 +43,26 @@ rules:
       - 'events'
     verbs:
       - '*'
+  - apiGroups:
+      - ""
+    resources:
+      - serviceaccounts
+    verbs:
+      - "create"
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - roles
+    verbs:
+      - escalate
+      - create
+      - bind
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - rolebindings
+    verbs:
+      - create
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/integrationtests/controller/gitrepo/gitrepo_test.go
+++ b/integrationtests/controller/gitrepo/gitrepo_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
 
 	corev1 "k8s.io/api/core/v1"
-	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
@@ -56,29 +55,6 @@ var _ = Describe("GitRepo", func() {
 		JustBeforeEach(func() {
 			err := k8sClient.Create(ctx, gitrepo)
 			Expect(err).NotTo(HaveOccurred())
-		})
-
-		It("creates RBAC resources", func() {
-			Expect(gitrepo.Spec.PollingInterval).To(BeNil())
-
-			Eventually(func() bool {
-				ns := types.NamespacedName{
-					Name:      fmt.Sprintf("git-%s", gitrepoName),
-					Namespace: namespace,
-				}
-
-				if err := k8sClient.Get(ctx, ns, &corev1.ServiceAccount{}); err != nil {
-					return false
-				}
-				if err := k8sClient.Get(ctx, ns, &rbacv1.Role{}); err != nil {
-					return false
-				}
-				if err := k8sClient.Get(ctx, ns, &rbacv1.RoleBinding{}); err != nil {
-					return false
-				}
-
-				return true
-			}).Should(BeTrue())
 		})
 
 		It("updates the gitrepo status", func() {

--- a/internal/cmd/controller/errorutil/errorutil.go
+++ b/internal/cmd/controller/errorutil/errorutil.go
@@ -1,0 +1,10 @@
+package errorutil
+
+import apierrors "k8s.io/apimachinery/pkg/api/errors"
+
+func IgnoreConflict(err error) error {
+	if apierrors.IsConflict(err) {
+		return nil
+	}
+	return err
+}

--- a/internal/cmd/controller/reconciler/cluster_controller.go
+++ b/internal/cmd/controller/reconciler/cluster_controller.go
@@ -15,6 +15,7 @@ import (
 	"github.com/rancher/fleet/pkg/durations"
 	"github.com/rancher/fleet/pkg/sharding"
 
+	fleetutil "github.com/rancher/fleet/internal/cmd/controller/errorutil"
 	"github.com/rancher/wrangler/v2/pkg/condition"
 
 	corev1 "k8s.io/api/core/v1"
@@ -202,7 +203,7 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 func (r *ClusterReconciler) setCondition(status *fleet.ClusterStatus, err error) {
 	cond := condition.Cond(fleet.ClusterConditionProcessed)
 	origStatus := status.DeepCopy()
-	cond.SetError(status, "", ignoreConflict(err))
+	cond.SetError(status, "", fleetutil.IgnoreConflict(err))
 	if !equality.Semantic.DeepEqual(origStatus, status) {
 		cond.LastUpdated(status, time.Now().UTC().Format(time.RFC3339))
 	}

--- a/internal/cmd/controller/reconciler/clustergroup_controller.go
+++ b/internal/cmd/controller/reconciler/clustergroup_controller.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	fleetutil "github.com/rancher/fleet/internal/cmd/controller/errorutil"
 	"github.com/rancher/fleet/internal/cmd/controller/summary"
 	"github.com/rancher/fleet/internal/metrics"
 	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
@@ -129,7 +130,7 @@ func (r *ClusterGroupReconciler) Reconcile(ctx context.Context, req ctrl.Request
 func (r *ClusterGroupReconciler) setCondition(status *fleet.ClusterGroupStatus, err error) {
 	cond := condition.Cond(fleet.ClusterGroupConditionProcessed)
 	origStatus := status.DeepCopy()
-	cond.SetError(status, "", ignoreConflict(err))
+	cond.SetError(status, "", fleetutil.IgnoreConflict(err))
 	if !equality.Semantic.DeepEqual(origStatus, status) {
 		cond.LastUpdated(status, time.Now().UTC().Format(time.RFC3339))
 	}


### PR DESCRIPTION
Moves the following from `gitrepo` controller to `gitjob` controller:
* AuthorizeAndAssignDefaults
* RBAC resources creation
* Helm secrets check
* NewTargetsConfigMap

The `gitrepo` controller still purges `bundles` and `bundledeployments` on `gitrepo` deletion and handles the status coming from `bundles` and `bundledeployments`

Some functionality that was shared between both controllers has been moved to a common package to avoid code repetition.

Refers to: https://github.com/rancher/fleet/issues/2435