### PR TITLE
Include drift end-to-end tests in CI workflows

### DIFF
--- a/.github/workflows/aks.yml
+++ b/.github/workflows/aks.yml
@@ -135,7 +135,7 @@ jobs:
           FLEET_E2E_NS: fleet-local
         run: |
           export KUBECONFIG="$GITHUB_WORKSPACE/kubeconfig-fleet-ci"
-          ginkgo --github-output --label-filter="!infra-setup" e2e/single-cluster e2e/keep-resources
+          ginkgo --github-output --label-filter='!infra-setup' e2e/single-cluster e2e/keep-resources e2e/drift
       -
         name: Acceptance Tests for Examples
         env:

--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -104,7 +104,7 @@ jobs:
           export CI_OCI_CERTS_DIR="$(git rev-parse --show-toplevel)/FleetCI-RootCA"
 
           # 1. Run test cases not needing infra
-          ginkgo --github-output --label-filter='!infra-setup' e2e/single-cluster e2e/keep-resources
+          ginkgo --github-output --label-filter='!infra-setup' e2e/single-cluster e2e/keep-resources e2e/drift
 
           # 2. Run tests for metrics
           ginkgo --github-output e2e/metrics

--- a/.github/workflows/gke.yml
+++ b/.github/workflows/gke.yml
@@ -138,7 +138,7 @@ jobs:
         env:
           FLEET_E2E_NS: fleet-local
         run: |
-          ginkgo --github-output --label-filter="!infra-setup" e2e/single-cluster e2e/keep-resources
+          ginkgo --github-output --label-filter='!infra-setup' e2e/single-cluster e2e/keep-resources e2e/drift
       -
         name: Acceptance Tests for Examples
         env:

--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -107,7 +107,7 @@ jobs:
           export CI_OCI_CERTS_DIR="$(git rev-parse --show-toplevel)/FleetCI-RootCA"
 
           # 1. Run test cases not needing infra
-          ginkgo --github-output --label-filter='!infra-setup' e2e/single-cluster e2e/keep-resources
+          ginkgo --github-output --label-filter='!infra-setup' e2e/single-cluster e2e/keep-resources e2e/drift
 
           # 2. Run tests for metrics
           ginkgo --github-output e2e/metrics

--- a/e2e/assets/drift/correction-disabled/gitrepo.yaml
+++ b/e2e/assets/drift/correction-disabled/gitrepo.yaml
@@ -2,7 +2,6 @@ kind: GitRepo
 apiVersion: fleet.cattle.io/v1alpha1
 metadata:
   name: drift-test
-  namespace: fleet-default
 spec:
   repo: https://github.com/rancher/fleet-test-data
   branch: master

--- a/e2e/assets/drift/correction-enabled/gitrepo.yaml
+++ b/e2e/assets/drift/correction-enabled/gitrepo.yaml
@@ -2,7 +2,6 @@ kind: GitRepo
 apiVersion: fleet.cattle.io/v1alpha1
 metadata:
   name: drift-correction-test
-  namespace: fleet-default
 spec:
   repo: https://github.com/rancher/fleet-test-data
   branch: master

--- a/e2e/assets/drift/force/gitrepo.yaml
+++ b/e2e/assets/drift/force/gitrepo.yaml
@@ -2,7 +2,6 @@ kind: GitRepo
 apiVersion: fleet.cattle.io/v1alpha1
 metadata:
   name: drift-force-test
-  namespace: fleet-default
 spec:
   repo: https://github.com/rancher/fleet-test-data
   branch: master

--- a/e2e/drift/drift_test.go
+++ b/e2e/drift/drift_test.go
@@ -12,7 +12,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-var _ = Describe("Drift", func() {
+var _ = Describe("Drift", Ordered, func() {
 	var (
 		asset      string
 		k          kubectl.Command
@@ -134,7 +134,7 @@ var _ = Describe("Drift", func() {
 				out, err := kw.Patch(
 					"configmap", "configmap",
 					"--type=json",
-					"-p", `[{"op": "replace", "path": "data/foo", "value": "modified"}]`,
+					"-p", `[{"op": "replace", "path": "/data/foo", "value": "modified"}]`,
 				)
 				Expect(err).ToNot(HaveOccurred(), out)
 			})

--- a/e2e/drift/suite_test.go
+++ b/e2e/drift/suite_test.go
@@ -2,6 +2,7 @@ package examples_test
 
 import (
 	"testing"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -19,6 +20,7 @@ var (
 
 var _ = BeforeSuite(func() {
 	SetDefaultEventuallyTimeout(testenv.Timeout)
+	SetDefaultEventuallyPollingInterval(time.Second)
 	testenv.SetRoot("../..")
 
 	env = testenv.New()


### PR DESCRIPTION
This includes drift tests, previously omitted, in our CI workflows running single-cluster end-to-end tests.