### PR TITLE
Provide release tag as custom tag to GoReleaser

### DIFF
--- a/.github/workflows/release-fleet.yml
+++ b/.github/workflows/release-fleet.yml
@@ -89,6 +89,7 @@ jobs:
           args: release --clean --verbose
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GORELEASER_CURRENT_TAG: ${{ github.ref_name }}
 
       - name: Upload charts to release
         env:


### PR DESCRIPTION
to work around the issue where it can not determine the correct tag in case of double tags (un-rcing).

Refers to https://goreleaser.com/cookbooks/set-a-custom-git-tag/