### PR TITLE
Populate bundle status from bundleDeployment status resources

### DIFF
--- a/internal/cmd/controller/reconciler/bundle_status.go
+++ b/internal/cmd/controller/reconciler/bundle_status.go
@@ -1,21 +1,12 @@
 package reconciler
 
 import (
-	"context"
 	"fmt"
-	"sort"
 
-	"github.com/sirupsen/logrus"
-
-	"github.com/rancher/fleet/internal/cmd/controller/options"
 	"github.com/rancher/fleet/internal/cmd/controller/summary"
 	"github.com/rancher/fleet/internal/cmd/controller/target"
-	"github.com/rancher/fleet/internal/helmdeployer"
-	"github.com/rancher/fleet/internal/manifest"
 	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
-
-	"k8s.io/apimachinery/pkg/api/meta"
-	"k8s.io/apimachinery/pkg/runtime/schema"
+	"github.com/sirupsen/logrus"
 )
 
 const (
@@ -41,64 +32,26 @@ func updateDisplay(status *fleet.BundleStatus) {
 	status.Display.State = string(summary.GetSummaryState(status.Summary))
 }
 
-// setResourceKey updates status.ResourceKey from the bundle, by running helm template (does not mutate bundle)
-func setResourceKey(ctx context.Context, status *fleet.BundleStatus, bundle *fleet.Bundle, manifest *manifest.Manifest, isNSed func(schema.GroupVersionKind) bool) error {
-	seen := map[fleet.ResourceKey]struct{}{}
-
-	// iterate over the defined targets, from "targets.yaml", not the
-	// actually matched targets to avoid duplicates
-	for i := range bundle.Spec.Targets {
-		opts := options.Merge(bundle.Spec.BundleDeploymentOptions, bundle.Spec.Targets[i].BundleDeploymentOptions)
-		objs, err := helmdeployer.Template(ctx, bundle.Name, manifest, opts)
-		if err != nil {
-			logrus.Infof("While calculating status.ResourceKey, error running helm template for bundle %s with target options from %s: %v", bundle.Name, bundle.Spec.Targets[i].Name, err)
+// setResourceKey updates status.ResourceKey from the bundleDeployments
+func setResourceKey(status *fleet.BundleStatus, allTargets []*target.Target) {
+	keys := []fleet.ResourceKey{}
+	for _, target := range allTargets {
+		if target.Deployment == nil {
 			continue
 		}
-
-		for _, obj := range objs {
-			m, err := meta.Accessor(obj)
-			if err != nil {
-				return err
-			}
+		if target.Deployment.Namespace == "" {
+			logrus.Infof("Skipping bundledeployment with empty namespace %q", target.Deployment.Name)
+			continue
+		}
+		for _, resource := range target.Deployment.Status.Resources {
 			key := fleet.ResourceKey{
-				Namespace: m.GetNamespace(),
-				Name:      m.GetName(),
+				Name:       resource.Name,
+				Namespace:  resource.Namespace,
+				APIVersion: resource.APIVersion,
+				Kind:       resource.Kind,
 			}
-			gvk := obj.GetObjectKind().GroupVersionKind()
-			if key.Namespace == "" && isNSed(gvk) {
-				if opts.DefaultNamespace == "" {
-					key.Namespace = "default"
-				} else {
-					key.Namespace = opts.DefaultNamespace
-				}
-			}
-			key.APIVersion, key.Kind = gvk.ToAPIVersionAndKind()
-			seen[key] = struct{}{}
+			keys = append(keys, key)
 		}
 	}
-
-	keys := []fleet.ResourceKey{}
-	for k := range seen {
-		keys = append(keys, k)
-	}
-	sort.Slice(keys, func(i, j int) bool {
-		keyi := keys[i]
-		keyj := keys[j]
-		if keyi.APIVersion != keyj.APIVersion {
-			return keyi.APIVersion < keyj.APIVersion
-		}
-		if keyi.Kind != keyj.Kind {
-			return keyi.Kind < keyj.Kind
-		}
-		if keyi.Namespace != keyj.Namespace {
-			return keyi.Namespace < keyj.Namespace
-		}
-		if keyi.Name != keyj.Name {
-			return keyi.Name < keyj.Name
-		}
-		return false
-	})
 	status.ResourceKey = keys
-
-	return nil
 }


### PR DESCRIPTION
Refers to #2115
- [x] status derived from new `bundledeployment.status.resources` in bundle reconciler
