### PR TITLE
[0.9] Honor Helm's MaxHistory when using drift correction

### DIFF
--- a/e2e/drift/drift_test.go
+++ b/e2e/drift/drift_test.go
@@ -153,7 +153,7 @@ var _ = Describe("Drift", func() {
 				}).Should(BeTrue())
 				Expect(func() string {
 					kw := k.Namespace(namespace)
-					n, _ := kw.Get("secrets", "--field-selector=type=helm.sh/release.v1", "-o=go-template='{{printf \"%d\\n\" (len  .items)}}'")
+					n, _ := kw.Get("secrets", "--field-selector=type=helm.sh/release.v1", `-o=go-template='{{printf "%d\n" (len  .items)}}'`)
 					return n
 				}).Should(Equal("2")) // Max Helm history
 			})

--- a/e2e/drift/drift_test.go
+++ b/e2e/drift/drift_test.go
@@ -151,6 +151,11 @@ var _ = Describe("Drift", func() {
 					_ = json.Unmarshal([]byte(out), &configMap)
 					return configMap.Data["foo"] == "bar"
 				}).Should(BeTrue())
+				Expect(func() string {
+					kw := k.Namespace(namespace)
+					n, _ := kw.Get("secrets", "--field-selector=type=helm.sh/release.v1", "-o=go-template='{{printf \"%d\\n\" (len  .items)}}'")
+					return n
+				}).Should(Equal("2"))
 			})
 		})
 

--- a/e2e/drift/drift_test.go
+++ b/e2e/drift/drift_test.go
@@ -155,7 +155,7 @@ var _ = Describe("Drift", func() {
 					kw := k.Namespace(namespace)
 					n, _ := kw.Get("secrets", "--field-selector=type=helm.sh/release.v1", "-o=go-template='{{printf \"%d\\n\" (len  .items)}}'")
 					return n
-				}).Should(Equal("2"))
+				}).Should(Equal("2")) // Max Helm history
 			})
 		})
 

--- a/internal/cmd/agent/deployer/monitor.go
+++ b/internal/cmd/agent/deployer/monitor.go
@@ -175,7 +175,7 @@ func (m *Manager) UpdateBundleDeploymentStatus(mapper meta.RESTMapper, bd *fleet
 	if len(bd.Status.ModifiedStatus) == 0 {
 		bd.Status.NonModified = true
 	} else if bd.Spec.CorrectDrift != nil && bd.Spec.CorrectDrift.Enabled {
-		err = m.deployer.RemoveExternalChanges(bd)
+		resources, err := m.deployer.RemoveExternalChanges(bd)
 		if err != nil {
 			// Update BundleDeployment status as wrangler doesn't update the status if error is not nil.
 			_, errStatus := m.bundleDeploymentController.UpdateStatus(bd)
@@ -184,6 +184,7 @@ func (m *Manager) UpdateBundleDeploymentStatus(mapper meta.RESTMapper, bd *fleet
 			}
 			return errors.Wrapf(err, "error reconciling drift")
 		}
+		bd.Status.Release = resources.ID
 	}
 
 	bd.Status.Resources = []fleet.BundleDeploymentResource{}

--- a/internal/cmd/agent/deployer/monitor.go
+++ b/internal/cmd/agent/deployer/monitor.go
@@ -175,7 +175,7 @@ func (m *Manager) UpdateBundleDeploymentStatus(mapper meta.RESTMapper, bd *fleet
 	if len(bd.Status.ModifiedStatus) == 0 {
 		bd.Status.NonModified = true
 	} else if bd.Spec.CorrectDrift != nil && bd.Spec.CorrectDrift.Enabled {
-		resources, err := m.deployer.RemoveExternalChanges(bd)
+		release, err := m.deployer.RemoveExternalChanges(bd)
 		if err != nil {
 			// Update BundleDeployment status as wrangler doesn't update the status if error is not nil.
 			_, errStatus := m.bundleDeploymentController.UpdateStatus(bd)
@@ -184,7 +184,7 @@ func (m *Manager) UpdateBundleDeploymentStatus(mapper meta.RESTMapper, bd *fleet
 			}
 			return errors.Wrapf(err, "error reconciling drift")
 		}
-		bd.Status.Release = resources.ID
+		bd.Status.Release = release
 	}
 
 	bd.Status.Resources = []fleet.BundleDeploymentResource{}

--- a/internal/helmdeployer/deployer.go
+++ b/internal/helmdeployer/deployer.go
@@ -261,6 +261,10 @@ func (h *Helm) RemoveExternalChanges(bd *fleet.BundleDeployment) error {
 
 	r := action.NewRollback(&cfg)
 	r.Version = currentRelease.Version
+	r.MaxHistory = bd.Spec.Options.Helm.MaxHistory
+	if r.MaxHistory == 0 {
+		r.MaxHistory = MaxHelmHistory
+	}
 	if bd.Spec.CorrectDrift.Force {
 		r.Force = true
 	}


### PR DESCRIPTION
<!-- Specify the issue ID that this pull request is solving -->
Refers to #2515
<!-- Make sure that the referenced issue provides steps to reproduce it -->

<!-- Describe the changes introduced by this pull request -->
* Drift correction (self-healing) uses Helm's [Rollback action](https://pkg.go.dev/helm.sh/helm/v3/pkg/action#Rollback), which has a `MaxHistory` field. This value takes precedence over the config value. Unlike the [`Upgrade` action](https://github.com/rancher/fleet/blob/68597ce1aca9bfac58547f8b92ad060b7aa90cf5/internal/helmdeployer/install.go#L163-L166), we omitted to set this value, so the releases will only shrink when running an upgrade but not rollbacks`.
* I noticed that sometimes, a regular upgrades would be deployed (creating a new). Initially I thought this would happen if all the releases in the remaining history were rollbacks, but realized the problem is that the BundleDeployment status has a `release` field, referencing the latest release installed. This value is not being updated on rollbacks, hence making the status differ from what `helm history` reflects.

<!--
  Please provide a unit, integration (`./integrationtests/`) or e2e (`./e2e/`) test if possible.
-->