### PR TITLE
BundleDeployment status error message improvement 

### DIFF
--- a/charts/fleet-crd/templates/crds.yaml
+++ b/charts/fleet-crd/templates/crds.yaml
@@ -908,6 +908,12 @@ spec:
                         type: string
                       delete:
                         type: boolean
+                      exist:
+                        description: Exist is true if the resource exists but is not
+                          owned by us. This can happen if a resource was adopted by
+                          another bundle whereas the first bundle still exists and
+                          due to that reports that it does not own it.
+                        type: boolean
                       kind:
                         nullable: true
                         type: string
@@ -2735,6 +2741,14 @@ spec:
                                         type: string
                                       delete:
                                         type: boolean
+                                      exist:
+                                        description: Exist is true if the resource
+                                          exists but is not owned by us. This can
+                                          happen if a resource was adopted by another
+                                          bundle whereas the first bundle still exists
+                                          and due to that reports that it does not
+                                          own it.
+                                        type: boolean
                                       kind:
                                         nullable: true
                                         type: string
@@ -2950,6 +2964,13 @@ spec:
                                   nullable: true
                                   type: string
                                 delete:
+                                  type: boolean
+                                exist:
+                                  description: Exist is true if the resource exists
+                                    but is not owned by us. This can happen if a resource
+                                    was adopted by another bundle whereas the first
+                                    bundle still exists and due to that reports that
+                                    it does not own it.
                                   type: boolean
                                 kind:
                                   nullable: true
@@ -3382,6 +3403,13 @@ spec:
                                   nullable: true
                                   type: string
                                 delete:
+                                  type: boolean
+                                exist:
+                                  description: Exist is true if the resource exists
+                                    but is not owned by us. This can happen if a resource
+                                    was adopted by another bundle whereas the first
+                                    bundle still exists and due to that reports that
+                                    it does not own it.
                                   type: boolean
                                 kind:
                                   nullable: true
@@ -5777,6 +5805,13 @@ spec:
                                   type: string
                                 delete:
                                   type: boolean
+                                exist:
+                                  description: Exist is true if the resource exists
+                                    but is not owned by us. This can happen if a resource
+                                    was adopted by another bundle whereas the first
+                                    bundle still exists and due to that reports that
+                                    it does not own it.
+                                  type: boolean
                                 kind:
                                   nullable: true
                                   type: string
@@ -6738,6 +6773,13 @@ spec:
                                   nullable: true
                                   type: string
                                 delete:
+                                  type: boolean
+                                exist:
+                                  description: Exist is true if the resource exists
+                                    but is not owned by us. This can happen if a resource
+                                    was adopted by another bundle whereas the first
+                                    bundle still exists and due to that reports that
+                                    it does not own it.
                                   type: boolean
                                 kind:
                                   nullable: true

