### PR TITLE
Skip checks on logs in sharding end-to-end tests

### DIFF
--- a/e2e/single-cluster/sharding_test.go
+++ b/e2e/single-cluster/sharding_test.go
@@ -153,7 +153,7 @@ var _ = Describe("Filtering events by shard", Label("sharding"), func() {
 
 		It("does not deploy the gitrepo", func() {
 			By("checking the configmap does not exist")
-			Eventually(func() string {
+			Consistently(func() string {
 				out, _ := k.Namespace(targetNamespace).Get("configmaps")
 				return out
 			}).ShouldNot(ContainSubstring("test-simple-chart-config"))

--- a/e2e/single-cluster/sharding_test.go
+++ b/e2e/single-cluster/sharding_test.go
@@ -7,14 +7,13 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/onsi/gomega/matchers"
 	"github.com/rancher/fleet/e2e/testenv"
 	"github.com/rancher/fleet/e2e/testenv/kubectl"
 )
 
 var shards = []string{"shard0", "shard1", "shard2"}
 
-var _ = Describe("Filtering events by shard", Label("sharding"), Ordered, func() {
+var _ = Describe("Filtering events by shard", Label("sharding"), func() {
 	var (
 		k               kubectl.Command
 		gitrepoName     string
@@ -22,32 +21,16 @@ var _ = Describe("Filtering events by shard", Label("sharding"), Ordered, func()
 		targetNamespace string
 	)
 
-	BeforeAll(func() {
-		// No sharded gitjob controller should have reconciled any GitRepo until this point.
-		for _, shard := range shards {
-			logs, err := k.Namespace("cattle-fleet-system").Logs(
-				"-l",
-				"app=gitjob",
-				"-l",
-				fmt.Sprintf("fleet.cattle.io/shard-id=%s", shard),
-				"--tail=-1",
-			)
-			Expect(err).ToNot(HaveOccurred())
-			regexMatcher := matchers.MatchRegexpMatcher{Regexp: "Reconciling GitRepo.*"}
-			hasReconciledGitRepos, err := regexMatcher.Match(logs)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(hasReconciledGitRepos).To(BeFalse())
-		}
-
+	BeforeEach(func() {
 		k = env.Kubectl.Namespace(env.Namespace)
+		targetNamespace = testenv.NewNamespaceName("target", r)
+		gitrepoName = testenv.RandomFilename("sharding-test", r)
+
 	})
 
 	for _, shard := range shards {
 		When(fmt.Sprintf("deploying a gitrepo labeled with shard ID %s", shard), func() {
 			JustBeforeEach(func() {
-				targetNamespace = testenv.NewNamespaceName("target", r)
-				gitrepoName = testenv.RandomFilename("sharding-test", r)
-
 				err := testenv.ApplyTemplate(
 					k,
 					testenv.AssetPath("gitrepo/gitrepo_sharded.yaml"),
@@ -108,42 +91,6 @@ var _ = Describe("Filtering events by shard", Label("sharding"), Ordered, func()
 					g.Expect(podNodeSelector).ToNot(BeEmpty())
 					g.Expect(podNodeSelector).To(Equal(shardNodeSelector))
 				}).Should(Succeed())
-
-				for _, s := range shards {
-					Eventually(func(g Gomega) {
-						logs, err := k.Namespace("cattle-fleet-system").Logs(
-							"-l",
-							"app=gitjob",
-							"-l",
-							fmt.Sprintf("fleet.cattle.io/shard-id=%s", s),
-							"--tail=100",
-						)
-						g.Expect(err).ToNot(HaveOccurred())
-						regexMatcher := matchers.MatchRegexpMatcher{
-							Regexp: fmt.Sprintf(`Reconciling GitRepo.*"name":"%s"`, gitrepoName),
-						}
-						hasReconciledGitRepo, err := regexMatcher.Match(logs)
-						g.Expect(err).ToNot(HaveOccurred())
-						if s == shard {
-							g.Expect(hasReconciledGitRepo).To(BeTrueBecause(
-								"GitRepo %q labeled with shard %q should have been"+
-									" deployed by gitjob for shard %q in namespace %q",
-								gitrepoName,
-								shard,
-								shard,
-								env.Namespace,
-							))
-						} else {
-							g.Expect(hasReconciledGitRepo).To(BeFalseBecause(
-								"GitRepo %q labeled with shard %q should not have been"+
-									" deployed by gitjob for shard %q",
-								gitrepoName,
-								shard,
-								s,
-							))
-						}
-					}).Should(Succeed())
-				}
 			})
 
 			AfterEach(func() {
@@ -155,9 +102,6 @@ var _ = Describe("Filtering events by shard", Label("sharding"), Ordered, func()
 
 	When("deploying a gitrepo labeled with an unknown shard ID", func() {
 		JustBeforeEach(func() {
-			targetNamespace = testenv.NewNamespaceName("target", r)
-			gitrepoName = testenv.RandomFilename("sharding-test", r)
-
 			err := testenv.ApplyTemplate(k, testenv.AssetPath("gitrepo/gitrepo_sharded.yaml"), struct {
 				Name            string
 				Repo            string
@@ -182,32 +126,6 @@ var _ = Describe("Filtering events by shard", Label("sharding"), Ordered, func()
 				out, _ := k.Namespace(targetNamespace).Get("configmaps")
 				return out
 			}).ShouldNot(ContainSubstring("test-simple-chart-config"))
-
-			for _, s := range shards {
-				logs, err := k.Namespace("cattle-fleet-system").Logs(
-					"-l",
-					"app=gitjob",
-					"-l",
-					fmt.Sprintf("fleet.cattle.io/shard-id=%s", s),
-					"--tail=100",
-				)
-				Expect(err).ToNot(HaveOccurred())
-				regexMatcher := matchers.MatchRegexpMatcher{
-					Regexp: fmt.Sprintf(
-						`Reconciling GitRepo.*"GitRepo": {"name":"%s","namespace":"%s"}`,
-						gitrepoName,
-						env.Namespace,
-					),
-				}
-				hasReconciledGitRepos, err := regexMatcher.Match(logs)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(hasReconciledGitRepos).To(BeFalseBecause(
-					"GitRepo labeled with shard %q should not have been deployed by"+
-						" gitjob for shard %q",
-					"unknown",
-					s,
-				))
-			}
 		})
 
 		AfterEach(func() {


### PR DESCRIPTION
Sharding end-to-end tests would previously read `debug` controller logs, which was brittle as it would fail:
* when running the test suite multiple times, as those checks relied on the _absence_ of some logs
* when debug logging was disabled

They now check that bundles and bundle deployments created through `GitRepo`s are labelled with the right shard ID instead.

Refers to #2826