### PR TITLE
Rename Fleet manager references as Fleet controller

### DIFF
--- a/charts/fleet-agent/Chart.yaml
+++ b/charts/fleet-agent/Chart.yaml
@@ -7,7 +7,7 @@ annotations:
   catalog.cattle.io/permits-os: linux,windows
 apiVersion: v2
 appVersion: 0.0.0
-description: Fleet Manager Agent - GitOps at Scale
+description: Fleet Agent - GitOps at Scale
 icon: https://charts.rancher.io/assets/logos/fleet.svg
 name: fleet-agent
 version: 0.0.0

--- a/charts/fleet-agent/values.yaml
+++ b/charts/fleet-agent/values.yaml
@@ -3,11 +3,11 @@ image:
   repository: rancher/fleet-agent
   tag: dev
 
-# The public URL of the Kubernetes API server running the Fleet Manager must be set here
+# The public URL of the Kubernetes API server running the Fleet Controller must be set here
 # Example: https://example.com:6443
 apiServerURL: ""
 
-# The the pem encoded value of the CA of the Kubernetes API server running the Fleet Manager.
+# The pem encoded value of the CA of the Kubernetes API server running the Fleet Controller.
 # If left empty it is assumed this Kubernetes API TLS is signed by a well known CA.
 apiServerCA: ""
 

--- a/charts/fleet-crd/Chart.yaml
+++ b/charts/fleet-crd/Chart.yaml
@@ -7,7 +7,7 @@ annotations:
   catalog.cattle.io/release-name: fleet-crd
 apiVersion: v2
 appVersion: 0.0.0
-description: Fleet Manager CustomResourceDefinitions
+description: Fleet CustomResourceDefinitions
 icon: https://charts.rancher.io/assets/logos/fleet.svg
 name: fleet-crd
 version: 0.0.0

--- a/charts/fleet-crd/README.md
+++ b/charts/fleet-crd/README.md
@@ -1,5 +1,5 @@
 # Fleet CRD Helm Chart
 
-Fleet Manager CustomResourceDefinitions Helm chart is a requirement for the Fleet Helm Chart.
+Fleet CustomResourceDefinitions Helm chart is a requirement for the Fleet Helm Chart.
 
 The Fleet documentation is centralized in the [doc website](https://fleet.rancher.io/).

--- a/charts/fleet-crd/templates/crds.yaml
+++ b/charts/fleet-crd/templates/crds.yaml
@@ -3709,7 +3709,7 @@ spec:
 
             Clusters to which Fleet deploys manifests are referred to as downstream
 
-            clusters. In the single cluster use case, the Fleet manager Kubernetes
+            clusters. In the single cluster use case, the Fleet Kubernetes
 
             cluster is both the manager and downstream cluster at the same time.'
           properties:

--- a/charts/fleet/Chart.yaml
+++ b/charts/fleet/Chart.yaml
@@ -10,7 +10,7 @@ annotations:
   catalog.cattle.io/release-name: fleet
 apiVersion: v2
 appVersion: 0.0.0
-description: Fleet Manager - GitOps at Scale
+description: Fleet Controller - GitOps at Scale
 icon: https://charts.rancher.io/assets/logos/fleet.svg
 name: fleet
 version: 0.0.0

--- a/cmd/docs/generate-cli-docs.go
+++ b/cmd/docs/generate-cli-docs.go
@@ -18,6 +18,11 @@ import (
 )
 
 func main() {
+	if len(os.Args) < 2 {
+		usage()
+		os.Exit(1)
+	}
+
 	docDir := filepath.Join("./", os.Args[1])
 
 	// fleet cli for gitjob
@@ -145,4 +150,8 @@ sidebar_label: "%s"
 `, sidebarLabel)
 
 	return errors.Wrap(err, "error writing file header")
+}
+
+func usage() {
+	fmt.Fprintln(os.Stdout, "Usage: ", os.Args[0], " <directory>")
 }

--- a/internal/cmd/controller/root.go
+++ b/internal/cmd/controller/root.go
@@ -29,7 +29,7 @@ import (
 	"github.com/rancher/fleet/pkg/version"
 )
 
-type FleetManager struct {
+type FleetController struct {
 	command.DebugConfig
 	Kubeconfig     string `usage:"Kubeconfig file"`
 	Namespace      string `usage:"namespace to watch" default:"cattle-fleet-system" env:"NAMESPACE"`
@@ -55,7 +55,7 @@ var (
 	}
 )
 
-func (f *FleetManager) PersistentPre(_ *cobra.Command, _ []string) error {
+func (f *FleetController) PersistentPre(_ *cobra.Command, _ []string) error {
 	if err := f.SetupDebug(); err != nil {
 		return fmt.Errorf("failed to setup debug logging: %w", err)
 	}
@@ -64,7 +64,7 @@ func (f *FleetManager) PersistentPre(_ *cobra.Command, _ []string) error {
 	return nil
 }
 
-func (f *FleetManager) Run(cmd *cobra.Command, args []string) error {
+func (f *FleetController) Run(cmd *cobra.Command, args []string) error {
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(zopts)))
 	ctx := clog.IntoContext(cmd.Context(), ctrl.Log)
 
@@ -124,7 +124,7 @@ func (f *FleetManager) Run(cmd *cobra.Command, args []string) error {
 }
 
 func App() *cobra.Command {
-	root := command.Command(&FleetManager{}, cobra.Command{
+	root := command.Command(&FleetController{}, cobra.Command{
 		Version: version.FriendlyVersion(),
 	})
 	fs := flag.NewFlagSet("", flag.ExitOnError)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,4 +1,4 @@
-// Package config implements the config for the fleet manager and agent
+// Package config implements the config for the fleet controller and agent
 package config
 
 import (
@@ -24,7 +24,7 @@ const (
 	AgentTLSModeSystemStore  = "system-store"
 	Key                      = "config"
 	// DefaultNamespace is the default for the system namespace, which
-	// contains the manager and agent
+	// contains the controller and agent
 	DefaultNamespace       = "cattle-fleet-system"
 	LegacyDefaultNamespace = "fleet-system"
 	// ImportTokenSecretValuesKey is the key in the import token secret,
@@ -53,7 +53,7 @@ var (
 	callbackLock sync.Mutex
 )
 
-// Config is the config for the fleet manager and agent. Each use slightly
+// Config is the config for the fleet controller and agent. Each use slightly
 // different fields from this struct. It is stored as JSON in configmaps under
 // the 'config' key.
 type Config struct {

--- a/pkg/apis/fleet.cattle.io/v1alpha1/cluster_types.go
+++ b/pkg/apis/fleet.cattle.io/v1alpha1/cluster_types.go
@@ -54,7 +54,7 @@ var (
 
 // Cluster corresponds to a Kubernetes cluster. Fleet deploys bundles to targeted clusters.
 // Clusters to which Fleet deploys manifests are referred to as downstream
-// clusters. In the single cluster use case, the Fleet manager Kubernetes
+// clusters. In the single cluster use case, the Fleet Kubernetes
 // cluster is both the manager and downstream cluster at the same time.
 type Cluster struct {
 	metav1.TypeMeta   `json:",inline"`


### PR DESCRIPTION
This removes manager references from non-controller Fleet chart descriptions, and renames the `FleetManager` struct as `FleetController` to enable correct Markdown documentation to be generated from it through `generate-cli-docs.go`.

This could be taken further by renaming eg. `Manager-initiated [cluster] registration` as `Controller-initiated registration` for more consistency.