### PR TITLE
Remove leftover `disable-gitops` mentions

### DIFF
--- a/internal/cmd/controller/agentmanagement/root.go
+++ b/internal/cmd/controller/agentmanagement/root.go
@@ -20,7 +20,6 @@ type AgentManagement struct {
 
 // HelpFunc hides the global flag from the help output
 func (a *AgentManagement) HelpFunc(cmd *cobra.Command, strings []string) {
-	_ = cmd.Flags().MarkHidden("disable-gitops")
 	_ = cmd.Flags().MarkHidden("disable-metrics")
 	_ = cmd.Flags().MarkHidden("shard-id")
 	_ = cmd.Flags().MarkHidden("shard-node-selector")

--- a/internal/cmd/controller/cleanup/root.go
+++ b/internal/cmd/controller/cleanup/root.go
@@ -15,7 +15,6 @@ type CleanUp struct {
 
 // HelpFunc hides the global flags from the help output
 func (c *CleanUp) HelpFunc(cmd *cobra.Command, strings []string) {
-	_ = cmd.Flags().MarkHidden("disable-gitops")
 	_ = cmd.Flags().MarkHidden("disable-metrics")
 	_ = cmd.Flags().MarkHidden("shard-id")
 	_ = cmd.Flags().MarkHidden("shard-node-selector")

--- a/internal/cmd/controller/gitops/operator.go
+++ b/internal/cmd/controller/gitops/operator.go
@@ -66,7 +66,6 @@ func App(zo *zap.Options) *cobra.Command {
 
 // HelpFunc hides the global flag from the help output
 func (c *GitOperator) HelpFunc(cmd *cobra.Command, strings []string) {
-	_ = cmd.Flags().MarkHidden("disable-gitops")
 	_ = cmd.Flags().MarkHidden("disable-metrics")
 	_ = cmd.Flags().MarkHidden("shard-id")
 	_ = cmd.Flags().MarkHidden("shard-node-selector")


### PR DESCRIPTION
That flag was removed when merging the `GitRepo` and gitOps controllers.

Refers to #2513.
Follow-up to #2537.
