### PR TITLE
Make gitops controller exit when losing leader lease

### DIFF
--- a/internal/cmd/controller/gitops/operator.go
+++ b/internal/cmd/controller/gitops/operator.go
@@ -119,12 +119,13 @@ func (g *GitOperator) Run(cmd *cobra.Command, args []string) error {
 		ShardID:   g.ShardID,
 	}
 
-	group := errgroup.Group{}
+	group, ctx := errgroup.WithContext(ctx)
 	group.Go(func() error {
 		return startWebhook(ctx, namespace, g.Listen, mgr.GetClient(), mgr.GetCache())
 	})
 	group.Go(func() error {
 		setupLog.Info("starting manager")
+
 		if err = reconciler.SetupWithManager(mgr); err != nil {
 			return err
 		}


### PR DESCRIPTION
<!-- Specify the issue ID that this pull request is solving -->
Refers to #2138 
<!-- Make sure that the referenced issue provides steps to reproduce it -->

<!-- Describe the changes introduced by this pull request -->

<!--
  Please provide a unit, integration (`./integrationtests/`) or e2e (`./e2e/`) test if possible.
-->

Going from

> A zero Group is valid, has no limit on the number of active goroutines, and does not cancel on error.

to

> WithContext returns a new Group and an associated Context derived from ctx.
> 
> The derived Context is canceled the first time a function passed to Go returns a non-nil error or the first time Wait returns, whichever occurs first.
> 