### PR TITLE
Adds e2e test to check that bundledeployments are deleted

### DIFF
--- a/e2e/assets/multi-cluster/bundle-deployment-labels.yaml
+++ b/e2e/assets/multi-cluster/bundle-deployment-labels.yaml
@@ -1,0 +1,21 @@
+kind: GitRepo
+apiVersion: fleet.cattle.io/v1alpha1
+metadata:
+  name: simpleapplabels
+  namespace: {{.ProjectNamespace}}
+  labels:
+    team: one
+
+spec:
+  repo: https://github.com/rancher/fleet-test-data
+  branch: master
+  paths:
+  - simple
+
+  targetNamespace: {{.TargetNamespace}}
+
+  targets:
+  - name: test
+    clusterSelector:
+      matchLabels:
+        envlabels: test

--- a/e2e/multi-cluster/not_matching_targets_delete_bd_test.go
+++ b/e2e/multi-cluster/not_matching_targets_delete_bd_test.go
@@ -1,0 +1,94 @@
+package multicluster_test
+
+import (
+	"math/rand"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/rancher/fleet/e2e/testenv"
+	"github.com/rancher/fleet/e2e/testenv/kubectl"
+)
+
+// This test uses labels in clusters to demonstrate that applying or
+// deleting the label installs or uninstalls the bundle deployment
+var _ = Describe("Target clusters by label", func() {
+	var (
+		k  kubectl.Command
+		kd kubectl.Command
+
+		asset     string
+		namespace string
+		data      any
+
+		r = rand.New(rand.NewSource(GinkgoRandomSeed()))
+	)
+
+	type TemplateData struct {
+		ProjectNamespace string
+		TargetNamespace  string
+	}
+
+	BeforeEach(func() {
+		k = env.Kubectl.Context(env.Upstream)
+		kd = env.Kubectl.Context(env.ManagedDownstream)
+	})
+
+	JustBeforeEach(func() {
+		err := testenv.ApplyTemplate(k.Namespace(env.ClusterRegistrationNamespace), testenv.AssetPath(asset), data)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		out, err := k.Namespace(env.ClusterRegistrationNamespace).Delete("gitrepo", "simpleapplabels", "--wait=false")
+		Expect(err).ToNot(HaveOccurred(), out)
+	})
+
+	Context("if cluster has the expected label, bundle is deployed", func() {
+		BeforeEach(func() {
+			namespace = testenv.NewNamespaceName("label-not-set", r)
+			asset = "multi-cluster/bundle-deployment-labels.yaml"
+			data = TemplateData{env.ClusterRegistrationNamespace, namespace}
+			// set the expected label
+			out, err := k.Namespace(env.ClusterRegistrationNamespace).Label("clusters", "second", "envlabels=test")
+			Expect(err).ToNot(HaveOccurred(), out)
+		})
+
+		It("deploys to the mapped downstream cluster and when label is deleted it removes the deployment", func() {
+			Eventually(func() string {
+				out, _ := k.Get("bundledeployments", "-A", "-l", "fleet.cattle.io/bundle-name=simpleapplabels-simple")
+				return out
+			}).Should(ContainSubstring("simpleapplabels-simple"))
+			Eventually(func() string {
+				out, _ := kd.Get("configmaps", "-A")
+				return out
+			}).Should(ContainSubstring("simple-config"))
+
+			// delete the label (bundledeployment should be deleted and resources in cluster deleted)
+			out, err := k.Namespace(env.ClusterRegistrationNamespace).Label("clusters", "second", "envlabels-")
+			Expect(err).ToNot(HaveOccurred(), out)
+
+			Eventually(func() string {
+				out, _ := k.Get("bundledeployments", "-A", "-l", "fleet.cattle.io/bundle-name=simpleapplabels-simple")
+				return out
+			}).ShouldNot(ContainSubstring("simpleapplabels-simple"))
+			Eventually(func() string {
+				out, _ := kd.Namespace(namespace).Get("configmaps")
+				return out
+			}).ShouldNot(ContainSubstring("simple-config"))
+
+			// re-apply the label (bundledeployment should be created and applied again)
+			out, err = k.Namespace(env.ClusterRegistrationNamespace).Label("clusters", "second", "envlabels=test")
+			Expect(err).ToNot(HaveOccurred(), out)
+
+			Eventually(func() string {
+				out, _ := k.Get("bundledeployments", "-A", "-l", "fleet.cattle.io/bundle-name=simpleapplabels-simple")
+				return out
+			}).Should(ContainSubstring("simpleapplabels-simple"))
+			Eventually(func() string {
+				out, _ := kd.Namespace(namespace).Get("configmaps")
+				return out
+			}).Should(ContainSubstring("simple-config"))
+		})
+	})
+})

--- a/e2e/testenv/env.go
+++ b/e2e/testenv/env.go
@@ -19,6 +19,8 @@ type Env struct {
 	Upstream string
 	// Downstream context for fleet-agent cluster
 	Downstream string
+	// Managed downstream cluster
+	ManagedDownstream string
 	// Namespace which contains the cluster resource for most E2E tests
 	// (cluster registration namespace)
 	Namespace string
@@ -32,6 +34,7 @@ func New() *Env {
 		Kubectl:                      kubectl.New("", "default"),
 		Upstream:                     "k3d-upstream",
 		Downstream:                   "k3d-downstream",
+		ManagedDownstream:            "k3d-managed-downstream",
 		Namespace:                    "fleet-local",
 		ClusterRegistrationNamespace: "fleet-default",
 	}

--- a/e2e/testenv/kubectl/kubectl.go
+++ b/e2e/testenv/kubectl/kubectl.go
@@ -70,6 +70,10 @@ func (c Command) Patch(args ...string) (string, error) {
 	return c.Run(append([]string{"patch"}, args...)...)
 }
 
+func (c Command) Label(args ...string) (string, error) {
+	return c.Run(append([]string{"label"}, args...)...)
+}
+
 func (c Command) Run(args ...string) (string, error) {
 	if c.cnt != "" {
 		args = append([]string{"--context", c.cnt}, args...)


### PR DESCRIPTION
This adds a new test to check that when applying a gitrepo that targets based on labels it deploys/deletes the bundledeployment depending if the label for targetting is present or not in the downstream cluster

This is related to: https://github.com/rancher/fleet/pull/2820
Refers to: https://github.com/rancher/fleet/issues/2768
