### PR TITLE
Use the same linter version in GoReleaser as for prs

### DIFF
--- a/.github/workflows/release-fleet.yml
+++ b/.github/workflows/release-fleet.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always
           # use the latest patch version.
-          version: v1.55
+          version: v1.58
           args: --timeout=10m --config=.golangci.json
 
       - name: "Read Vault Secrets"


### PR DESCRIPTION
This fixes issue with the [removal of gosec warning for stored pointers](https://github.com/rancher/fleet/commit/0f8a3cd5a81619f87cc9d1d3e23149f381998b90).