### PR TITLE
Fix extraEnv in gitjob controller template

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,15 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      -
+        name: Set up chart-testing
+        uses: helm/chart-testing-action@v2.3.1
+        with:
+          version: v3.3.0
+      -
+        name: Run chart-testing (lint)
+        run: ct lint --all --validate-maintainers=false charts/
       -
         uses: actions/setup-go@v5
         with:

--- a/charts/fleet-agent/.helmignore
+++ b/charts/fleet-agent/.helmignore
@@ -1,0 +1,2 @@
+.helmignore
+ci/

--- a/charts/fleet-agent/ci/default-values.yaml
+++ b/charts/fleet-agent/ci/default-values.yaml
@@ -1,0 +1,2 @@
+apiServerURL: "https://localhost"
+apiServerCA: "abc"

--- a/charts/fleet-agent/values.yaml
+++ b/charts/fleet-agent/values.yaml
@@ -19,8 +19,8 @@ agentTLSMode: "system-store"
 token: ""
 
 # Labels to add to the cluster upon registration only. They are not added after the fact.
-#labels:
-#  foo: bar
+# labels:
+#   foo: bar
 
 # The client ID of the cluster to associate with
 clientID: ""

--- a/charts/fleet/.helmignore
+++ b/charts/fleet/.helmignore
@@ -1,0 +1,2 @@
+.helmignore
+ci/

--- a/charts/fleet/ci/debug-values.yaml
+++ b/charts/fleet/ci/debug-values.yaml
@@ -1,0 +1,64 @@
+bootstrap:
+  enabled: true
+
+global:
+  cattle:
+    systemDefaultRegistry: "ghcr.io"
+
+nodeSelector:
+  kubernetes.io/os: os2
+
+tolerations:
+  - key: node.cloudprovider.kubernetes.io/uninitialized
+    operator: "Equal"
+    value: "true"
+    effect: NoSchedule
+
+priorityClassName: "prio1"
+
+gitops:
+  enabled: true
+
+metrics:
+  enabled: true
+
+debug: true
+debugLevel: 4
+propagateDebugSettingsToAgents: true
+
+cpuPprof:
+  period: "60s"
+  volumeConfiguration:
+    hostPath:
+      path: /tmp/pprof
+      type: DirectoryOrCreate
+
+migrations:
+  clusterRegistrationCleanup: true
+
+leaderElection:
+  leaseDuration: 30s
+  retryPeriod: 10s
+  renewDeadline: 25s
+
+controller:
+  reconciler:
+    workers:
+      gitrepo: "1"
+      bundle: "1"
+      bundledeployment: "1"
+
+extraEnv:
+  - name: EXPERIMENTAL_OCI_STORAGE
+    value: "true"
+
+shards:
+  - id: shard0
+    nodeSelector:
+      kubernetes.io/hostname: k3d-upstream-server-0
+  - id: shard1
+    nodeSelector:
+      kubernetes.io/hostname: k3d-upstream-server-1
+  - id: shard2
+    nodeSelector:
+      kubernetes.io/hostname: k3d-upstream-server-2

--- a/charts/fleet/ci/nobootstrap-values.yaml
+++ b/charts/fleet/ci/nobootstrap-values.yaml
@@ -1,0 +1,64 @@
+bootstrap:
+  enabled: false
+
+global:
+  cattle:
+    systemDefaultRegistry: "ghcr.io"
+
+nodeSelector:
+  kubernetes.io/os: mac
+
+tolerations:
+  - key: node.cloudprovider.kubernetes.io/uninitialized
+    operator: "Equal"
+    value: "true"
+    effect: NoSchedule
+
+priorityClassName: "prio1"
+
+gitops:
+  enabled: true
+
+metrics:
+  enabled: true
+
+debug: false
+debugLevel: 4
+propagateDebugSettingsToAgents: true
+
+cpuPprof:
+  period: "60s"
+  volumeConfiguration:
+    hostPath:
+      path: /tmp/pprof
+      type: DirectoryOrCreate
+
+migrations:
+  clusterRegistrationCleanup: true
+
+leaderElection:
+  leaseDuration: 30s
+  retryPeriod: 10s
+  renewDeadline: 25s
+
+controller:
+  reconciler:
+    workers:
+      gitrepo: "1"
+      bundle: "1"
+      bundledeployment: "1"
+
+extraEnv:
+  - name: EXPERIMENTAL_OCI_STORAGE
+    value: "true"
+
+shards:
+  - id: shard0
+    nodeSelector:
+      kubernetes.io/hostname: k3d-upstream-server-0
+  - id: shard1
+    nodeSelector:
+      kubernetes.io/hostname: k3d-upstream-server-1
+  - id: shard2
+    nodeSelector:
+      kubernetes.io/hostname: k3d-upstream-server-2

