### PR TITLE
Remove kubeapiwarning message via crds

### DIFF
--- a/charts/fleet-crd/templates/crds.yaml
+++ b/charts/fleet-crd/templates/crds.yaml
@@ -1652,15 +1652,19 @@ spec:
                     properties:
                       content:
                         description: The content of the resource, can be compressed.
+                        nullable: true
                         type: string
                       encoding:
                         description: Encoding is either empty or "base64+gz".
+                        nullable: true
                         type: string
                       name:
                         description: Name of the resource, can include the bundle's
                           internal path.
+                        nullable: true
                         type: string
                     type: object
+                  nullable: true
                   type: array
                 rolloutStrategy:
                   description: 'RolloutStrategy controls the rollout of bundles, by
@@ -1730,6 +1734,7 @@ spec:
                           clusterGroupSelector:
                             description: Selector matching cluster group labels to
                               include in this partition
+                            nullable: true
                             properties:
                               matchExpressions:
                                 description: matchExpressions is a list of label selector
@@ -1865,6 +1870,7 @@ spec:
                           name:
                             description: A user-friendly name given to the partition
                               used for Display (optional).
+                            nullable: true
                             type: string
                         type: object
                       nullable: true
@@ -2743,6 +2749,7 @@ spec:
                                         nullable: true
                                         type: string
                                     type: object
+                                  nullable: true
                                   type: array
                                 name:
                                   description: Name is the name of the resource.
@@ -2793,8 +2800,10 @@ spec:
                                         nullable: true
                                         type: string
                                     type: object
+                                  nullable: true
                                   type: array
                               type: object
+                            nullable: true
                             type: array
                           notReady:
                             description: 'NotReady is the number of bundle deployments
@@ -2866,6 +2875,7 @@ spec:
                         nullable: true
                         type: string
                     type: object
+                  nullable: true
                   type: array
                 resourcesSha256Sum:
                   description: ResourcesSHA256Sum corresponds to the JSON serialization
@@ -2955,6 +2965,7 @@ spec:
                                   nullable: true
                                   type: string
                               type: object
+                            nullable: true
                             type: array
                           name:
                             description: Name is the name of the resource.
@@ -3004,8 +3015,10 @@ spec:
                                   nullable: true
                                   type: string
                               type: object
+                            nullable: true
                             type: array
                         type: object
+                      nullable: true
                       type: array
                     notReady:
                       description: 'NotReady is the number of bundle deployments that
@@ -3384,6 +3397,7 @@ spec:
                                   nullable: true
                                   type: string
                               type: object
+                            nullable: true
                             type: array
                           name:
                             description: Name is the name of the resource.
@@ -3433,8 +3447,10 @@ spec:
                                   nullable: true
                                   type: string
                               type: object
+                            nullable: true
                             type: array
                         type: object
+                      nullable: true
                       type: array
                     notReady:
                       description: 'NotReady is the number of bundle deployments that
@@ -5282,6 +5298,7 @@ spec:
                     required:
                       - name
                     type: object
+                  nullable: true
                   type: array
                 agentNamespace:
                   description: AgentNamespace defaults to the system namespace, e.g.
@@ -5414,6 +5431,7 @@ spec:
                           just a regular string.'
                         type: string
                     type: object
+                  nullable: true
                   type: array
                 clientID:
                   description: 'ClientID is a unique string that will identify the
@@ -5456,7 +5474,9 @@ spec:
                 templateValues:
                   description: TemplateValues defines a cluster specific mapping of
                     values to be sent to fleet.yaml values templating.
+                  nullable: true
                   type: object
+                  x-kubernetes-preserve-unknown-fields: true
               type: object
             status:
               properties:
@@ -5621,6 +5641,7 @@ spec:
                     state:
                       description: State of the cluster, either one of the bundle
                         states, or "WaitCheckIn".
+                      nullable: true
                       type: string
                   type: object
                 namespace:
@@ -5754,6 +5775,7 @@ spec:
                                   nullable: true
                                   type: string
                               type: object
