### PR TITLE
Cleanup completed gitjobs

### DIFF
--- a/charts/fleet/templates/job_cleanup_clusterregistrations.yaml
+++ b/charts/fleet/templates/job_cleanup_clusterregistrations.yaml
@@ -34,6 +34,7 @@ spec:
         - fleet
         args:
         - cleanup
+        - clusterregistration
       nodeSelector: {{ include "linux-node-selector" . | nindent 8 }}
       tolerations: {{ include "linux-node-tolerations" . | nindent 8 }}
   backoffLimit: 1

--- a/charts/fleet/templates/job_cleanup_gitrepojobs.yaml
+++ b/charts/fleet/templates/job_cleanup_gitrepojobs.yaml
@@ -1,0 +1,47 @@
+{{- if .Values.migrations.gitrepoJobsCleanup }}
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: fleet-cleanup-gitrepo-jobs
+  annotations:
+    "helm.sh/hook": post-install, post-upgrade
+    "helm.sh/hook-delete-policy": hook-succeeded, before-hook-creation
+spec:
+  schedule: "@daily"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 0
+  failedJobsHistoryLimit: 1
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            app: fleet-job
+        spec:
+          serviceAccountName: fleet-controller
+          restartPolicy: Never
+          securityContext:
+            runAsNonRoot: true
+            runAsGroup: 1000
+            runAsUser: 1000
+          containers:
+          - name: cleanup
+            image: "{{ template "system_default_registry" . }}{{.Values.image.repository}}:{{.Values.image.tag}}"
+            imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop:
+                - ALL
+              readOnlyRootFilesystem: false
+              privileged: false
+            command:
+            - fleet
+            args:
+            - cleanup
+            - gitjob
+          nodeSelector: {{ include "linux-node-selector" . | nindent 12 }}
+          tolerations: {{ include "linux-node-tolerations" . | nindent 12 }}
+      backoffLimit: 1
+{{- end }}

--- a/charts/fleet/values.yaml
+++ b/charts/fleet/values.yaml
@@ -96,6 +96,7 @@ propagateDebugSettingsToAgents: true
 
 migrations:
   clusterRegistrationCleanup: true
+  gitrepoJobsCleanup: true
 
 ## Leader election configuration
 leaderElection:

