### PR TITLE
[v0.8] Add fossa folder to gitignore (#2599)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ e2e/testenv/infra/infra
 ^fleet$
 FleetCI-RootCA
 .envrc
+/fossa


### PR DESCRIPTION
to prevent GoReleaser from failing.