### PR TITLE
Fix linting error

### DIFF
--- a/internal/cmd/controller/agentmanagement/agent/manifest.go
+++ b/internal/cmd/controller/agentmanagement/agent/manifest.go
@@ -138,7 +138,7 @@ func Manifest(namespace string, agentScope string, opts ManifestOptions) []runti
 	return objs
 }
 
-func resolve(global, prefix, image string) string {
+func Resolve(global, prefix, image string) string {
 	if global != "" && prefix != "" {
 		image = strings.TrimPrefix(image, global)
 	}
@@ -152,7 +152,7 @@ func resolve(global, prefix, image string) string {
 func agentApp(namespace string, agentScope string, opts ManifestOptions) *appsv1.StatefulSet {
 	name := DefaultName
 	serviceAccount := DefaultName
-	image := resolve(opts.SystemDefaultRegistry, opts.PrivateRepoURL, opts.AgentImage)
+	image := Resolve(opts.SystemDefaultRegistry, opts.PrivateRepoURL, opts.AgentImage)
 
 	app := &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
Getting an agent StatefulSet from a manifest for unit tests always happens in namespace `fleet-system`, which is now a package-wide constant.
To prevent that constant from being used in the implementation package, unit tests now live in a separate `agent_test` package.

This should fix `golangci-lint` workflow failures such as [this one](https://github.com/rancher/fleet/actions/runs/10138467073/job/28030207568).