--- a/integrationtests/cli/cleanup/cleanup_clusterregistrations_test.go
+++ b/integrationtests/cli/cleanup/cleanup_clusterregistrations_test.go
@@ -12,7 +12,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("Fleet CLI cleanup", Ordered, func() {
+var _ = Describe("Fleet CLI clusterregistration cleanup", Ordered, func() {
 	var (
 		options              cleanup.Options
 		clusters             []fleetv1.Cluster

--- a/integrationtests/cli/cleanup/cleanup_jobs_test.go
+++ b/integrationtests/cli/cleanup/cleanup_jobs_test.go
@@ -1,0 +1,191 @@
+package cleanup
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/rancher/fleet/internal/cmd/cli/cleanup"
+
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Fleet CLI jobs cleanup", Ordered, func() {
+	var (
+		jobs    []batchv1.Job
+		otherns string
+	)
+
+	BeforeEach(func() {
+		otherns = namespace + "-other"
+		Expect(k8sClient.Create(ctx, &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: otherns,
+			},
+		})).ToNot(HaveOccurred())
+	})
+
+	JustBeforeEach(func() {
+		for _, c := range jobs {
+			tmp := c.DeepCopy()
+			err := k8sClient.Create(ctx, tmp)
+			Expect(err).NotTo(HaveOccurred())
+
+			tmp.Status = c.Status
+			err = k8sClient.Status().Update(ctx, tmp)
+			Expect(err).NotTo(HaveOccurred())
+		}
+	})
+
+	act := func() error {
+		return cleanup.GitJobs(ctx, k8sClient, 1)
+	}
+
+	When("cleaning up", func() {
+		BeforeEach(func() {
+			owner1 := metav1.OwnerReference{
+				APIVersion: "fleet.cattle.io/v1alpha1",
+				Kind:       "GitRepo",
+				Name:       "gitrepo-1",
+				UID:        "1",
+			}
+
+			owner2 := metav1.OwnerReference{
+				APIVersion: "fleet.cattle.io/v1alpha1",
+				Kind:       "GitRepo",
+				Name:       "gitrepo-2",
+				UID:        "1",
+			}
+
+			owner3 := metav1.OwnerReference{
+				APIVersion: "fleet.cattle.io/v1alpha1",
+				Kind:       "GitRepo",
+				Name:       "gitrepo-3",
+				UID:        "1",
+			}
+
+			spec := batchv1.JobSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						RestartPolicy: corev1.RestartPolicyNever,
+						Containers: []corev1.Container{
+							{
+								Name:  "busybox",
+								Image: "pause",
+							},
+						},
+					},
+				},
+			}
+
+			succeeded := func(t time.Time) batchv1.JobStatus {
+				return batchv1.JobStatus{
+					CompletionTime: &metav1.Time{Time: t},
+					Succeeded:      1,
+				}
+			}
+
+			// list is sorted by latest to oldest
+			jobs = []batchv1.Job{
+				// one running job
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "job-running",
+						Namespace:       namespace,
+						OwnerReferences: []metav1.OwnerReference{owner1},
+					},
+					Spec: spec,
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "job-old-1",
+						Namespace:       namespace,
+						OwnerReferences: []metav1.OwnerReference{owner1},
+					},
+					Spec:   spec,
+					Status: succeeded(time.Now()),
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "job-old-2",
+						Namespace:       namespace,
+						OwnerReferences: []metav1.OwnerReference{owner1},
+					},
+					Spec:   spec,
+					Status: succeeded(time.Now().Add(-1 * time.Hour)),
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "job-old-3",
+						Namespace:       namespace,
+						OwnerReferences: []metav1.OwnerReference{owner1},
+					},
+					Spec:   spec,
+					Status: succeeded(time.Now().Add(-2 * time.Hour)),
+				},
+				// all succeeded, sharing namespace
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "another-job",
+						Namespace:       namespace,
+						OwnerReferences: []metav1.OwnerReference{owner2},
+					},
+					Spec:   spec,
+					Status: succeeded(time.Now()),
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "another-job-old-1",
+						Namespace:       namespace,
+						OwnerReferences: []metav1.OwnerReference{owner2},
+					},
+					Spec:   spec,
+					Status: succeeded(time.Now().Add(-1 * time.Hour)),
+				},
+				// separate namespace
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "job-1",
+						Namespace:       otherns,
+						OwnerReferences: []metav1.OwnerReference{owner3},
+					},
+					Spec:   spec,
+					Status: succeeded(time.Now()),
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "job-old-2",
+						Namespace:       otherns,
+						OwnerReferences: []metav1.OwnerReference{owner3},
+					},
+					Spec:   spec,
+					Status: succeeded(time.Now().Add(-1 * time.Hour)),
+				},
+			}
+		})
+
+		It("deletes all resources and leaves most recent ones", func() {
+			Expect(act()).NotTo(HaveOccurred())
+
+			Eventually(func(g Gomega) {
+				list := &batchv1.JobList{}
+				err := k8sClient.List(ctx, list)
+				g.Expect(err).NotTo(HaveOccurred())
+
+				names := []string{}
+				for _, cr := range list.Items {
+					names = append(names, fmt.Sprintf("%s/%s", cr.Namespace, cr.Name))
+				}
+				g.Expect(names).To(ConsistOf(
+					namespace+"/job-running",
+					namespace+"/another-job",
+					otherns+"/job-1",
+				))
+			}, 20*time.Second, 1*time.Second).Should(Succeed())
+		})
+	})
+})

