### PR TITLE
Remove content cleanup from bundle deployment reconciler

### DIFF
--- a/internal/cmd/controller/reconciler/bundledeployment_controller.go
+++ b/internal/cmd/controller/reconciler/bundledeployment_controller.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"reflect"
 
-	"github.com/rancher/fleet/internal/cmd/controller/finalize"
 	"github.com/rancher/fleet/internal/cmd/controller/summary"
 	"github.com/rancher/fleet/internal/metrics"
 	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
@@ -80,19 +79,6 @@ func (r *BundleDeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Req
 			})
 			if err != nil {
 				return ctrl.Result{}, err
-			}
-
-			if !bd.Spec.OCIContents {
-				if err := finalize.PurgeContent(ctx, r.Client, bd.Name, bd.Spec.DeploymentID); err != nil {
-					logger.Error(
-						err,
-						"Reconcile failed to purge old content resource",
-						"bundledeployment",
-						bd,
-						"deploymentID",
-						bd.Spec.DeploymentID,
-					)
-				}
 			}
 		}
 


### PR DESCRIPTION
Purging content resources happens when triggering bundle deployment deletion from a bundle deletion, or even a `GitRepo` deletion.
Direct bundle deployment deletion is not supported, and does not work because:
* a bundle deployment is not meant to be created on its own, ie without a bundle
* deleting a bundle deployment before deleting the bundle from which it was created will lead to that bundle deployment being re-created by the bundle reconciler.

Follow-up to #2566
Refers to #2464