### PR TITLE
Use Go 1.22 as default in Rancher Release workflow

### DIFF
--- a/.github/workflows/release-against-rancher.yml
+++ b/.github/workflows/release-against-rancher.yml
@@ -25,7 +25,7 @@ on:
       go_version:
         description: "Go version used for bumping the api. This should be the same version as in the go.mod file of the project."
         required: true
-        default: '1.21.*'
+        default: '1.22.*'
 
 env:
   GOARCH: amd64


### PR DESCRIPTION
since Go 1.21 is not supported anymore and now used in Fleet 0.9 and 0.10.