### PR TITLE
[v0.9] Bump Go to 1.22.7

### DIFF
--- a/e2e/testenv/infra/go.mod
+++ b/e2e/testenv/infra/go.mod
@@ -1,6 +1,6 @@
 module github.com/rancher/fleet/e2e/testenv/infra
 
-go 1.21
+go 1.22
 
 toolchain go1.22.7
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/rancher/fleet
 
-go 1.21
+go 1.22
+
+toolchain go1.22.7
 
 replace (
 	github.com/rancher/fleet/pkg/apis => ./pkg/apis


### PR DESCRIPTION
This is a follow-up to [CVE-2022-30635](https://www.cve.org/CVERecord?id=CVE-2024-34156).