### PR TITLE
[v0.10] Fixes finalizer deletion in bundle deployments

### DIFF
--- a/internal/cmd/controller/reconciler/bundledeployment_controller.go
+++ b/internal/cmd/controller/reconciler/bundledeployment_controller.go
@@ -75,7 +75,7 @@ func (r *BundleDeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Req
 
 				controllerutil.RemoveFinalizer(t, bundleDeploymentFinalizer)
 
-				return r.Update(ctx, bd)
+				return r.Update(ctx, t)
 			})
 			if err != nil {
 				return ctrl.Result{}, err
@@ -139,7 +139,7 @@ func bundleDeploymentStatusChangedPredicate() predicate.Funcs {
 			if n == nil || o == nil {
 				return false
 			}
-			return !reflect.DeepEqual(n.Status, o.Status)
+			return !n.DeletionTimestamp.IsZero() || !reflect.DeepEqual(n.Status, o.Status)
 		},
 	}
 }


### PR DESCRIPTION
This issue is affecting the `BundleDeployment` when it is deleted after targetting discards it as a valid target.

The reconciler was not called when `DeletionTimestamp` was set and there was a typo that prevented the finalizer to be deleted.

Refers to: https://github.com/rancher/fleet/issues/2768

Backport of: https://github.com/rancher/fleet/pull/2820
