### PR TITLE
Propagate drift correction force mode to Helm rollback

### DIFF
--- a/e2e/drift/drift_test.go
+++ b/e2e/drift/drift_test.go
@@ -200,15 +200,7 @@ var _ = Describe("Drift", Ordered, func() {
 				GinkgoWriter.Print(out)
 			})
 
-			It("Modifies bundle status", func() {
-				Eventually(func() string {
-					out, _ := k.Namespace(env.Namespace).Get("bundles", bundleName, "-o=jsonpath={.status.conditions[*].message}")
-					return out
-				}).Should(ContainSubstring(`service.v1 drift/drift-dummy-service modified {"spec":{"ports":[` +
-					`{"name":"http","port":80,"protocol":"TCP","targetPort":"http-web-svc"},` +
-					`{"name":"http","port":1234,"protocol":"TCP","targetPort":"http-web-svc"}]}}`))
-			})
-
+			// Note: more accurate checks on status changes are now done in integration tests.
 			It("Corrects drift when drift correction is set to force", func() {
 				Eventually(func() string {
 					out, _ := k.Namespace(env.Namespace).Get("bundles", bundleName, "-o=jsonpath={.status.conditions[*].message}")

--- a/integrationtests/agent/bundle_deployment_drift_test.go
+++ b/integrationtests/agent/bundle_deployment_drift_test.go
@@ -115,7 +115,7 @@ var _ = Describe("BundleDeployment drift correction", Ordered, func() {
 			}))
 		})
 
-		Context("A release resource is modified", func() {
+		Context("A release resource is modified", Ordered, func() {
 			It("Receives a modification on a service", func() {
 				svc, err := env.getService(svcName)
 				Expect(err).NotTo(HaveOccurred())

--- a/internal/helmdeployer/install.go
+++ b/internal/helmdeployer/install.go
@@ -159,6 +159,9 @@ func (h *Helm) install(ctx context.Context, bundleID string, manifest *manifest.
 	u.TakeOwnership = true
 	u.EnableDNS = !options.Helm.DisableDNS
 	u.Force = options.Helm.Force
+	if options.CorrectDrift != nil {
+		u.Force = u.Force || options.CorrectDrift.Force
+	}
 	u.Atomic = options.Helm.Atomic
 	u.MaxHistory = options.Helm.MaxHistory
 	if u.MaxHistory == 0 {


### PR DESCRIPTION
This enables drift correction to be forced after the fact, which can help users deal with edge cases such as patching ports services, a case known not to be [supported](https://github.com/helm/helm/issues/12974) by Helm.

Depends on #2792.
Refers to #2609