### PR TITLE
Changes post render error when using targetNamespace or namespace

### DIFF
--- a/internal/helmdeployer/postrender.go
+++ b/internal/helmdeployer/postrender.go
@@ -99,7 +99,7 @@ func (p *postRender) Run(renderedManifests *bytes.Buffer) (modifiedManifests *by
 				}
 				if mapping.Scope.Name() == meta.RESTScopeNameRoot {
 					apiVersion, kind := gvk.ToAPIVersionAndKind()
-					return nil, fmt.Errorf("invalid cluster scoped object [name=%s kind=%v apiVersion=%s] found, consider using \"defaultNamespace\", not \"namespace\" in fleet.yaml", m.GetName(),
+					return nil, fmt.Errorf("invalid cluster scoped object [name=%s kind=%v apiVersion=%s] found. Your config uses targetNamespace or namespace and thus forbids cluster scoped resources. If you do not intend to disallow cluster scoped resources, you could switch to defaultNamespace", m.GetName(),
 						kind, apiVersion)
 				}
 			}

--- a/internal/helmdeployer/postrender.go
+++ b/internal/helmdeployer/postrender.go
@@ -99,7 +99,10 @@ func (p *postRender) Run(renderedManifests *bytes.Buffer) (modifiedManifests *by
 				}
 				if mapping.Scope.Name() == meta.RESTScopeNameRoot {
 					apiVersion, kind := gvk.ToAPIVersionAndKind()
-					return nil, fmt.Errorf("invalid cluster scoped object [name=%s kind=%v apiVersion=%s] found. Your config uses targetNamespace or namespace and thus forbids cluster scoped resources. If you do not intend to disallow cluster scoped resources, you could switch to defaultNamespace", m.GetName(),
+					return nil, fmt.Errorf("invalid cluster scoped object [name=%s kind=%v apiVersion=%s] found. "+
+						"Your config uses targetNamespace or namespace and thus forbids cluster-scoped resources. "+
+						"If you do not intend to disallow cluster scoped resources, you could switch to defaultNamespace",
+						m.GetName(),
 						kind, apiVersion)
 				}
 			}


### PR DESCRIPTION
Changes the error message when `targetNamespace` or `namespace` is specified and there are cluster wide resources to be deployed. 

I've tested also with `rancher` so we can see how it looks like in the UI (pretty large, but hopefully more explanatory) 

<img width="1476" alt="Screenshot 2024-07-22 at 17 39 05" src="https://github.com/user-attachments/assets/5c9fc2ad-4f7a-4a39-932a-9ec5a1be8dad">


Refers to: https://github.com/rancher/fleet/issues/2484