### PR TITLE
Fix example values.yaml for enabling OCI storage

### DIFF
--- a/charts/fleet/values.yaml
+++ b/charts/fleet/values.yaml
@@ -103,4 +103,4 @@ controller:
 # Extra environment variables passed to the fleet pods.
 # extraEnv:
 # - name: EXPERIMENTAL_OCI_STORAGE
-#   value: true
+#   value: "true"


### PR DESCRIPTION
<!-- Specify the issue ID that this pull request is solving -->
Refers to #XXX
<!-- Make sure that the referenced issue provides steps to reproduce it -->
Try installing the chart with the example in the values.yaml uncommented, this will not apply cleanly.

<!-- Describe the changes introduced by this pull request -->
This changes the example in the values.yaml for enabling the OCI storage to be valid for insertion into the "env" for a container.

Previously, it was a boolean, which would lead to a failure to unmarshal a bool to a string.
<!--
  Please provide a unit, integration (`./integrationtests/`) or e2e (`./e2e/`) test if possible.
-->