### PR TITLE
Deletes `Bundles` after deleting all its `BundleDeployments`

### DIFF
--- a/internal/cmd/controller/finalize/finalize.go
+++ b/internal/cmd/controller/finalize/finalize.go
@@ -50,14 +50,14 @@ func PurgeBundles(ctx context.Context, c client.Client, gitrepo types.Namespaced
 	}
 
 	for _, bundle := range bundles.Items {
-		err := c.Delete(ctx, &bundle)
-		if client.IgnoreNotFound(err) != nil {
-			return err
-		}
-
 		nn := types.NamespacedName{Namespace: bundle.Namespace, Name: bundle.Name}
 		if err = PurgeBundleDeployments(ctx, c, nn); err != nil {
 			return client.IgnoreNotFound(err)
+		}
+
+		err := c.Delete(ctx, &bundle)
+		if client.IgnoreNotFound(err) != nil {
+			return err
 		}
 	}
 


### PR DESCRIPTION
When testing https://github.com/rancher/fleet/issues/2586 the `Bundle` reconciler found that the `Bundle` was gone as was trying to delete the same `BundleDeployments` in parallel.

Deleting the `Bundle` after deleting all its `BundleDeployments` seems to help to prevent that race condition between both reconcilers

Refers to: https://github.com/rancher/fleet/issues/2586