+                            nullable: true
                             type: array
                           name:
                             description: Name is the name of the resource.
@@ -5803,8 +5825,10 @@ spec:
                                   nullable: true
                                   type: string
                               type: object
+                            nullable: true
                             type: array
                         type: object
+                      nullable: true
                       type: array
                     notReady:
                       description: 'NotReady is the number of bundle deployments that
@@ -6536,6 +6560,7 @@ spec:
                     properties:
                       apiVersion:
                         description: APIVersion is the API version of the resource.
+                        nullable: true
                         type: string
                       error:
                         description: Error is true if any Error in the PerClusterState
@@ -6544,6 +6569,7 @@ spec:
                       id:
                         description: ID is the name of the resource, e.g. "namespace1/my-config"
                           or "backingimagemanagers.storage.io".
+                        nullable: true
                         type: string
                       incompleteState:
                         description: 'IncompleteState is true if a bundle summary
@@ -6556,15 +6582,19 @@ spec:
                         type: boolean
                       kind:
                         description: Kind is the k8s kind of the resource.
+                        nullable: true
                         type: string
                       message:
                         description: Message is the first message from the PerClusterStates.
+                        nullable: true
                         type: string
                       name:
                         description: Name of the resource.
+                        nullable: true
                         type: string
                       namespace:
                         description: Namespace of the resource.
+                        nullable: true
                         type: string
                       perClusterState:
                         description: PerClusterState is a list of states for each
@@ -6575,6 +6605,7 @@ spec:
                           properties:
                             clusterId:
                               description: ClusterID is the id of the cluster.
+                              nullable: true
                               type: string
                             error:
                               description: Error is true if the resource is in an
@@ -6585,12 +6616,16 @@ spec:
                               description: Message combines the messages from the
                                 bundle's summary. Messages are joined with the delimiter
                                 ';'.
+                              nullable: true
                               type: string
                             patch:
                               description: Patch for modified resources.
+                              nullable: true
                               type: object
+                              x-kubernetes-preserve-unknown-fields: true
                             state:
                               description: State is the state of the resource.
+                              nullable: true
                               type: string
                             transitioning:
                               description: 'Transitioning is true if the resource
@@ -6599,6 +6634,7 @@ spec:
                                 copied from the bundle''s summary for non-ready resources.'
                               type: boolean
                           type: object
+                        nullable: true
                         type: array
                       state:
                         description: State is the state of the resource, e.g. "Unknown",
@@ -6696,6 +6732,7 @@ spec:
                                   nullable: true
                                   type: string
                               type: object
+                            nullable: true
                             type: array
                           name:
                             description: Name is the name of the resource.
@@ -6745,8 +6782,10 @@ spec:
                                   nullable: true
                                   type: string
                               type: object
+                            nullable: true
                             type: array
                         type: object
+                      nullable: true
                       type: array
                     notReady:
                       description: 'NotReady is the number of bundle deployments that

--- a/dev/update-agent-k3d
+++ b/dev/update-agent-k3d
@@ -12,7 +12,6 @@ export GOARCH="${GOARCH:-amd64}"
 export CGO_ENABLED=0
 
 # fleet agent
-go build -gcflags='all=-N -l' -o "bin/fleet-linux-$GOARCH" ./cmd/fleetcli
 go build -gcflags='all=-N -l' -o "bin/fleetagent-linux-$GOARCH" ./cmd/fleetagent
 docker build -f package/Dockerfile.agent -t rancher/fleet-agent:dev --build-arg="ARCH=$GOARCH" .
 

--- a/dev/update-controller-k3d
+++ b/dev/update-controller-k3d
@@ -13,6 +13,7 @@ export CGO_ENABLED=0
 
 # fleetcontroller
 go build -gcflags='all=-N -l' -o bin/fleetcontroller-linux-"$GOARCH" ./cmd/fleetcontroller
