### PR TITLE
[v0.10] Bump Go to 1.22.7

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/rancher/fleet
 
 go 1.22.0
 
-toolchain go1.22.5
+toolchain go1.22.7
 
 replace (
 	github.com/imdario/mergo => github.com/imdario/mergo v0.3.16

--- a/pkg/apis/go.mod
+++ b/pkg/apis/go.mod
@@ -2,7 +2,7 @@ module github.com/rancher/fleet/pkg/apis
 
 go 1.22.0
 
-toolchain go1.22.5
+toolchain go1.22.7
 
 require (
 	github.com/rancher/wrangler/v3 v3.0.0


### PR DESCRIPTION
This is a follow-up to [CVE-2022-30635](https://www.cve.org/CVERecord?id=CVE-2024-34156).