### PR TITLE
Gitcloner recurses submodules

### DIFF
--- a/internal/cmd/agent/register/register.go
+++ b/internal/cmd/agent/register/register.go
@@ -326,6 +326,7 @@ func createClientConfigFromSecret(secret *corev1.Secret, trustSystemStoreCAs boo
 	token := string(data[Token])
 
 	if trustSystemStoreCAs { // Save a request to the API server URL if system CAs are not to be trusted.
+		// NOTE(manno): client-go will use the system trust store even if a CA is configured. So, why do this?
 		if _, err := http.Get(apiServerURL); err == nil {
 			apiServerCA = nil
 		}

--- a/internal/cmd/cli/gitcloner/cloner.go
+++ b/internal/cmd/cli/gitcloner/cloner.go
@@ -73,12 +73,13 @@ func (c *Cloner) CloneRepo(opts *GitCloner) error {
 
 func cloneBranch(opts *GitCloner, auth transport.AuthMethod, caBundle []byte) error {
 	_, err := plainClone(opts.Path, false, &git.CloneOptions{
-		URL:             opts.Repo,
-		Auth:            auth,
-		InsecureSkipTLS: opts.InsecureSkipTLS,
-		CABundle:        caBundle,
-		SingleBranch:    true,
-		ReferenceName:   plumbing.ReferenceName(opts.Branch),
+		URL:               opts.Repo,
+		Auth:              auth,
+		InsecureSkipTLS:   opts.InsecureSkipTLS,
+		CABundle:          caBundle,
+		SingleBranch:      true,
+		ReferenceName:     plumbing.ReferenceName(opts.Branch),
+		RecurseSubmodules: git.DefaultSubmoduleRecursionDepth,
 	})
 
 	return err
@@ -86,10 +87,11 @@ func cloneBranch(opts *GitCloner, auth transport.AuthMethod, caBundle []byte) er
 
 func cloneRevision(opts *GitCloner, auth transport.AuthMethod, caBundle []byte) error {
 	r, err := plainClone(opts.Path, false, &git.CloneOptions{
-		URL:             opts.Repo,
-		Auth:            auth,
-		InsecureSkipTLS: opts.InsecureSkipTLS,
-		CABundle:        caBundle,
+		URL:               opts.Repo,
+		Auth:              auth,
+		InsecureSkipTLS:   opts.InsecureSkipTLS,
+		CABundle:          caBundle,
+		RecurseSubmodules: git.DefaultSubmoduleRecursionDepth,
 	})
 	if err != nil {
 		return err

--- a/internal/cmd/cli/gitcloner/cloner_test.go
+++ b/internal/cmd/cli/gitcloner/cloner_test.go
@@ -83,9 +83,10 @@ udiSlDctMM/X3ZM2JN5M1rtAJ2WR3ZQtmWbOjZAbG2Eq
 				Branch: "master",
 			},
 			expectedCloneOpts: &git.CloneOptions{
-				URL:           "repo",
-				SingleBranch:  true,
-				ReferenceName: "master",
+				URL:               "repo",
+				SingleBranch:      true,
+				ReferenceName:     "master",
+				RecurseSubmodules: git.DefaultSubmoduleRecursionDepth,
 			},
 		},
 		"branch basic auth": {
@@ -104,6 +105,7 @@ udiSlDctMM/X3ZM2JN5M1rtAJ2WR3ZQtmWbOjZAbG2Eq
 					Username: "user",
 					Password: passwordFileContent,
 				},
+				RecurseSubmodules: git.DefaultSubmoduleRecursionDepth,
 			},
 		},
 		"branch ssh auth": {
@@ -114,10 +116,11 @@ udiSlDctMM/X3ZM2JN5M1rtAJ2WR3ZQtmWbOjZAbG2Eq
 				SSHPrivateKeyFile: sshPrivateKeyFile,
 			},
 			expectedCloneOpts: &git.CloneOptions{
-				URL:           "ssh://git@localhost/test/test-repo",
-				SingleBranch:  true,
-				ReferenceName: "master",
-				Auth:          sshAuth,
+				URL:               "ssh://git@localhost/test/test-repo",
+				SingleBranch:      true,
+				ReferenceName:     "master",
+				Auth:              sshAuth,
+				RecurseSubmodules: git.DefaultSubmoduleRecursionDepth,
 			},
 		},
 		"password file does not exist": {


### PR DESCRIPTION
Refers to https://github.com/rancher/fleet/issues/2492


Pull request content for Rancher QA verification.

## Additional QA
 
### Problem

Since switching to go-git, Fleet would no longer clone submodules.
 
### Solution

According to the go-git documentation this is how to enable submodule cloning.
 
### Testing

### Engineering Testing
#### Manual Testing

Tested with fleet-test-data submodule in https://github.com/manno/fleet-experiments

```
kind: GitRepo
apiVersion: fleet.cattle.io/v1alpha1
metadata:
  name: crd-experiment
spec:
  repo: https://github.com/manno/fleet-experiments
  branch: main
  paths:
    - fleet-test-data/simple-chart
  targets:
    - clusterSelector: {}
    
 ```

#### Automated Testing

### QA Testing Considerations

We would need another repo like rancher/fleet-test-data to include as a submodule.

#### Regressions Considerations

Too many nested repos are a problem for performance.