### PR TITLE
Document agent garbage collection interval in charts

### DIFF
--- a/charts/fleet-agent/values.yaml
+++ b/charts/fleet-agent/values.yaml
@@ -15,6 +15,10 @@ apiServerCA: ""
 # management cluster. True in `system-store` mode, false in `strict` mode.
 agentTLSMode: "system-store"
 
+# The amount of time that agents will wait before they clean up old Helm releases.
+# A non-existent value or 0 will result in an interval of 15 minutes.
+garbageCollectionInterval: "15m"
+
 # The cluster registration value
 token: ""
 

--- a/charts/fleet/values.yaml
+++ b/charts/fleet/values.yaml
@@ -23,6 +23,10 @@ agentTLSMode: "system-store"
 # A duration string for how often agents should report a heartbeat
 agentCheckinInterval: "15m"
 
+# The amount of time that agents will wait before they clean up old Helm releases.
+# A non-existent value or 0 will result in an interval of 15 minutes.
+garbageCollectionInterval: "15m"
+
 # Whether you want to allow cluster upon registration to specify their labels.
 ignoreClusterRegistrationLabels: false
 


### PR DESCRIPTION
This mentions the garbage collection interval, which can be set on both `fleet` and `fleet-agent` charts (the former will propagate it to the latter), and clarifies what happens when no duration, or `0s`, is configured.

Follow-up to #2665.
Refers to #2169