--- a/charts/fleet/ci/nodebug-values.yaml
+++ b/charts/fleet/ci/nodebug-values.yaml
@@ -1,0 +1,64 @@
+bootstrap:
+  enabled: true
+
+global:
+  cattle:
+    systemDefaultRegistry: "ghcr.io"
+
+nodeSelector:
+  kubernetes.io/os: plan9
+
+tolerations:
+  - key: node.cloudprovider.kubernetes.io/uninitialized
+    operator: "Equal"
+    value: "true"
+    effect: NoSchedule
+
+priorityClassName: "prio1"
+
+gitops:
+  enabled: true
+
+metrics:
+  enabled: true
+
+debug: false
+debugLevel: 4
+propagateDebugSettingsToAgents: true
+
+cpuPprof:
+  period: "60s"
+  volumeConfiguration:
+    hostPath:
+      path: /tmp/pprof
+      type: DirectoryOrCreate
+
+migrations:
+  clusterRegistrationCleanup: true
+
+leaderElection:
+  leaseDuration: 30s
+  retryPeriod: 10s
+  renewDeadline: 25s
+
+controller:
+  reconciler:
+    workers:
+      gitrepo: "1"
+      bundle: "1"
+      bundledeployment: "1"
+
+extraEnv:
+  - name: EXPERIMENTAL_OCI_STORAGE
+    value: "true"
+
+shards:
+  - id: shard0
+    nodeSelector:
+      kubernetes.io/hostname: k3d-upstream-server-0
+  - id: shard1
+    nodeSelector:
+      kubernetes.io/hostname: k3d-upstream-server-1
+  - id: shard2
+    nodeSelector:
+      kubernetes.io/hostname: k3d-upstream-server-2

--- a/charts/fleet/ci/nogitops-values.yaml
+++ b/charts/fleet/ci/nogitops-values.yaml
@@ -1,0 +1,64 @@
+bootstrap:
+  enabled: true
+
+global:
+  cattle:
+    systemDefaultRegistry: "ghcr.io"
+
+nodeSelector:
+  kubernetes.io/os: winxp
+
+tolerations:
+  - key: node.cloudprovider.kubernetes.io/uninitialized
+    operator: "Equal"
+    value: "true"
+    effect: NoSchedule
+
+priorityClassName: "prio1"
+
+gitops:
+  enabled: false
+
+metrics:
+  enabled: true
+
+debug: false
+debugLevel: 4
+propagateDebugSettingsToAgents: true
+
+cpuPprof:
+  period: "60s"
+  volumeConfiguration:
+    hostPath:
+      path: /tmp/pprof
+      type: DirectoryOrCreate
+
+migrations:
+  clusterRegistrationCleanup: true
+
+leaderElection:
+  leaseDuration: 30s
+  retryPeriod: 10s
+  renewDeadline: 25s
+
+controller:
+  reconciler:
+    workers:
+      gitrepo: "1"
+      bundle: "1"
+      bundledeployment: "1"
+
+extraEnv:
+  - name: EXPERIMENTAL_OCI_STORAGE
+    value: "true"
+
+shards:
+  - id: shard0
+    nodeSelector:
+      kubernetes.io/hostname: k3d-upstream-server-0
+  - id: shard1
+    nodeSelector:
+      kubernetes.io/hostname: k3d-upstream-server-1
+  - id: shard2
+    nodeSelector:
+      kubernetes.io/hostname: k3d-upstream-server-2

--- a/charts/fleet/templates/deployment_gitjob.yaml
+++ b/charts/fleet/templates/deployment_gitjob.yaml
@@ -83,6 +83,9 @@ spec:
             - name: GITREPO_RECONCILER_WORKERS
               value: {{ quote $.Values.controller.reconciler.workers.gitrepo }}
           {{- end }}
+{{- if $.Values.extraEnv }}
+{{ toYaml $.Values.extraEnv | indent 12}}
+{{- end }}
           {{- if $.Values.debug }}
             - name: CATTLE_DEV_MODE
               value: "true"
@@ -95,9 +98,6 @@ spec:
                 drop:
                 - ALL
           {{- end }}
-{{- if $.Values.extraEnv }}
-{{ toYaml $.Values.extraEnv | indent 12}}
-{{- end }}
       nodeSelector: {{ include "linux-node-selector" $shard.id | nindent 8 }}
 {{- if $.Values.nodeSelector }}
 {{ toYaml $.Values.nodeSelector | indent 8 }}

--- a/charts/fleet/values.yaml
+++ b/charts/fleet/values.yaml
@@ -78,12 +78,12 @@ propagateDebugSettingsToAgents: true
 
 ## Optional CPU pprof configuration. Profiles are collected continuously and saved every period
 ## Any valid volume configuration can be provided, the example below uses hostPath
-#cpuPprof:
-#  period: "60s"
-#  volumeConfiguration:
-#    hostPath:
-#      path: /tmp/pprof
-#      type: DirectoryOrCreate
+# cpuPprof:
+#   period: "60s"
+#   volumeConfiguration:
+#     hostPath:
+#       path: /tmp/pprof
+#       type: DirectoryOrCreate
 
 migrations:
   clusterRegistrationCleanup: true


### PR DESCRIPTION
Setting debug to false would put the additional env vars outside the env block.

```
% helm template --set 'extraEnv[0].name="foo"' --set 'extraEnv[0].value="bar"' fleet charts/fleet
Error: YAML parse error on fleet/templates/deployment_gitjob.yaml: error converting YAML to JSON: yaml: line 47: did not find expected key

Use --debug flag to render out invalid YAML
```