### PR TITLE
Fix flaky agent modified status test

### DIFF
--- a/integrationtests/agent/bundle_deployment_status_test.go
+++ b/integrationtests/agent/bundle_deployment_status_test.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"os"
+	"time"
 
 	"github.com/rancher/fleet/integrationtests/utils"
 	"github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
@@ -193,7 +194,7 @@ var _ = Describe("BundleDeployment status", Ordered, func() {
 						Patch:      "",
 					}
 					return env.isNotReadyAndModified(name, modifiedStatus, "service.v1 "+namespace+"/svc-finalizer extra")
-				}).Should(BeTrue())
+				}, timeout, 20*time.Millisecond).Should(BeTrue())
 			})
 
 			It("Remove finalizer", func() {

--- a/integrationtests/gitcloner/clone_test.go
+++ b/integrationtests/gitcloner/clone_test.go
@@ -52,7 +52,10 @@ var (
 	gogsCABundle []byte
 )
 
-var _ = Describe("Applying a git job gets content from git repo", Ordered, func() {
+// This test starts gogs in a container outside the cluster. The exposed ports
+// need to be reachable. Out of the box this does not work when the container
+// runtime is in a VM, e.g. on Mac.
+var _ = Describe("Applying a git job gets content from git repo", Label("networking"), Ordered, func() {
 
 	var (
 		opts          *gitcloner.GitCloner

--- a/internal/cmd/agent/controller/bundledeployment_controller.go
+++ b/internal/cmd/agent/controller/bundledeployment_controller.go
@@ -119,7 +119,6 @@ func (r *BundleDeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		return ctrl.Result{}, errutil.NewAggregate(merr)
 	}
 
-	var result ctrl.Result
 	if monitor.ShouldUpdateStatus(bd) {
 		// update the bundledeployment status and check if we deploy an agent, or if we need to trigger drift correction
 		status, err = r.Monitor.UpdateStatus(ctx, bd, resources)
@@ -171,7 +170,7 @@ func (r *BundleDeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		merr = append(merr, fmt.Errorf("failed final update to bundledeployment status: %w", err))
 	}
 
-	return result, errutil.NewAggregate(merr)
+	return ctrl.Result{}, errutil.NewAggregate(merr)
 }
 
 func (r *BundleDeploymentReconciler) updateStatus(ctx context.Context, req types.NamespacedName, status fleetv1.BundleDeploymentStatus) error {


### PR DESCRIPTION
* clone test doesn't work with docker in VM, needs more than k8s API port exposed
* agent/bundle_deployment_status_test is flaky, missed error in ModifiedStatus. Is this the correct agent behavior?