### PR TITLE
Fixes error display and improves user experience in git poller

### DIFF
--- a/pkg/durations/durations.go
+++ b/pkg/durations/durations.go
@@ -1,6 +1,10 @@
 package durations
 
-import "time"
+import (
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
 
 const (
 	AgentRegistrationRetry         = time.Minute * 1
@@ -27,3 +31,14 @@ const (
 	TriggerSleep          = time.Second * 5
 	DefaultCpuPprofPeriod = time.Minute
 )
+
+// Equal reports whether the duration t is equal to u.
+func Equal(t *metav1.Duration, u *metav1.Duration) bool {
+	if t == nil && u == nil {
+		return true
+	}
+	if t != nil && u != nil {
+		return t.Duration == u.Duration
+	}
+	return false
+}

--- a/pkg/git/poll/gitrepopolljob.go
+++ b/pkg/git/poll/gitrepopolljob.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/rancher/fleet/internal/cmd/controller/grutil"
 	v1alpha1 "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
 	"github.com/reugn/go-quartz/quartz"
 	"golang.org/x/sync/semaphore"
@@ -66,6 +67,8 @@ func (j *GitRepoPollJob) fetchLatestCommitAndUpdateStatus(ctx context.Context) {
 	commit, err := j.fetcher.LatestCommit(ctx, &j.GitRepo, j.client)
 	if err != nil {
 		logger.Error(err, "error fetching commit", "gitrepo", j.GitRepo)
+		nsName := types.NamespacedName{Name: j.GitRepo.Name, Namespace: j.GitRepo.Namespace}
+		_ = grutil.UpdateErrorStatus(ctx, j.client, nsName, j.GitRepo.Status, err)
 		return
 	}
 	if j.GitRepo.Status.Commit != commit {

--- a/pkg/git/poll/gitrepopolljob_test.go
+++ b/pkg/git/poll/gitrepopolljob_test.go
@@ -86,6 +86,13 @@ var _ = Describe("GitRepoPollJob tests", func() {
 			err := client.Get(ctx, types.NamespacedName{Name: gitRepo.Name, Namespace: gitRepo.Namespace}, &updatedGitRepo)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(updatedGitRepo.Status.Commit).To(Equal(gitRepo.Status.Commit))
+			errorFound := false
+			for _, c := range updatedGitRepo.Status.Conditions {
+				if c.Message == "Some error" {
+					errorFound = true
+				}
+			}
+			Expect(errorFound).To(BeTrue())
 		})
 	})
 })


### PR DESCRIPTION
When the gitpoller job returns an error it is added to the `gitrepo` conditions so it can be properly displayed by the UI.

It also reschedules the gitpoller job when the `gitrepo` spec is changed so the job is immediately executed.

Refers to: https://github.com/rancher/fleet/issues/2520