### PR TITLE
[v0.10] Fixes status not being populated to cluster and clustergroups

### DIFF
--- a/e2e/single-cluster/status_test.go
+++ b/e2e/single-cluster/status_test.go
@@ -71,6 +71,27 @@ var _ = Describe("Checks status updates happen for a simple deployment", Ordered
 			}).Should(Succeed())
 		})
 
+		It("correctly sets the status values for Clusters", func() {
+			Eventually(func(g Gomega) {
+				out, err := k.Get("cluster", "local", "-n", "fleet-local", "-o", "jsonpath='{.status.display.readyBundles}'")
+				g.Expect(err).ToNot(HaveOccurred(), out)
+
+				g.Expect(out).Should(Equal("'2/2'"))
+			}).Should(Succeed())
+		})
+
+		It("correctly sets the status values for ClusterGroups", func() {
+			Eventually(func(g Gomega) {
+				out, err := k.Get("clustergroup", "default", "-n", "fleet-local", "-o", "jsonpath='{.status.display.readyBundles}'")
+				g.Expect(err).ToNot(HaveOccurred(), out)
+				g.Expect(out).Should(Equal("'2/2'"))
+
+				out, err = k.Get("clustergroup", "default", "-n", "fleet-local", "-o", "jsonpath='{.status.display.readyClusters}'")
+				g.Expect(err).ToNot(HaveOccurred(), out)
+				g.Expect(out).Should(Equal("'1/1'"))
+			}).Should(Succeed())
+		})
+
 		It("correctly sets the status values for bundle", func() {
 			Eventually(func(g Gomega) {
 				out, err := k.Get("bundle", "my-gitrepo-helm-verify", "-n", "fleet-local", "-o", "jsonpath='{.status.summary}'")

--- a/internal/cmd/controller/reconciler/cluster_controller.go
+++ b/internal/cmd/controller/reconciler/cluster_controller.go
@@ -85,6 +85,9 @@ func (r *ClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 					if n.Status.AppliedDeploymentID != o.Status.AppliedDeploymentID {
 						return true
 					}
+					if n.Status.Ready != o.Status.Ready {
+						return true
+					}
 					return false
 				},
 				DeleteFunc: func(e event.DeleteEvent) bool {


### PR DESCRIPTION
It simply takes Status.Display in the cluster controller into account.

<!-- Specify the issue ID that this pull request is solving -->
Refers to #2699
<!-- Make sure that the referenced issue provides steps to reproduce it -->

<!-- Describe the changes introduced by this pull request -->

<!--
  Please provide a unit, integration (`./integrationtests/`) or e2e (`./e2e/`) test if possible.
-->