### PR TITLE
Bump go releaser config

### DIFF
--- a/.github/workflows/release-fleet.yml
+++ b/.github/workflows/release-fleet.yml
@@ -93,7 +93,7 @@ jobs:
         id: goreleaser
         with:
           distribution: goreleaser
-          version: v1.24.0
+          version: '~> v2'
           args: release --clean --verbose
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-fleet.yml
+++ b/.github/workflows/release-fleet.yml
@@ -89,7 +89,7 @@ jobs:
           password: ${{ env.DOCKER_PASSWORD }}
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v5
+        uses: goreleaser/goreleaser-action@v6
         id: goreleaser
         with:
           distribution: goreleaser

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,4 +1,6 @@
 ---
+version: 2
+
 project_name: fleet
 release:
   prerelease: auto


### PR DESCRIPTION
I have migrated the config following: https://goreleaser.com/blog/goreleaser-v2/

Since we do not seem to use any deprecated options, I have just had to add the version to the config file.

I have ran the goreleaser check with the following output:

```
$ goreleaser check
  • checking                                 path=.goreleaser.yaml
  • 1 configuration file(s) validated
  • thanks for using goreleaser!
```

