### PR TITLE
Support Deploying Helm Releases with the Same Name in Different Namespaces

### DIFF
--- a/internal/helmdeployer/deployer.go
+++ b/internal/helmdeployer/deployer.go
@@ -82,7 +82,7 @@ func (h *Helm) Setup(ctx context.Context, client client.Client, getter genericcl
 	h.client = client
 	h.getter = getter
 
-	cfg, err := h.createCfg(ctx, "")
+	cfg, err := h.createCfg(ctx, h.defaultNamespace)
 	if err != nil {
 		return err
 	}
@@ -126,10 +126,6 @@ func (h *Helm) getCfg(ctx context.Context, namespace, serviceAccountName string)
 		cfg    action.Configuration
 		getter = h.getter
 	)
-
-	if h.useGlobalCfg {
-		return h.globalCfg, nil
-	}
 
 	serviceAccountNamespace, serviceAccountName, err := h.getServiceAccount(ctx, serviceAccountName)
 	if err != nil {


### PR DESCRIPTION
… different namespaces

<!-- Specify the issue ID that this pull request is solving -->
Refers to #1812 
<!-- Make sure that the referenced issue provides steps to reproduce it -->

<!-- Describe the changes introduced by this pull request -->
The Helm deployer was updated to use namespace-specific configurations instead of a global configuration.
<!--
  Please provide a unit, integration (`./integrationtests/`) or e2e (`./e2e/`) test if possible.
-->