### PR TITLE
Fix helm.sh/resource-policy being added to everything and not just CRDs

### DIFF
--- a/internal/helmdeployer/postrender.go
+++ b/internal/helmdeployer/postrender.go
@@ -83,12 +83,13 @@ func (p *postRender) Run(renderedManifests *bytes.Buffer) (modifiedManifests *by
 		if err != nil {
 			return nil, err
 		}
+		objAnnotations := mergeMaps(m.GetAnnotations(), annotations)
 		if !p.opts.DeleteCRDResources &&
 			obj.GetObjectKind().GroupVersionKind().Kind == CRDKind {
-			annotations[kube.ResourcePolicyAnno] = kube.KeepPolicy
+			objAnnotations[kube.ResourcePolicyAnno] = kube.KeepPolicy
 		}
 		m.SetLabels(mergeMaps(m.GetLabels(), labels))
-		m.SetAnnotations(mergeMaps(m.GetAnnotations(), annotations))
+		m.SetAnnotations(objAnnotations)
 
 		if p.opts.TargetNamespace != "" {
 			if p.mapper != nil {

--- a/internal/helmdeployer/postrender_test.go
+++ b/internal/helmdeployer/postrender_test.go
@@ -116,4 +116,64 @@ func TestPostRenderer_Run_DeleteCRDs(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("Multiple resources, only add to CRDs", func(t *testing.T) {
+		crd := &apiextensionsv1.CustomResourceDefinition{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       CRDKind,
+				APIVersion: "apiextensions.k8s.io/v1",
+			},
+		}
+		pod := &corev1.Pod{
+			TypeMeta: metav1.TypeMeta{
+				Kind: "Pod",
+			},
+		}
+
+		data, err := yaml.ToBytes([]kruntime.Object{crd, pod})
+		if err != nil {
+			t.Errorf("unexpected error %v", err)
+		}
+		renderedManifests := bytes.NewBuffer(data)
+
+		pr := postRender{
+			manifest: &manifest.Manifest{
+				Resources: []v1alpha1.BundleResource{},
+			},
+			chart: &chart.Chart{},
+			opts: v1alpha1.BundleDeploymentOptions{
+				DeleteCRDResources: false,
+			},
+		}
+		postRenderedManifests, err := pr.Run(renderedManifests)
+		if err != nil {
+			t.Errorf("unexpected error %v", err)
+		}
+
+		data = postRenderedManifests.Bytes()
+		objs, err := yaml.ToObjects(bytes.NewBuffer(data))
+		if err != nil {
+			t.Errorf("unexpected error %v", err)
+		}
+
+		for _, obj := range objs {
+			m, err := meta.Accessor(obj)
+			if err != nil {
+				t.Errorf("unexpected error %v", err)
+			}
+
+			annotations := m.GetAnnotations()
+			kind := obj.GetObjectKind().GroupVersionKind().Kind
+			if kind == CRDKind {
+				if val, ok := annotations[kube.ResourcePolicyAnno]; !ok || val != kube.KeepPolicy {
+					t.Errorf("expected %s, got %s", kube.KeepPolicy, annotations[kube.ResourcePolicyAnno])
+				}
+			} else {
+				if val, ok := annotations[kube.ResourcePolicyAnno]; ok {
+					t.Errorf("unexpected annotation on %s, got %s: %s", kind, kube.ResourcePolicyAnno, val)
+				}
+			}
+		}
+	})
+
 }


### PR DESCRIPTION
<!-- Specify the issue ID that this pull request is solving -->
Refers to #2716
<!-- Make sure that the referenced issue provides steps to reproduce it -->

<!-- Describe the changes introduced by this pull request -->
When `deleteCRDResources` was disabled (default), the `helm.sh/resource-policy` annotation was added to more resources than just CRDs, because as soon as there was one CRD, the `annotations` variable was modified which also gets used by other resources in the loop (resources that were processed before the first CRD are fine). The fix is now to only modify a copy of the annotations that doesn't get reused for other resources.

This same bug also exists in the 0.9 branch in the [`deployer.go`](https://github.com/rancher/fleet/blob/release/v0.9/internal/helmdeployer/deployer.go#L170-L175). Should I also create a separate PR for that branch?
<!--
  Please provide a unit, integration (`./integrationtests/`) or e2e (`./e2e/`) test if possible.
-->