--- a/integrationtests/agent/adoption_test.go
+++ b/integrationtests/agent/adoption_test.go
@@ -1,0 +1,387 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
+)
+
+func init() {
+	resources["BundleDeploymentConfigMap"] = []v1alpha1.BundleResource{
+		{
+			Name: "configmap.yaml",
+			Content: `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cm1
+data:
+  key: value
+`,
+			Encoding: "",
+		},
+	}
+}
+
+var _ = Describe("Adoption", Label("adopt"), func() {
+	var (
+		namespace string
+		env       *specEnv
+	)
+
+	createBundleDeployment := func(name string, takeOwnership bool) {
+		bundled := v1alpha1.BundleDeployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: clusterNS,
+			},
+			Spec: v1alpha1.BundleDeploymentSpec{
+				DeploymentID: "BundleDeploymentConfigMap",
+				Options: v1alpha1.BundleDeploymentOptions{
+					DefaultNamespace: namespace,
+					Helm: &v1alpha1.HelmOptions{
+						TakeOwnership: takeOwnership,
+					},
+				},
+			},
+		}
+
+		err := k8sClient.Create(context.TODO(), &bundled)
+		Expect(err).To(BeNil())
+		Expect(bundled).To(Not(BeNil()))
+		Expect(bundled.Spec.DeploymentID).ToNot(Equal(bundled.Status.AppliedDeploymentID))
+		Expect(bundled.Status.Ready).To(BeFalse())
+		Eventually(func() bool {
+			err := k8sClient.Get(context.TODO(), types.NamespacedName{Namespace: clusterNS, Name: name}, &bundled)
+			if err != nil {
+				return false
+			}
+			return bundled.Status.Ready
+		}).Should(BeTrue(), "BundleDeployment not ready: status: %+v", bundled.Status)
+		Expect(bundled.Spec.DeploymentID).To(Equal(bundled.Status.AppliedDeploymentID))
+	}
+
+	waitForConfigMap := func(name string) {
+		Eventually(func() error {
+			_, err := env.getConfigMap(name)
+			return err
+		}).Should(Succeed())
+	}
+
+	createConfigMap := func(data, labels, annotations map[string]string) *corev1.ConfigMap {
+		cm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "cm1",
+				Namespace:   namespace,
+				Labels:      labels,
+				Annotations: annotations,
+			},
+			Data: data,
+		}
+		Expect(k8sClient.Create(ctx, cm)).To(Succeed())
+		waitForConfigMap("cm1")
+		return cm
+	}
+
+	// assertConfigMap checks that the ConfigMap exists and that it passes the
+	// provided validate function.
+	assertConfigMap := func(validate func(corev1.ConfigMap) error) {
+		cm := corev1.ConfigMap{}
+		var err error
+		Eventually(func() error {
+			err = k8sClient.Get(
+				ctx,
+				types.NamespacedName{Namespace: namespace, Name: "cm1"},
+				&cm,
+			)
+			if err != nil {
+				return err
+			}
+			return validate(cm)
+		}).Should(Succeed(), "assertConfigMap error: %v in %+v", err, cm)
+	}
+
+	// assertBundleDeployment checks that the BundleDeployment exists and that it
+	// passes the provided validate function.
+	assertBundleDeployment := func(name string, validate func(*v1alpha1.BundleDeployment) error) {
+		bd := v1alpha1.BundleDeployment{}
+		var err error
+		Eventually(func() error {
+			err = k8sClient.Get(
+				ctx,
+				types.NamespacedName{Namespace: clusterNS, Name: name},
+				&bd,
+			)
+			if err != nil {
+				return err
+			}
+			return validate(&bd)
+		}).Should(Succeed(), "assertBundleDeployment: error %v in %+v", err, bd)
+	}
+
+	// mapPartialMatch checks that the super map contains all the keys and values
+	// of the sub map. If the value in the sub map is an empty string, the key
+	// must exist in the super map but the value is not compared.
+	mapPartialMatch := func(super, sub map[string]string) error {
+		for k, v := range sub {
+			if v == "" {
+				if _, ok := super[k]; !ok {
+					return fmt.Errorf("key %s not found in %+v", k, super)
+				}
+			} else {
+				if v2, ok := super[k]; !ok || v2 != v {
+					return fmt.Errorf("key %s not found or value %s does not match %s in %+v", k, v2, v, super)
+				}
+			}
+		}
+		return nil
+	}
+
+	// configMapAdoptedAndMerged checks that the ConfigMap is adopted. It may
+	// need to be extended to check for more labels and annotations.
+	isConfigMapAdopted := func(cm *corev1.ConfigMap) error {
+		err := mapPartialMatch(cm.Labels, map[string]string{
+			"app.kubernetes.io/managed-by": "Helm",
+		})
+		if err != nil {
+			return err
+		}
+		err = mapPartialMatch(cm.Annotations, map[string]string{
+			"meta.helm.sh/release-name":      "",
+			"meta.helm.sh/release-namespace": "",
+		})
+		if err != nil {
+			return err
+		}
+		return nil
+	}
+
+	changeConfigMap := func(name string, change func(*corev1.ConfigMap)) {
+		cm := &corev1.ConfigMap{}
+		Eventually(func() error {
+			return k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, cm)
+		}).Should(Succeed())
+		change(cm)
+		Eventually(func() error {
+			return k8sClient.Update(ctx, cm)
+		}).Should(Succeed())
+	}
+
+	deleteConfigMap := func(name string) {
+		cm := &corev1.ConfigMap{}
+		Eventually(func() error {
+			return k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, cm)
+		}).Should(Succeed())
+		Eventually(func() error {
+			return k8sClient.Delete(ctx, cm)
+		}).Should(Succeed())
+	}
+
+	bundleDeploymentResourceMissing := func(bd *v1alpha1.BundleDeployment) error {
+		const msgPrefix = "BundleDeployment resource:"
+		for _, condition := range bd.Status.Conditions {
+			if condition.Type != v1alpha1.BundleDeploymentConditionReady {
+				continue
+			}
+			if condition.Status != corev1.ConditionFalse {
+				return fmt.Errorf("%s Status is not False", msgPrefix)
+			}
+			if condition.Reason != "Error" {
+				return fmt.Errorf("%s Reason is not Error", msgPrefix)
+			}
+			if !strings.Contains(condition.Message, "missing") {
+				return fmt.Errorf("%s Message does not contain 'missing'", msgPrefix)
+			}
+		}
+		return nil
+	}
+
+	bundleDeploymentNotOwnedByUs := func(bd *v1alpha1.BundleDeployment) error {
+		for _, condition := range bd.Status.Conditions {
+			if condition.Type == v1alpha1.BundleDeploymentConditionReady &&
+				condition.Status == corev1.ConditionFalse &&
+				condition.Reason == "Error" &&
+				strings.Contains(condition.Message, "not owned by us") {
+				return nil
+			}
+		}
+		return fmt.Errorf("does not match expected condition")
+	}
+
+	bundleDeploymentReady := func(bd *v1alpha1.BundleDeployment) error {
+		for _, condition := range bd.Status.Conditions {
+			if condition.Type == v1alpha1.BundleDeploymentConditionReady &&
+				condition.Status == corev1.ConditionTrue {
+				return nil
+			}
+		}
+		return fmt.Errorf("does not match expected condition")
+	}
+
+	BeforeEach(func() {
+		namespace = createNamespace()
+		DeferCleanup(func() {
+			Expect(k8sClient.Delete(ctx, &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{Name: namespace}})).ToNot(HaveOccurred())
+		})
+		env = &specEnv{namespace: namespace}
+	})
+
+	When("a resource of a bundle deployment is removed", Label("remove-resource"), func() {
+		It("should report the deleted resource as missing", func() {
+			createBundleDeployment("remove-resource", false)
+			assertConfigMap(func(cm corev1.ConfigMap) error {
+				var err error
+				err = mapPartialMatch(cm.Data, map[string]string{"key": "value"})
+				if err != nil {
+					return err
+				}
+				err = mapPartialMatch(cm.Annotations, map[string]string{
+					"meta.helm.sh/release-name":      "remove-resource",
+					"meta.helm.sh/release-namespace": "",
+					"objectset.rio.cattle.io/id":     "default-remove-resource",
+				})
+				if err != nil {
+					return err
+				}
+				err = mapPartialMatch(cm.Labels, map[string]string{
+					"app.kubernetes.io/managed-by": "Helm",
+					"objectset.rio.cattle.io/hash": "ca7682543199bb801d0c14587a1158d936508160",
+				})
+				if err != nil {
+					return err
+				}
+				return nil
+			})
+			// This is required for the resource to be watched.
+			time.Sleep(5 * time.Second)
+			deleteConfigMap("cm1")
+			assertBundleDeployment("remove-resource", bundleDeploymentResourceMissing)
+		})
+	})
+
+	When("all labels of a resource of a bundle deployment are removed", Label("remove-labels"), func() {
+		It("should report that resource as \"not owned by us\"", func() {
+			createBundleDeployment("remove-metadata", false)
+			assertConfigMap(func(cm corev1.ConfigMap) error {
+				if err := mapPartialMatch(cm.Data, map[string]string{"key": "value"}); err != nil {
+					return err
+				}
+				if err := mapPartialMatch(cm.Annotations, map[string]string{
+					"meta.helm.sh/release-name":      "remove-metadata",
+					"meta.helm.sh/release-namespace": "",
+					"objectset.rio.cattle.io/id":     "default-remove-metadata",
+				}); err != nil {
+					return err
+				}
+
+				return mapPartialMatch(cm.Labels, map[string]string{
+					"app.kubernetes.io/managed-by": "Helm",
+					"objectset.rio.cattle.io/hash": "0f3e1d9d146fa8b290c0de403881184751430e59",
+				})
+			})
+			changeConfigMap("cm1", func(cm *corev1.ConfigMap) {
+				cm.Labels = map[string]string{}
+			})
+			assertBundleDeployment("remove-metadata", bundleDeploymentNotOwnedByUs)
+		})
+	})
+
+	When("a bundle deployment adopts a \"clean\" resource", Label("clean"), func() {
+		It("verifies that the ConfigMap is adopted and its content merged", func() {
+			createConfigMap(map[string]string{"foo": "bar"}, nil, nil)
+			createBundleDeployment("adopt-clean", true)
+			assertConfigMap(func(cm corev1.ConfigMap) error {
+				if err := isConfigMapAdopted(&cm); err != nil {
+					return err
+				}
+				return mapPartialMatch(cm.Data, map[string]string{"foo": "bar", "key": "value"})
+			})
+		})
+	})
+
+	When("a bundle deployment adopts a resource with wrangler metadata", Label("wrangler-metadata"), func() {
+		It("verifies that the ConfigMap is adopted, its content merged and ownership changed", func() {
+			const (
+				objectSetHashKey   = "objectset.rio.cattle.io/hash"
+				objectSetIDKey     = "objectset.rio.cattle.io/id"
+				objectSetHashValue = "33ed67317c57ea78702e369c4c025f8df88553cc"
+				objectSetIDValue   = "some-assumed-old-id"
+			)
+			createConfigMap(
+				map[string]string{"foo": "bar"},
+				map[string]string{objectSetHashKey: objectSetHashValue},
+				map[string]string{objectSetIDKey: objectSetIDValue},
+			)
+			createBundleDeployment("adopt-wrangler-metadata", true)
+			assertConfigMap(func(cm corev1.ConfigMap) error {
+				if err := isConfigMapAdopted(&cm); err != nil {
+					return err
+				}
+				if err := mapPartialMatch(cm.Data, map[string]string{"foo": "bar", "key": "value"}); err != nil {
+					return err
+				}
+				if mapPartialMatch(cm.Annotations, map[string]string{objectSetIDKey: objectSetIDValue}) == nil {
+					return fmt.Errorf("ObjectSet ID should have been updated")
+				}
+				if mapPartialMatch(cm.Labels, map[string]string{objectSetHashKey: objectSetHashValue}) == nil {
+					return fmt.Errorf("ObjectSet Hash should have been updated")
+				}
+				return nil
+			})
+		})
+	})
+
+	When("a bundle deployment adopts a resource with invalid wrangler metadata", Label("wrangler-metadata"), func() {
+		It("verifies that the ConfigMap is adopted and its content merged", func() {
+			createConfigMap(
+				map[string]string{"foo": "bar"},
+				map[string]string{"objectset.rio.cattle.io/hash": "234"},
+				map[string]string{"objectset.rio.cattle.io/id": "$#@"},
+			)
+			createBundleDeployment("adopt-invalid-wrangler-metadata", true)
+			assertConfigMap(func(cm corev1.ConfigMap) error {
+				if err := isConfigMapAdopted(&cm); err != nil {
+					return err
+				}
+				return mapPartialMatch(cm.Data, map[string]string{"foo": "bar", "key": "value"})
+			})
+		})
+	})
+
+	When("a bundle deployment adopts a resource with random metadata", Label("random-metadata"), func() {
+		It("verifies that the ConfigMap is adopted and its content merged", func() {
+			createConfigMap(
+				map[string]string{"foo": "bar"},
+				map[string]string{"foo": "234"},
+				map[string]string{"bar": "xzy"},
+			)
+			createBundleDeployment("adopt-random-metadata", true)
+			assertConfigMap(func(cm corev1.ConfigMap) error {
+				if err := isConfigMapAdopted(&cm); err != nil {
+					return err
+				}
+				return mapPartialMatch(cm.Data, map[string]string{"foo": "bar", "key": "value"})
+			})
+		})
+	})
+
+	When("a bundle adopts a resource that is deployed by another bundle", Label("competing-bundles"), func() {
+		It("should complain about not owning the resource", func() {
+			createBundleDeployment("one", false)
+			waitForConfigMap("cm1")
+			createBundleDeployment("two", true)
+			assertBundleDeployment("one", bundleDeploymentNotOwnedByUs)
+			assertBundleDeployment("two", bundleDeploymentReady)
+		})
+	})
+})

