### PR TITLE
Fixes e2e flaky test.

### DIFF
--- a/e2e/single-cluster/gitrepo_polling_disabled_test.go
+++ b/e2e/single-cluster/gitrepo_polling_disabled_test.go
@@ -74,8 +74,8 @@ var _ = Describe("GitRepoPollingDisabled", Label("infra-setup"), func() {
 			`ERROR.*Reconciler error.*Bundle(Deployment)?.fleet.cattle.io \\".*\\" not found`,
 		))
 
-		_, err = k.Delete("ns", targetNamespace)
-		Expect(err).ToNot(HaveOccurred())
+		out, err = k.Delete("ns", targetNamespace, "--wait=false")
+		Expect(err).ToNot(HaveOccurred(), out)
 	})
 
 	When("applying a gitrepo with disable polling", func() {


### PR DESCRIPTION
Avoid waiting for namespace to be deleted.
This was causing issues like on other e2e tests.

The output is used in case of error.

I've been testing in a loop for a few hours while doing other stuff and all namespaces were deleted correctly.