--- a/integrationtests/cli/cleanup/suite_test.go
+++ b/integrationtests/cli/cleanup/suite_test.go
@@ -2,6 +2,7 @@ package cleanup
 
 import (
 	"context"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -19,6 +20,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -47,7 +49,9 @@ func TestFleetCLICleanUp(t *testing.T) {
 var _ = BeforeSuite(func() {
 	SetDefaultEventuallyTimeout(timeout)
 	ctx, cancel = context.WithCancel(context.TODO())
-	// Debugging: ctrl.SetLogger(zap.New(zap.UseFlagOptions(&zap.Options{Development: true})))
+	if os.Getenv("DEBUG") != "" {
+		ctrl.SetLogger(zap.New(zap.UseFlagOptions(&zap.Options{Development: true})))
+	}
 	ctx = log.IntoContext(ctx, ctrl.Log)
 
 	testEnv = &envtest.Environment{

--- a/integrationtests/cli/cleanup/suite_test.go
+++ b/integrationtests/cli/cleanup/suite_test.go
@@ -7,17 +7,18 @@ import (
 	"time"
 
 	"github.com/rancher/fleet/integrationtests/utils"
-	cliclient "github.com/rancher/fleet/internal/client"
-	"github.com/rancher/fleet/pkg/generated/controllers/fleet.cattle.io"
-
-	"github.com/rancher/wrangler/v3/pkg/generated/controllers/core"
-	"github.com/rancher/wrangler/v3/pkg/generated/controllers/rbac"
+	"github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -28,24 +29,15 @@ const (
 )
 
 var (
-	cfg       *rest.Config
-	testEnv   *envtest.Environment
-	ctx       context.Context
-	cancel    context.CancelFunc
-	env       *cliclient.Client
+	cfg     *rest.Config
+	testEnv *envtest.Environment
+	ctx     context.Context
+	cancel  context.CancelFunc
+
+	namespace string
+	scheme    = runtime.NewScheme()
 	k8sClient client.Client
 )
-
-type getter struct {
-}
-
-func (g *getter) Get() (*cliclient.Client, error) {
-	return env, nil
-}
-
-func (g *getter) GetNamespace() string {
-	return ""
-}
 
 func TestFleetCLICleanUp(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -55,6 +47,9 @@ func TestFleetCLICleanUp(t *testing.T) {
 var _ = BeforeSuite(func() {
 	SetDefaultEventuallyTimeout(timeout)
 	ctx, cancel = context.WithCancel(context.TODO())
+	// Debugging: ctrl.SetLogger(zap.New(zap.UseFlagOptions(&zap.Options{Development: true})))
+	ctx = log.IntoContext(ctx, ctrl.Log)
+
 	testEnv = &envtest.Environment{
 		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "charts", "fleet-crd", "templates", "crds.yaml")},
 		ErrorIfCRDPathMissing: true,
@@ -65,11 +60,16 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 	Expect(cfg).NotTo(BeNil())
 
-	k8sClient, err = client.New(cfg, client.Options{})
+	// scheme for k8sClient
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(v1alpha1.AddToScheme(scheme))
+
+	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme})
 	Expect(err).NotTo(HaveOccurred())
 	Expect(k8sClient).NotTo(BeNil())
 
-	namespace, err := utils.NewNamespaceName()
+	// create a namespace
+	namespace, err = utils.NewNamespaceName()
 	Expect(err).ToNot(HaveOccurred())
 	Expect(k8sClient.Create(ctx, &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
@@ -77,22 +77,6 @@ var _ = BeforeSuite(func() {
 		},
 	})).ToNot(HaveOccurred())
 
-	// set up clients
-	rbac, err := rbac.NewFactoryFromConfig(cfg)
-	Expect(err).ToNot(HaveOccurred())
-
-	fleet, err := fleet.NewFactoryFromConfig(cfg)
-	Expect(err).ToNot(HaveOccurred())
-
-	core, err := core.NewFactoryFromConfig(cfg)
-	Expect(err).ToNot(HaveOccurred())
-
-	env = &cliclient.Client{
-		Namespace: namespace,
-		RBAC:      rbac.Rbac().V1(),
-		Core:      core.Core().V1(),
-		Fleet:     fleet.Fleet().V1alpha1(),
-	}
 })
 
 var _ = AfterSuite(func() {

--- a/internal/cmd/cli/cleanup.go
+++ b/internal/cmd/cli/cleanup.go
@@ -16,20 +16,41 @@ import (
 
 // NewCleanup returns a subcommand to `cleanup` cluster registrations
 func NewCleanUp() *cobra.Command {
-	return command.Command(&CleanUp{}, cobra.Command{
-		Use:   "cleanup [flags]",
-		Short: "Clean up outdated cluster registrations",
+	cleanup := command.Command(&Cleanup{}, cobra.Command{
+		Short:         "Clean up outdated resources",
+		SilenceUsage:  true,
+		SilenceErrors: true,
+	})
+	cleanup.AddCommand(
+		NewClusterRegistration(),
+	)
+	return cleanup
+}
+
+func NewClusterRegistration() *cobra.Command {
+	return command.Command(&ClusterRegistration{}, cobra.Command{
+		Use:           "clusterregistration [flags]",
+		Short:         "Clean up outdated cluster registrations",
+		SilenceUsage:  true,
+		SilenceErrors: true,
 	})
 }
 
-type CleanUp struct {
+type Cleanup struct {
+}
+
+func (c *Cleanup) Run(cmd *cobra.Command, args []string) error {
+	return cmd.Help()
+}
+
+type ClusterRegistration struct {
 	FleetClient
 	Min    string `usage:"Minimum delay between deletes (default: 10ms)" name:"min"`
 	Max    string `usage:"Maximum delay between deletes (default: 5s)" name:"max"`
 	Factor string `usage:"Factor to increase delay between deletes (default: 1.1)" name:"factor"`
 }
 
-func (r *CleanUp) PersistentPre(_ *cobra.Command, _ []string) error {
+func (r *ClusterRegistration) PersistentPre(_ *cobra.Command, _ []string) error {
 	if err := r.SetupDebug(); err != nil {
 		return fmt.Errorf("failed to set up debug logging: %w", err)
 	}
@@ -37,8 +58,9 @@ func (r *CleanUp) PersistentPre(_ *cobra.Command, _ []string) error {
 	return nil
 }
 
-func (a *CleanUp) Run(cmd *cobra.Command, args []string) error {
+func (a *ClusterRegistration) Run(cmd *cobra.Command, args []string) error {
 	var err error
+
 	min := 10 * time.Millisecond
 	if a.Min != "" {
 		min, err = time.ParseDuration(a.Min)

--- a/internal/cmd/cli/cleanup.go
+++ b/internal/cmd/cli/cleanup.go
@@ -12,7 +12,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	"github.com/rancher/fleet/internal/client"
 	command "github.com/rancher/fleet/internal/cmd"
 	"github.com/rancher/fleet/internal/cmd/cli/cleanup"
 )
@@ -26,6 +25,7 @@ func NewCleanUp() *cobra.Command {
 	})
 	cleanup.AddCommand(
 		NewClusterRegistration(),
+		NewGitjob(),
 	)
 	return cleanup
 }
@@ -34,6 +34,15 @@ func NewClusterRegistration() *cobra.Command {
 	return command.Command(&ClusterRegistration{}, cobra.Command{
 		Use:           "clusterregistration [flags]",
 		Short:         "Clean up outdated cluster registrations",
+		SilenceUsage:  true,
+		SilenceErrors: true,
+	})
+}
+
+func NewGitjob() *cobra.Command {
+	return command.Command(&Gitjob{}, cobra.Command{
+		Use:           "gitjob [flags]",
+		Short:         "Clean up outdated git jobs",
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	})
@@ -57,7 +66,6 @@ func (r *ClusterRegistration) PersistentPre(_ *cobra.Command, _ []string) error 
 	if err := r.SetupDebug(); err != nil {
 		return fmt.Errorf("failed to set up debug logging: %w", err)
 	}
-	Client = client.NewGetter(r.Kubeconfig, r.Context, r.Namespace)
 	return nil
 }
 
@@ -119,4 +127,36 @@ func (a *ClusterRegistration) Run(cmd *cobra.Command, args []string) error {
 	fmt.Printf("Cleaning up outdated cluster registrations: %#v\n", opts)
 
 	return cleanup.ClusterRegistrations(ctx, client, opts)
+}
+
+type Gitjob struct {
+	FleetClient
+	BatchSize int `usage:"Number of git jobs to retrieve at once" name:"batch-size" default:"5000"`
+}
+
+func (r *Gitjob) PersistentPre(_ *cobra.Command, _ []string) error {
+	if err := r.SetupDebug(); err != nil {
+		return fmt.Errorf("failed to set up debug logging: %w", err)
+	}
+	return nil
+}
+
+func (r *Gitjob) Run(cmd *cobra.Command, args []string) error {
+	bs := r.BatchSize
+	if bs <= 1 {
+		return errors.New("factor must be greater than 1")
+	}
+
+	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&zopts)))
+	ctx := log.IntoContext(cmd.Context(), ctrl.Log)
+
+	cfg := ctrl.GetConfigOrDie()
+	client, err := newClient(ctx, cfg)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Cleaning up outdated git jobs, batch size at %d\n", bs)
+
+	return cleanup.GitJobs(ctx, client, bs)
 }

--- a/internal/cmd/cli/cleanup.go
+++ b/internal/cmd/cli/cleanup.go
@@ -8,6 +8,9 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	"github.com/rancher/fleet/internal/client"
 	command "github.com/rancher/fleet/internal/cmd"
@@ -104,7 +107,16 @@ func (a *ClusterRegistration) Run(cmd *cobra.Command, args []string) error {
 		Factor: factor,
 	}
 
+	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&zopts)))
+	ctx := log.IntoContext(cmd.Context(), ctrl.Log)
+
+	cfg := ctrl.GetConfigOrDie()
+	client, err := newClient(ctx, cfg)
+	if err != nil {
+		return err
+	}
+
 	fmt.Printf("Cleaning up outdated cluster registrations: %#v\n", opts)
 
-	return cleanup.ClusterRegistrations(cmd.Context(), Client, opts)
+	return cleanup.ClusterRegistrations(ctx, client, opts)
 }

--- a/internal/cmd/cli/cleanup/cleanup.go
+++ b/internal/cmd/cli/cleanup/cleanup.go
@@ -2,12 +2,15 @@ package cleanup
 
 import (
 	"context"
+	"sort"
 	"time"
 
+	"github.com/go-logr/logr"
 	"github.com/jpillora/backoff"
 
 	fleetv1 "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
 
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -69,7 +72,7 @@ func ClusterRegistrations(ctx context.Context, cl client.Client, opts Options) e
 	// * requests before that are outdated
 	for _, cr := range crList.Items {
 		logger := logger.WithValues("namespace", cr.Namespace, "name", cr.Name)
-		logger.Info("Inspect cluster registration")
+		logger.Info("Inspecting cluster registration")
 		if cr.Status.ClusterName == "" {
 			continue
 		}
@@ -130,5 +133,89 @@ func ClusterRegistrations(ctx context.Context, cl client.Client, opts Options) e
 		}
 	}
 
+	return nil
+}
+
+func GitJobs(ctx context.Context, cl client.Client, bs int) error {
+	logger := log.FromContext(ctx).WithName("cleanup-jobs").WithValues("batchSize", bs)
+
+	list := &batchv1.JobList{}
+	if err := cl.List(ctx, list, client.Limit(bs)); err != nil {
+		return err
+	}
+	logger.Info("Listing resources", "jobs", len(list.Items))
+
+	jobs := list.Items
+
+	for list.Continue != "" {
+		if err := cl.List(ctx, list, client.Limit(bs), client.Continue(list.Continue)); err != nil {
+			return err
+		}
+		logger.Info("Listing more resources", "jobs", len(list.Items))
+
+		jobs = append(jobs, list.Items...)
+	}
+
+	if err := cleanupGitJobs(ctx, logger, cl, jobs); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func cleanupGitJobs(ctx context.Context, logger logr.Logger, cl client.Client, jobs []batchv1.Job) error {
+	// jobs by namespace, gitrepo
+	gitjobs := map[string]map[string][]batchv1.Job{}
+	// gitrepos with running jobs
+	running := map[string]map[string]struct{}{}
+
+	for _, job := range jobs {
+		if job.OwnerReferences == nil {
+			continue
+		}
+		for _, or := range job.OwnerReferences {
+			if or.Kind != "GitRepo" || or.APIVersion != "fleet.cattle.io/v1alpha1" {
+				continue
+			}
+			if job.Status.Succeeded != 1 || job.Status.CompletionTime == nil {
+				if running[job.Namespace] == nil {
+					running[job.Namespace] = map[string]struct{}{}
+				}
+				running[job.Namespace][or.Name] = struct{}{}
+			} else {
+				if gitjobs[job.Namespace] == nil {
+					gitjobs[job.Namespace] = map[string][]batchv1.Job{}
+				}
+				gitjobs[job.Namespace][or.Name] = append(gitjobs[job.Namespace][or.Name], job)
+			}
+			break
+		}
+	}
+
+	for ns, gitrepos := range gitjobs {
+		for gitrepo, jobs := range gitrepos {
+			sort.Slice(jobs, func(i, j int) bool {
+				return jobs[j].Status.CompletionTime.Before(jobs[i].Status.CompletionTime)
+			})
+
+			// if there is a running job delete all the jobs in the
+			// list, otherwise all but the newest
+			start := 1
+			if _, ok := running[ns][gitrepo]; ok {
+				start = 0
+			}
+
+			logger.V(1).Info("Deleting jobs for gitrepo", "n", len(jobs)-start, "namespace", ns, "gitrepo", gitrepo)
+
+			for i := start; i < len(jobs); i++ {
+				job := jobs[i]
+				logger.V(1).Info("Deleting job", "namespace", ns, "name", job.Name, "gitrepo", gitrepo)
+				err := cl.Delete(ctx, &job, client.PropagationPolicy(metav1.DeletePropagationBackground))
+				if err != nil && !apierrors.IsNotFound(err) {
+					logger.Error(err, "Failed to delete job", "namespace", ns, "name", job.Name)
+				}
+			}
+		}
+	}
 	return nil
 }


### PR DESCRIPTION
Refers to https://github.com/rancher/fleet/issues/2870

This is a workaround until the gitops controller removes jobs as needed in a future release.

## Testing

After creating several commits in a git repo, observe there are many completed jobs. One per commit.
Change the new CronJob schedule to minutes: `* */1 * * *`, observe that all but the latest job are removed for each gitrepo .