+go build -gcflags='all=-N -l' -o "bin/fleet-linux-$GOARCH" ./cmd/fleetcli
 docker build -f package/Dockerfile -t rancher/fleet:dev --build-arg="ARCH=$GOARCH"  .
 
 fleet_ctx=$(kubectl config current-context)

--- a/pkg/apis/fleet.cattle.io/v1alpha1/bundle_types.go
+++ b/pkg/apis/fleet.cattle.io/v1alpha1/bundle_types.go
@@ -98,6 +98,7 @@ type BundleSpec struct {
 
 	// Resources contains the resources that were read from the bundle's
 	// path. This includes the content of downloaded helm charts.
+	// +nullable
 	Resources []BundleResource `json:"resources,omitempty"`
 
 	// Targets refer to the clusters which will be deployed to.
@@ -128,10 +129,13 @@ type BundleRef struct {
 // BundleResource represents the content of a single resource from the bundle, like a YAML manifest.
 type BundleResource struct {
 	// Name of the resource, can include the bundle's internal path.
+	// +nullable
 	Name string `json:"name,omitempty"`
 	// The content of the resource, can be compressed.
+	// +nullable
 	Content string `json:"content,omitempty"`
 	// Encoding is either empty or "base64+gz".
+	// +nullable
 	Encoding string `json:"encoding,omitempty"`
 }
 
@@ -164,6 +168,7 @@ type RolloutStrategy struct {
 // Partition defines a separate rollout strategy for a set of clusters.
 type Partition struct {
 	// A user-friendly name given to the partition used for Display (optional).
+	// +nullable
 	Name string `json:"name,omitempty"`
 	// A number or percentage of clusters that can be unavailable in this
 	// partition before this partition is treated as done.
@@ -176,6 +181,7 @@ type Partition struct {
 	// A cluster group name to include in this partition
 	ClusterGroup string `json:"clusterGroup,omitempty"`
 	// Selector matching cluster group labels to include in this partition
+	// +nullable
 	ClusterGroupSelector *metav1.LabelSelector `json:"clusterGroupSelector,omitempty"`
 }
 
@@ -258,6 +264,7 @@ type BundleSummary struct {
 	DesiredReady int `json:"desiredReady"`
 	// NonReadyClusters is a list of states, which is filled for a bundle
 	// that is not ready.
+	// +nullable
 	NonReadyResources []NonReadyResource `json:"nonReadyResources,omitempty"`
 }
 
@@ -275,8 +282,10 @@ type NonReadyResource struct {
 	// +nullable
 	Message string `json:"message,omitempty"`
 	// ModifiedStatus lists the state for each modified resource.
+	// +nullable
 	ModifiedStatus []ModifiedStatus `json:"modifiedStatus,omitempty"`
 	// NonReadyStatus lists the state for each non-ready resource.
+	// +nullable
 	NonReadyStatus []NonReadyStatus `json:"nonReadyStatus,omitempty"`
 }
 
@@ -338,6 +347,7 @@ type BundleStatus struct {
 	// ResourceKey lists resources, which will likely be deployed. The
 	// actual list of resources on a cluster might differ, depending on the
 	// helm chart, value templating, etc..
+	// +nullable
 	ResourceKey []ResourceKey `json:"resourceKey,omitempty"`
 	// OCIReference is the OCI reference used to store contents, this is
 	// only for informational purposes.

--- a/pkg/apis/fleet.cattle.io/v1alpha1/cluster_types.go
+++ b/pkg/apis/fleet.cattle.io/v1alpha1/cluster_types.go
@@ -97,6 +97,7 @@ type ClusterSpec struct {
 	RedeployAgentGeneration int64 `json:"redeployAgentGeneration,omitempty"`
 
 	// AgentEnvVars are extra environment variables to be added to the agent deployment.
+	// +nullable
 	AgentEnvVars []corev1.EnvVar `json:"agentEnvVars,omitempty"`
 
 	// AgentNamespace defaults to the system namespace, e.g. cattle-fleet-system.
@@ -108,9 +109,12 @@ type ClusterSpec struct {
 	PrivateRepoURL string `json:"privateRepoURL,omitempty"`
 
 	// TemplateValues defines a cluster specific mapping of values to be sent to fleet.yaml values templating.
+	// +nullable
+	// +kubebuilder:validation:XPreserveUnknownFields
 	TemplateValues *GenericMap `json:"templateValues,omitempty"`
 
 	// AgentTolerations defines an extra set of Tolerations to be added to the Agent deployment.
+	// +nullable
 	AgentTolerations []corev1.Toleration `json:"agentTolerations,omitempty"`
 
 	// AgentAffinity overrides the default affinity for the cluster's agent
@@ -209,6 +213,7 @@ type ClusterDisplay struct {
 	// to be ready.
 	ReadyBundles string `json:"readyBundles,omitempty"`
 	// State of the cluster, either one of the bundle states, or "WaitCheckIn".
+	// +nullable
 	State string `json:"state,omitempty"`
 }
 

--- a/pkg/apis/fleet.cattle.io/v1alpha1/gitrepo_types.go
+++ b/pkg/apis/fleet.cattle.io/v1alpha1/gitrepo_types.go
@@ -240,16 +240,21 @@ type GitRepoDisplay struct {
 // GitRepoResource contains metadata about the resources of a bundle.
 type GitRepoResource struct {
 	// APIVersion is the API version of the resource.
+	// +nullable
 	APIVersion string `json:"apiVersion,omitempty"`
 	// Kind is the k8s kind of the resource.
+	// +nullable
 	Kind string `json:"kind,omitempty"`
 	// Type is the type of the resource, e.g. "apiextensions.k8s.io.customresourcedefinition" or "configmap".
 	Type string `json:"type,omitempty"`
 	// ID is the name of the resource, e.g. "namespace1/my-config" or "backingimagemanagers.storage.io".
+	// +nullable
 	ID string `json:"id,omitempty"`
 	// Namespace of the resource.
+	// +nullable
 	Namespace string `json:"namespace,omitempty"`
 	// Name of the resource.
+	// +nullable
 	Name string `json:"name,omitempty"`
 	// IncompleteState is true if a bundle summary has 10 or more non-ready
 	// resources or a non-ready resource has more 10 or more non-ready or
@@ -262,14 +267,17 @@ type GitRepoResource struct {
 	// Transitioning is true if any Transitioning in the PerClusterState is true.
 	Transitioning bool `json:"transitioning,omitempty"`
 	// Message is the first message from the PerClusterStates.
+	// +nullable
 	Message string `json:"message,omitempty"`
 	// PerClusterState is a list of states for each cluster. Derived from the summaries non-ready resources.
+	// +nullable
 	PerClusterState []ResourcePerClusterState `json:"perClusterState,omitempty"`
 }
 
 // ResourcePerClusterState is generated for each non-ready resource of the bundles.
 type ResourcePerClusterState struct {
 	// State is the state of the resource.
+	// +nullable
 	State string `json:"state,omitempty"`
 	// Error is true if the resource is in an error state, copied from the bundle's summary for non-ready resources.
 	Error bool `json:"error,omitempty"`
@@ -277,10 +285,14 @@ type ResourcePerClusterState struct {
 	// copied from the bundle's summary for non-ready resources.
 	Transitioning bool `json:"transitioning,omitempty"`
 	// Message combines the messages from the bundle's summary. Messages are joined with the delimiter ';'.
+	// +nullable
 	Message string `json:"message,omitempty"`
 	// Patch for modified resources.
+	// +nullable
+	// +kubebuilder:validation:XPreserveUnknownFields
 	Patch *GenericMap `json:"patch,omitempty"`
 	// ClusterID is the id of the cluster.
+	// +nullable
 	ClusterID string `json:"clusterId,omitempty"`
 }
 


### PR DESCRIPTION
Gitops controller was complaining about `KubeAPIWarningLogger	unknown field "status.resources[0].perClusterState[0].patch.data"`

Diff against 0.9.3 showed some missing markers in the generated CRD.