### PR TITLE
KubeVersion fix for fleet deploy --dry-run

### DIFF
--- a/integrationtests/cli/assets/bundledeployment/bd-with-kube-version.yaml
+++ b/integrationtests/cli/assets/bundledeployment/bd-with-kube-version.yaml
@@ -1,0 +1,41 @@
+---
+apiVersion: fleet.cattle.io/v1alpha1
+content: H4sICORfomYAA2NoYXJ0Lmpzb24AjVKxasMwFJztr3hojpU4hQ6GFkrWds1SdXixnxNRWTaSbBqM/72SnIRQmpDBAr+7e3cnNKYJM2Tb3pRkWQGfaZKM/kuYxob8gJWtruU+Kw9o3HITTn7ERrFFZHnUkXaBiJ3ckrGy1QUMa6HDggKu5UJXZEsjOxdJb+DIOogQuAM6GMjIWpIF6exJKbQ7dn4Pdp2SJQal0MPZZ8VzvhLagxdrwXKeP/spE/q739EV8PoCOV+fMObzT4v7dR01nUKfcjmPG+weKZ97Z6mrAjZR9YGd0A05rNBhITTAfDWhfWalt6DZLztXvhADJSQfUPWUr59C8LN8HIFvw9zyMIBpeqzUMGv+7zGvrqjGXrks/N1cWiuiW2/hQKqJBaLl31cAMGeIjHMd+sF4ExG6aXo3fG9UAXvV7lDxOV2peuvIvOOO1HxNp81p8pVOvw+bEsv9AgAA
+kind: Content
+metadata:
+  creationTimestamp: null
+  name: s-f616452ccd6c2e6962b6b48419504496f87dc6ee536ce834eb994035ce00f
+sha256sum: f616452ccd6c2e6962b6b48419504496f87dc6ee536ce834eb994035ce00fd24
+
+---
+apiVersion: fleet.cattle.io/v1alpha1
+kind: BundleDeployment
+metadata:
+  creationTimestamp: null
+  labels:
+    fleet.cattle.io/bundle-name: testbundle-simple-chart
+    fleet.cattle.io/bundle-namespace: fleet-local
+    fleet.cattle.io/cluster: local
+    fleet.cattle.io/cluster-namespace: fleet-local
+    fleet.cattle.io/commit: e40edabfeada51874ac9caf5770655b720177380
+    fleet.cattle.io/managed: "true"
+  name: testbundle-simple-chart
+  namespace: cluster-fleet-local-local-1a3d67d0a899
+spec:
+  deploymentID: s-f616452ccd6c2e6962b6b48419504496f87dc6ee536ce834eb994035ce00f:c32e813ecbf48f56833aa2267cd3d8758eecc94f9948fb0dea510147a57760b5
+  options:
+    helm:
+      chart: config-chart
+      values:
+        name: example-value
+    ignore: {}
+  stagedDeploymentID: s-f616452ccd6c2e6962b6b48419504496f87dc6ee536ce834eb994035ce00f:c32e813ecbf48f56833aa2267cd3d8758eecc94f9948fb0dea510147a57760b5
+  stagedOptions:
+    helm:
+      chart: config-chart
+      values:
+        name: example-value
+    ignore: {}
+status:
+  display: {}
+

--- a/integrationtests/cli/deploy/deploy_test.go
+++ b/integrationtests/cli/deploy/deploy_test.go
@@ -166,4 +166,26 @@ var _ = Describe("Fleet CLI Deploy", func() {
 			Expect(apierrors.IsNotFound(err)).To(BeTrue())
 		})
 	})
+
+	When("Printing results with --dry-run where the chart specifies kubeVersion >= 1.26.0", func() {
+		BeforeEach(func() {
+			args = []string{
+				"--input-file", clihelper.AssetsPath + "bundledeployment/bd-with-kube-version.yaml",
+				"--dry-run",
+				"--kube-version", "v1.27.0",
+			}
+		})
+
+		It("prints a manifest and bundledeployment", func() {
+			buf, err := act(args)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(buf).To(gbytes.Say("- apiVersion: v1"))
+			Expect(buf).To(gbytes.Say("  data:"))
+			Expect(buf).To(gbytes.Say("    name: example-value"))
+
+			cm := &corev1.ConfigMap{}
+			err = k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "test-simple-chart-config"}, cm)
+			Expect(apierrors.IsNotFound(err)).To(BeTrue())
+		})
+	})
 })

