### PR TITLE
Fix flaky integration test for git job with polling disabled

### DIFF
--- a/integrationtests/gitjob/controller/controller_test.go
+++ b/integrationtests/gitjob/controller/controller_test.go
@@ -24,8 +24,8 @@ const (
 	gitRepoNamespace   = "default"
 	repo               = "https://www.github.com/rancher/fleet"
 	commit             = "9ca3a0ad308ed8bffa6602572e2a1343af9c3d2e"
-	stableCommitBranch = "renovate/golang.org-x-crypto-0.x"
-	stableCommit       = "7b4c2b25a2da2160604bde2773ae8aa44ed481dd"
+	stableCommitBranch = "release/v0.6"
+	stableCommit       = "26bdd9326b0238bb2fb743f863d9380c3c5d43e0"
 )
 
 var _ = Describe("GitJob controller", func() {


### PR DESCRIPTION
That test relied on branch `renovate/golang.org-x-crypto-0.x`, which no longer exists on `rancher/fleet`.
Instead, this now relies on an old release branch, which is both less likely to be deleted and unlikely to be updated, since the corresponding version is no longer maintained.