### PR TITLE
Simplify target customisations for namespace labels and annotations

### DIFF
--- a/e2e/assets/single-cluster/namespaceLabels_targetCustomization.yaml
+++ b/e2e/assets/single-cluster/namespaceLabels_targetCustomization.yaml
@@ -4,7 +4,7 @@ metadata:
   name: test
   namespace: fleet-local
 spec:
-  repo: https://github.com/Tommy12789/fleet-examples-tommy
-  branch: test
+  repo: https://github.com/rancher/fleet-test-data
+  branch: master
   paths:
-    - namespaceLabels_targetCustomization
+    - target-customization-namespace-labels

--- a/internal/cmd/agent/deployer/deployer.go
+++ b/internal/cmd/agent/deployer/deployer.go
@@ -176,13 +176,13 @@ func (d *Deployer) setNamespaceLabelsAndAnnotations(ctx context.Context, bd *fle
 	}
 
 	if bd.Spec.Options.NamespaceLabels != nil {
-		addLabelsFromOptions(ns.Labels, *bd.Spec.Options.NamespaceLabels)
+		addLabelsFromOptions(ns.Labels, bd.Spec.Options.NamespaceLabels)
 	}
 	if bd.Spec.Options.NamespaceAnnotations != nil {
 		if ns.Annotations == nil {
 			ns.Annotations = map[string]string{}
 		}
-		addAnnotationsFromOptions(ns.Annotations, *bd.Spec.Options.NamespaceAnnotations)
+		addAnnotationsFromOptions(ns.Annotations, bd.Spec.Options.NamespaceAnnotations)
 	}
 	err = d.updateNamespace(ctx, ns)
 	if err != nil {

--- a/internal/cmd/agent/deployer/deployer_test.go
+++ b/internal/cmd/agent/deployer/deployer_test.go
@@ -23,11 +23,34 @@ func TestSetNamespaceLabelsAndAnnotations(t *testing.T) {
 		release    string
 		expectedNs corev1.Namespace
 	}{
+		"Empty sets of NamespaceLabels and NamespaceAnnotations are supported": {
+			bd: &fleet.BundleDeployment{Spec: fleet.BundleDeploymentSpec{
+				Options: fleet.BundleDeploymentOptions{
+					NamespaceLabels:      nil, // equivalent to map[string]string{}
+					NamespaceAnnotations: nil,
+				},
+			}},
+			ns: corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "namespace",
+					Labels: map[string]string{"kubernetes.io/metadata.name": "namespace"},
+				},
+			},
+			release: "namespace/foo/bar",
+			expectedNs: corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "namespace",
+					Labels:      map[string]string{"kubernetes.io/metadata.name": "namespace"},
+					Annotations: nil,
+				},
+			},
+		},
+
 		"NamespaceLabels and NamespaceAnnotations are appended": {
 			bd: &fleet.BundleDeployment{Spec: fleet.BundleDeploymentSpec{
 				Options: fleet.BundleDeploymentOptions{
-					NamespaceLabels:      &map[string]string{"optLabel1": "optValue1", "optLabel2": "optValue2"},
-					NamespaceAnnotations: &map[string]string{"optAnn1": "optValue1"},
+					NamespaceLabels:      map[string]string{"optLabel1": "optValue1", "optLabel2": "optValue2"},
+					NamespaceAnnotations: map[string]string{"optAnn1": "optValue1"},
 				},
 			}},
 			ns: corev1.Namespace{
@@ -49,8 +72,8 @@ func TestSetNamespaceLabelsAndAnnotations(t *testing.T) {
 		"NamespaceLabels and NamespaceAnnotations removes entries that are not in the options, except the name label": {
 			bd: &fleet.BundleDeployment{Spec: fleet.BundleDeploymentSpec{
 				Options: fleet.BundleDeploymentOptions{
-					NamespaceLabels:      &map[string]string{"optLabel": "optValue"},
-					NamespaceAnnotations: &map[string]string{},
+					NamespaceLabels:      map[string]string{"optLabel": "optValue"},
+					NamespaceAnnotations: map[string]string{},
 				},
 			}},
 			ns: corev1.Namespace{
@@ -73,8 +96,8 @@ func TestSetNamespaceLabelsAndAnnotations(t *testing.T) {
 		"NamespaceLabels and NamespaceAnnotations updates existing values": {
 			bd: &fleet.BundleDeployment{Spec: fleet.BundleDeploymentSpec{
 				Options: fleet.BundleDeploymentOptions{
-					NamespaceLabels:      &map[string]string{"bdLabel": "labelUpdated"},
-					NamespaceAnnotations: &map[string]string{"bdAnn": "annUpdated"},
+					NamespaceLabels:      map[string]string{"bdLabel": "labelUpdated"},
+					NamespaceAnnotations: map[string]string{"bdAnn": "annUpdated"},
 				},
 			}},
 			ns: corev1.Namespace{
@@ -130,8 +153,8 @@ func TestSetNamespaceLabelsAndAnnotations(t *testing.T) {
 func TestSetNamespaceLabelsAndAnnotationsError(t *testing.T) {
 	bd := &fleet.BundleDeployment{Spec: fleet.BundleDeploymentSpec{
 		Options: fleet.BundleDeploymentOptions{
-			NamespaceLabels:      &map[string]string{"optLabel1": "optValue1", "optLabel2": "optValue2"},
-			NamespaceAnnotations: &map[string]string{"optAnn1": "optValue1"},
+			NamespaceLabels:      map[string]string{"optLabel1": "optValue1", "optLabel2": "optValue2"},
+			NamespaceAnnotations: map[string]string{"optAnn1": "optValue1"},
 		},
 	}}
 	release := "test/foo/bar"

--- a/internal/cmd/controller/target/target.go
+++ b/internal/cmd/controller/target/target.go
@@ -60,18 +60,14 @@ func (t *Target) BundleDeployment() *fleet.BundleDeployment {
 	bd.Spec.Paused = t.IsPaused()
 
 	for _, bundleTarget := range t.Bundle.Spec.Targets {
-		if bundleTarget.NamespaceLabels != nil {
-			for key, value := range *bundleTarget.NamespaceLabels {
-				(*bd.Spec.Options.NamespaceLabels)[key] = value
-				(*bd.Spec.StagedOptions.NamespaceLabels)[key] = value
-			}
+		for key, value := range bundleTarget.NamespaceLabels {
+			(*bd.Spec.Options.NamespaceLabels)[key] = value
+			(*bd.Spec.StagedOptions.NamespaceLabels)[key] = value
 		}
 
-		if bundleTarget.NamespaceAnnotations != nil {
-			for key, value := range *bundleTarget.NamespaceAnnotations {
-				(*bd.Spec.Options.NamespaceAnnotations)[key] = value
-				(*bd.Spec.StagedOptions.NamespaceAnnotations)[key] = value
-			}
+		for key, value := range bundleTarget.NamespaceAnnotations {
+			(*bd.Spec.Options.NamespaceAnnotations)[key] = value
+			(*bd.Spec.StagedOptions.NamespaceAnnotations)[key] = value
 		}
 	}
 

--- a/internal/cmd/controller/target/target.go
+++ b/internal/cmd/controller/target/target.go
@@ -61,13 +61,13 @@ func (t *Target) BundleDeployment() *fleet.BundleDeployment {
 
 	for _, bundleTarget := range t.Bundle.Spec.Targets {
 		for key, value := range bundleTarget.NamespaceLabels {
-			(*bd.Spec.Options.NamespaceLabels)[key] = value
-			(*bd.Spec.StagedOptions.NamespaceLabels)[key] = value
+			bd.Spec.Options.NamespaceLabels[key] = value
+			bd.Spec.StagedOptions.NamespaceLabels[key] = value
 		}
 
 		for key, value := range bundleTarget.NamespaceAnnotations {
-			(*bd.Spec.Options.NamespaceAnnotations)[key] = value
-			(*bd.Spec.StagedOptions.NamespaceAnnotations)[key] = value
+			bd.Spec.Options.NamespaceAnnotations[key] = value
+			bd.Spec.StagedOptions.NamespaceAnnotations[key] = value
 		}
 	}
 

--- a/internal/cmd/controller/target/target.go
+++ b/internal/cmd/controller/target/target.go
@@ -58,6 +58,7 @@ func (t *Target) BundleDeployment() *fleet.BundleDeployment {
 		Spec: t.Deployment.Spec,
 	}
 	bd.Spec.Paused = t.IsPaused()
+
 	for _, bundleTarget := range t.Bundle.Spec.Targets {
 		if bundleTarget.NamespaceLabels != nil {
 			for key, value := range *bundleTarget.NamespaceLabels {
@@ -65,15 +66,15 @@ func (t *Target) BundleDeployment() *fleet.BundleDeployment {
 				(*bd.Spec.StagedOptions.NamespaceLabels)[key] = value
 			}
 		}
-	}
-	for _, bundleTargets := range t.Bundle.Spec.Targets {
-		if bundleTargets.NamespaceAnnotations != nil {
-			for key, value := range *bundleTargets.NamespaceAnnotations {
+
+		if bundleTarget.NamespaceAnnotations != nil {
+			for key, value := range *bundleTarget.NamespaceAnnotations {
 				(*bd.Spec.Options.NamespaceAnnotations)[key] = value
 				(*bd.Spec.StagedOptions.NamespaceAnnotations)[key] = value
 			}
 		}
 	}
+
 	bd.Spec.DependsOn = t.Bundle.Spec.DependsOn
 	bd.Spec.CorrectDrift = t.Options.CorrectDrift
 	return bd

--- a/pkg/apis/fleet.cattle.io/v1alpha1/bundle_types.go
+++ b/pkg/apis/fleet.cattle.io/v1alpha1/bundle_types.go
@@ -229,10 +229,10 @@ type BundleTarget struct {
 	DoNotDeploy bool `json:"doNotDeploy,omitempty"`
 	// NamespaceLabels are labels that will be appended to the namespace created by Fleet.
 	// +nullable
-	NamespaceLabels *map[string]string `json:"namespaceLabels,omitempty"`
+	NamespaceLabels map[string]string `json:"namespaceLabels,omitempty"`
 	// NamespaceAnnotations are annotations that will be appended to the namespace created by Fleet.
 	// +nullable
-	NamespaceAnnotations *map[string]string `json:"namespaceAnnotations,omitempty"`
+	NamespaceAnnotations map[string]string `json:"namespaceAnnotations,omitempty"`
 }
 
 // BundleSummary contains the number of bundle deployments in each state and a

--- a/pkg/apis/fleet.cattle.io/v1alpha1/bundledeployment_types.go
+++ b/pkg/apis/fleet.cattle.io/v1alpha1/bundledeployment_types.go
@@ -103,11 +103,11 @@ type BundleDeploymentOptions struct {
 
 	// NamespaceLabels are labels that will be appended to the namespace created by Fleet.
 	// +nullable
-	NamespaceLabels *map[string]string `json:"namespaceLabels,omitempty"`
+	NamespaceLabels map[string]string `json:"namespaceLabels,omitempty"`
 
 	// NamespaceAnnotations are annotations that will be appended to the namespace created by Fleet.
 	// +nullable
-	NamespaceAnnotations *map[string]string `json:"namespaceAnnotations,omitempty"`
+	NamespaceAnnotations map[string]string `json:"namespaceAnnotations,omitempty"`
 
 	// DeleteCRDResources deletes CRDs. Warning! this will also delete all your Custom Resources.
 	DeleteCRDResources bool `json:"deleteCRDResources,omitempty"`

--- a/pkg/apis/fleet.cattle.io/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/fleet.cattle.io/v1alpha1/zz_generated.deepcopy.go
@@ -581,24 +581,16 @@ func (in *BundleTarget) DeepCopyInto(out *BundleTarget) {
 	}
 	if in.NamespaceLabels != nil {
 		in, out := &in.NamespaceLabels, &out.NamespaceLabels
-		*out = new(map[string]string)
-		if **in != nil {
-			in, out := *in, *out
-			*out = make(map[string]string, len(*in))
-			for key, val := range *in {
-				(*out)[key] = val
-			}
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
 		}
 	}
 	if in.NamespaceAnnotations != nil {
 		in, out := &in.NamespaceAnnotations, &out.NamespaceAnnotations
-		*out = new(map[string]string)
-		if **in != nil {
-			in, out := *in, *out
-			*out = make(map[string]string, len(*in))
-			for key, val := range *in {
-				(*out)[key] = val
-			}
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
 		}
 	}
 }

--- a/pkg/apis/fleet.cattle.io/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/fleet.cattle.io/v1alpha1/zz_generated.deepcopy.go
@@ -191,24 +191,16 @@ func (in *BundleDeploymentOptions) DeepCopyInto(out *BundleDeploymentOptions) {
 	}
 	if in.NamespaceLabels != nil {
 		in, out := &in.NamespaceLabels, &out.NamespaceLabels
-		*out = new(map[string]string)
-		if **in != nil {
-			in, out := *in, *out
-			*out = make(map[string]string, len(*in))
-			for key, val := range *in {
-				(*out)[key] = val
-			}
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
 		}
 	}
 	if in.NamespaceAnnotations != nil {
 		in, out := &in.NamespaceAnnotations, &out.NamespaceAnnotations
-		*out = new(map[string]string)
-		if **in != nil {
-			in, out := *in, *out
-			*out = make(map[string]string, len(*in))
-			for key, val := range *in {
-				(*out)[key] = val
-			}
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
 		}
 	}
 }


### PR DESCRIPTION
Follow-up to #2583.
Refers to #2262 and #2441.

This simplifies end-to-end tests and the implementation for using namespace labels and annotations as target customisations.

In bundle deployment options, maps are used directly instead of pointers to maps for namespace labels and namespace annotations.
Manual tests suggest that Kubernetes represents bundles deployments with identical YAML in both cases, ie whether pointers to maps or simple maps are used to represent those fields.
