### PR TITLE
Fix summary and details tags in bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.yml
@@ -67,12 +67,13 @@ body:
       If you paste long logs, you could also add them into a collapsed block:
 
       &lt;details&gt;
-        &lt;summary&gt;Click to expand&lt;summary&gt;
+        &lt;summary&gt;Click to expand&lt;/summary&gt;
 
         \```
         pasted log
         \```
-      &lt;details&gt;
+        
+      &lt;/details&gt;
 
     render: markdown
   validations:


### PR DESCRIPTION
While creating issue to the Fleet repository, I got to know that collapsed blocks are not closed.

<!-- Specify the issue ID that this pull request is solving -->

<!-- Make sure that the referenced issue provides steps to reproduce it -->

<!-- Describe the changes introduced by this pull request -->

<!--
  Please provide a unit, integration (`./integrationtests/`) or e2e (`./e2e/`) test if possible.
-->