### PR TITLE
[v0.10] Tolerate unitialized node taint

### DIFF
--- a/internal/cmd/controller/gitops/reconciler/gitjob_controller.go
+++ b/internal/cmd/controller/gitops/reconciler/gitjob_controller.go
@@ -683,12 +683,20 @@ func (r *GitJobReconciler) newJobSpec(ctx context.Context, gitrepo *v1alpha1.Git
 					},
 				},
 				NodeSelector: nodeSelector,
-				Tolerations: []corev1.Toleration{{
-					Key:      "cattle.io/os",
-					Operator: "Equal",
-					Value:    "linux",
-					Effect:   "NoSchedule",
-				}},
+				Tolerations: []corev1.Toleration{
+					{
+						Key:      "cattle.io/os",
+						Operator: "Equal",
+						Value:    "linux",
+						Effect:   "NoSchedule",
+					},
+					{
+						Key:      "node.cloudprovider.kubernetes.io/uninitialized",
+						Operator: "Equal",
+						Value:    "true",
+						Effect:   "NoSchedule",
+					},
+				},
 			},
 		},
 	}, nil


### PR DESCRIPTION
In order to bootstrap cluster with fleet (to deploy CPI), we need gitjob to tolerate unitialized node taint

<!-- Specify the issue ID that this pull request is solving -->
Refers to #2862
Backport of #2782.
<!-- Make sure that the referenced issue provides steps to reproduce it -->

<!-- Describe the changes introduced by this pull request -->

<!--
  Please provide a unit, integration (`./integrationtests/`) or e2e (`./e2e/`) test if possible.
-->