### PR TITLE
Add strict TLS mode support

### DIFF
--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -63,7 +63,7 @@ jobs:
         # k3d will automatically create a network named k3d-test-cluster-1 with the range 172.18.0.0/16
         with:
           k3d-version: ${{ env.SETUP_K3D_VERSION }}
-          cluster-name: "k3s-default"
+          cluster-name: "upstream"
           args: >-
             --agents 1
             --network "nw01"
@@ -71,7 +71,7 @@ jobs:
       -
         name: Import Images Into k3d
         run: |
-          ./.github/scripts/k3d-import-retry.sh rancher/fleet:dev rancher/fleet-agent:dev nginx-git:test
+          ./.github/scripts/k3d-import-retry.sh rancher/fleet:dev rancher/fleet-agent:dev nginx-git:test -c upstream
       -
         name: Set Up Tmate Debug Session
         if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.enable_tmate == 'true' }}

--- a/.github/workflows/e2e-multicluster-ci.yml
+++ b/.github/workflows/e2e-multicluster-ci.yml
@@ -135,6 +135,8 @@ jobs:
         run: |
           kubectl config use-context k3d-upstream
           ginkgo --github-output e2e/multi-cluster
+
+          ginkgo --github-output e2e/multi-cluster/installation
       -
         name: Acceptance Tests for Examples
         if: >

--- a/.github/workflows/e2e-multicluster-ci.yml
+++ b/.github/workflows/e2e-multicluster-ci.yml
@@ -58,7 +58,7 @@ jobs:
             --agents 1
             --network "nw01"
       -
-        name: Provision k3d Downstream Cluster
+        name: Provision k3d Downstream Cluster for agent-initiated registration
         uses: AbsaOSS/k3d-action@v2
         with:
           k3d-version: ${{ env.SETUP_K3D_VERSION }}
@@ -70,10 +70,23 @@ jobs:
             --agents 1
             --network "nw01"
       -
+        name: Provision k3d Downstream Cluster for manager-initiated registration
+        uses: AbsaOSS/k3d-action@v2
+        with:
+          k3d-version: ${{ env.SETUP_K3D_VERSION }}
+          cluster-name: "managed-downstream"
+          args: >-
+            -p "82:80@agent:0:direct"
+            -p "445:443@agent:0:direct"
+            --api-port 6645
+            --agents 1
+            --network "nw01"
+      -
         name: Import Images Into k3d
         run: |
           ./.github/scripts/k3d-import-retry.sh rancher/fleet:dev rancher/fleet-agent:dev -c upstream
           ./.github/scripts/k3d-import-retry.sh rancher/fleet-agent:dev -c downstream
+          ./.github/scripts/k3d-import-retry.sh rancher/fleet-agent:dev -c managed-downstream
       -
         name: Set Up Tmate Debug Session
         if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.enable_tmate == 'true' }}
@@ -127,6 +140,61 @@ jobs:
           while [ $(kubectl -n fleet-default get cluster -o jsonpath='{.items[0].status.summary.ready}') -ne 1 ]; do
             sleep 1
           done
+
+      -
+        name: Deploy and Register Managed Downstream Fleet
+        run: |
+          kubectl config use-context k3d-managed-downstream
+          host=$(kubectl get node k3d-managed-downstream-server-0 -o jsonpath='{.status.addresses[?(@.type=="InternalIP")].address}')
+          ca=$( kubectl config view --flatten -o jsonpath='{.clusters[?(@.name == "k3d-managed-downstream")].cluster.certificate-authority-data}' )
+          client_cert=$( kubectl config view --flatten -o jsonpath='{.users[?(@.name == "admin@k3d-managed-downstream")].user.client-certificate-data}' )
+          token=$( kubectl config view --flatten -o jsonpath='{.users[?(@.name == "admin@k3d-managed-downstream")].user.client-key-data}' )
+          server="https://$host:6443"
+
+          kubectl config use-context k3d-upstream
+
+          value=$(cat <<EOF
+          apiVersion: v1
+          kind: Config
+          current-context: default
+          clusters:
+          - cluster:
+              certificate-authority-data: $ca
+              server: $server
+            name: cluster
+          contexts:
+          - context:
+              cluster: cluster
+              user: user
+            name: default
+          preferences: {}
+          users:
+          - name: user
+            user:
+              client-certificate-data: $client_cert
+              client-key-data: $token
+          EOF
+          )
+
+          kubectl create ns fleet-default || true
+          kubectl delete secret -n fleet-default kbcfg-second || true
+          # Rancher sets a token value in the secret, but our docs don't mention it
+          # * https://github.com/rancher/rancher/blob/c24fb8b0869a0b445f55b3307c6ed4582e147747/pkg/provisioningv2/kubeconfig/manager.go#L362
+          # * https://fleet.rancher.io/0.5/manager-initiated#kubeconfig-secret-1
+          kubectl create secret generic -n fleet-default kbcfg-second --from-literal=token="$token" --from-literal=value="$value"
+
+          kubectl apply -n fleet-default -f - <<EOF
+          apiVersion: "fleet.cattle.io/v1alpha1"
+          kind: Cluster
+          metadata:
+            name: second
+            namespace: fleet-default
+            labels:
+              name: second
+          spec:
+            kubeConfigSecret: kbcfg-second
+          EOF
+
       -
         name: E2E tests
         env:
