### PR TITLE
Gitopts reconciler just deletes the Bundle, not BundleDeployments

### DIFF
--- a/internal/cmd/controller/finalize/finalize.go
+++ b/internal/cmd/controller/finalize/finalize.go
@@ -50,11 +50,7 @@ func PurgeBundles(ctx context.Context, c client.Client, gitrepo types.Namespaced
 	}
 
 	for _, bundle := range bundles.Items {
-		nn := types.NamespacedName{Namespace: bundle.Namespace, Name: bundle.Name}
-		if err = PurgeBundleDeployments(ctx, c, nn); err != nil {
-			return client.IgnoreNotFound(err)
-		}
-
+		// Just delete the bundle and let the Bundle reconciler purge its BundleDeployments
 		err := c.Delete(ctx, &bundle)
 		if client.IgnoreNotFound(err) != nil {
 			return err


### PR DESCRIPTION
As we are using finalizers for Bundles we can let the Bundle reconciler deal with its BundleDeployments and just delete the Bundle in the gitops reconciler.

That way we avoid having race conditions between both reconcilers trying to delete the same BundleDeployments

Related to: https://github.com/rancher/fleet/issues/2586