--- a/internal/cmd/cli/deploy.go
+++ b/internal/cmd/cli/deploy.go
@@ -44,9 +44,10 @@ func NewDeploy() *cobra.Command {
 }
 
 type Deploy struct {
-	InputFile string `usage:"Location of the YAML file containing the content and the bundledeployment resource" short:"i"`
-	DryRun    bool   `usage:"Print the resources that would be deployed, but do not actually deploy them" short:"d"`
-	Namespace string `usage:"Set the default namespace. Deploy helm chart into this namespace." short:"n"`
+	InputFile   string `usage:"Location of the YAML file containing the content and the bundledeployment resource" short:"i"`
+	DryRun      bool   `usage:"Print the resources that would be deployed, but do not actually deploy them" short:"d"`
+	Namespace   string `usage:"Set the default namespace. Deploy helm chart into this namespace." short:"n"`
+	KubeVersion string `usage:"For dry runs, sets the Kubernetes version to assume when validating Chart Kubernetes version constraints."`
 
 	// AgentNamespace is set as an annotation on the chart.yaml in the helm release. Fleet-agent will manage charts with a matching label.
 	AgentNamespace string `usage:"Set the agent namespace, normally cattle-fleet-system. If set, fleet agent will garbage collect the helm release, i.e. delete it if the bundledeployment is missing." short:"a"`
@@ -116,7 +117,7 @@ func (d *Deploy) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	if d.DryRun {
-		resources, err := helmdeployer.Template(ctx, bd.Name, manifest, bd.Spec.Options)
+		resources, err := helmdeployer.Template(ctx, bd.Name, manifest, bd.Spec.Options, d.KubeVersion)
 		if err != nil {
 			return err
 		}

--- a/internal/cmd/cli/match/match.go
+++ b/internal/cmd/cli/match/match.go
@@ -89,7 +89,7 @@ func printMatch(ctx context.Context, bundle *fleet.Bundle, target *fleet.BundleT
 
 	manifest := manifest.New(bundle.Spec.Resources)
 
-	objs, err := helmdeployer.Template(ctx, bundle.Name, manifest, opts)
+	objs, err := helmdeployer.Template(ctx, bundle.Name, manifest, opts, "")
 	if err != nil {
 		return err
 	}

--- a/internal/helmdeployer/capabilities.go
+++ b/internal/helmdeployer/capabilities.go
@@ -54,7 +54,7 @@ func getCapabilities(c action.Configuration) (*chartutil.Capabilities, error) {
 		}
 	}
 
-	c.Capabilities = chartutil.DefaultCapabilities
+	c.Capabilities = chartutil.DefaultCapabilities.Copy()
 	c.Capabilities.APIVersions = apiVersions
 	c.Capabilities.KubeVersion = chartutil.KubeVersion{
 		Version: kubeVersion.GitVersion,

--- a/internal/helmdeployer/template.go
+++ b/internal/helmdeployer/template.go
@@ -2,8 +2,10 @@ package helmdeployer
 
 import (
 	"context"
+	"fmt"
 	"io"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/rancher/fleet/internal/manifest"
 	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
 
@@ -18,8 +20,12 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
+var (
+	defaultKubernetesVersion = "v1.25.0"
+)
+
 // Template runs helm template and returns the resources as a list of objects, without applying them.
-func Template(ctx context.Context, bundleID string, manifest *manifest.Manifest, options fleet.BundleDeploymentOptions) ([]runtime.Object, error) {
+func Template(ctx context.Context, bundleID string, manifest *manifest.Manifest, options fleet.BundleDeploymentOptions, kubeVersionString string) ([]runtime.Object, error) {
 	h := &Helm{
 		globalCfg:    action.Configuration{},
 		useGlobalCfg: true,
@@ -28,8 +34,20 @@ func Template(ctx context.Context, bundleID string, manifest *manifest.Manifest,
 
 	mem := driver.NewMemory()
 	mem.SetNamespace("default")
-
-	h.globalCfg.Capabilities = chartutil.DefaultCapabilities
+	kubeVersionToUse := defaultKubernetesVersion
+	if kubeVersionString != "" {
+		kubeVersionToUse = kubeVersionString
+	}
+	kubeVersion, err := semver.NewVersion(kubeVersionToUse)
+	if err != nil {
+		return nil, fmt.Errorf("invalid kubeVersion: %s", kubeVersionToUse)
+	}
+	h.globalCfg.Capabilities = chartutil.DefaultCapabilities.Copy()
+	h.globalCfg.Capabilities.KubeVersion = chartutil.KubeVersion{
+		Version: kubeVersion.String(),
+		Major:   fmt.Sprint(kubeVersion.Major()),
+		Minor:   fmt.Sprint(kubeVersion.Minor()),
+	}
 	h.globalCfg.KubeClient = &kubefake.PrintingKubeClient{Out: io.Discard}
 	h.globalCfg.Log = logrus.Infof
 	h.globalCfg.Releases = storage.Init(mem)


### PR DESCRIPTION
<!-- Specify the issue ID that this pull request is solving -->
Refers to #2633
<!-- Make sure that the referenced issue provides steps to reproduce it -->

<!-- Describe the changes introduced by this pull request -->
This Pull Requests fixes the kubeVersion validation error by:
1.) Introducing a new argument `--kube-version` to allow users to override the target version Helm charts can be validated against. This follows the exact same semantics as the `--kube-version` argument of the `helm template` command.
2.) Where no `--kuberversion` is specified, a more reasonable default of 1.25.0 is provided.
<!--
  Please provide a unit, integration (`./integrationtests/`) or e2e (`./e2e/`) test if possible.
-->

An integration test, "Printing results with --dry-run where the chart specifies kubeVersion >= 1.26.0", was added  in integrationtests/cli/deploy/deploy_test.go to illustrate both the issue and the fix