### PR TITLE
Override Kubernetes node when deploying Fleet to AKS/GKE

### DIFF
--- a/.github/scripts/deploy-fleet.sh
+++ b/.github/scripts/deploy-fleet.sh
@@ -3,6 +3,7 @@
 set -euxo pipefail
 
 shards_json=${SHARDS-""}
+node=${NODE-k3d-upstream-server-0}
 
 function eventually {
   for _ in $(seq 1 3); do
@@ -24,7 +25,7 @@ else
   agentTag="dev"
 fi
 
-host=$(kubectl get node k3d-upstream-server-0 -o jsonpath='{.status.addresses[?(@.type=="InternalIP")].address}')
+host=$(kubectl get node $node -o jsonpath='{.status.addresses[?(@.type=="InternalIP")].address}')
 ca=$( kubectl config view --flatten -o jsonpath='{.clusters[?(@.name == "k3d-upstream")].cluster.certificate-authority-data}' | base64 -d )
 server="https://$host:6443"
 

--- a/.github/workflows/aks.yml
+++ b/.github/workflows/aks.yml
@@ -125,8 +125,10 @@ jobs:
         name: Deploy Fleet
         run: |
           export KUBECONFIG="$GITHUB_WORKSPACE/kubeconfig-fleet-ci"
+          kc_node=$(kubectl get nodes --no-headers -o name | head -n 1)
+          node=${kc_node#node/}
           echo "${{ steps.meta-fleet.outputs.tags }} ${{ steps.meta-fleet-agent.outputs.tags }}"
-          SHARDS='[{"id":"shard0"},{"id":"shard1"},{"id":"shard2"}]' ./.github/scripts/deploy-fleet.sh \
+          NODE=$node SHARDS='[{"id":"shard0"},{"id":"shard1"},{"id":"shard2"}]' ./.github/scripts/deploy-fleet.sh \
                                        ${{ steps.meta-fleet.outputs.tags }} \
                                        ${{ steps.meta-fleet-agent.outputs.tags }}
       -

--- a/.github/workflows/gke.yml
+++ b/.github/workflows/gke.yml
@@ -129,8 +129,10 @@ jobs:
       -
         name: Deploy Fleet
         run: |
+          kc_node=$(kubectl get nodes --no-headers -o name | head -n 1)
+          node=${kc_node#node/}
           echo "${{ steps.meta-fleet.outputs.tags }} ${{ steps.meta-fleet-agent.outputs.tags }}"
-          SHARDS='[{"id":"shard0"},{"id":"shard1"},{"id":"shard2"}]' ./.github/scripts/deploy-fleet.sh \
+          NODE=$node SHARDS='[{"id":"shard0"},{"id":"shard1"},{"id":"shard2"}]' ./.github/scripts/deploy-fleet.sh \
                                        ${{ steps.meta-fleet.outputs.tags }} \
                                        ${{ steps.meta-fleet-agent.outputs.tags }}
       -


### PR DESCRIPTION
This should prevent CI failures ([AKS](https://github.com/rancher/fleet/actions/runs/9731245163/job/26855427978), [GKE](https://github.com/rancher/fleet/actions/runs/9736989252/job/26868427918)) caused by nodes not being created by k3d on those clusters.
The root cause for these failures is the recent introduction of logic to override the API server URL and CA for strict TLS mode testing.