@@ -135,7 +203,14 @@ jobs:
         run: |
           kubectl config use-context k3d-upstream
           ginkgo --github-output e2e/multi-cluster
-
+      -
+        name: E2E tests with managed downstream agent
+        env:
+          FLEET_E2E_NS: fleet-local
+          FLEET_E2E_NS_DOWNSTREAM: fleet-default
+          FLEET_E2E_CLUSTER_DOWNSTREAM: k3d-managed-downstream
+        run: |
+          kubectl config use-context k3d-upstream
           ginkgo --github-output e2e/multi-cluster/installation
       -
         name: Acceptance Tests for Examples

--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -64,7 +64,7 @@ jobs:
         # k3d will automatically create a network named k3d-test-cluster-1 with the range 172.18.0.0/16
         with:
           k3d-version: ${{ env.SETUP_K3D_VERSION }}
-          cluster-name: "k3s-default"
+          cluster-name: "upstream"
           args: >-
             --agents 1
             --network "nw01"
@@ -72,7 +72,7 @@ jobs:
       -
         name: Import Images Into k3d
         run: |
-          ./.github/scripts/k3d-import-retry.sh rancher/fleet:dev rancher/fleet-agent:dev nginx-git:test
+          ./.github/scripts/k3d-import-retry.sh rancher/fleet:dev rancher/fleet-agent:dev nginx-git:test -c upstream
       -
         name: Set Up Tmate Debug Session
         if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.enable_tmate == 'true' }}

--- a/charts/fleet-agent/templates/configmap.yaml
+++ b/charts/fleet-agent/templates/configmap.yaml
@@ -8,5 +8,6 @@ data:
       {{ if .Values.labels }}
       "labels":{{toJson .Values.labels}},
       {{ end }}
-      "clientID":"{{.Values.clientID}}"
+      "clientID":"{{.Values.clientID}}",
+      "agentTLSMode": "{{.Values.agentTLSMode}}"
     }

--- a/charts/fleet-agent/values.yaml
+++ b/charts/fleet-agent/values.yaml
@@ -11,6 +11,10 @@ apiServerURL: ""
 # If left empty it is assumed this Kubernetes API TLS is signed by a well known CA.
 apiServerCA: ""
 
+# Determines whether the agent should trust CA bundles from the operating system's trust store when connecting to a
+# management cluster. True in `system-store` mode, false in `strict` mode.
+agentTLSMode: "system-store"
+
 # The cluster registration value
 token: ""
 

--- a/charts/fleet-crd/templates/crds.yaml
+++ b/charts/fleet-crd/templates/crds.yaml
@@ -5173,6 +5173,20 @@ spec:
                     used to detect changes.'
                   nullable: true
                   type: string
+                agentTLSMode:
+                  description: 'AgentTLSMode supports two values: `system-store` and
+                    `strict`. If set to
+
+                    `system-store`, instructs the agent to trust CA bundles from the
+                    operating
+
+                    system''s store. If set to `strict`, then the agent shall only
+                    connect to a
+
+                    server which uses the exact CA configured when creating/updating
+                    the agent.'
+                  nullable: true
+                  type: string
                 agentTolerationsHash:
                   description: 'AgentTolerationsHash is a hash of the agent''s tolerations
 