--- a/integrationtests/agent/adoption_test.go
+++ b/integrationtests/agent/adoption_test.go
@@ -54,7 +54,8 @@ var _ = Describe("Adoption", Label("adopt"), func() {
 				g.Expect(cm.Labels).To(HaveKeyWithValue("app.kubernetes.io/managed-by", "Helm"))
 				g.Expect(cm.Labels).To(HaveKey("objectset.rio.cattle.io/hash"))
 			})
-			// This is required for the resource to be watched.
+			// This is required for the resource to be properly watched, so that
+			// when it is deleted, the bundle changes its status.
 			time.Sleep(5 * time.Second)
 			env.deleteConfigMap("cm1")
 			env.assertBundleDeployment("remove-resource", env.bundleDeploymentResourceMissing)

--- a/integrationtests/agent/adoption_test.go
+++ b/integrationtests/agent/adoption_test.go
@@ -35,13 +35,11 @@ data:
 var _ = Describe("Adoption", Label("adopt"), func() {
 	var (
 		namespace string
-		// env       *specEnv
 		env adoptEnv
 	)
 
 	BeforeEach(func() {
 		namespace = createNamespace()
-		// env = &specEnv{namespace: namespace}
 		env = adoptEnv{namespace: namespace, env: &specEnv{namespace: namespace}}
 	})
 

--- a/integrationtests/agent/adoption_test.go
+++ b/integrationtests/agent/adoption_test.go
@@ -35,173 +35,20 @@ data:
 var _ = Describe("Adoption", Label("adopt"), func() {
 	var (
 		namespace string
-		env       *specEnv
+		// env       *specEnv
+		env adoptEnv
 	)
-
-	createBundleDeployment := func(name string, takeOwnership bool) {
-		bundled := v1alpha1.BundleDeployment{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      name,
-				Namespace: clusterNS,
-			},
-			Spec: v1alpha1.BundleDeploymentSpec{
-				DeploymentID: "BundleDeploymentConfigMap",
-				Options: v1alpha1.BundleDeploymentOptions{
-					DefaultNamespace: namespace,
-					Helm: &v1alpha1.HelmOptions{
-						TakeOwnership: takeOwnership,
-					},
-				},
-			},
-		}
-
-		err := k8sClient.Create(context.TODO(), &bundled)
-		Expect(err).To(BeNil())
-		Expect(bundled).To(Not(BeNil()))
-		Expect(bundled.Spec.DeploymentID).ToNot(Equal(bundled.Status.AppliedDeploymentID))
-		Expect(bundled.Status.Ready).To(BeFalse())
-		Eventually(func(g Gomega) {
-			g.Expect(k8sClient.Get(
-				context.TODO(),
-				types.NamespacedName{Namespace: clusterNS, Name: name},
-				&bundled,
-			)).To(Succeed())
-			g.Expect(bundled.Status.Ready).To(BeTrue())
-		}).Should(Succeed(), "BundleDeployment not ready: status: %+v", bundled.Status)
-		Expect(bundled.Spec.DeploymentID).To(Equal(bundled.Status.AppliedDeploymentID))
-	}
-
-	waitForConfigMap := func(name string) {
-		Eventually(func() error {
-			_, err := env.getConfigMap(name)
-			return err
-		}).Should(Succeed())
-	}
-
-	createConfigMap := func(data, labels, annotations map[string]string) *corev1.ConfigMap {
-		cm := &corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:        "cm1",
-				Namespace:   namespace,
-				Labels:      labels,
-				Annotations: annotations,
-			},
-			Data: data,
-		}
-		Expect(k8sClient.Create(ctx, cm)).To(Succeed())
-		waitForConfigMap("cm1")
-		return cm
-	}
-
-	// assertConfigMap checks that the ConfigMap exists and that it passes the
-	// provided validate function.
-	assertConfigMap := func(validate func(Gomega, corev1.ConfigMap)) {
-		cm := corev1.ConfigMap{}
-		var err error
-		Eventually(func(g Gomega) {
-			err = k8sClient.Get(
-				ctx,
-				types.NamespacedName{Namespace: namespace, Name: "cm1"},
-				&cm,
-			)
-			g.Expect(err).To(Succeed())
-			validate(g, cm)
-			g.Expect(err).To(Succeed())
-		}).Should(Succeed(), "assertConfigMap error: %v in %+v", err, cm)
-	}
-
-	// assertBundleDeployment checks that the BundleDeployment exists and that it
-	// passes the provided validate function.
-	assertBundleDeployment := func(name string, validate func(*v1alpha1.BundleDeployment) error) {
-		bd := v1alpha1.BundleDeployment{}
-		var err error
-		Eventually(func(g Gomega) {
-			err = k8sClient.Get(
-				ctx,
-				types.NamespacedName{Namespace: clusterNS, Name: name},
-				&bd,
-			)
-			g.Expect(err).ToNot(HaveOccurred())
-			err = validate(&bd)
-			g.Expect(err).ToNot(HaveOccurred())
-		}).Should(Succeed(), "assertBundleDeployment: error %v in %+v", err, bd)
-	}
-
-	// configMapAdoptedAndMerged checks that the ConfigMap is adopted. It may
-	// need to be extended to check for more labels and annotations.
-	assertConfigMapAdopted := func(g Gomega, cm *corev1.ConfigMap) {
-		g.Expect(cm.Labels).To(HaveKeyWithValue("app.kubernetes.io/managed-by", "Helm"))
-		g.Expect(cm.Annotations).To(HaveKey("meta.helm.sh/release-name"))
-		g.Expect(cm.Annotations).To(HaveKey("meta.helm.sh/release-namespace"))
-	}
-
-	updateConfigMap := func(name string, update func(*corev1.ConfigMap)) {
-		cm := &corev1.ConfigMap{}
-		Eventually(func(g Gomega) {
-			g.Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, cm)).To(Succeed())
-			update(cm)
-			g.Expect(k8sClient.Update(ctx, cm)).To(Succeed())
-		}).Should(Succeed())
-	}
-
-	deleteConfigMap := func(name string) {
-		cm := &corev1.ConfigMap{}
-		Eventually(func(g Gomega) {
-			g.Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, cm)).To(Succeed())
-			g.Expect(k8sClient.Delete(ctx, cm)).To(Succeed())
-		}).Should(Succeed())
-	}
-
-	bundleDeploymentResourceMissing := func(bd *v1alpha1.BundleDeployment) error {
-		const msgPrefix = "BundleDeployment resource:"
-		for _, condition := range bd.Status.Conditions {
-			if condition.Type != v1alpha1.BundleDeploymentConditionReady {
-				continue
-			}
-			if condition.Status != corev1.ConditionFalse {
-				return fmt.Errorf("%s Status is not False", msgPrefix)
-			}
-			if condition.Reason != "Error" {
-				return fmt.Errorf("%s Reason is not Error", msgPrefix)
-			}
-			if !strings.Contains(condition.Message, "missing") {
-				return fmt.Errorf("%s Message does not contain 'missing'", msgPrefix)
-			}
-		}
-		return nil
-	}
-
-	bundleDeploymentNotOwnedByUs := func(bd *v1alpha1.BundleDeployment) error {
-		for _, condition := range bd.Status.Conditions {
-			if condition.Type == v1alpha1.BundleDeploymentConditionReady &&
-				condition.Status == corev1.ConditionFalse &&
-				condition.Reason == "Error" &&
-				strings.Contains(condition.Message, "not owned by us") {
-				return nil
-			}
-		}
-		return fmt.Errorf("does not match expected condition")
-	}
-
-	bundleDeploymentReady := func(bd *v1alpha1.BundleDeployment) error {
-		for _, condition := range bd.Status.Conditions {
-			if condition.Type == v1alpha1.BundleDeploymentConditionReady &&
-				condition.Status == corev1.ConditionTrue {
-				return nil
-			}
-		}
-		return fmt.Errorf("does not match expected condition")
-	}
 
 	BeforeEach(func() {
 		namespace = createNamespace()
-		env = &specEnv{namespace: namespace}
+		// env = &specEnv{namespace: namespace}
+		env = adoptEnv{namespace: namespace, env: &specEnv{namespace: namespace}}
 	})
 
 	When("a resource of a bundle deployment is removed", Label("remove-resource"), func() {
 		It("should report the deleted resource as missing", func() {
-			createBundleDeployment("remove-resource", false)
-			assertConfigMap(func(g Gomega, cm corev1.ConfigMap) {
+			env.createBundleDeployment("remove-resource", false)
+			env.assertConfigMap(func(g Gomega, cm corev1.ConfigMap) {
 				g.Expect(cm.Data).To(Equal(map[string]string{"key": "value"}))
 				g.Expect(cm.Annotations).To(HaveKeyWithValue("meta.helm.sh/release-name", "remove-resource"))
 				g.Expect(cm.Annotations).To(HaveKeyWithValue("objectset.rio.cattle.io/id", "default-remove-resource"))
@@ -211,15 +58,15 @@ var _ = Describe("Adoption", Label("adopt"), func() {
 			})
 			// This is required for the resource to be watched.
 			time.Sleep(5 * time.Second)
-			deleteConfigMap("cm1")
-			assertBundleDeployment("remove-resource", bundleDeploymentResourceMissing)
+			env.deleteConfigMap("cm1")
+			env.assertBundleDeployment("remove-resource", env.bundleDeploymentResourceMissing)
 		})
 	})
 
 	When("all labels of a resource of a bundle deployment are removed", Label("remove-labels"), func() {
 		It("should report that resource as \"not owned by us\"", func() {
-			createBundleDeployment("remove-metadata", false)
-			assertConfigMap(func(g Gomega, cm corev1.ConfigMap) {
+			env.createBundleDeployment("remove-metadata", false)
+			env.assertConfigMap(func(g Gomega, cm corev1.ConfigMap) {
 				g.Expect(cm.Data).To(Equal(map[string]string{"key": "value"}))
 				g.Expect(cm.Annotations).To(HaveKeyWithValue("meta.helm.sh/release-name", "remove-metadata"))
 				g.Expect(cm.Annotations).To(HaveKeyWithValue("objectset.rio.cattle.io/id", "default-remove-metadata"))
@@ -227,20 +74,20 @@ var _ = Describe("Adoption", Label("adopt"), func() {
 				g.Expect(cm.Labels).To(HaveKeyWithValue("app.kubernetes.io/managed-by", "Helm"))
 				g.Expect(cm.Labels).To(HaveKeyWithValue("objectset.rio.cattle.io/hash", "0f3e1d9d146fa8b290c0de403881184751430e59"))
 			})
-			updateConfigMap("cm1", func(cm *corev1.ConfigMap) {
+			env.updateConfigMap("cm1", func(cm *corev1.ConfigMap) {
 				cm.Labels = map[string]string{}
 			})
-			assertBundleDeployment("remove-metadata", bundleDeploymentNotOwnedByUs)
+			env.assertBundleDeployment("remove-metadata", env.bundleDeploymentNotOwnedByUs)
 		})
 	})
 
 	When("a bundle deployment adopts a \"clean\" resource", Label("clean"), func() {
 		// A clean resource is a resource that does not bear labels or annotations indicating that it would belong to any other resource than our bundle deployment.
 		It("verifies that the ConfigMap is adopted and its content merged", func() {
-			createConfigMap(map[string]string{"foo": "bar"}, nil, nil)
-			createBundleDeployment("adopt-clean", true)
-			assertConfigMap(func(g Gomega, cm corev1.ConfigMap) {
-				assertConfigMapAdopted(g, &cm)
+			env.createConfigMap(map[string]string{"foo": "bar"}, nil, nil)
+			env.createBundleDeployment("adopt-clean", true)
+			env.assertConfigMap(func(g Gomega, cm corev1.ConfigMap) {
+				env.assertConfigMapAdopted(g, &cm)
 				g.Expect(cm.Data).To(Equal(map[string]string{"foo": "bar", "key": "value"}))
 			})
 		})
@@ -254,14 +101,14 @@ var _ = Describe("Adoption", Label("adopt"), func() {
 				objectSetHashValue = "33ed67317c57ea78702e369c4c025f8df88553cc"
 				objectSetIDValue   = "some-assumed-old-id"
 			)
-			createConfigMap(
+			env.createConfigMap(
 				map[string]string{"foo": "bar"},
 				map[string]string{objectSetHashKey: objectSetHashValue},
 				map[string]string{objectSetIDKey: objectSetIDValue},
 			)
-			createBundleDeployment("adopt-wrangler-metadata", true)
-			assertConfigMap(func(g Gomega, cm corev1.ConfigMap) {
-				assertConfigMapAdopted(g, &cm)
+			env.createBundleDeployment("adopt-wrangler-metadata", true)
+			env.assertConfigMap(func(g Gomega, cm corev1.ConfigMap) {
+				env.assertConfigMapAdopted(g, &cm)
 				g.Expect(cm.Data).To(Equal(map[string]string{"foo": "bar", "key": "value"}))
 				g.Expect(cm.Annotations).ToNot(HaveKeyWithValue(objectSetIDKey, objectSetIDValue))
 				g.Expect(cm.Labels).ToNot(HaveKeyWithValue(objectSetHashKey, objectSetHashValue))
@@ -271,14 +118,14 @@ var _ = Describe("Adoption", Label("adopt"), func() {
 
 	When("a bundle deployment adopts a resource with invalid wrangler metadata", Label("wrangler-metadata"), func() {
 		It("verifies that the ConfigMap is adopted and its content merged", func() {
-			createConfigMap(
+			env.createConfigMap(
 				map[string]string{"foo": "bar"},
 				map[string]string{"objectset.rio.cattle.io/hash": "234"},
 				map[string]string{"objectset.rio.cattle.io/id": "$#@"},
 			)
-			createBundleDeployment("adopt-invalid-wrangler-metadata", true)
-			assertConfigMap(func(g Gomega, cm corev1.ConfigMap) {
-				assertConfigMapAdopted(g, &cm)
+			env.createBundleDeployment("adopt-invalid-wrangler-metadata", true)
+			env.assertConfigMap(func(g Gomega, cm corev1.ConfigMap) {
+				env.assertConfigMapAdopted(g, &cm)
 				g.Expect(cm.Data).To(Equal(map[string]string{"foo": "bar", "key": "value"}))
 				g.Expect(cm.Annotations).ToNot(HaveKeyWithValue("objectset.rio.cattle.io/id", "$#@"))
 				g.Expect(cm.Labels).ToNot(HaveKeyWithValue("objectset.rio.cattle.io/hash", "234"))
@@ -288,14 +135,14 @@ var _ = Describe("Adoption", Label("adopt"), func() {
 
 	When("a bundle deployment adopts a resource with random metadata", Label("random-metadata"), func() {
 		It("verifies that the ConfigMap is adopted and its content merged", func() {
-			createConfigMap(
+			env.createConfigMap(
 				map[string]string{"foo": "bar"},
 				map[string]string{"foo": "234"},
 				map[string]string{"bar": "xzy"},
 			)
-			createBundleDeployment("adopt-random-metadata", true)
-			assertConfigMap(func(g Gomega, cm corev1.ConfigMap) {
-				assertConfigMapAdopted(g, &cm)
+			env.createBundleDeployment("adopt-random-metadata", true)
+			env.assertConfigMap(func(g Gomega, cm corev1.ConfigMap) {
+				env.assertConfigMapAdopted(g, &cm)
 				g.Expect(cm.Data).To(Equal(map[string]string{"foo": "bar", "key": "value"}))
 				g.Expect(cm.Annotations).To(HaveKeyWithValue("bar", "xzy"))
 				g.Expect(cm.Labels).To(HaveKeyWithValue("foo", "234"))
@@ -305,11 +152,171 @@ var _ = Describe("Adoption", Label("adopt"), func() {
 
 	When("a bundle adopts a resource that is deployed by another bundle", Label("competing-bundles"), func() {
 		It("should complain about not owning the resource", func() {
-			createBundleDeployment("one", false)
-			waitForConfigMap("cm1")
-			createBundleDeployment("two", true)
-			assertBundleDeployment("one", bundleDeploymentNotOwnedByUs)
-			assertBundleDeployment("two", bundleDeploymentReady)
+			env.createBundleDeployment("one", false)
+			env.waitForConfigMap("cm1")
+			env.createBundleDeployment("two", true)
+			env.assertBundleDeployment("one", env.bundleDeploymentNotOwnedByUs)
+			env.assertBundleDeployment("two", env.bundleDeploymentReady)
 		})
 	})
 })
+
+type adoptEnv struct {
+	namespace string
+	env       *specEnv
+}
+
+func (e adoptEnv) createBundleDeployment(name string, takeOwnership bool) {
+	bundled := v1alpha1.BundleDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: clusterNS,
+		},
+		Spec: v1alpha1.BundleDeploymentSpec{
+			DeploymentID: "BundleDeploymentConfigMap",
+			Options: v1alpha1.BundleDeploymentOptions{
+				DefaultNamespace: e.namespace,
+				Helm: &v1alpha1.HelmOptions{
+					TakeOwnership: takeOwnership,
+				},
+			},
+		},
+	}
+
+	err := k8sClient.Create(context.TODO(), &bundled)
+	Expect(err).To(BeNil())
+	Expect(bundled).To(Not(BeNil()))
+	Expect(bundled.Spec.DeploymentID).ToNot(Equal(bundled.Status.AppliedDeploymentID))
+	Expect(bundled.Status.Ready).To(BeFalse())
+	Eventually(func(g Gomega) {
+		g.Expect(k8sClient.Get(
+			context.TODO(),
+			types.NamespacedName{Namespace: clusterNS, Name: name},
+			&bundled,
+		)).To(Succeed())
+		g.Expect(bundled.Status.Ready).To(BeTrue())
+	}).Should(Succeed(), "BundleDeployment not ready: status: %+v", bundled.Status)
+	Expect(bundled.Spec.DeploymentID).To(Equal(bundled.Status.AppliedDeploymentID))
+}
+
+func (e adoptEnv) waitForConfigMap(name string) {
+	Eventually(func() error {
+		_, err := e.env.getConfigMap(name)
+		return err
+	}).Should(Succeed())
+}
+
+func (e adoptEnv) createConfigMap(data, labels, annotations map[string]string) *corev1.ConfigMap {
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "cm1",
+			Namespace:   e.namespace,
+			Labels:      labels,
+			Annotations: annotations,
+		},
+		Data: data,
+	}
+	Expect(k8sClient.Create(ctx, cm)).To(Succeed())
+	e.waitForConfigMap("cm1")
+	return cm
+}
+
+// assertConfigMap checks that the ConfigMap exists and that it passes the
+// provided validate function.
+func (e adoptEnv) assertConfigMap(validate func(Gomega, corev1.ConfigMap)) {
+	cm := corev1.ConfigMap{}
+	var err error
+	Eventually(func(g Gomega) {
+		err = k8sClient.Get(
+			ctx,
+			types.NamespacedName{Namespace: e.namespace, Name: "cm1"},
+			&cm,
+		)
+		g.Expect(err).To(Succeed())
+		validate(g, cm)
+		g.Expect(err).To(Succeed())
+	}).Should(Succeed(), "assertConfigMap error: %v in %+v", err, cm)
+}
+
+// assertBundleDeployment checks that the BundleDeployment exists and that it
+// passes the provided validate function.
+func (e adoptEnv) assertBundleDeployment(name string, validate func(*v1alpha1.BundleDeployment) error) {
+	bd := v1alpha1.BundleDeployment{}
+	var err error
+	Eventually(func(g Gomega) {
+		err = k8sClient.Get(
+			ctx,
+			types.NamespacedName{Namespace: clusterNS, Name: name},
+			&bd,
+		)
+		g.Expect(err).ToNot(HaveOccurred())
+		err = validate(&bd)
+		g.Expect(err).ToNot(HaveOccurred())
+	}).Should(Succeed(), "assertBundleDeployment: error %v in %+v", err, bd)
+}
+
+// configMapAdoptedAndMerged checks that the ConfigMap is adopted. It may
+// need to be extended to check for more labels and annotations.
+func (e adoptEnv) assertConfigMapAdopted(g Gomega, cm *corev1.ConfigMap) {
+	g.Expect(cm.Labels).To(HaveKeyWithValue("app.kubernetes.io/managed-by", "Helm"))
+	g.Expect(cm.Annotations).To(HaveKey("meta.helm.sh/release-name"))
+	g.Expect(cm.Annotations).To(HaveKey("meta.helm.sh/release-namespace"))
+}
+
+func (e adoptEnv) updateConfigMap(name string, update func(*corev1.ConfigMap)) {
+	cm := &corev1.ConfigMap{}
+	Eventually(func(g Gomega) {
+		g.Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: e.namespace, Name: name}, cm)).To(Succeed())
+		update(cm)
+		g.Expect(k8sClient.Update(ctx, cm)).To(Succeed())
+	}).Should(Succeed())
+}
+
+func (e adoptEnv) deleteConfigMap(name string) {
+	cm := &corev1.ConfigMap{}
+	Eventually(func(g Gomega) {
+		g.Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: e.namespace, Name: name}, cm)).To(Succeed())
+		g.Expect(k8sClient.Delete(ctx, cm)).To(Succeed())
+	}).Should(Succeed())
+}
+
+func (e adoptEnv) bundleDeploymentResourceMissing(bd *v1alpha1.BundleDeployment) error {
+	const msgPrefix = "BundleDeployment resource:"
+	for _, condition := range bd.Status.Conditions {
+		if condition.Type != v1alpha1.BundleDeploymentConditionReady {
+			continue
+		}
+		if condition.Status != corev1.ConditionFalse {
+			return fmt.Errorf("%s Status is not False", msgPrefix)
+		}
+		if condition.Reason != "Error" {
+			return fmt.Errorf("%s Reason is not Error", msgPrefix)
+		}
+		if !strings.Contains(condition.Message, "missing") {
+			return fmt.Errorf("%s Message does not contain 'missing'", msgPrefix)
+		}
+	}
+	return nil
+}
+
+func (e adoptEnv) bundleDeploymentNotOwnedByUs(bd *v1alpha1.BundleDeployment) error {
+	for _, condition := range bd.Status.Conditions {
+		if condition.Type == v1alpha1.BundleDeploymentConditionReady &&
+			condition.Status == corev1.ConditionFalse &&
+			condition.Reason == "Error" &&
+			strings.Contains(condition.Message, "not owned by us") {
+			return nil
+		}
+	}
+	return fmt.Errorf("does not match expected condition")
+}
+
+func (e adoptEnv) bundleDeploymentReady(bd *v1alpha1.BundleDeployment) error {
+	for _, condition := range bd.Status.Conditions {
+		if condition.Type == v1alpha1.BundleDeploymentConditionReady &&
+			condition.Status == corev1.ConditionTrue {
+			return nil
+		}
+	}
+	return fmt.Errorf("does not match expected condition")
+}

--- a/integrationtests/agent/adoption_test.go
+++ b/integrationtests/agent/adoption_test.go
@@ -214,12 +214,11 @@ func (e adoptEnv) waitForConfigMap(name string) {
 	}).Should(Succeed())
 }
 
-func (e adoptEnv) createConfigMap(cm *corev1.ConfigMap) *corev1.ConfigMap {
+func (e adoptEnv) createConfigMap(cm *corev1.ConfigMap) {
 	cm.ObjectMeta.Name = "cm1"
 	cm.ObjectMeta.Namespace = e.namespace
 	Expect(k8sClient.Create(ctx, cm)).To(Succeed())
 	e.waitForConfigMap("cm1")
-	return cm
 }
 
 // assertConfigMap checks that the ConfigMap exists and that it passes the

--- a/integrationtests/agent/adoption_test.go
+++ b/integrationtests/agent/adoption_test.go
@@ -207,7 +207,6 @@ func (e adoptEnv) createBundleDeployment(name string, takeOwnership bool) {
 }
 
 func (e adoptEnv) waitForConfigMap(name string) {
-	time.Sleep(5 * time.Second)
 	Eventually(func() error {
 		_, err := e.env.getConfigMap(name)
 		return err
@@ -234,7 +233,6 @@ func (e adoptEnv) assertConfigMap(validate func(Gomega, corev1.ConfigMap)) {
 		)
 		g.Expect(err).ToNot(HaveOccurred())
 		validate(g, cm)
-		g.Expect(err).ToNot(HaveOccurred())
 	}).Should(Succeed(), "assertConfigMap error: %v in %+v", err, cm)
 }
 

--- a/integrationtests/agent/bundle_deployment_drift_test.go
+++ b/integrationtests/agent/bundle_deployment_drift_test.go
@@ -6,9 +6,6 @@ import (
 	"os"
 	"time"
 
-	"github.com/rancher/fleet/integrationtests/utils"
-	"github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -19,6 +16,9 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/rancher/fleet/integrationtests/utils"
+	"github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
 )
 
 func init() {

--- a/integrationtests/agent/bundle_deployment_status_test.go
+++ b/integrationtests/agent/bundle_deployment_status_test.go
@@ -5,9 +5,6 @@ import (
 	"os"
 	"time"
 
-	"github.com/rancher/fleet/integrationtests/utils"
-	"github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -16,6 +13,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
 )
 
 func init() {
@@ -68,16 +67,6 @@ var _ = Describe("BundleDeployment status", Ordered, func() {
 		err := k8sClient.Create(context.TODO(), &bundled)
 		Expect(err).To(BeNil())
 		Expect(bundled).To(Not(BeNil()))
-	}
-
-	createNamespace := func() string {
-		namespace, err := utils.NewNamespaceName()
-		Expect(err).ToNot(HaveOccurred())
-
-		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}
-		Expect(k8sClient.Create(context.Background(), ns)).ToNot(HaveOccurred())
-
-		return namespace
 	}
 
 	When("New bundle deployment is created", func() {

--- a/integrationtests/agent/bundle_deployment_status_test.go
+++ b/integrationtests/agent/bundle_deployment_status_test.go
@@ -73,10 +73,6 @@ var _ = Describe("BundleDeployment status", Ordered, func() {
 		BeforeAll(func() {
 			name = "orphanbundletest1"
 			namespace = createNamespace()
-			DeferCleanup(func() {
-				Expect(k8sClient.Delete(ctx, &corev1.Namespace{
-					ObjectMeta: metav1.ObjectMeta{Name: namespace}})).ToNot(HaveOccurred())
-			})
 			env = &specEnv{namespace: namespace}
 
 			// this BundleDeployment will create a deployment with the resources from assets/deployment-v1.yaml

--- a/integrationtests/agent/helm_capabilities_test.go
+++ b/integrationtests/agent/helm_capabilities_test.go
@@ -62,9 +62,6 @@ var _ = Describe("Helm Chart uses Capabilities", Ordered, func() {
 
 		Expect(k8sClient.Create(context.Background(),
 			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}})).ToNot(HaveOccurred())
-		DeferCleanup(func() {
-			Expect(k8sClient.Delete(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: env.namespace}})).ToNot(HaveOccurred())
-		})
 	})
 
 	createBundle := func(env *specEnv, id string, name string) {

--- a/internal/cmd/agent/deployer/monitor/updatestatus.go
+++ b/internal/cmd/agent/deployer/monitor/updatestatus.go
@@ -11,25 +11,29 @@ import (
 	"strings"
 
 	"github.com/go-logr/logr"
-	"github.com/rancher/fleet/internal/cmd/agent/deployer/applied"
-	"github.com/rancher/fleet/internal/helmdeployer"
-	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/rancher/wrangler/v3/pkg/apply"
 	"github.com/rancher/wrangler/v3/pkg/condition"
 	"github.com/rancher/wrangler/v3/pkg/objectset"
 	"github.com/rancher/wrangler/v3/pkg/summary"
 
-	"k8s.io/apimachinery/pkg/api/meta"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"sigs.k8s.io/controller-runtime/pkg/log"
+	"github.com/rancher/fleet/internal/cmd/agent/deployer/applied"
+	"github.com/rancher/fleet/internal/helmdeployer"
+	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
 )
 
 type Monitor struct {
+	client  client.Client
 	applied *applied.Applied
-	mapper  meta.RESTMapper
 
 	deployer *helmdeployer.Helm
 
@@ -38,10 +42,10 @@ type Monitor struct {
 	labelSuffix      string
 }
 
-func New(applied *applied.Applied, mapper meta.RESTMapper, deployer *helmdeployer.Helm, defaultNamespace string, labelSuffix string) *Monitor {
+func New(client client.Client, applied *applied.Applied, deployer *helmdeployer.Helm, defaultNamespace string, labelSuffix string) *Monitor {
 	return &Monitor{
+		client:           client,
 		applied:          applied,
-		mapper:           mapper,
 		deployer:         deployer,
 		defaultNamespace: defaultNamespace,
 		labelPrefix:      defaultNamespace,
@@ -173,7 +177,7 @@ func (m *Monitor) updateFromResources(logger logr.Logger, bd *fleet.BundleDeploy
 	}
 
 	bd.Status.NonReadyStatus = nonReady(logger, plan, bd.Spec.Options.IgnoreOptions)
-	bd.Status.ModifiedStatus = modified(plan, resourcesPreviousRelease)
+	bd.Status.ModifiedStatus = modified(m.client, logger, plan, resourcesPreviousRelease)
 	bd.Status.Ready = false
 	bd.Status.NonModified = false
 
@@ -193,7 +197,7 @@ func (m *Monitor) updateFromResources(logger logr.Logger, bd *fleet.BundleDeploy
 
 		ns := ma.GetNamespace()
 		gvk := obj.GetObjectKind().GroupVersionKind()
-		if ns == "" && isNamespaced(m.mapper, gvk) {
+		if ns == "" && isNamespaced(m.client.RESTMapper(), gvk) {
 			ns = resources.DefaultNamespace
 		}
 
@@ -249,7 +253,7 @@ func nonReady(logger logr.Logger, plan apply.Plan, ignoreOptions fleet.IgnoreOpt
 // The function iterates through the plan's create, delete, and update actions and constructs a modified status
 // for each resource.
 // If the number of modified statuses exceeds 10, the function stops and returns the current result.
-func modified(plan apply.Plan, resourcesPreviousRelease *helmdeployer.Resources) (result []fleet.ModifiedStatus) {
+func modified(c client.Client, logger logr.Logger, plan apply.Plan, resourcesPreviousRelease *helmdeployer.Resources) (result []fleet.ModifiedStatus) {
 	defer func() {
 		sort.Slice(result, func(i, j int) bool {
 			return sortKey(result[i]) < sortKey(result[j])
@@ -262,12 +266,38 @@ func modified(plan apply.Plan, resourcesPreviousRelease *helmdeployer.Resources)
 			}
 
 			apiVersion, kind := gvk.ToAPIVersionAndKind()
+
+			obj := &unstructured.Unstructured{}
+			obj.SetGroupVersionKind(gvk)
+			key := client.ObjectKey{
+				Namespace: key.Namespace,
+				Name:      key.Name,
+			}
+			err := c.Get(context.Background(), key, obj)
+
+			exists := true
+			if apierrors.IsNotFound(err) {
+				exists = false
+			}
+
+			if exists {
+				logger.Info("BundleDeployment resource not owned by us",
+					"name", key.Name,
+					"kind", kind,
+					"apiVersion", apiVersion,
+					"namespace", key.Namespace,
+					"labels", obj.GetLabels(),
+					"annotations", obj.GetAnnotations(),
+				)
+			}
+
 			result = append(result, fleet.ModifiedStatus{
 				Kind:       kind,
 				APIVersion: apiVersion,
 				Namespace:  key.Namespace,
 				Name:       key.Name,
 				Create:     true,
+				Exist:      exists,
 			})
 		}
 	}

--- a/internal/cmd/agent/deployer/monitor/updatestatus.go
+++ b/internal/cmd/agent/deployer/monitor/updatestatus.go
@@ -275,13 +275,10 @@ func modified(c client.Client, logger logr.Logger, plan apply.Plan, resourcesPre
 			}
 			err := c.Get(context.Background(), key, obj)
 
-			exists := true
-			if apierrors.IsNotFound(err) {
-				exists = false
-			}
+			exists := !apierrors.IsNotFound(err)
 
 			if exists {
-				logger.Info("BundleDeployment resource not owned by us",
+				logger.Info("Resource of BundleDeployment not owned by us",
 					"name", key.Name,
 					"kind", kind,
 					"apiVersion", apiVersion,

--- a/internal/cmd/agent/operator.go
+++ b/internal/cmd/agent/operator.go
@@ -217,8 +217,8 @@ func newReconciler(
 		return nil, err
 	}
 	monitor := monitor.New(
+		localClient,
 		applied,
-		localClient.RESTMapper(),
 		helmDeployer,
 		defaultNamespace,
 		agentScope,

--- a/pkg/apis/fleet.cattle.io/v1alpha1/bundledeployment_types.go
+++ b/pkg/apis/fleet.cattle.io/v1alpha1/bundledeployment_types.go
@@ -4,10 +4,11 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/rancher/wrangler/v3/pkg/genericcondition"
-	"github.com/rancher/wrangler/v3/pkg/summary"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/rancher/wrangler/v3/pkg/genericcondition"
+	"github.com/rancher/wrangler/v3/pkg/summary"
 )
 
 const BundleDeploymentResourceNamePlural = "bundledeployments"
@@ -408,7 +409,9 @@ type ModifiedStatus struct {
 	// +nullable
 	Name   string `json:"name,omitempty"`
 	Create bool   `json:"missing,omitempty"`
-	Delete bool   `json:"delete,omitempty"`
+	// Exist is true if the resource exists but is not owned by us. This can happen if a resource was adopted by another bundle whereas the first bundle still exists and due to that reports that it does not own it.
+	Exist  bool `json:"exist,omitempty"`
+	Delete bool `json:"delete,omitempty"`
 	// +nullable
 	Patch string `json:"patch,omitempty"`
 }
@@ -416,7 +419,11 @@ type ModifiedStatus struct {
 func (in ModifiedStatus) String() string {
 	msg := name(in.APIVersion, in.Kind, in.Namespace, in.Name)
 	if in.Create {
-		return msg + " missing"
+		if in.Exist {
+			return msg + " is not owned by us"
+		} else {
+			return msg + " missing"
+		}
 	} else if in.Delete {
 		return msg + " extra"
 	}


### PR DESCRIPTION
When a resource of a BundleDeployment is removed after the Bundle has been created, the BundleDeployment says it is missing. This is also the case if the resource is not removed but changes its owner. In that case, the message of a resource that is missing might be misleading. These changes adapt the message to say "<resource> is not owned by us" instead of saying that the "\<resource\> is missing".

Part of #2134

<!-- Specify the issue ID that this pull request is solving -->

<!-- Make sure that the referenced issue provides steps to reproduce it -->

<!-- Describe the changes introduced by this pull request -->

<!--
  Please provide a unit, integration (`./integrationtests/`) or e2e (`./e2e/`) test if possible.
-->