### PR TITLE
Security context needs to be on container

### DIFF
--- a/charts/fleet/templates/deployment_gitjob.yaml
+++ b/charts/fleet/templates/deployment_gitjob.yaml
@@ -40,6 +40,14 @@ spec:
           {{- if .Values.debug }}
             - name: CATTLE_DEV_MODE
               value: "true"
+          {{- else }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            privileged: false
+            capabilities:
+                drop:
+                - ALL
           {{- end }}
 {{- if $.Values.extraEnv }}
 {{ toYaml $.Values.extraEnv | indent 12}}
@@ -62,10 +70,4 @@ spec:
         runAsNonRoot: true
         runAsUser: 1000
         runAsGroup: 1000
-        allowPrivilegeEscalation: false
-        readOnlyRootFilesystem: true
-        privileged: false
-        capabilities:
-            drop:
-            - ALL
 {{- end }}


### PR DESCRIPTION
The settings were not effective, see helm warning when installing the chart with debug=false.
Settings need to be in the containers `securityContext`, not the pod's.

Refers to https://github.com/rancher/fleet/issues/2359