--- a/charts/fleet/templates/configmap.yaml
+++ b/charts/fleet/templates/configmap.yaml
@@ -11,6 +11,7 @@ data:
       "apiServerURL": "{{.Values.apiServerURL}}",
       "apiServerCA": "{{b64enc .Values.apiServerCA}}",
       "agentCheckinInterval": "{{.Values.agentCheckinInterval}}",
+      "agentTLSMode": "{{.Values.agentTLSMode}}",
       "ignoreClusterRegistrationLabels": {{.Values.ignoreClusterRegistrationLabels}},
       "bootstrap": {
         "paths": "{{.Values.bootstrap.paths}}",

--- a/charts/fleet/values.yaml
+++ b/charts/fleet/values.yaml
@@ -16,6 +16,10 @@ apiServerURL: ""
 # If left empty it is assumed this Kubernetes API TLS is signed by a well known CA.
 apiServerCA: ""
 
+# Determines whether the agent should trust CA bundles from the operating system's trust store when connecting to a
+# management cluster. True in `system-store` mode, false in `strict` mode.
+agentTLSMode: "system-store"
+
 # A duration string for how often agents should report a heartbeat
 agentCheckinInterval: "15m"
 

--- a/dev/setup-fleet-downstream
+++ b/dev/setup-fleet-downstream
@@ -3,15 +3,14 @@
 
 set -euxo pipefail
 
-root_dir=$(git rev-parse --show-toplevel)
-cd "$root_dir"
+if [ ! -d ./charts/fleet ]; then
+  echo "please change the current directory to the fleet repo checkout"
+  exit 1
+fi
 
 upstream_ctx="${FLEET_E2E_CLUSTER-k3d-upstream}"
 downstream_ctx="${FLEET_E2E_CLUSTER_DOWNSTREAM-k3d-downstream}"
 ns="${FLEET_E2E_NS_DOWNSTREAM-fleet-local}"
-force_empty_ca="${FORCE_EMPTY_AGENT_CA-}"
-api_server_url="${FORCE_API_SERVER_URL-}"
-agent_tls_mode="${AGENT_TLS_MODE-system-store}"
 
 kubectl create ns "$ns"|| true
 
@@ -46,34 +45,27 @@ kubectl wait clusterregistrationtoken -n "$ns" --for=jsonpath='{.status.secretNa
 token=$(kubectl get secret -n "$ns" second-token -o go-template='{{index .data "values" | base64decode}}' | yq .token -)
 
 ca=""
-if [ -z $force_empty_ca ]; then
-    serverver=$(kubectl version -ojson 2> /dev/null | jq '.serverVersion.minor' | sed 's/"//g')
-    if [ "$serverver" -gt 23 ]; then
-      ca=$(kubectl get secret -n cattle-fleet-system fleet-controller-bootstrap-token -o go-template='{{index .data "ca.crt" | base64decode}}')
-    else
-      name=$(kubectl get -n default sa default -o=jsonpath='{.secrets[0].name}')
-      ca=$(kubectl get -n default secret "$name" -o go-template='{{index .data "ca.crt" | base64decode}}')
-    fi
+serverver=$(kubectl version -ojson 2> /dev/null | jq '.serverVersion.minor' | sed 's/"//g')
+if [ "$serverver" -gt 23 ]; then
+  ca=$(kubectl get secret -n cattle-fleet-system fleet-controller-bootstrap-token -o go-template='{{index .data "ca.crt" | base64decode}}')
+else
+  name=$(kubectl get -n default sa default -o=jsonpath='{.secrets[0].name}')
+  ca=$(kubectl get -n default secret "$name" -o go-template='{{index .data "ca.crt" | base64decode}}')
 fi
 
 # docker network inspect bridge -f '{{(index .IPAM.Config 0).Gateway}}'
 # public_hostname="${public_hostname-172.17.0.1.sslip.io}"
 
-# works due to same network of k3d clusters and patched SAN cert
+# works due to same network of k3d clustres and patched SAN cert
 public_hostname="${public_hostname-k3d-upstream-server-0}"
-
-if [ -z $api_server_url ]; then
-    api_server_url="https://$public_hostname:6443"
-fi
 
 kubectl config use-context "$downstream_ctx"
 helm -n cattle-fleet-system upgrade --install --create-namespace --wait fleet-agent charts/fleet-agent \
   --set-string labels.env=test \
   --set apiServerCA="$ca" \
-  --set apiServerURL="$api_server_url" \
+  --set apiServerURL="https://$public_hostname:6443" \
   --set clusterNamespace="$ns" \
-  --set token="$token" \
-  --set agentTLSMode="$agent_tls_mode"
+  --set token="$token"
   #--set systemRegistrationNamespace="fleet-clusters-system" \
   #--set clientID="fake-random" \
   # --set global.cattle.systemDefaultRegistry=public.ecr.aws/b3e3i8k2 \

--- a/dev/setup-fleet-downstream
+++ b/dev/setup-fleet-downstream
@@ -3,14 +3,15 @@
 
 set -euxo pipefail
 
-if [ ! -d ./charts/fleet ]; then
-  echo "please change the current directory to the fleet repo checkout"
-  exit 1
-fi
+root_dir=$(git rev-parse --show-toplevel)
+cd "$root_dir"
 
 upstream_ctx="${FLEET_E2E_CLUSTER-k3d-upstream}"
 downstream_ctx="${FLEET_E2E_CLUSTER_DOWNSTREAM-k3d-downstream}"
 ns="${FLEET_E2E_NS_DOWNSTREAM-fleet-local}"
+force_empty_ca="${FORCE_EMPTY_AGENT_CA-''}"
+api_server_url="${FORCE_API_SERVER_URL-''}"
+agent_tls_mode="${AGENT_TLS_MODE-system-store}"
 
 kubectl create ns "$ns"|| true
 
@@ -45,27 +46,34 @@ kubectl wait clusterregistrationtoken -n "$ns" --for=jsonpath='{.status.secretNa
 token=$(kubectl get secret -n "$ns" second-token -o go-template='{{index .data "values" | base64decode}}' | yq .token -)
 
 ca=""
-serverver=$(kubectl version -ojson 2> /dev/null | jq '.serverVersion.minor' | sed 's/"//g')
-if [ "$serverver" -gt 23 ]; then
-  ca=$(kubectl get secret -n cattle-fleet-system fleet-controller-bootstrap-token -o go-template='{{index .data "ca.crt" | base64decode}}')
-else
-  name=$(kubectl get -n default sa default -o=jsonpath='{.secrets[0].name}')
-  ca=$(kubectl get -n default secret "$name" -o go-template='{{index .data "ca.crt" | base64decode}}')
+if [ -z $force_empty_ca ]; then
+    serverver=$(kubectl version -ojson 2> /dev/null | jq '.serverVersion.minor' | sed 's/"//g')
+    if [ "$serverver" -gt 23 ]; then
+      ca=$(kubectl get secret -n cattle-fleet-system fleet-controller-bootstrap-token -o go-template='{{index .data "ca.crt" | base64decode}}')
+    else
+      name=$(kubectl get -n default sa default -o=jsonpath='{.secrets[0].name}')
+      ca=$(kubectl get -n default secret "$name" -o go-template='{{index .data "ca.crt" | base64decode}}')
+    fi
 fi
 
 # docker network inspect bridge -f '{{(index .IPAM.Config 0).Gateway}}'
 # public_hostname="${public_hostname-172.17.0.1.sslip.io}"
 
-# works due to same network of k3d clustres and patched SAN cert
+# works due to same network of k3d clusters and patched SAN cert
 public_hostname="${public_hostname-k3d-upstream-server-0}"
+
+if [ -z $api_server_url ]; then
+    api_server_url="https://$public_hostname:6443"
+fi
 
 kubectl config use-context "$downstream_ctx"
 helm -n cattle-fleet-system upgrade --install --create-namespace --wait fleet-agent charts/fleet-agent \
   --set-string labels.env=test \
   --set apiServerCA="$ca" \
-  --set apiServerURL="https://$public_hostname:6443" \
+  --set apiServerURL="$api_server_url" \
   --set clusterNamespace="$ns" \
-  --set token="$token"
+  --set token="$token" \
+  --set agentTLSMode="$agent_tls_mode"
   #--set systemRegistrationNamespace="fleet-clusters-system" \
   #--set clientID="fake-random" \
   # --set global.cattle.systemDefaultRegistry=public.ecr.aws/b3e3i8k2 \

--- a/dev/setup-fleet-downstream
+++ b/dev/setup-fleet-downstream
@@ -9,8 +9,8 @@ cd "$root_dir"
 upstream_ctx="${FLEET_E2E_CLUSTER-k3d-upstream}"
 downstream_ctx="${FLEET_E2E_CLUSTER_DOWNSTREAM-k3d-downstream}"
 ns="${FLEET_E2E_NS_DOWNSTREAM-fleet-local}"
-force_empty_ca="${FORCE_EMPTY_AGENT_CA-''}"
-api_server_url="${FORCE_API_SERVER_URL-''}"
+force_empty_ca="${FORCE_EMPTY_AGENT_CA-}"
+api_server_url="${FORCE_API_SERVER_URL-}"
 agent_tls_mode="${AGENT_TLS_MODE-system-store}"
 
 kubectl create ns "$ns"|| true

--- a/e2e/multi-cluster/installation/agent_test.go
+++ b/e2e/multi-cluster/installation/agent_test.go
@@ -2,7 +2,6 @@ package installation_test
 
 import (
 	"fmt"
-	"os"
 	"os/exec"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -36,14 +35,6 @@ var _ = Describe("Fleet installation with TLS agent modes", func() {
 
 		deleteOut, err := kd.Delete("ns", "cattle-fleet-system", "--now")
 		Expect(err).ToNot(HaveOccurred(), deleteOut)
-
-		err = os.Setenv("FORCE_EMPTY_AGENT_CA", "yes")
-		Expect(err).ToNot(HaveOccurred())
-		err = os.Setenv("FORCE_API_SERVER_URL", "https://google.com")
-		Expect(err).ToNot(HaveOccurred())
-
-		err = os.Setenv("AGENT_TLS_MODE", agentMode)
-		Expect(err).ToNot(HaveOccurred())
 
 		go func() {
 			cmd := exec.Command(

--- a/e2e/multi-cluster/installation/agent_test.go
+++ b/e2e/multi-cluster/installation/agent_test.go
@@ -1,0 +1,116 @@
+package installation_test
+
+import (
+	"os"
+	"os/exec"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/matchers"
+	"github.com/rancher/fleet/e2e/testenv/kubectl"
+)
+
+var (
+	agentMode string
+	kd        kubectl.Command
+	setupCmd  *exec.Cmd
+)
+
+var _ = Describe("Fleet installation with TLS agent modes", func() {
+	BeforeEach(func() {
+		kd = env.Kubectl.Context(env.Downstream)
+	})
+
+	JustBeforeEach(func() {
+		cmd := exec.Command(
+			"helm",
+			"--kube-context",
+			"k3d-downstream",
+			"uninstall",
+			"fleet-agent",
+			"-n",
+			"cattle-fleet-system",
+			"--wait",
+		)
+		_ = cmd.Run() // Ignore errors, Fleet might not be installed
+
+		err := os.Setenv("FORCE_EMPTY_AGENT_CA", "yes")
+		Expect(err).ToNot(HaveOccurred())
+		err = os.Setenv("FORCE_API_SERVER_URL", "https://google.com")
+		Expect(err).ToNot(HaveOccurred())
+
+		err = os.Setenv("AGENT_TLS_MODE", agentMode)
+		Expect(err).ToNot(HaveOccurred())
+
+		go func() {
+			setupCmd = exec.Command("../../../dev/setup-fleet-downstream")
+			_ = setupCmd.Run()
+		}()
+	})
+
+	Context("with non-strict agent TLS mode", func() {
+		When("fetching fleet-agent-register logs", func() {
+			BeforeEach(func() {
+				agentMode = "system-store"
+			})
+
+			It("reaches the server without cert issues", func() {
+				Eventually(func() bool {
+					logs, err := kd.Namespace("cattle-fleet-system").Logs(
+						"-l",
+						"app=fleet-agent",
+						"-c",
+						"fleet-agent-register",
+						"--tail=-1",
+					)
+					if err != nil {
+						return false
+					}
+
+					regexMatcher := matchers.MatchRegexpMatcher{
+						Regexp: "Failed to register agent.*could not find the requested resource",
+					}
+					reachesServerWithoutCertIssue, err := regexMatcher.Match(logs)
+					if err != nil {
+						return false
+					}
+
+					return reachesServerWithoutCertIssue
+				}).Should(BeTrue())
+			})
+		})
+	})
+
+	Context("with strict agent TLS mode", func() {
+		When("fetching fleet-agent-register logs", func() {
+			BeforeEach(func() {
+				agentMode = "strict"
+			})
+
+			It("cannot reach the server because the cert is signed by an unknown authority", func() {
+				Eventually(func() bool {
+					logs, err := kd.Namespace("cattle-fleet-system").Logs(
+						"-l",
+						"app=fleet-agent",
+						"-c",
+						"fleet-agent-register",
+						"--tail=-1",
+					)
+					if err != nil {
+						return false
+					}
+
+					regexMatcher := matchers.MatchRegexpMatcher{
+						Regexp: "Failed to register agent.*signed by unknown authority",
+					}
+					reachesServerWithoutCertIssue, err := regexMatcher.Match(logs)
+					if err != nil {
+						return false
+					}
+
+					return reachesServerWithoutCertIssue
+				}).Should(BeTrue())
+			})
+		})
+	})
+})

--- a/e2e/multi-cluster/installation/agent_test.go
+++ b/e2e/multi-cluster/installation/agent_test.go
@@ -12,13 +12,11 @@ import (
 var (
 	agentMode string
 	kd        kubectl.Command
-	ku        kubectl.Command
 )
 
 var _ = Describe("Fleet installation with TLS agent modes", func() {
 	BeforeEach(func() {
 		kd = env.Kubectl.Context(env.Downstream)
-		ku = env.Kubectl.Context(env.Upstream)
 	})
 
 	JustBeforeEach(func() {

--- a/e2e/multi-cluster/installation/suite_test.go
+++ b/e2e/multi-cluster/installation/suite_test.go
@@ -1,0 +1,28 @@
+// Package installation contains e2e tests deploying Fleet to multiple clusters. The tests use kubectl to apply
+// manifests. Expectations are verified by checking cluster resources.
+package installation_test
+
+import (
+	"testing"
+
+	"github.com/rancher/fleet/e2e/testenv"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestE2E(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "E2E Installation Suite for Multi-Cluster")
+}
+
+var (
+	env *testenv.Env
+)
+
+var _ = BeforeSuite(func() {
+	SetDefaultEventuallyTimeout(testenv.Timeout)
+	testenv.SetRoot("../..")
+
+	env = testenv.New()
+})

--- a/internal/cmd/agent/register/register.go
+++ b/internal/cmd/agent/register/register.go
@@ -330,13 +330,15 @@ func createClientConfigFromSecret(secret *corev1.Secret, trustSystemStoreCAs boo
 			apiServerCA = nil
 		}
 	} else {
-		// Bypass the OS trust store.
-		err := os.Setenv("SSL_CERT_FILE", "/var/does-not-exist.pem")
+		// Bypass the OS trust store through env vars, see https://pkg.go.dev/crypto/x509#SystemCertPool
+		// We set values to paths belonging to the root filesystem, which is read-only, to prevent tampering.
+		// Note: this will not work on Windows nor Mac OS. Agent are expected to run on Linux nodes.
+		err := os.Setenv("SSL_CERT_FILE", "/dev/null")
 		if err != nil {
 			logrus.Errorf("failed to set env var SSL_CERT_FILE: %s", err.Error())
 		}
 
-		err = os.Setenv("SSL_CERT_DIR", "/var/does-not-exist-either")
+		err = os.Setenv("SSL_CERT_DIR", "/dev/null")
 		if err != nil {
 			logrus.Errorf("failed to set env var SSL_CERT_DIR: %s", err.Error())
 		}

--- a/internal/cmd/agent/register/register.go
+++ b/internal/cmd/agent/register/register.go
@@ -167,7 +167,12 @@ func runRegistration(ctx context.Context, k8s coreInterface, namespace string) (
 		return nil, fmt.Errorf("looking up secret %s/%s: %w", namespace, config.AgentBootstrapConfigName, err)
 	}
 
-	clientConfig := createClientConfigFromSecret(secret)
+	cfg, err := config.Lookup(ctx, secret.Namespace, config.AgentConfigName, k8s.ConfigMap())
+	if err != nil {
+		return nil, fmt.Errorf("failed to look up client config %s/%s: %w", secret.Namespace, config.AgentConfigName, err)
+	}
+
+	clientConfig := createClientConfigFromSecret(secret, cfg.AgentTLSMode == config.AgentTLSModeSystemStore)
 
 	ns, _, err := clientConfig.Namespace()
 	if err != nil {
@@ -177,11 +182,6 @@ func runRegistration(ctx context.Context, k8s coreInterface, namespace string) (
 	kc, err := clientConfig.ClientConfig()
 	if err != nil {
 		return nil, err
-	}
-
-	cfg, err := config.Lookup(ctx, secret.Namespace, config.AgentConfigName, k8s.ConfigMap())
-	if err != nil {
-		return nil, fmt.Errorf("failed to look up client config %s/%s: %w", secret.Namespace, config.AgentConfigName, err)
 	}
 
 	fleetK8s, err := kubernetes.NewForConfig(kc)
@@ -318,15 +318,28 @@ func values(data map[string][]byte) map[string][]byte {
 
 // createClientConfigFromSecret reads the fleet-agent-bootstrap secret and
 // creates a clientConfig to access the upstream cluster
-func createClientConfigFromSecret(secret *corev1.Secret) clientcmd.ClientConfig {
+func createClientConfigFromSecret(secret *corev1.Secret, trustSystemStoreCAs bool) clientcmd.ClientConfig {
 	data := values(secret.Data)
 	apiServerURL := string(data[config.APIServerURLKey])
 	apiServerCA := data[config.APIServerCAKey]
 	namespace := string(data[ClusterNamespace])
 	token := string(data[Token])
 
-	if _, err := http.Get(apiServerURL); err == nil {
-		apiServerCA = nil
+	if trustSystemStoreCAs { // Save a request to the API server URL if system CAs are not to be trusted.
+		if _, err := http.Get(apiServerURL); err == nil {
+			apiServerCA = nil
+		}
+	} else {
+		// Bypass the OS trust store.
+		err := os.Setenv("SSL_CERT_FILE", "/var/does-not-exist.pem")
+		if err != nil {
+			logrus.Errorf("failed to set env var SSL_CERT_FILE: %s", err.Error())
+		}
+
+		err = os.Setenv("SSL_CERT_DIR", "/var/does-not-exist-either")
+		if err != nil {
+			logrus.Errorf("failed to set env var SSL_CERT_DIR: %s", err.Error())
+		}
 	}
 
 	cfg := clientcmdapi.Config{

--- a/internal/cmd/controller/agentmanagement/agent/config.go
+++ b/internal/cmd/controller/agentmanagement/agent/config.go
@@ -12,8 +12,9 @@ import (
 )
 
 type ConfigOptions struct {
-	Labels   map[string]string
-	ClientID string
+	Labels       map[string]string
+	ClientID     string
+	AgentTLSMode string
 }
 
 func agentConfig(ctx context.Context, agentNamespace, controllerNamespace string, cg *client.Getter, opts *ConfigOptions) ([]runtime.Object, error) {
@@ -32,13 +33,14 @@ func agentConfig(ctx context.Context, agentNamespace, controllerNamespace string
 		return nil, err
 	}
 
-	return configObjects(agentNamespace, opts.Labels, opts.ClientID)
+	return configObjects(agentNamespace, opts)
 }
 
-func configObjects(controllerNamespace string, clusterLabels map[string]string, clientID string) ([]runtime.Object, error) {
+func configObjects(controllerNamespace string, co *ConfigOptions) ([]runtime.Object, error) {
 	cm, err := config.ToConfigMap(controllerNamespace, config.AgentConfigName, &config.Config{
-		Labels:   clusterLabels,
-		ClientID: clientID,
+		Labels:       co.Labels,
+		ClientID:     co.ClientID,
+		AgentTLSMode: co.AgentTLSMode,
 	})
 	if err != nil {
 		return nil, err

--- a/internal/cmd/controller/agentmanagement/controllers/cluster/import.go
+++ b/internal/cmd/controller/agentmanagement/controllers/cluster/import.go
@@ -92,7 +92,12 @@ func (i *importHandler) onConfig(config *config.Config) error {
 		if cluster.Spec.KubeConfigSecret == "" {
 			continue
 		}
-		if config.APIServerURL != cluster.Status.APIServerURL || hashStatusField(config.APIServerCA) != cluster.Status.APIServerCAHash {
+
+		hasConfigChanged := config.APIServerURL != cluster.Status.APIServerURL ||
+			hashStatusField(config.APIServerCA) != cluster.Status.APIServerCAHash ||
+			config.AgentTLSMode != cluster.Status.AgentTLSMode
+
+		if hasConfigChanged {
 			logrus.Infof("API server config changed, trigger cluster import for cluster %s/%s", cluster.Namespace, cluster.Name)
 			c := cluster.DeepCopy()
 			c.Status.AgentConfigChanged = true
@@ -388,6 +393,8 @@ func (i *importHandler) importCluster(cluster *fleet.Cluster, status fleet.Clust
 	status.AgentConfigChanged = false
 	status.APIServerURL = apiServerURL
 	status.APIServerCAHash = hashStatusField(apiServerCA)
+	status.AgentTLSMode = cfg.AgentTLSMode
+
 	return status, nil
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,6 +20,8 @@ const (
 	ManagerConfigName        = "fleet-controller"
 	AgentConfigName          = "fleet-agent"
 	AgentBootstrapConfigName = "fleet-agent-bootstrap"
+	AgentTLSModeStrict       = "strict"
+	AgentTLSModeSystemStore  = "system-store"
 	Key                      = "config"
 	// DefaultNamespace is the default for the system namespace, which
 	// contains the manager and agent
@@ -101,6 +103,11 @@ type Config struct {
 
 	// IgnoreClusterRegistrationLabels if set to true, the labels on the cluster registration resource will not be copied to the cluster resource.
 	IgnoreClusterRegistrationLabels bool `json:"ignoreClusterRegistrationLabels,omitempty"`
+
+	// AgentTLSMode supports two values: `system-store` and `strict`. If set to `system-store`, instructs the agent
+	// to trust CA bundles from the operating system's store. If set to `strict`, then the agent shall only connect
+	// to a server which uses the exact CA configured when creating/updating the agent.
+	AgentTLSMode string `json:"agentTLSMode,omitempty"`
 }
 
 type Bootstrap struct {

--- a/pkg/apis/fleet.cattle.io/v1alpha1/cluster_types.go
+++ b/pkg/apis/fleet.cattle.io/v1alpha1/cluster_types.go
@@ -190,6 +190,13 @@ type ClusterStatus struct {
 	// +nullable
 	APIServerCAHash string `json:"apiServerCAHash,omitempty"`
 
+	// AgentTLSMode supports two values: `system-store` and `strict`. If set to
+	// `system-store`, instructs the agent to trust CA bundles from the operating
+	// system's store. If set to `strict`, then the agent shall only connect to a
+	// server which uses the exact CA configured when creating/updating the agent.
+	// +nullable
+	AgentTLSMode string `json:"agentTLSMode,omitempty"`
+
 	// Display contains the number of ready bundles, nodes and a summary state.
 	Display ClusterDisplay `json:"display,omitempty"`
 	// AgentStatus contains information about the agent.


### PR DESCRIPTION
Refers to #2171

This adds a new Helm value named `agentTLSMode`, with two supported values:
* `system-store`, the default: in this mode, the Fleet agent behaves as it has so far, trusting certificates signed by any CA installed in the system store when registering against an upstream cluster.
    * In this mode, Fleet will also ignore a configured CA, if the system trust store is sufficient.
* `strict`, to ignore the system store during the cluster registration process

Updating that value in the `fleet-controller` config map triggers redeployment of the Fleet agent, on the upstream cluster and on downstream clusters _which had been registered following a manager-initiated process_ (as would typically be the case when importing clusters through Rancher). This does not work for agent-initiated registration.

Open points:
* bypassing the system-wide CA store is done by setting environment variables `SSL_CERT_FILE` and `SSL_CERT_DIR`, mentioned [here](https://pkg.go.dev/crypto/x509#SystemCertPool), to nonexistent paths. This is admittedly a bit hacky. Is there a cleaner way, keeping in mind that Fleet agent containers run with a read-only filesystem?