### PR TITLE
[v0.10] Skip CA bundle secret creation with empty payload

### DIFF
--- a/internal/cmd/controller/gitops/reconciler/gitjob_controller.go
+++ b/internal/cmd/controller/gitops/reconciler/gitjob_controller.go
@@ -397,6 +397,10 @@ func (r *GitJobReconciler) createTargetsConfigMap(ctx context.Context, gitrepo *
 }
 
 func (r *GitJobReconciler) createCABundleSecret(ctx context.Context, gitrepo *v1alpha1.GitRepo) error {
+	if len(gitrepo.Spec.CABundle) == 0 {
+		return nil
+	}
+
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: gitrepo.ObjectMeta.Namespace,


### PR DESCRIPTION
When no `caBundle` field is configured on a `GitRepo`, the gitOps controller now skips creation of the corresponding secret.

Refers to #2922
Backport of #2918 to `release/v0.10`.