### PR TITLE
Refactor reconcilers and remove foldin func

### DIFF
--- a/internal/bundlereader/read.go
+++ b/internal/bundlereader/read.go
@@ -23,6 +23,7 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
+// Options include the GitRepo overrides, which are passed via command line args
 type Options struct {
 	Compress         bool
 	Labels           map[string]string

--- a/internal/cmd/controller/options/calculate.go
+++ b/internal/cmd/controller/options/calculate.go
@@ -1,4 +1,4 @@
-// Package options merges the BundleDeploymentOptions
+// Package options merges the BundleDeploymentOptions, so that targetCustomizations take effect.
 package options
 
 import (


### PR DESCRIPTION
### Move SetupWithManager before Reconcile

We often lookup what triggers a reconcile, though receiver funcs are not
alphabetically sorted anymore, this should be easier to find now.

### Inline foldInDeployments

Targets returns a list of targets and an error.
foldInDeployments cleverly mutated the returned list. No more.
