### PR TITLE
Switch dev scripts to managed clusters

### DIFF
--- a/dev/setup-fleet-managed-downstream
+++ b/dev/setup-fleet-managed-downstream
@@ -40,10 +40,7 @@ EOF
 
 kubectl create ns fleet-default || true
 kubectl delete secret -n fleet-default kbcfg-second || true
-# Rancher sets a token value in the secret, but our docs don't mention it
-# * https://github.com/rancher/rancher/blob/c24fb8b0869a0b445f55b3307c6ed4582e147747/pkg/provisioningv2/kubeconfig/manager.go#L362
-# * https://fleet.rancher.io/0.5/manager-initiated#kubeconfig-secret-1
-kubectl create secret generic -n fleet-default kbcfg-second --from-literal=token="$token" --from-literal=value="$value"
+kubectl create secret generic -n fleet-default kbcfg-second --from-literal=value="$value"
 
 kubectl apply -n fleet-default -f - <<EOF
 apiVersion: "fleet.cattle.io/v1alpha1"

--- a/dev/setup-fleet-multi-cluster
+++ b/dev/setup-fleet-multi-cluster
@@ -13,7 +13,7 @@ upstream_ctx="${FLEET_E2E_CLUSTER-k3d-upstream}"
 kubectl config use-context "$upstream_ctx"
 
 dev/setup-fleet
-dev/setup-fleet-downstream
+dev/setup-fleet-managed-downstream
 
 kubectl config use-context "$upstream_ctx"
 

--- a/dev/setup-rancher-clusters
+++ b/dev/setup-rancher-clusters
@@ -10,6 +10,7 @@ fi
 public_hostname="${public_hostname-172.18.0.1.sslip.io}"
 upstream_ctx="${FLEET_E2E_CLUSTER-k3d-upstream}"
 downstream_ctx="${FLEET_E2E_CLUSTER_DOWNSTREAM-k3d-downstream}"
+rancherpassword="${RANCHER_PASSWORD-rancherpassword}"
 
 # helm repo add rancher-latest https://releases.rancher.com/server-charts/latest
 # helm repo update rancher-latest
@@ -37,7 +38,9 @@ helm upgrade rancher rancher-latest/rancher --version "$version" \
   --set "extraEnv[0].name=CATTLE_SERVER_URL" \
   --set "extraEnv[0].value=https://$public_hostname" \
   --set "extraEnv[1].name=CATTLE_BOOTSTRAP_PASSWORD" \
-  --set "extraEnv[1].value=rancherpassword"
+  --set "extraEnv[1].value=$rancherpassword" \
+  --set "extraEnv[2].name=CATTLE_AGENT_TLS_MODE" \
+  --set "extraEnv[2].value=system-store"
 
 # wait for deployment of rancher
 kubectl -n cattle-system rollout status deploy/rancher


### PR DESCRIPTION
I had problems with the agent-initiated dev script, which needs a public URL.

* also remove unneeded token
* disable strict TLS mode

