### PR TITLE
[v0.10] Add integration test checks for CA bundle secret

### DIFF
--- a/integrationtests/gitjob/controller/controller_test.go
+++ b/integrationtests/gitjob/controller/controller_test.go
@@ -17,6 +17,8 @@ import (
 	"github.com/rancher/wrangler/v3/pkg/genericcondition"
 	"github.com/rancher/wrangler/v3/pkg/name"
 
+	"github.com/onsi/gomega/gcustom"
+	gomegatypes "github.com/onsi/gomega/types"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -59,11 +61,14 @@ var _ = Describe("GitJob controller", func() {
 			gitRepoName string
 			job         batchv1.Job
 			jobName     string
+			secretName  string
 		)
 
 		JustBeforeEach(func() {
 			expectedCommit = commit
 			gitRepo = createGitRepo(gitRepoName)
+			gitRepo.Spec.CABundle = []byte("LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tZm9vLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=")
+
 			Expect(k8sClient.Create(ctx, &gitRepo)).ToNot(HaveOccurred())
 			Eventually(func() string {
 				var gitRepoFromCluster v1alpha1.GitRepo
@@ -89,23 +94,44 @@ var _ = Describe("GitJob controller", func() {
 			Expect(job.Spec.Template.Spec.Containers).To(HaveLen(1))
 			Expect(job.Spec.Template.Spec.Containers[0].Args).To(ContainElements("fleet", "apply"))
 
+			gitRepoOwnerRef := metav1.OwnerReference{
+				Kind:       "GitRepo",
+				APIVersion: "fleet.cattle.io/v1alpha1",
+				Name:       gitRepoName,
+			}
+
 			// it should create RBAC resources for that gitRepo
-			Eventually(func() bool {
+			Eventually(func(g Gomega) {
 				saName := name.SafeConcatName("git", gitRepo.Name)
 				ns := types.NamespacedName{Name: saName, Namespace: gitRepo.Namespace}
 
-				if err := k8sClient.Get(ctx, ns, &corev1.ServiceAccount{}); err != nil {
-					return false
-				}
-				if err := k8sClient.Get(ctx, ns, &rbacv1.Role{}); err != nil {
-					return false
-				}
-				if err := k8sClient.Get(ctx, ns, &rbacv1.RoleBinding{}); err != nil {
-					return false
-				}
+				var sa corev1.ServiceAccount
+				g.Expect(k8sClient.Get(ctx, ns, &sa)).ToNot(HaveOccurred())
+				Expect(sa.ObjectMeta).To(beOwnedBy(gitRepoOwnerRef))
 
-				return true
-			}).Should(BeTrue())
+				var ro rbacv1.Role
+				g.Expect(k8sClient.Get(ctx, ns, &ro)).ToNot(HaveOccurred())
+				Expect(ro.ObjectMeta).To(beOwnedBy(gitRepoOwnerRef))
+
+				var rb rbacv1.RoleBinding
+				g.Expect(k8sClient.Get(ctx, ns, &rb)).ToNot(HaveOccurred())
+				Expect(rb.ObjectMeta).To(beOwnedBy(gitRepoOwnerRef))
+			}).Should(Succeed())
+
+			// it should create a secret for the CA bundle
+			Eventually(func(g Gomega) {
+				secretName = fmt.Sprintf("%s-cabundle", gitRepoName)
+				ns := types.NamespacedName{Name: secretName, Namespace: gitRepo.Namespace}
+				var secret corev1.Secret
+
+				err := k8sClient.Get(ctx, ns, &secret)
+				g.Expect(err).ToNot(HaveOccurred())
+				Expect(secret.ObjectMeta).To(beOwnedBy(gitRepoOwnerRef))
+
+				data, ok := secret.Data["additional-ca.crt"]
+				g.Expect(ok).To(BeTrue())
+				g.Expect(data).To(Equal(gitRepo.Spec.CABundle))
+			}).Should(Succeed())
 		})
 
 		When("a job completes successfully", func() {
@@ -814,4 +840,24 @@ func waitDeleteGitrepo(gitRepo v1alpha1.GitRepo) {
 		err := k8sClient.Get(ctx, types.NamespacedName{Name: gitRepo.Name, Namespace: gitRepo.Namespace}, &gitRepoFromCluster)
 		return errors.IsNotFound(err)
 	}).Should(BeTrue())
+}
+
+func beOwnedBy(expected interface{}) gomegatypes.GomegaMatcher {
+	return gcustom.MakeMatcher(func(meta metav1.ObjectMeta) (bool, error) {
+		ref, ok := expected.(metav1.OwnerReference)
+		if !ok {
+			return false, fmt.Errorf("beOwnedBy matcher expects metav1.OwnerReference")
+		}
+
+		for _, or := range meta.OwnerReferences {
+			if or.Kind == ref.Kind && or.APIVersion == ref.APIVersion && or.Name == ref.Name {
+				return true, nil
+			}
+		}
+
+		return false, nil
+	}).WithTemplate(
+		"Expected:\n{{.FormattedActual}}\n{{.To}} contain owner reference " +
+			"matching Kind, APIVersion and Name of \n{{format .Data 1}}",
+	).WithTemplateData(expected)
 }


### PR DESCRIPTION
Backport of #2846 to `release/v0.10`.
Refers to #2829.

When a git job is created for a `GitRepo` with a configured CA bundle, integration tests now validate that a secret is created with the contents of that bundle and validate its contents against the `GitRepo` spec.

This also validates through integration tests that RBAC resources and the CA bundle secret are owned by their `GitRepo` and will therefore be deleted as soon as the `GitRepo` is.
Validation does not actually delete anything, due to a limitation [1] of the test framework.

[1]: https://book.kubebuilder.io/reference/envtest#testing-considerations