### PR TITLE
Fix linting errors caused by workqueue rate limiter

### DIFF
--- a/.golangci.json
+++ b/.golangci.json
@@ -56,6 +56,10 @@
         "text": "G107: Potential HTTP request made with variable url"
       },
       {
+        "path": "internal/cmd",
+        "text": "SA1019: workqueue.RateLimiter is deprecated"
+      },
+      {
         "path": "internal/cmd/agent/deployer/internal/",
         "linters": [
           "revive"

--- a/internal/cmd/agent/clusterstatus.go
+++ b/internal/cmd/agent/clusterstatus.go
@@ -172,7 +172,10 @@ func newSharedControllerFactory(config *rest.Config, mapper meta.RESTMapper, nam
 		DefaultNamespace: namespace,
 		DefaultResync:    durations.DefaultResyncAgent,
 	})
-	slowRateLimiter := workqueue.NewItemExponentialFailureRateLimiter(durations.SlowFailureRateLimiterBase, durations.SlowFailureRateLimiterMax)
+	slowRateLimiter := workqueue.NewTypedItemExponentialFailureRateLimiter[any](
+		durations.SlowFailureRateLimiterBase,
+		durations.SlowFailureRateLimiterMax,
+	)
 
 	return controller.NewSharedControllerFactory(cacheFactory, &controller.SharedControllerFactoryOptions{
 		KindRateLimiter: map[schema.GroupVersionKind]workqueue.RateLimiter{

--- a/internal/cmd/controller/agentmanagement/controllers/controllers.go
+++ b/internal/cmd/controller/agentmanagement/controllers/controllers.go
@@ -209,8 +209,14 @@ func NewAppContext(cfg clientcmd.ClientConfig) (*AppContext, error) {
 }
 
 func controllerFactory(rest *rest.Config) (controller.SharedControllerFactory, error) {
-	rateLimit := workqueue.NewItemExponentialFailureRateLimiter(durations.FailureRateLimiterBase, durations.FailureRateLimiterMax)
-	clusterRateLimiter := workqueue.NewItemExponentialFailureRateLimiter(durations.SlowFailureRateLimiterBase, durations.SlowFailureRateLimiterMax)
+	rateLimit := workqueue.NewTypedItemExponentialFailureRateLimiter[any](
+		durations.FailureRateLimiterBase,
+		durations.FailureRateLimiterMax,
+	)
+	clusterRateLimiter := workqueue.NewTypedItemExponentialFailureRateLimiter[any](
+		durations.SlowFailureRateLimiterBase,
+		durations.SlowFailureRateLimiterMax,
+	)
 	clientFactory, err := client.NewSharedClientFactory(rest, nil)
 	if err != nil {
 		return nil, err

--- a/internal/cmd/controller/cleanup/controllers/controllers.go
+++ b/internal/cmd/controller/cleanup/controllers/controllers.go
@@ -140,8 +140,14 @@ func NewAppContext(cfg clientcmd.ClientConfig) (*AppContext, error) {
 }
 
 func controllerFactory(rest *rest.Config) (controller.SharedControllerFactory, error) {
-	rateLimit := workqueue.NewItemExponentialFailureRateLimiter(durations.FailureRateLimiterBase, durations.FailureRateLimiterMax)
-	clusterRateLimiter := workqueue.NewItemExponentialFailureRateLimiter(durations.SlowFailureRateLimiterBase, durations.SlowFailureRateLimiterMax)
+	rateLimit := workqueue.NewTypedItemExponentialFailureRateLimiter[any](
+		durations.FailureRateLimiterBase,
+		durations.FailureRateLimiterMax,
+	)
+	clusterRateLimiter := workqueue.NewTypedItemExponentialFailureRateLimiter[any](
+		durations.SlowFailureRateLimiterBase,
+		durations.SlowFailureRateLimiterMax,
+	)
 	clientFactory, err := client.NewSharedClientFactory(rest, nil)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This updates rate limiters where possible to make use of newer, generic, rate limiters.
Eliminating remaining errors would require updating `rancher/lasso`'s [SharedControllerFactoryOptions](https://github.com/rancher/lasso/blob/master/pkg/controller/sharedcontrollerfactory.go#L31), therefore this commit simply ignores them through `golangci-lint` configuration.