### PR TITLE
Fixes infinite job generation after ForceSyncGeneration changed

### DIFF
--- a/internal/cmd/controller/gitops/reconciler/gitjob_controller.go
+++ b/internal/cmd/controller/gitops/reconciler/gitjob_controller.go
@@ -196,6 +196,7 @@ func (r *GitJobReconciler) updateStatus(ctx context.Context, gitRepo *v1alpha1.G
 
 		currentGitRepo.Status.GitJobStatus = result.Status.String()
 		currentGitRepo.Status.ObservedGeneration = gitRepo.Generation
+		currentGitRepo.Status.UpdateGeneration = gitRepo.Status.UpdateGeneration
 
 		for _, con := range result.Conditions {
 			condition.Cond(con.Type.String()).SetStatus(currentGitRepo, string(con.Status))


### PR DESCRIPTION
`gitrepo`s `Status.UpdateGeneration` value was changed but not updated, which made the controller to enter in an infinite loop regenerating the job.

Refers to: https://github.com/rancher/fleet/issues/2474
