### PR TITLE
Adds extraEnv to gitjob and fleet-controller deployments

### DIFF
--- a/charts/fleet/templates/deployment.yaml
+++ b/charts/fleet/templates/deployment.yaml
@@ -76,6 +76,9 @@ spec:
         - name: BUNDLEDEPLOYMENT_RECONCILER_WORKERS
           value: {{ quote $.Values.controller.reconciler.workers.bundledeployment }}
         {{- end }}
+{{- if $.Values.extraEnv }}
+{{ toYaml $.Values.extraEnv | indent 8}}
+{{- end }}
         image: '{{ template "system_default_registry" $ }}{{ $.Values.image.repository }}:{{ $.Values.image.tag }}'
         name: fleet-controller
         imagePullPolicy: "{{ $.Values.image.imagePullPolicy }}"

--- a/charts/fleet/templates/deployment_gitjob.yaml
+++ b/charts/fleet/templates/deployment_gitjob.yaml
@@ -41,6 +41,9 @@ spec:
             - name: CATTLE_DEV_MODE
               value: "true"
           {{- end }}
+{{- if $.Values.extraEnv }}
+{{ toYaml $.Values.extraEnv | indent 12}}
+{{- end }}
       nodeSelector: {{ include "linux-node-selector" . | nindent 8 }}
 {{- if .Values.nodeSelector }}
 {{ toYaml .Values.nodeSelector | indent 8 }}

--- a/charts/fleet/values.yaml
+++ b/charts/fleet/values.yaml
@@ -99,3 +99,8 @@ controller:
       gitrepo: "1"
       bundle: "1"
       bundledeployment: "1"
+
+# Extra environment variables passed to the fleet pods.
+# extraEnv:
+# - name: EXPERIMENTAL_OCI_STORAGE
+#   value: true


### PR DESCRIPTION
This will enable to pass, for example, experimental features to the upstream fleet pods.

Refers to: https://github.com/rancher/fleet/issues/2465
Related to: https://github.com/rancher/fleet/issues/2114