### PR TITLE
Detect offline clusters

### DIFF
--- a/.github/scripts/deploy-fleet.sh
+++ b/.github/scripts/deploy-fleet.sh
@@ -63,7 +63,10 @@ eventually helm upgrade --install fleet charts/fleet \
   --set agentImage.tag="$agentTag" \
   --set agentImage.imagePullPolicy=IfNotPresent \
   --set bootstrap.agentNamespace=cattle-fleet-local-system \
+  --set agentCheckinInterval=5s \
   --set clusterMonitor.enabled=true \
+  --set clusterMonitor.threshold=20s \
+  --set clusterMonitor.interval=10s \
   --set apiServerCA="$ca" \
   --set apiServerURL="$server" \
   $shards_settings \

--- a/.github/scripts/deploy-fleet.sh
+++ b/.github/scripts/deploy-fleet.sh
@@ -63,6 +63,7 @@ eventually helm upgrade --install fleet charts/fleet \
   --set agentImage.tag="$agentTag" \
   --set agentImage.imagePullPolicy=IfNotPresent \
   --set bootstrap.agentNamespace=cattle-fleet-local-system \
+  --set clusterMonitor.enabled=true \
   --set apiServerCA="$ca" \
   --set apiServerURL="$server" \
   $shards_settings \

--- a/.github/workflows/e2e-multicluster-ci.yml
+++ b/.github/workflows/e2e-multicluster-ci.yml
@@ -82,7 +82,7 @@ jobs:
             -p "443:443@agent:0:direct" \
             --api-port 6443 \
             --agents 1 \
-            --network "nw01"
+            --network "fleet"
       -
         name: Provision k3d Downstream Cluster for agent-initiated registration
         run: |
@@ -91,7 +91,7 @@ jobs:
             -p "444:443@agent:0:direct" \
             --api-port 6644 \
             --agents 1 \
-            --network "nw01"
+            --network "fleet"
       -
         name: Provision k3d Downstream Cluster for manager-initiated registration
         run: |
@@ -100,7 +100,7 @@ jobs:
             -p "445:443@agent:0:direct" \
             --api-port 6645 \
             --agents 1 \
-            --network "nw01"
+            --network "fleet"
       -
         name: Import Images Into k3d
         run: |
@@ -213,6 +213,7 @@ jobs:
         env:
           FLEET_E2E_NS: fleet-local
           FLEET_E2E_NS_DOWNSTREAM: fleet-default
+          FLEET_E2E_CLUSTER_DOWNSTREAM: k3d-downstream
         run: |
           # Force use of non-managed downstream cluster for portability
           export CI_REGISTERED_CLUSTER=$(kubectl get clusters.fleet.cattle.io -n $FLEET_E2E_NS_DOWNSTREAM -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}' | grep -v second)

--- a/charts/fleet/templates/configmap.yaml
+++ b/charts/fleet/templates/configmap.yaml
@@ -16,6 +16,8 @@ data:
             "bundledeployment": "{{.Values.agent.reconciler.workers.bundledeployment}}",
             "drift": "{{.Values.agent.reconciler.workers.drift}}"
       },
+      "clusterMonitorInterval": "{{.Values.clusterMonitorInterval}}",
+      "clusterMonitorThreshold": "{{.Values.clusterMonitorThreshold}}",
       {{ if .Values.garbageCollectionInterval }}
       "garbageCollectionInterval": "{{.Values.garbageCollectionInterval}}",
       {{ end }}

--- a/charts/fleet/templates/configmap.yaml
+++ b/charts/fleet/templates/configmap.yaml
@@ -16,8 +16,11 @@ data:
             "bundledeployment": "{{.Values.agent.reconciler.workers.bundledeployment}}",
             "drift": "{{.Values.agent.reconciler.workers.drift}}"
       },
-      "clusterMonitorInterval": "{{.Values.clusterMonitorInterval}}",
-      "clusterMonitorThreshold": "{{.Values.clusterMonitorThreshold}}",
+      "clusterMonitor": {
+            "enabled": {{.Values.clusterMonitor.enabled}},
+            "interval": "{{.Values.clusterMonitor.interval}}",
+            "threshold": "{{.Values.clusterMonitor.threshold}}"
+      },
       {{ if .Values.garbageCollectionInterval }}
       "garbageCollectionInterval": "{{.Values.garbageCollectionInterval}}",
       {{ end }}

--- a/charts/fleet/values.yaml
+++ b/charts/fleet/values.yaml
@@ -23,6 +23,15 @@ agentTLSMode: "system-store"
 # A duration string for how often agents should report a heartbeat
 agentCheckinInterval: "15m"
 
+# Determines how long must have elapsed since a downstream cluster's Fleet agent last reported its status to the
+# management cluster, before that downstream cluster is considered offline.
+# If this configured value is shorter than three times the agent check-in interval, then that check-in
+# interval-based value will be used instead to prevent false positives.
+clusterMonitorThreshold: "45m"
+
+# Determines how often the cluster monitor will check for offline downstream clusters.
+clusterMonitorInterval: "10m"
+
 # The amount of time that agents will wait before they clean up old Helm releases.
 # A non-existent value or 0 will result in an interval of 15 minutes.
 garbageCollectionInterval: "15m"

--- a/charts/fleet/values.yaml
+++ b/charts/fleet/values.yaml
@@ -23,15 +23,6 @@ agentTLSMode: "system-store"
 # A duration string for how often agents should report a heartbeat
 agentCheckinInterval: "15m"
 
-# Determines how long must have elapsed since a downstream cluster's Fleet agent last reported its status to the
-# management cluster, before that downstream cluster is considered offline.
-# If this configured value is shorter than three times the agent check-in interval, then that check-in
-# interval-based value will be used instead to prevent false positives.
-clusterMonitorThreshold: "45m"
-
-# Determines how often the cluster monitor will check for offline downstream clusters.
-clusterMonitorInterval: "10m"
-
 # The amount of time that agents will wait before they clean up old Helm releases.
 # A non-existent value or 0 will result in an interval of 15 minutes.
 garbageCollectionInterval: "15m"
@@ -78,6 +69,17 @@ bootstrap:
   secret: ""
   branch: master
   paths: ""
+
+## Cluster monitor for offline cluster detection
+clusterMonitor:
+  enabled: false
+  # Determines how long must have elapsed since a downstream cluster's Fleet agent last reported its status to the
+  # management cluster, before that downstream cluster is considered offline.
+  # If this configured value is shorter than three times the agent check-in interval, then that check-in
+  # interval-based value will be used instead to prevent false positives.
+  threshold: "45m"
+  # Determines how often the cluster monitor will check for offline downstream clusters.
+  interval: "10m"
 
 global:
   cattle:

--- a/dev/setup-fleet
+++ b/dev/setup-fleet
@@ -44,7 +44,10 @@ helm -n cattle-fleet-system upgrade --install --create-namespace --wait --reset-
   --set agent.leaderElection.leaseDuration=10s \
   --set agent.leaderElection.retryPeriod=1s \
   --set agent.leaderElection.renewDeadline=5s \
+  --set agentCheckinInterval=5s \
   --set clusterMonitor.enabled=true \
+  --set clusterMonitor.threshold=20s \
+  --set clusterMonitor.interval=10s \
   --set garbageCollectionInterval=1s \
   --set insecureSkipHostKeyChecks=false \
   --set imagescan.enabled=true \

--- a/dev/setup-fleet
+++ b/dev/setup-fleet
@@ -44,6 +44,7 @@ helm -n cattle-fleet-system upgrade --install --create-namespace --wait --reset-
   --set agent.leaderElection.leaseDuration=10s \
   --set agent.leaderElection.retryPeriod=1s \
   --set agent.leaderElection.renewDeadline=5s \
+  --set clusterMonitor.enabled=true \
   --set garbageCollectionInterval=1s \
   --set insecureSkipHostKeyChecks=false \
   --set imagescan.enabled=true \

--- a/e2e/multi-cluster/installation/agent_test.go
+++ b/e2e/multi-cluster/installation/agent_test.go
@@ -36,8 +36,9 @@ var _ = Describe("Fleet installation with TLS agent modes", func() {
 			"cattle-fleet-system",
 			"--type=merge",
 			"-p",
+			// Agent check-in interval cannot be 0. Any other value will do here.
 			fmt.Sprintf(
-				`{"data":{"config":"{\"apiServerURL\": \"https://google.com\", \"apiServerCA\": \"\", \"agentTLSMode\": \"%s\"}"}}`,
+				`{"data":{"config":"{\"apiServerURL\": \"https://google.com\", \"apiServerCA\": \"\", \"agentTLSMode\": \"%s\", \"agentCheckinInterval\": \"1m\"}"}}`,
 				agentMode,
 			),
 		)

--- a/e2e/multi-cluster/offline_cluster_test.go
+++ b/e2e/multi-cluster/offline_cluster_test.go
@@ -2,6 +2,7 @@ package multicluster_test
 
 import (
 	"encoding/json"
+	"os/exec"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -18,14 +19,12 @@ import (
 var _ = Describe("Offline cluster detection", func() {
 	var (
 		k     kubectl.Command
-		kd    kubectl.Command
 		asset string
 		name  string
 	)
 
 	BeforeEach(func() {
 		k = env.Kubectl.Context(env.Upstream)
-		kd = env.Kubectl.Context(env.Downstream).Namespace("fleet-default")
 	})
 
 	Context("cluster with deployed workload becomes offline", func() {
@@ -55,8 +54,8 @@ var _ = Describe("Offline cluster detection", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			DeferCleanup(func() {
-				out, err := kd.Namespace("cattle-fleet-system").Run("scale", "deployment", "fleet-agent", "--replicas=1", "--timeout=60s")
-				Expect(err).ToNot(HaveOccurred(), out)
+				connectCmd := exec.Command("docker", "network", "connect", "fleet", "k3d-"+k3dDownstreamCluster+"-server-0")
+				_, _ = connectCmd.CombinedOutput() // will fail if the node is already connected.
 
 				_, _ = k.Namespace(env.ClusterRegistrationNamespace).Delete("helmop", name)
 			})
@@ -88,8 +87,9 @@ var _ = Describe("Offline cluster detection", func() {
 			}).To(Succeed())
 
 			By("taking the cluster offline")
-			out, err := kd.Namespace("cattle-fleet-system").Run("scale", "deployment", "fleet-agent", "--replicas=0", "--timeout=60s")
-			Expect(err).ToNot(HaveOccurred(), out)
+			disconnectCmd := exec.Command("docker", "network", "disconnect", "fleet", "k3d-"+k3dDownstreamCluster+"-server-0")
+			out, err := disconnectCmd.CombinedOutput()
+			Expect(err).ToNot(HaveOccurred(), string(out))
 
 			By("checking that the bundle deployment and the cluster appear offline")
 			// Cluster should be offline
@@ -117,8 +117,9 @@ var _ = Describe("Offline cluster detection", func() {
 			}).To(Succeed())
 
 			By("taking the cluster back online")
-			out, err = kd.Namespace("cattle-fleet-system").Run("scale", "deployment", "fleet-agent", "--replicas=1", "--timeout=60s")
-			Expect(err).ToNot(HaveOccurred(), out)
+			connectCmd := exec.Command("docker", "network", "connect", "fleet", "k3d-"+k3dDownstreamCluster+"-server-0")
+			out, err = connectCmd.CombinedOutput()
+			Expect(err).ToNot(HaveOccurred(), string(out))
 
 			By("checking the new online state of the cluster")
 			// Cluster should be ready again

--- a/e2e/multi-cluster/offline_cluster_test.go
+++ b/e2e/multi-cluster/offline_cluster_test.go
@@ -116,7 +116,35 @@ var _ = Describe("Offline cluster detection", func() {
 
 				checkReadyCondition(g, out, "cluster is offline", "Unknown")
 			}).To(Succeed())
-			// TODO bring cluster back online and check that all is well
+
+			By("taking the cluster back online")
+			out, err = kd.Namespace("cattle-fleet-system").Run("scale", "deployment", "fleet-agent", "--replicas=1", "--timeout=60s")
+			Expect(err).ToNot(HaveOccurred(), out)
+
+			By("checking the new online state of the cluster")
+			// Cluster should be ready again
+			Eventually(func(g Gomega) {
+				out, err := k.Get(
+					"cluster", "-n", env.ClusterRegistrationNamespace,
+					"-o", `jsonpath={.items[0].status.conditions}`,
+				)
+				g.Expect(err).ToNot(HaveOccurred(), out)
+
+				checkReadyCondition(g, out, "", "True")
+			}).To(Succeed())
+
+			// Bundle deployment should be ready again
+			Eventually(func(g Gomega) {
+				out, err := k.Get(
+					"bundledeployments", "-A",
+					"-l", fmt.Sprintf("fleet.cattle.io/bundle-name=%s", name),
+					"-l", fmt.Sprintf("fleet.cattle.io/bundle-namespace=%s", env.ClusterRegistrationNamespace),
+					"-o", `jsonpath={.items[0].status.conditions}`,
+				)
+				g.Expect(err).ToNot(HaveOccurred(), out)
+
+				checkReadyCondition(g, out, "", "True")
+			}).To(Succeed())
 		})
 	})
 })

--- a/e2e/multi-cluster/offline_cluster_test.go
+++ b/e2e/multi-cluster/offline_cluster_test.go
@@ -1,0 +1,139 @@
+package multicluster_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/rancher/fleet/e2e/testenv"
+	"github.com/rancher/fleet/e2e/testenv/kubectl"
+	"github.com/rancher/wrangler/v3/pkg/genericcondition"
+)
+
+// This test uses two clusters to demonstrate offline cluster handling.
+var _ = Describe("Offline cluster detection", func() {
+	var (
+		k     kubectl.Command
+		kd    kubectl.Command
+		asset string
+		name  string
+	)
+
+	BeforeEach(func() {
+		k = env.Kubectl.Context(env.Upstream)
+		kd = env.Kubectl.Context(env.Downstream).Namespace("fleet-default")
+	})
+
+	Context("cluster with deployed workload becomes offline", func() {
+		BeforeEach(func() {
+			asset = "multi-cluster/helmop.yaml"
+			name = "test-offline-cluster"
+
+			err := testenv.ApplyTemplate(k.Namespace(env.ClusterRegistrationNamespace), testenv.AssetPath(asset), struct {
+				Name                  string
+				Namespace             string
+				Repo                  string
+				Chart                 string
+				Version               string
+				PollingInterval       time.Duration
+				HelmSecretName        string
+				InsecureSkipTLSVerify bool
+			}{
+				name,
+				env.ClusterRegistrationNamespace,
+				"",
+				"https://github.com/rancher/fleet/raw/refs/heads/main/integrationtests/cli/assets/helmrepository/config-chart-0.1.0.tgz",
+				"",
+				0,
+				"",
+				false,
+			})
+			Expect(err).ToNot(HaveOccurred())
+
+			DeferCleanup(func() {
+				out, err := kd.Namespace("cattle-fleet-system").Run("scale", "deployment", "fleet-agent", "--replicas=1", "--timeout=60s")
+				Expect(err).ToNot(HaveOccurred(), out)
+
+				_, _ = k.Namespace(env.ClusterRegistrationNamespace).Delete("helmop", name)
+			})
+		})
+		It("marks any offline cluster as such, along with its bundle deployments", func() {
+			By("checking the initial online state of the cluster")
+			// Cluster should be ready
+			Eventually(func(g Gomega) {
+				out, err := k.Get(
+					"cluster", "-n", env.ClusterRegistrationNamespace,
+					"-o", `jsonpath={.items[0].status.conditions}`,
+				)
+				g.Expect(err).ToNot(HaveOccurred(), out)
+
+				checkReadyCondition(g, out, "", "True")
+			}).To(Succeed())
+
+			// Bundle deployment should be ready
+			Eventually(func(g Gomega) {
+				out, err := k.Get(
+					"bundledeployments", "-A",
+					"-l", fmt.Sprintf("fleet.cattle.io/bundle-name=%s", name),
+					"-l", fmt.Sprintf("fleet.cattle.io/bundle-namespace=%s", env.ClusterRegistrationNamespace),
+					"-o", `jsonpath={.items[0].status.conditions}`,
+				)
+				g.Expect(err).ToNot(HaveOccurred(), out)
+
+				checkReadyCondition(g, out, "", "True")
+			}).To(Succeed())
+
+			By("taking the cluster offline")
+			out, err := kd.Namespace("cattle-fleet-system").Run("scale", "deployment", "fleet-agent", "--replicas=0", "--timeout=60s")
+			Expect(err).ToNot(HaveOccurred(), out)
+
+			By("checking that the bundle deployment and the cluster appear offline")
+			// Cluster should be offline
+			Eventually(func(g Gomega) {
+				out, err := k.Get(
+					"cluster", "-n", env.ClusterRegistrationNamespace,
+					"-o", `jsonpath={.items[0].status.conditions}`,
+				)
+				g.Expect(err).ToNot(HaveOccurred(), out)
+
+				checkReadyCondition(g, out, "cluster is offline", "Unknown")
+			}).To(Succeed())
+
+			// Bundle deployment should be offline
+			Eventually(func(g Gomega) {
+				out, err := k.Get(
+					"bundledeployments", "-A",
+					"-l", fmt.Sprintf("fleet.cattle.io/bundle-name=%s", name),
+					"-l", fmt.Sprintf("fleet.cattle.io/bundle-namespace=%s", env.ClusterRegistrationNamespace),
+					"-o", `jsonpath={.items[0].status.conditions}`,
+				)
+				g.Expect(err).ToNot(HaveOccurred(), out)
+
+				checkReadyCondition(g, out, "cluster is offline", "Unknown")
+			}).To(Succeed())
+			// TODO bring cluster back online and check that all is well
+		})
+	})
+})
+
+func checkReadyCondition(g Gomega, out, msg, status string) {
+	conds := []genericcondition.GenericCondition{}
+	err := json.Unmarshal([]byte(out), &conds)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	var readyCond *genericcondition.GenericCondition
+	for _, c := range conds {
+		if c.Type == "Ready" {
+			readyCond = &c
+		}
+	}
+
+	g.Expect(readyCond).NotTo(BeNil())
+	g.Expect(readyCond.Message).To(ContainSubstring(msg))
+	g.Expect(readyCond.Status).To(Equal(corev1.ConditionStatus(status)))
+}

--- a/e2e/multi-cluster/offline_cluster_test.go
+++ b/e2e/multi-cluster/offline_cluster_test.go
@@ -155,9 +155,9 @@ func checkReadyCondition(g Gomega, out, msg, status string) {
 	g.Expect(err).ToNot(HaveOccurred())
 
 	var readyCond *genericcondition.GenericCondition
-	for _, c := range conds {
+	for i, c := range conds {
 		if c.Type == "Ready" {
-			readyCond = &c
+			readyCond = &conds[i]
 		}
 	}
 

--- a/e2e/multi-cluster/offline_cluster_test.go
+++ b/e2e/multi-cluster/offline_cluster_test.go
@@ -2,7 +2,6 @@ package multicluster_test
 
 import (
 	"encoding/json"
-	"fmt"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -79,8 +78,8 @@ var _ = Describe("Offline cluster detection", func() {
 			Eventually(func(g Gomega) {
 				out, err := k.Get(
 					"bundledeployments", "-A",
-					"-l", fmt.Sprintf("fleet.cattle.io/bundle-name=%s", name),
-					"-l", fmt.Sprintf("fleet.cattle.io/bundle-namespace=%s", env.ClusterRegistrationNamespace),
+					"-l", "fleet.cattle.io/bundle-name="+name,
+					"-l", "fleet.cattle.io/bundle-namespace="+env.ClusterRegistrationNamespace,
 					"-o", `jsonpath={.items[0].status.conditions}`,
 				)
 				g.Expect(err).ToNot(HaveOccurred(), out)
@@ -108,8 +107,8 @@ var _ = Describe("Offline cluster detection", func() {
 			Eventually(func(g Gomega) {
 				out, err := k.Get(
 					"bundledeployments", "-A",
-					"-l", fmt.Sprintf("fleet.cattle.io/bundle-name=%s", name),
-					"-l", fmt.Sprintf("fleet.cattle.io/bundle-namespace=%s", env.ClusterRegistrationNamespace),
+					"-l", "fleet.cattle.io/bundle-name="+name,
+					"-l", "fleet.cattle.io/bundle-namespace="+env.ClusterRegistrationNamespace,
 					"-o", `jsonpath={.items[0].status.conditions}`,
 				)
 				g.Expect(err).ToNot(HaveOccurred(), out)
@@ -137,8 +136,8 @@ var _ = Describe("Offline cluster detection", func() {
 			Eventually(func(g Gomega) {
 				out, err := k.Get(
 					"bundledeployments", "-A",
-					"-l", fmt.Sprintf("fleet.cattle.io/bundle-name=%s", name),
-					"-l", fmt.Sprintf("fleet.cattle.io/bundle-namespace=%s", env.ClusterRegistrationNamespace),
+					"-l", "fleet.cattle.io/bundle-name="+name,
+					"-l", "fleet.cattle.io/bundle-namespace="+env.ClusterRegistrationNamespace,
 					"-o", `jsonpath={.items[0].status.conditions}`,
 				)
 				g.Expect(err).ToNot(HaveOccurred(), out)

--- a/e2e/multi-cluster/suite_test.go
+++ b/e2e/multi-cluster/suite_test.go
@@ -3,6 +3,7 @@ package multicluster_test
 
 import (
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/rancher/fleet/e2e/testenv"
@@ -17,8 +18,9 @@ func TestE2E(t *testing.T) {
 }
 
 var (
-	env       *testenv.Env
-	dsCluster = "second"
+	env                  *testenv.Env
+	dsCluster            = "second" // name of the Fleet Cluster resource
+	k3dDownstreamCluster = "downstream"
 )
 
 var _ = BeforeSuite(func() {
@@ -29,5 +31,9 @@ var _ = BeforeSuite(func() {
 
 	if dsClusterEnvVar := os.Getenv("CI_REGISTERED_CLUSTER"); dsClusterEnvVar != "" {
 		dsCluster = dsClusterEnvVar
+	}
+
+	if k3dDSClusterEnvVar := os.Getenv("FLEET_E2E_CLUSTER_DOWNSTREAM"); k3dDSClusterEnvVar != "" {
+		k3dDownstreamCluster = strings.TrimPrefix(k3dDSClusterEnvVar, "k3d-")
 	}
 })

--- a/integrationtests/controller/cluster/status_test.go
+++ b/integrationtests/controller/cluster/status_test.go
@@ -1,12 +1,14 @@
 package cluster
 
 import (
+	"errors"
 	"fmt"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	"github.com/rancher/fleet/integrationtests/utils"
+	"github.com/rancher/fleet/internal/cmd/agent/deployer/monitor"
 
 	"github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
 
@@ -191,6 +193,64 @@ var _ = Describe("Cluster Status Fields", func() {
 			}).Should(Succeed())
 			Expect(cluster.Status.Display.ReadyBundles).To(Equal("2/2"))
 			Expect(cluster.Status.Summary.Ready).To(Equal(2))
+		})
+	})
+
+	When("A bundle deployment is marked offline by the cluster monitor", func() {
+		BeforeEach(func() {
+			cluster, err := utils.CreateCluster(ctx, k8sClient, "cluster", namespace, nil, namespace)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cluster).To(Not(BeNil()))
+
+			targets := []v1alpha1.BundleTarget{
+				{
+					BundleDeploymentOptions: v1alpha1.BundleDeploymentOptions{
+						TargetNamespace: "targetNs",
+					},
+					Name:        "cluster",
+					ClusterName: "cluster",
+				},
+			}
+
+			bundle, err := utils.CreateBundle(ctx, k8sClient, "my-bundle", namespace, targets, targets)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(bundle).To(Not(BeNil()))
+		})
+
+		It("marks the cluster as offline", func() {
+			By("Marking the bundledeployment as offline, as the monitor would")
+			bd := &v1alpha1.BundleDeployment{}
+			Eventually(func() error {
+				err := k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "my-bundle"}, bd)
+				if err != nil {
+					return err
+				}
+
+				mc := monitor.Cond(v1alpha1.BundleDeploymentConditionReady)
+				mc.SetError(&bd.Status, "Cluster offline", errors.New(v1alpha1.ClusterOfflineMsg))
+				mc.Unknown(&bd.Status)
+
+				mc = monitor.Cond(v1alpha1.BundleDeploymentConditionMonitored)
+				mc.SetError(&bd.Status, "Cluster offline", errors.New(v1alpha1.ClusterOfflineMsg))
+
+				return k8sClient.Status().Update(ctx, bd)
+			}).ShouldNot(HaveOccurred())
+
+			By("Checking cluster status")
+			cluster := &v1alpha1.Cluster{}
+			Eventually(func(g Gomega) {
+				err := k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "cluster"}, cluster)
+				g.Expect(err).NotTo(HaveOccurred())
+
+				for _, cond := range cluster.Status.Conditions {
+					switch cond.Type {
+					case v1alpha1.ClusterConditionReady, "Reconciled":
+						g.Expect(cond.Message).To(Equal("cluster is offline"))
+						g.Expect(cond.Reason).To(Equal("Cluster offline"))
+						g.Expect(cond.Status).To(Equal(corev1.ConditionStatus("Unknown")))
+					}
+				}
+			}).Should(Succeed())
 		})
 	})
 })

--- a/integrationtests/controller/cluster/status_test.go
+++ b/integrationtests/controller/cluster/status_test.go
@@ -7,9 +7,9 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	fleet_testenv "github.com/rancher/fleet/e2e/testenv"
 	"github.com/rancher/fleet/integrationtests/utils"
 	"github.com/rancher/fleet/internal/cmd/agent/deployer/monitor"
-
 	"github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
 
 	corev1 "k8s.io/api/core/v1"
@@ -236,7 +236,7 @@ var _ = Describe("Cluster Status Fields", func() {
 				return k8sClient.Status().Update(ctx, bd)
 			}).ShouldNot(HaveOccurred())
 
-			By("Checking cluster status")
+			By("Checking offline cluster status")
 			cluster := &v1alpha1.Cluster{}
 			Eventually(func(g Gomega) {
 				err := k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "cluster"}, cluster)
@@ -251,6 +251,40 @@ var _ = Describe("Cluster Status Fields", func() {
 					}
 				}
 			}).Should(Succeed())
+
+			By("Marking the bundledeployment as online again")
+			bd = &v1alpha1.BundleDeployment{}
+			Eventually(func() error {
+				err := k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "my-bundle"}, bd)
+				if err != nil {
+					return err
+				}
+
+				mc := monitor.Cond(v1alpha1.BundleDeploymentConditionReady)
+				mc.SetError(&bd.Status, "", nil)
+				mc.True(&bd.Status)
+
+				mc = monitor.Cond(v1alpha1.BundleDeploymentConditionMonitored)
+				mc.SetError(&bd.Status, "", nil)
+				mc.True(&bd.Status)
+
+				return k8sClient.Status().Update(ctx, bd)
+			}).ShouldNot(HaveOccurred())
+
+			By("Checking online cluster status")
+			Eventually(func(g Gomega) {
+				cluster = &v1alpha1.Cluster{}
+				err := k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "cluster"}, cluster)
+				g.Expect(err).NotTo(HaveOccurred())
+
+				for _, cond := range cluster.Status.Conditions {
+					switch cond.Type {
+					case v1alpha1.ClusterConditionReady, "Reconciled":
+						g.Expect(cond.Message).NotTo(ContainSubstring("offline")) // may be "WaitApplied..."
+						g.Expect(cond.Reason).To(BeEmpty())
+					}
+				}
+			}, fleet_testenv.MediumTimeout, fleet_testenv.ShortTimeout).Should(Succeed())
 		})
 	})
 })

--- a/internal/cmd/agent/deployer/monitor/condition.go
+++ b/internal/cmd/agent/deployer/monitor/condition.go
@@ -45,6 +45,14 @@ func (c Cond) IsFalse(obj any) bool {
 	return getStatus(obj, string(c)) == "False"
 }
 
+func (c Cond) Unknown(obj interface{}) {
+	setStatus(obj, string(c), "Unknown")
+}
+
+func (c Cond) IsUnknown(obj interface{}) bool {
+	return getStatus(obj, string(c)) == "Unknown"
+}
+
 func (c Cond) Reason(obj any, reason string) {
 	cond := findOrCreateCond(obj, string(c))
 	getFieldValue(cond, "Reason").SetString(reason)

--- a/internal/cmd/agent/deployer/monitor/condition.go
+++ b/internal/cmd/agent/deployer/monitor/condition.go
@@ -45,11 +45,11 @@ func (c Cond) IsFalse(obj any) bool {
 	return getStatus(obj, string(c)) == "False"
 }
 
-func (c Cond) Unknown(obj interface{}) {
+func (c Cond) Unknown(obj any) {
 	setStatus(obj, string(c), "Unknown")
 }
 
-func (c Cond) IsUnknown(obj interface{}) bool {
+func (c Cond) IsUnknown(obj any) bool {
 	return getStatus(obj, string(c)) == "Unknown"
 }
 

--- a/internal/cmd/controller/agentmanagement/controllers/cluster/import.go
+++ b/internal/cmd/controller/agentmanagement/controllers/cluster/import.go
@@ -318,6 +318,10 @@ func (i *importHandler) importCluster(cluster *fleet.Cluster, status fleet.Clust
 		apiServerCA  = secret.Data[config.APIServerCAKey]
 	)
 
+	if cfg.AgentCheckinInterval.Seconds() == 0 {
+		return status, fmt.Errorf("agent check-in interval cannot be 0")
+	}
+
 	if apiServerURL == "" {
 		if len(cfg.APIServerURL) == 0 {
 			// Current config cannot be deployed, so remove the "config changed" mark

--- a/internal/cmd/controller/agentmanagement/controllers/cluster/import.go
+++ b/internal/cmd/controller/agentmanagement/controllers/cluster/import.go
@@ -319,7 +319,7 @@ func (i *importHandler) importCluster(cluster *fleet.Cluster, status fleet.Clust
 	)
 
 	if cfg.AgentCheckinInterval.Seconds() == 0 {
-		return status, fmt.Errorf("agent check-in interval cannot be 0")
+		return status, errors.New("agent check-in interval cannot be 0")
 	}
 
 	if apiServerURL == "" {

--- a/internal/cmd/controller/agentmanagement/controllers/manageagent/manageagent.go
+++ b/internal/cmd/controller/agentmanagement/controllers/manageagent/manageagent.go
@@ -11,6 +11,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"sort"
 
 	"github.com/sirupsen/logrus"
@@ -328,6 +329,10 @@ func (h *handler) newAgentBundle(ns string, cluster *fleet.Cluster) (runtime.Obj
 	priorityClassName := ""
 	if cluster.Spec.AgentSchedulingCustomization != nil && cluster.Spec.AgentSchedulingCustomization.PriorityClass != nil {
 		priorityClassName = scheduling.FleetAgentPriorityClassName
+	}
+
+	if cfg.AgentCheckinInterval.Seconds() == 0 {
+		return nil, errors.New("agent check-in interval cannot be 0")
 	}
 
 	if cluster.Spec.AgentTolerations != nil {

--- a/internal/cmd/controller/agentmanagement/controllers/manageagent/manageagent_test.go
+++ b/internal/cmd/controller/agentmanagement/controllers/manageagent/manageagent_test.go
@@ -1,7 +1,6 @@
 package manageagent
 
 import (
-	"os"
 	"reflect"
 	"strings"
 	"testing"
@@ -26,9 +25,9 @@ func TestNewAgentBundle(t *testing.T) {
 	config.Set(&config.Config{AgentCheckinInterval: metav1.Duration{Duration: 0 * time.Second}})
 
 	// ensure leader election env is set so NewLeaderElectionOptionsWithPrefix doesn't error
-	os.Setenv("FLEET_AGENT_ELECTION_LEASE_DURATION", "15s")
-	os.Setenv("FLEET_AGENT_ELECTION_RENEW_DEADLINE", "10s")
-	os.Setenv("FLEET_AGENT_ELECTION_RETRY_PERIOD", "2s")
+	t.Setenv("FLEET_AGENT_ELECTION_LEASE_DURATION", "15s")
+	t.Setenv("FLEET_AGENT_ELECTION_RENEW_DEADLINE", "10s")
+	t.Setenv("FLEET_AGENT_ELECTION_RETRY_PERIOD", "2s")
 
 	h := handler{systemNamespace: "blah"}
 	obj, err := h.newAgentBundle("foo", &fleet.Cluster{Spec: fleet.ClusterSpec{AgentNamespace: "bar"}})

--- a/internal/cmd/controller/agentmanagement/controllers/manageagent/manageagent_test.go
+++ b/internal/cmd/controller/agentmanagement/controllers/manageagent/manageagent_test.go
@@ -1,9 +1,11 @@
 package manageagent
 
 import (
+	"os"
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/rancher/wrangler/v3/pkg/generic/fake"
 	"github.com/rancher/wrangler/v3/pkg/schemes"
@@ -13,13 +15,33 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
+	"github.com/rancher/fleet/internal/config"
 	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	networkv1 "k8s.io/api/networking/v1"
 	"sigs.k8s.io/yaml"
-
-	"github.com/rancher/fleet/internal/config"
 )
+
+func TestNewAgentBundle(t *testing.T) {
+	config.Set(&config.Config{AgentCheckinInterval: metav1.Duration{Duration: 0 * time.Second}})
+
+	// ensure leader election env is set so NewLeaderElectionOptionsWithPrefix doesn't error
+	os.Setenv("FLEET_AGENT_ELECTION_LEASE_DURATION", "15s")
+	os.Setenv("FLEET_AGENT_ELECTION_RENEW_DEADLINE", "10s")
+	os.Setenv("FLEET_AGENT_ELECTION_RETRY_PERIOD", "2s")
+
+	h := handler{systemNamespace: "blah"}
+	obj, err := h.newAgentBundle("foo", &fleet.Cluster{Spec: fleet.ClusterSpec{AgentNamespace: "bar"}})
+
+	if obj != nil {
+		t.Fatalf("expected obj returned by newAgentBundle to be nil")
+	}
+
+	expectedStr := "interval cannot be 0"
+	if !strings.Contains(err.Error(), expectedStr) {
+		t.Fatalf("expected error %q returned by newAgentBundle to contain %q", err, expectedStr)
+	}
+}
 
 func TestOnClusterChangeAffinity(t *testing.T) {
 	ctrl := gomock.NewController(t)
@@ -118,7 +140,9 @@ func TestOnClusterChangeAffinity(t *testing.T) {
 
 func TestNewAgentBundle_SortsAgentTolerations(t *testing.T) {
 	// make sure config is set for newAgentBundle
-	config.Set(config.DefaultConfig())
+	cfg := config.DefaultConfig()
+	cfg.AgentCheckinInterval = metav1.Duration{Duration: 1 * time.Second} // non-zero to prevent errors covered elsewhere.
+	config.Set(cfg)
 
 	checkRegisterAddToScheme(t, appsv1.AddToScheme)
 	checkRegisterAddToScheme(t, networkv1.AddToScheme)

--- a/internal/cmd/controller/clustermonitor/monitor.go
+++ b/internal/cmd/controller/clustermonitor/monitor.go
@@ -115,12 +115,10 @@ func UpdateOfflineBundleDeployments(ctx context.Context, c client.Client, thresh
 				for _, cond := range bd.Status.Conditions {
 					switch cond.Type {
 					case "Ready":
-						// FIXME: avoid relying on agent pkg for this?
 						mc := monitor.Cond(v1alpha1.BundleDeploymentConditionReady)
 						mc.SetError(&t.Status, "Cluster offline", errors.New(offlineMsg))
 						mc.Unknown(&t.Status)
 						// XXX: do we want to set Deployed and Installed conditions as well?
-						// XXX: should we set conditions to `Unknown`?
 					case "Monitored":
 						mc := monitor.Cond(v1alpha1.BundleDeploymentConditionMonitored)
 						mc.SetError(&t.Status, "Cluster offline", errors.New(offlineMsg))

--- a/internal/cmd/controller/clustermonitor/monitor.go
+++ b/internal/cmd/controller/clustermonitor/monitor.go
@@ -1,0 +1,125 @@
+package clustermonitor
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/rancher/fleet/internal/cmd/agent/deployer/monitor"
+	"github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
+)
+
+// Run monitors Fleet cluster resources' agent last seen dates. If a cluster's agent was last seen longer ago than
+// threshold, then Run updates statuses of all bundle deployments targeting that cluster, to reflect the fact that the
+// cluster is offline. This prevents those bundle deployments from displaying outdated status information.
+//
+// Bundle deployment status updates done here are unlikely to conflict with those done by the bundle deployment
+// reconciler, which are either run from an online target cluster (from its Fleet agent) or triggered by other status
+// updates such as this one (eg. bundle deployment reconciler living in the Fleet controller).
+func Run(ctx context.Context, c client.Client, threshold time.Duration) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(threshold):
+		}
+
+		// XXX: should the same value be used for both the polling interval and the threshold?
+		UpdateOfflineBundleDeployments(ctx, c, threshold)
+	}
+}
+
+func UpdateOfflineBundleDeployments(ctx context.Context, c client.Client, threshold time.Duration) {
+	logger := ctrl.Log.WithName("cluster status monitor")
+
+	clusters := &v1alpha1.ClusterList{}
+	if err := c.List(ctx, clusters); err != nil {
+		logger.Error(err, "Failed to get list of clusters")
+		return
+	}
+
+	for _, cluster := range clusters.Items {
+		lastSeen := cluster.Status.Agent.LastSeen
+
+		// FIXME threshold should not be lower than cluster status refresh default value (15 min)
+
+		logger.Info("Checking cluster status", "cluster", cluster.Name, "last seen", lastSeen.UTC().String())
+
+		// XXX: do we want to run this more than once per cluster, updating the timestamp each time?
+		// Or would it make sense to keep the oldest possible timestamp in place, for users to know since when the
+		// cluster is offline?
+
+		// lastSeen being 0 would typically mean that the cluster is not registered yet, in which case bundle
+		// deployments should not be deployed there.
+		if lastSeen.IsZero() || time.Now().UTC().Sub(lastSeen.UTC()) < threshold {
+			continue
+		}
+
+		logger.Info("Detected offline cluster", "cluster", cluster.Name)
+
+		// Cluster is offline
+		bundleDeployments := &v1alpha1.BundleDeploymentList{}
+		if err := c.List(ctx, bundleDeployments, client.InNamespace(cluster.Status.Namespace)); err != nil {
+			logger.Error(
+				err,
+				"Failed to get list of bundle deployments for offline cluster",
+				"cluster",
+				cluster.Name,
+				"namespace",
+				cluster.Status.Namespace,
+			)
+			continue
+		}
+
+		for _, bd := range bundleDeployments.Items {
+			logger.Info("Updating bundle deployment in offline cluster", "cluster", cluster.Name, "bundledeployment", bd.Name)
+			err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				t := &v1alpha1.BundleDeployment{}
+				nsn := types.NamespacedName{Name: bd.Name, Namespace: bd.Namespace}
+				if err := c.Get(ctx, nsn, t); err != nil {
+					return err
+				}
+				t.Status = bd.Status
+				// Any information about resources living in an offline cluster is likely to be
+				// outdated.
+				t.Status.ModifiedStatus = nil
+				t.Status.NonReadyStatus = nil
+
+				for _, cond := range bd.Status.Conditions {
+					switch cond.Type {
+					// XXX: which messages do we want to set and where?
+					case "Ready":
+						// FIXME: avoid relying on agent pkg for this?
+						mc := monitor.Cond(v1alpha1.BundleDeploymentConditionReady)
+						mc.SetError(&t.Status, "Cluster offline", fmt.Errorf("cluster is offline"))
+						// XXX: do we want to set Deployed and Installed conditions as well?
+						// XXX: should we set conditions to `Unknown`?
+					case "Monitored":
+						mc := monitor.Cond(v1alpha1.BundleDeploymentConditionMonitored)
+						mc.SetError(&t.Status, "Cluster offline", fmt.Errorf("cluster is offline"))
+
+					}
+				}
+
+				return c.Status().Update(ctx, t)
+			})
+			if err != nil {
+				logger.Error(
+					err,
+					"Failed to update bundle deployment status for offline cluster",
+					"bundledeployment",
+					bd.Name,
+					"cluster",
+					cluster.Name,
+					"namespace",
+					cluster.Status.Namespace,
+				)
+			}
+		}
+	}
+}

--- a/internal/cmd/controller/clustermonitor/monitor.go
+++ b/internal/cmd/controller/clustermonitor/monitor.go
@@ -62,7 +62,12 @@ func UpdateOfflineBundleDeployments(ctx context.Context, c client.Client, thresh
 	for _, cluster := range clusters.Items {
 		lastSeen := cluster.Status.Agent.LastSeen
 
-		logger.Info("Checking cluster status", "cluster", cluster.Name, "last seen", lastSeen.UTC().String())
+		logger.Info(
+			"Checking cluster status",
+			"cluster", cluster.Name,
+			"threshold", threshold,
+			"last seen", lastSeen.UTC().String(),
+		)
 
 		// lastSeen being 0 would typically mean that the cluster is not registered yet, in which case bundle
 		// deployments should not be deployed there.

--- a/internal/cmd/controller/clustermonitor/monitor.go
+++ b/internal/cmd/controller/clustermonitor/monitor.go
@@ -16,8 +16,6 @@ import (
 	"github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
 )
 
-const offlineMsg = "cluster is offline"
-
 // Run monitors Fleet cluster resources' agent last seen dates. If a cluster's agent was last seen longer ago than
 // a certain threshold, then Run updates statuses of all bundle deployments targeting that cluster, to reflect the fact
 // that the cluster is offline. This prevents those bundle deployments from displaying outdated status information.
@@ -50,8 +48,9 @@ func Run(ctx context.Context, c client.Client, interval, threshold time.Duration
 // UpdateOfflineBundleDeployments looks for offline clusters based on the provided threshold duration. For each cluster
 // considered offline, this updates its bundle deployments' statuses accordingly.
 // If a cluster's bundle deployments have already been marked as offline, they will be skipped.
+// Cluster status updates are handled by the cluster reconciler, to prevent concurrent status updates.
 func UpdateOfflineBundleDeployments(ctx context.Context, c client.Client, threshold time.Duration) {
-	logger := ctrl.Log.WithName("cluster status monitor")
+	logger := ctrl.Log.WithName("cluster-status-monitor")
 
 	clusters := &v1alpha1.ClusterList{}
 	if err := c.List(ctx, clusters); err != nil {
@@ -77,7 +76,7 @@ func UpdateOfflineBundleDeployments(ctx context.Context, c client.Client, thresh
 
 		logger.Info("Detected offline cluster", "cluster", cluster.Name)
 
-		// Cluster is offline
+		// List and patch bundle deployments for cluster
 		bundleDeployments := &v1alpha1.BundleDeploymentList{}
 		if err := c.List(ctx, bundleDeployments, client.InNamespace(cluster.Status.Namespace)); err != nil {
 			logger.Error(
@@ -98,7 +97,7 @@ func UpdateOfflineBundleDeployments(ctx context.Context, c client.Client, thresh
 				case "Ready":
 					fallthrough
 				case "Monitored":
-					if cond.Message == offlineMsg {
+					if cond.Message == v1alpha1.ClusterOfflineMsg {
 						break bd_update
 					}
 				}
@@ -112,26 +111,29 @@ func UpdateOfflineBundleDeployments(ctx context.Context, c client.Client, thresh
 					return err
 				}
 				t.Status = bd.Status
+
+				orig := bd.DeepCopy()
+
 				// Any information about resources living in an offline cluster is likely to be
 				// outdated.
 				t.Status.ModifiedStatus = nil
 				t.Status.NonReadyStatus = nil
 
-				for _, cond := range bd.Status.Conditions {
-					switch cond.Type {
-					case "Ready":
-						mc := monitor.Cond(v1alpha1.BundleDeploymentConditionReady)
-						mc.SetError(&t.Status, "Cluster offline", errors.New(offlineMsg))
-						mc.Unknown(&t.Status)
-						// XXX: do we want to set Deployed and Installed conditions as well?
-					case "Monitored":
-						mc := monitor.Cond(v1alpha1.BundleDeploymentConditionMonitored)
-						mc.SetError(&t.Status, "Cluster offline", errors.New(offlineMsg))
+				mc := monitor.Cond(v1alpha1.BundleDeploymentConditionReady)
+				mc.SetError(&t.Status, "Cluster offline", errors.New(v1alpha1.ClusterOfflineMsg))
+				mc.Unknown(&t.Status)
+				// XXX: do we want to set Deployed and Installed conditions as well?
 
-					}
+				mc = monitor.Cond(v1alpha1.BundleDeploymentConditionMonitored)
+				mc.SetError(&t.Status, "Cluster offline", errors.New(v1alpha1.ClusterOfflineMsg))
+
+				statusPatch := client.MergeFrom(orig)
+
+				if patchData, err := statusPatch.Data(t); err != nil || string(patchData) != "{}" {
+					return c.Status().Patch(ctx, t, statusPatch)
 				}
 
-				return c.Status().Update(ctx, t)
+				return nil
 			})
 			if err != nil {
 				logger.Error(

--- a/internal/cmd/controller/clustermonitor/monitor.go
+++ b/internal/cmd/controller/clustermonitor/monitor.go
@@ -110,9 +110,8 @@ func UpdateOfflineBundleDeployments(ctx context.Context, c client.Client, thresh
 				if err := c.Get(ctx, nsn, t); err != nil {
 					return err
 				}
-				t.Status = bd.Status
 
-				orig := bd.DeepCopy()
+				orig := t.DeepCopy()
 
 				// Any information about resources living in an offline cluster is likely to be
 				// outdated.
@@ -129,7 +128,12 @@ func UpdateOfflineBundleDeployments(ctx context.Context, c client.Client, thresh
 
 				statusPatch := client.MergeFrom(orig)
 
-				if patchData, err := statusPatch.Data(t); err != nil || string(patchData) != "{}" {
+				patchData, err := statusPatch.Data(t)
+				if err != nil {
+					return err
+				}
+
+				if string(patchData) != "{}" {
 					return c.Status().Patch(ctx, t, statusPatch)
 				}
 

--- a/internal/cmd/controller/clustermonitor/monitor.go
+++ b/internal/cmd/controller/clustermonitor/monitor.go
@@ -98,7 +98,7 @@ func UpdateOfflineBundleDeployments(ctx context.Context, c client.Client, thresh
 					fallthrough
 				case "Monitored":
 					if cond.Message == v1alpha1.ClusterOfflineMsg {
-						break bd_update
+						continue bd_update // the bundle deployment is already marked offline; skip to next BD
 					}
 				}
 			}

--- a/internal/cmd/controller/clustermonitor/monitor_test.go
+++ b/internal/cmd/controller/clustermonitor/monitor_test.go
@@ -1,0 +1,365 @@
+package clustermonitor_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"go.uber.org/mock/gomock"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/rancher/fleet/internal/cmd/controller/clustermonitor"
+	"github.com/rancher/fleet/internal/mocks"
+	"github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
+	"github.com/rancher/wrangler/v3/pkg/genericcondition"
+)
+
+const threshold = 1 * time.Second
+
+// BDStatusMatcher implements a gomock matcher for bundle deployment status.
+// The matcher checks for empty modified and non-ready status, as well as offline state through Ready and Monitored
+// conditions.
+type BDStatusMatcher struct {
+}
+
+func (m BDStatusMatcher) Matches(x interface{}) bool {
+	bd, ok := x.(*v1alpha1.BundleDeployment)
+	if !ok {
+		return false
+	}
+
+	bdStatus := bd.Status
+
+	if bd == nil {
+		return false
+	}
+
+	if bdStatus.ModifiedStatus != nil || bdStatus.NonReadyStatus != nil {
+		return false
+	}
+
+	foundReady, foundMonitored := false, false
+	for _, cond := range bdStatus.Conditions {
+		if cond.Type == "Ready" {
+			foundReady = true
+
+			if !strings.Contains(cond.Message, "offline") {
+				return false
+			}
+		} else if cond.Type == "Monitored" {
+			foundMonitored = true
+
+			if !strings.Contains(cond.Message, "offline") {
+				return false
+			}
+		}
+
+	}
+
+	return foundReady && foundMonitored
+}
+
+func (m BDStatusMatcher) String() string {
+	return "Bundle deployment status for offline cluster"
+}
+
+type clusterWithOfflineMarker struct {
+	cluster   v1alpha1.Cluster
+	isOffline bool
+}
+
+func Test_Run(t *testing.T) {
+	cases := []struct {
+		name              string
+		clusters          []clusterWithOfflineMarker
+		listClustersErr   error
+		bundleDeployments map[string][]v1alpha1.BundleDeployment // indexed by cluster namespace
+		listBDErr         error
+	}{
+		{
+			name:              "no cluster",
+			clusters:          nil,
+			listClustersErr:   nil,
+			bundleDeployments: nil,
+			listBDErr:         nil,
+		},
+		{
+			name: "no offline cluster",
+			clusters: []clusterWithOfflineMarker{
+				{
+					cluster: v1alpha1.Cluster{
+						Status: v1alpha1.ClusterStatus{
+							Agent: v1alpha1.AgentStatus{
+								LastSeen: metav1.Time{Time: time.Now().UTC()},
+							},
+						},
+					},
+				},
+				{
+					cluster: v1alpha1.Cluster{
+						Status: v1alpha1.ClusterStatus{
+							Agent: v1alpha1.AgentStatus{
+								LastSeen: metav1.Time{Time: time.Now().UTC()},
+							},
+						},
+					},
+				},
+				{
+					cluster: v1alpha1.Cluster{
+						Status: v1alpha1.ClusterStatus{
+							// eg. not yet registered downstream cluster
+							Agent: v1alpha1.AgentStatus{ /* LastSeen is zero */ },
+						},
+					},
+				},
+			},
+			listClustersErr:   nil,
+			bundleDeployments: nil,
+			listBDErr:         nil,
+		},
+		{
+			name: "one offline cluster",
+			clusters: []clusterWithOfflineMarker{
+				{
+					cluster: v1alpha1.Cluster{
+						Status: v1alpha1.ClusterStatus{
+							Agent: v1alpha1.AgentStatus{
+								LastSeen: metav1.Time{Time: time.Now().UTC()},
+							},
+						},
+					},
+				},
+				{
+					cluster: v1alpha1.Cluster{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "mycluster",
+						},
+						Status: v1alpha1.ClusterStatus{
+							Agent: v1alpha1.AgentStatus{
+								LastSeen: metav1.Time{Time: time.Now().UTC().Add(-10 * threshold)},
+							},
+							Namespace: "clusterns1",
+						},
+					},
+					isOffline: true,
+				},
+			},
+			listClustersErr: nil,
+			bundleDeployments: map[string][]v1alpha1.BundleDeployment{
+				"clusterns1": {
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "mybundledeployment",
+							Namespace: "clusterns1",
+						},
+						Status: v1alpha1.BundleDeploymentStatus{
+							Conditions: []genericcondition.GenericCondition{
+								{
+									Type: "Ready",
+								},
+								{
+									Type: "Monitored",
+								},
+							},
+						},
+					},
+				},
+			},
+			listBDErr: nil,
+		},
+		{
+			name: "multiple offline clusters",
+			clusters: []clusterWithOfflineMarker{
+				{
+					cluster: v1alpha1.Cluster{
+						Status: v1alpha1.ClusterStatus{
+							Agent: v1alpha1.AgentStatus{
+								LastSeen: metav1.Time{Time: time.Now().UTC()},
+							},
+						},
+					},
+				},
+				{
+					cluster: v1alpha1.Cluster{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "mycluster",
+						},
+						Status: v1alpha1.ClusterStatus{
+							Agent: v1alpha1.AgentStatus{
+								LastSeen: metav1.Time{Time: time.Now().UTC().Add(-10 * threshold)},
+							},
+							Namespace: "clusterns1",
+						},
+					},
+					isOffline: true,
+				},
+				{
+					cluster: v1alpha1.Cluster{
+						Status: v1alpha1.ClusterStatus{
+							Agent: v1alpha1.AgentStatus{
+								LastSeen: metav1.Time{Time: time.Now().UTC()},
+							},
+						},
+					},
+				},
+				{
+					cluster: v1alpha1.Cluster{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "mycluster2",
+						},
+						Status: v1alpha1.ClusterStatus{
+							Agent: v1alpha1.AgentStatus{
+								LastSeen: metav1.Time{Time: time.Now().UTC().Add(-5 * threshold)},
+							},
+							Namespace: "clusterns2",
+						},
+					},
+					isOffline: true,
+				},
+				{
+					cluster: v1alpha1.Cluster{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "mycluster3",
+						},
+						Status: v1alpha1.ClusterStatus{
+							Agent: v1alpha1.AgentStatus{
+								LastSeen: metav1.Time{Time: time.Now().UTC().Add(-3 * threshold)},
+							},
+							Namespace: "clusterns3",
+						},
+					},
+					isOffline: true,
+				},
+			},
+			listClustersErr: nil,
+			bundleDeployments: map[string][]v1alpha1.BundleDeployment{
+				"clusterns1": {
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "mybundledeployment",
+							Namespace: "clusterns1",
+						},
+						Status: v1alpha1.BundleDeploymentStatus{
+							Conditions: []genericcondition.GenericCondition{
+								{
+									Type: "Ready",
+								},
+								{
+									Type: "Monitored",
+								},
+							},
+						},
+					},
+				},
+				"clusterns2": {
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "mybundledeployment",
+							Namespace: "clusterns2",
+						},
+						Status: v1alpha1.BundleDeploymentStatus{
+							Conditions: []genericcondition.GenericCondition{
+								{
+									Type: "Ready",
+								},
+								{
+									Type: "Monitored",
+								},
+							},
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "my-other-bundledeployment",
+							Namespace: "clusterns2",
+						},
+						Status: v1alpha1.BundleDeploymentStatus{
+							Conditions: []genericcondition.GenericCondition{
+								{
+									Type: "Ready",
+								},
+								{
+									Type: "Monitored",
+								},
+							},
+						},
+					},
+				},
+				"clusterns3": {
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "mybundledeployment",
+							Namespace: "clusterns3",
+						},
+						Status: v1alpha1.BundleDeploymentStatus{
+							Conditions: []genericcondition.GenericCondition{
+								{
+									Type: "Ready",
+								},
+								{
+									Type: "Monitored",
+								},
+							},
+						},
+					},
+				},
+			},
+			listBDErr: nil,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			testClient := mocks.NewMockK8sClient(ctrl)
+			ctx, cancel := context.WithCancel(context.Background())
+
+			defer cancel()
+
+			testClient.EXPECT().List(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
+				func(ctx context.Context, list *v1alpha1.ClusterList, opts ...client.ListOption) error {
+					for _, cl := range tc.clusters {
+						list.Items = append(list.Items, cl.cluster)
+					}
+
+					return tc.listClustersErr
+				},
+			)
+
+			for _, cl := range tc.clusters {
+				if !cl.isOffline {
+					continue
+				}
+
+				bundleDeplsForCluster := tc.bundleDeployments[cl.cluster.Status.Namespace]
+				testClient.EXPECT().List(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
+					func(ctx context.Context, list *v1alpha1.BundleDeploymentList, opts ...client.ListOption) error {
+						list.Items = append(list.Items, bundleDeplsForCluster...)
+
+						return tc.listBDErr
+					},
+				)
+
+				for _, bd := range bundleDeplsForCluster {
+					testClient.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
+						func(ctx context.Context, nsn types.NamespacedName, b *v1alpha1.BundleDeployment, opts ...client.GetOption) error {
+							b = &bd
+
+							return nil
+						},
+					)
+
+					srw := mocks.NewMockStatusWriter(ctrl)
+					testClient.EXPECT().Status().Return(srw)
+
+					srw.EXPECT().Update(ctx, &BDStatusMatcher{}).Return(nil)
+				}
+			}
+
+			clustermonitor.UpdateOfflineBundleDeployments(ctx, testClient, threshold)
+		})
+	}
+}

--- a/internal/cmd/controller/clustermonitor/monitor_test.go
+++ b/internal/cmd/controller/clustermonitor/monitor_test.go
@@ -39,7 +39,8 @@ func (m BDStatusMatcher) Matches(x interface{}) bool {
 
 	foundReady, foundMonitored := false, false
 	for _, cond := range bdStatus.Conditions {
-		if cond.Type == "Ready" {
+		switch cond.Type {
+		case "Ready":
 			foundReady = true
 
 			if cond.Status != "Unknown" ||
@@ -47,7 +48,7 @@ func (m BDStatusMatcher) Matches(x interface{}) bool {
 				!strings.Contains(cond.Message, "offline") {
 				return false
 			}
-		} else if cond.Type == "Monitored" {
+		case "Monitored":
 			foundMonitored = true
 
 			if cond.Status != "False" ||
@@ -56,7 +57,6 @@ func (m BDStatusMatcher) Matches(x interface{}) bool {
 				return false
 			}
 		}
-
 	}
 
 	return foundReady && foundMonitored
@@ -72,7 +72,7 @@ type clusterWithOfflineMarker struct {
 	isAlreadyMarkedOffline bool
 }
 
-func Test_Run(t *testing.T) { //nolint: funlen // this is a test function, its length should not be an issue
+func Test_Run(t *testing.T) {
 	cases := []struct {
 		name              string
 		clusters          []clusterWithOfflineMarker

--- a/internal/cmd/controller/clustermonitor/monitor_test.go
+++ b/internal/cmd/controller/clustermonitor/monitor_test.go
@@ -42,13 +42,17 @@ func (m BDStatusMatcher) Matches(x interface{}) bool {
 		if cond.Type == "Ready" {
 			foundReady = true
 
-			if !strings.Contains(cond.Message, "offline") {
+			if cond.Status != "False" ||
+				!strings.Contains(cond.Reason, "offline") ||
+				!strings.Contains(cond.Message, "offline") {
 				return false
 			}
 		} else if cond.Type == "Monitored" {
 			foundMonitored = true
 
-			if !strings.Contains(cond.Message, "offline") {
+			if cond.Status != "False" ||
+				!strings.Contains(cond.Reason, "offline") ||
+				!strings.Contains(cond.Message, "offline") {
 				return false
 			}
 		}

--- a/internal/cmd/controller/clustermonitor/monitor_test.go
+++ b/internal/cmd/controller/clustermonitor/monitor_test.go
@@ -27,15 +27,11 @@ type BDStatusMatcher struct {
 
 func (m BDStatusMatcher) Matches(x interface{}) bool {
 	bd, ok := x.(*v1alpha1.BundleDeployment)
-	if !ok {
+	if !ok || bd == nil {
 		return false
 	}
 
 	bdStatus := bd.Status
-
-	if bd == nil {
-		return false
-	}
 
 	if bdStatus.ModifiedStatus != nil || bdStatus.NonReadyStatus != nil {
 		return false
@@ -71,7 +67,7 @@ type clusterWithOfflineMarker struct {
 	isOffline bool
 }
 
-func Test_Run(t *testing.T) {
+func Test_Run(t *testing.T) { //nolint: funlen // this is a test function, its length should not be an issue
 	cases := []struct {
 		name              string
 		clusters          []clusterWithOfflineMarker
@@ -345,8 +341,16 @@ func Test_Run(t *testing.T) {
 
 				for _, bd := range bundleDeplsForCluster {
 					testClient.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
-						func(ctx context.Context, nsn types.NamespacedName, b *v1alpha1.BundleDeployment, opts ...client.GetOption) error {
-							b = &bd
+						func(
+							ctx context.Context,
+							nsn types.NamespacedName,
+							// b's initial value is never used, but the variable needs to be
+							// named for its value to be overwritten with values we care
+							// about, to simulate a response from the API server.
+							b *v1alpha1.BundleDeployment, //nolint: staticcheck
+							opts ...client.GetOption,
+						) error {
+							b = &bd //nolint: ineffassign,staticcheck // the value is used by the implementation, not directly by the tests.
 
 							return nil
 						},

--- a/internal/cmd/controller/clustermonitor/monitor_test.go
+++ b/internal/cmd/controller/clustermonitor/monitor_test.go
@@ -42,7 +42,7 @@ func (m BDStatusMatcher) Matches(x interface{}) bool {
 		if cond.Type == "Ready" {
 			foundReady = true
 
-			if cond.Status != "False" ||
+			if cond.Status != "Unknown" ||
 				!strings.Contains(cond.Reason, "offline") ||
 				!strings.Contains(cond.Message, "offline") {
 				return false

--- a/internal/cmd/controller/clustermonitor/monitor_test.go
+++ b/internal/cmd/controller/clustermonitor/monitor_test.go
@@ -454,10 +454,10 @@ func Test_Run(t *testing.T) {
 							// b's initial value is never used, but the variable needs to be
 							// named for its value to be overwritten with values we care
 							// about, to simulate a response from the API server.
-							b *v1alpha1.BundleDeployment, //nolint: staticcheck
+							b *v1alpha1.BundleDeployment,
 							opts ...client.GetOption,
 						) error {
-							*b = bd //nolint: ineffassign,staticcheck // the value is used by the implementation, not directly by the tests.
+							*b = bd
 
 							return nil
 						},

--- a/internal/cmd/controller/clustermonitor/monitor_test.go
+++ b/internal/cmd/controller/clustermonitor/monitor_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"go.uber.org/mock/gomock"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -18,53 +19,6 @@ import (
 )
 
 const threshold = 1 * time.Second
-
-// BDStatusMatcher implements a gomock matcher for bundle deployment status.
-// The matcher checks for empty modified and non-ready status, as well as offline state through Ready and Monitored
-// conditions.
-type BDStatusMatcher struct {
-}
-
-func (m BDStatusMatcher) Matches(x interface{}) bool {
-	bd, ok := x.(*v1alpha1.BundleDeployment)
-	if !ok || bd == nil {
-		return false
-	}
-
-	bdStatus := bd.Status
-
-	if bdStatus.ModifiedStatus != nil || bdStatus.NonReadyStatus != nil {
-		return false
-	}
-
-	foundReady, foundMonitored := false, false
-	for _, cond := range bdStatus.Conditions {
-		switch cond.Type {
-		case "Ready":
-			foundReady = true
-
-			if cond.Status != "Unknown" ||
-				!strings.Contains(cond.Reason, "offline") ||
-				!strings.Contains(cond.Message, "offline") {
-				return false
-			}
-		case "Monitored":
-			foundMonitored = true
-
-			if cond.Status != "False" ||
-				!strings.Contains(cond.Reason, "offline") ||
-				!strings.Contains(cond.Message, "offline") {
-				return false
-			}
-		}
-	}
-
-	return foundReady && foundMonitored
-}
-
-func (m BDStatusMatcher) String() string {
-	return "Bundle deployment status for offline cluster"
-}
 
 type clusterWithOfflineMarker struct {
 	cluster                v1alpha1.Cluster
@@ -514,7 +468,35 @@ func Test_Run(t *testing.T) {
 					srw := mocks.NewMockStatusWriter(ctrl)
 					testClient.EXPECT().Status().Return(srw)
 
-					srw.EXPECT().Update(ctx, &BDStatusMatcher{}).Return(nil)
+					srw.EXPECT().Patch(gomock.Any(), gomock.Any(), gomock.Any()).Do(
+						func(ctx context.Context, bd *v1alpha1.BundleDeployment, p client.Patch, opts ...interface{}) {
+							var foundReady, foundMonitored bool
+							for _, c := range bd.Status.Conditions {
+								switch c.Type {
+								case "Ready":
+									foundReady = true
+									if c.Status != corev1.ConditionStatus("Unknown") {
+										t.Errorf("expecting unknown ready condition status, got %s", c.Status)
+									}
+									if !strings.Contains(c.Message, "offline") {
+										t.Errorf("expecting ready condition message to reflect offline state, got %s", c.Message)
+									}
+								case "Monitored":
+									foundMonitored = true
+									if !strings.Contains(c.Message, "offline") {
+										t.Errorf("expecting ready condition message to reflect offline state, got %s", c.Message)
+									}
+								}
+							}
+
+							if !foundReady {
+								t.Errorf("ready condition not found in BD status %v", bd.Status)
+							}
+
+							if !foundMonitored {
+								t.Errorf("monitored condition not found in BD status %v", bd.Status)
+							}
+						}).Times(1)
 				}
 			}
 

--- a/internal/cmd/controller/clustermonitor/monitor_test.go
+++ b/internal/cmd/controller/clustermonitor/monitor_test.go
@@ -414,9 +414,7 @@ func Test_Run(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			testClient := mocks.NewMockK8sClient(ctrl)
-			ctx, cancel := context.WithCancel(context.Background())
-
-			defer cancel()
+			ctx := t.Context()
 
 			testClient.EXPECT().List(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
 				func(ctx context.Context, list *v1alpha1.ClusterList, opts ...client.ListOption) error {
@@ -469,7 +467,7 @@ func Test_Run(t *testing.T) {
 					testClient.EXPECT().Status().Return(srw)
 
 					srw.EXPECT().Patch(gomock.Any(), gomock.Any(), gomock.Any()).Do(
-						func(ctx context.Context, bd *v1alpha1.BundleDeployment, p client.Patch, opts ...interface{}) {
+						func(ctx context.Context, bd *v1alpha1.BundleDeployment, p client.Patch, opts ...any) {
 							var foundReady, foundMonitored bool
 							for _, c := range bd.Status.Conditions {
 								switch c.Type {

--- a/internal/cmd/controller/clustermonitor/monitor_test.go
+++ b/internal/cmd/controller/clustermonitor/monitor_test.go
@@ -457,7 +457,7 @@ func Test_Run(t *testing.T) {
 							b *v1alpha1.BundleDeployment, //nolint: staticcheck
 							opts ...client.GetOption,
 						) error {
-							b = &bd //nolint: ineffassign,staticcheck // the value is used by the implementation, not directly by the tests.
+							*b = bd //nolint: ineffassign,staticcheck // the value is used by the implementation, not directly by the tests.
 
 							return nil
 						},

--- a/internal/cmd/controller/operator.go
+++ b/internal/cmd/controller/operator.go
@@ -240,16 +240,18 @@ func start(
 		return err
 	}
 
-	setupLog.Info("starting cluster status monitor")
-	cfg := fleetcfg.Get()
-	// No need to run a similar check on the threshold, since its minimum value will be a multiple of the agent check-in
-	// interval anyway.
-	if cfg.ClusterMonitorInterval.Seconds() == 0 {
-		err := errors.New("cluster status monitor interval cannot be 0")
-		setupLog.Error(err, "cannot start cluster status monitor")
-		return err
+	if shardID == "" { // only one instance of the cluster status monitor needs to run.
+		setupLog.Info("starting cluster status monitor")
+		cfg := fleetcfg.Get()
+		// No need to run a similar check on the threshold, since its minimum value will be a multiple of the agent check-in
+		// interval anyway.
+		if cfg.ClusterMonitorInterval.Seconds() == 0 {
+			err := errors.New("cluster status monitor interval cannot be 0")
+			setupLog.Error(err, "cannot start cluster status monitor")
+			return err
+		}
+		go clustermonitor.Run(ctx, mgr.GetClient(), cfg.ClusterMonitorInterval.Duration, cfg.ClusterMonitorThreshold.Duration)
 	}
-	go clustermonitor.Run(ctx, mgr.GetClient(), cfg.ClusterMonitorInterval.Duration, cfg.ClusterMonitorThreshold.Duration)
 
 	setupLog.Info("starting job scheduler")
 	jobCtx, cancel := context.WithCancel(ctx)

--- a/internal/cmd/controller/operator.go
+++ b/internal/cmd/controller/operator.go
@@ -11,28 +11,24 @@ import (
 	"github.com/reugn/go-quartz/quartz"
 
 	"github.com/rancher/fleet/internal/cmd"
+	"github.com/rancher/fleet/internal/cmd/controller/clustermonitor"
 	"github.com/rancher/fleet/internal/cmd/controller/reconciler"
 	"github.com/rancher/fleet/internal/cmd/controller/target"
 	"github.com/rancher/fleet/internal/config"
 	"github.com/rancher/fleet/internal/experimental"
 	"github.com/rancher/fleet/internal/manifest"
 	"github.com/rancher/fleet/internal/metrics"
-	"github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
 	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
 
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
-
-	"github.com/rancher/fleet/internal/cmd/agent/deployer/monitor"
 )
 
 var (
@@ -245,7 +241,7 @@ func start(
 	}
 
 	setupLog.Info("starting cluster status monitor")
-	go runClusterStatusMonitor(ctx, mgr.GetClient())
+	go clustermonitor.Run(ctx, mgr.GetClient(), 15*time.Second) // TODO load or hard-code sensible value
 
 	setupLog.Info("starting job scheduler")
 	jobCtx, cancel := context.WithCancel(ctx)
@@ -308,106 +304,4 @@ func AddBundleDownstreamResourceIndexer(ctx context.Context, mgr manager.Manager
 			return resources
 		},
 	)
-}
-
-func runClusterStatusMonitor(ctx context.Context, c client.Client) {
-	threshold := 15 * time.Second // TODO load or hard-code sensible value
-
-	logger := ctrl.Log.WithName("cluster status monitor")
-
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-time.After(threshold):
-		}
-
-		clusters := &v1alpha1.ClusterList{}
-		if err := c.List(ctx, clusters); err != nil {
-			logger.Error(err, "Failed to get list of clusters")
-			continue
-		}
-
-		for _, cluster := range clusters.Items {
-			lastSeen := cluster.Status.Agent.LastSeen
-
-			// FIXME threshold should not be lower than cluster status refresh default value (15 min)
-
-			// XXX: should the same value be used for both the polling interval and the threshold?
-			logger.Info("Checking cluster status", "cluster", cluster.Name, "last seen", lastSeen.UTC().String())
-
-			// XXX: do we want to run this more than once per cluster, updating the timestamp each time?
-			// Or would it make sense to keep the oldest possible timestamp in place, for users to know since when the
-			// cluster is offline?
-
-			// lastSeen being 0 would typically mean that the cluster is not registered yet, in which case bundle
-			// deployments should not be deployed there.
-			if lastSeen.IsZero() || time.Now().UTC().Sub(lastSeen.UTC()) < threshold {
-				continue
-			}
-
-			logger.Info("Detected offline cluster", "cluster", cluster.Name)
-
-			// Cluster is offline
-			bundleDeployments := &v1alpha1.BundleDeploymentList{}
-			if err := c.List(ctx, bundleDeployments, client.InNamespace(cluster.Status.Namespace)); err != nil {
-				logger.Error(
-					err,
-					"Failed to get list of bundle deployments for offline cluster",
-					"cluster",
-					cluster.Name,
-					"namespace",
-					cluster.Status.Namespace,
-				)
-				continue
-			}
-
-			// These updates should not conflict with those done by the bundle deployment reconciler (offline vs online
-			// clusters).
-			for _, bd := range bundleDeployments.Items {
-				logger.Info("Updating bundle deployment in offline cluster", "cluster", cluster.Name, "bundledeployment", bd.Name)
-				err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-					t := &v1alpha1.BundleDeployment{}
-					nsn := types.NamespacedName{Name: bd.Name, Namespace: bd.Namespace}
-					if err := c.Get(ctx, nsn, t); err != nil {
-						return err
-					}
-					t.Status = bd.Status
-					// Any information about resources living in an offline cluster is likely to be
-					// outdated.
-					t.Status.ModifiedStatus = nil
-					t.Status.NonReadyStatus = nil
-
-					for _, cond := range bd.Status.Conditions {
-						switch cond.Type {
-						// XXX: which messages do we want to set and where?
-						case "Ready":
-							// FIXME: avoid relying on agent pkg for this?
-							mc := monitor.Cond(v1alpha1.BundleDeploymentConditionReady)
-							mc.SetError(&bd.Status, "Cluster offline", fmt.Errorf("cluster is offline"))
-							// XXX: do we want to set Deployed and Installed conditions as well?
-						case "Monitored":
-							mc := monitor.Cond(v1alpha1.BundleDeploymentConditionMonitored)
-							mc.SetError(&bd.Status, "Cluster offline", fmt.Errorf("cluster is offline"))
-
-						}
-					}
-
-					return c.Status().Update(ctx, t)
-				})
-				if err != nil {
-					logger.Error(
-						err,
-						"Failed to update bundle deployment status for offline cluster",
-						"bundledeployment",
-						bd.Name,
-						"cluster",
-						cluster.Name,
-						"namespace",
-						cluster.Status.Namespace,
-					)
-				}
-			}
-		}
-	}
 }

--- a/internal/cmd/controller/operator.go
+++ b/internal/cmd/controller/operator.go
@@ -369,26 +369,29 @@ func runClusterStatusMonitor(ctx context.Context, c client.Client) {
 				err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 					t := &v1alpha1.BundleDeployment{}
 					nsn := types.NamespacedName{Name: bd.Name, Namespace: bd.Namespace}
-					logger.Info("[DEBUG] getting bundle deployment", "cluster", cluster.Name, "bundledeployment", bd.Name)
 					if err := c.Get(ctx, nsn, t); err != nil {
 						return err
 					}
 					t.Status = bd.Status
-					// TODO status updates: update condition with type Ready
+					// Any information about resources living in an offline cluster is likely to be
+					// outdated.
 					t.Status.ModifiedStatus = nil
+					t.Status.NonReadyStatus = nil
 
 					for _, cond := range bd.Status.Conditions {
-						if cond.Type != "Ready" {
-							continue
+						switch cond.Type {
+						// XXX: which messages do we want to set and where?
+						case "Ready":
+							// FIXME: avoid relying on agent pkg for this?
+							mc := monitor.Cond(v1alpha1.BundleDeploymentConditionReady)
+							mc.SetError(&bd.Status, "Cluster offline", fmt.Errorf("cluster is offline"))
+							// XXX: do we want to set Deployed and Installed conditions as well?
+						case "Monitored":
+							mc := monitor.Cond(v1alpha1.BundleDeploymentConditionMonitored)
+							mc.SetError(&bd.Status, "Cluster offline", fmt.Errorf("cluster is offline"))
+
 						}
-
-						// FIXME: avoid relying on agent pkg for this?
-						mc := monitor.Cond(v1alpha1.BundleDeploymentConditionReady)
-						mc.SetError(&bd.Status, "Cluster offline", fmt.Errorf("cluster is offline"))
-						//cond.LastUpdated(status, time.Now().UTC().Format(time.RFC3339))
 					}
-
-					logger.Info("[DEBUG] updating bundle deployment status", "cluster", cluster.Name, "bundledeployment", bd.Name)
 
 					return c.Status().Update(ctx, t)
 				})

--- a/internal/cmd/controller/operator.go
+++ b/internal/cmd/controller/operator.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strconv"
@@ -13,7 +14,7 @@ import (
 	"github.com/rancher/fleet/internal/cmd/controller/clustermonitor"
 	"github.com/rancher/fleet/internal/cmd/controller/reconciler"
 	"github.com/rancher/fleet/internal/cmd/controller/target"
-	"github.com/rancher/fleet/internal/config"
+	fleetcfg "github.com/rancher/fleet/internal/config"
 	"github.com/rancher/fleet/internal/experimental"
 	"github.com/rancher/fleet/internal/manifest"
 	"github.com/rancher/fleet/internal/metrics"
@@ -240,7 +241,15 @@ func start(
 	}
 
 	setupLog.Info("starting cluster status monitor")
-	go clustermonitor.Run(ctx, mgr.GetClient())
+	cfg := fleetcfg.Get()
+	// No need to run a similar check on the threshold, since its minimum value will be a multiple of the agent check-in
+	// interval anyway.
+	if cfg.ClusterMonitorInterval.Seconds() == 0 {
+		err := errors.New("cluster status monitor interval cannot be 0")
+		setupLog.Error(err, "cannot start cluster status monitor")
+		return err
+	}
+	go clustermonitor.Run(ctx, mgr.GetClient(), cfg.ClusterMonitorInterval.Duration, cfg.ClusterMonitorThreshold.Duration)
 
 	setupLog.Info("starting job scheduler")
 	jobCtx, cancel := context.WithCancel(ctx)
@@ -263,7 +272,7 @@ func AddContentNameLabelIndexer(ctx context.Context, mgr manager.Manager) error 
 	return mgr.GetFieldIndexer().IndexField(
 		ctx,
 		&fleet.BundleDeployment{},
-		config.ContentNameIndex,
+		fleetcfg.ContentNameIndex,
 		func(obj client.Object) []string {
 			content, ok := obj.(*fleet.BundleDeployment)
 			if !ok {
@@ -284,7 +293,7 @@ func AddBundleDownstreamResourceIndexer(ctx context.Context, mgr manager.Manager
 	return mgr.GetFieldIndexer().IndexField(
 		ctx,
 		&fleet.Bundle{},
-		config.BundleDownstreamResourceIndex,
+		fleetcfg.BundleDownstreamResourceIndex,
 		func(obj client.Object) []string {
 			bundle, ok := obj.(*fleet.Bundle)
 			if !ok {

--- a/internal/cmd/controller/operator.go
+++ b/internal/cmd/controller/operator.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/reugn/go-quartz/quartz"
 
@@ -16,17 +17,22 @@ import (
 	"github.com/rancher/fleet/internal/experimental"
 	"github.com/rancher/fleet/internal/manifest"
 	"github.com/rancher/fleet/internal/metrics"
+	"github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
 	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
 
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+
+	"github.com/rancher/fleet/internal/cmd/agent/deployer/monitor"
 )
 
 var (
@@ -238,6 +244,9 @@ func start(
 		return err
 	}
 
+	setupLog.Info("starting cluster status monitor")
+	go runClusterStatusMonitor(ctx, mgr.GetClient())
+
 	setupLog.Info("starting job scheduler")
 	jobCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
@@ -299,4 +308,103 @@ func AddBundleDownstreamResourceIndexer(ctx context.Context, mgr manager.Manager
 			return resources
 		},
 	)
+}
+
+func runClusterStatusMonitor(ctx context.Context, c client.Client) {
+	threshold := 15 * time.Second // TODO load or hard-code sensible value
+
+	logger := ctrl.Log.WithName("cluster status monitor")
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(threshold):
+		}
+
+		clusters := &v1alpha1.ClusterList{}
+		if err := c.List(ctx, clusters); err != nil {
+			logger.Error(err, "Failed to get list of clusters")
+			continue
+		}
+
+		for _, cluster := range clusters.Items {
+			lastSeen := cluster.Status.Agent.LastSeen
+
+			// FIXME threshold should not be lower than cluster status refresh default value (15 min)
+
+			// XXX: should the same value be used for both the polling interval and the threshold?
+			logger.Info("Checking cluster status", "cluster", cluster.Name, "last seen", lastSeen.UTC().String())
+
+			// XXX: do we want to run this more than once per cluster, updating the timestamp each time?
+			// Or would it make sense to keep the oldest possible timestamp in place, for users to know since when the
+			// cluster is offline?
+
+			// lastSeen being 0 would typically mean that the cluster is not registered yet, in which case bundle
+			// deployments should not be deployed there.
+			if lastSeen.IsZero() || time.Now().UTC().Sub(lastSeen.UTC()) < threshold {
+				continue
+			}
+
+			logger.Info("Detected offline cluster", "cluster", cluster.Name)
+
+			// Cluster is offline
+			bundleDeployments := &v1alpha1.BundleDeploymentList{}
+			if err := c.List(ctx, bundleDeployments, client.InNamespace(cluster.Status.Namespace)); err != nil {
+				logger.Error(
+					err,
+					"Failed to get list of bundle deployments for offline cluster",
+					"cluster",
+					cluster.Name,
+					"namespace",
+					cluster.Status.Namespace,
+				)
+				continue
+			}
+
+			// These updates should not conflict with those done by the bundle deployment reconciler (offline vs online
+			// clusters).
+			for _, bd := range bundleDeployments.Items {
+				logger.Info("Updating bundle deployment in offline cluster", "cluster", cluster.Name, "bundledeployment", bd.Name)
+				err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+					t := &v1alpha1.BundleDeployment{}
+					nsn := types.NamespacedName{Name: bd.Name, Namespace: bd.Namespace}
+					logger.Info("[DEBUG] getting bundle deployment", "cluster", cluster.Name, "bundledeployment", bd.Name)
+					if err := c.Get(ctx, nsn, t); err != nil {
+						return err
+					}
+					t.Status = bd.Status
+					// TODO status updates: update condition with type Ready
+					t.Status.ModifiedStatus = nil
+
+					for _, cond := range bd.Status.Conditions {
+						if cond.Type != "Ready" {
+							continue
+						}
+
+						// FIXME: avoid relying on agent pkg for this?
+						mc := monitor.Cond(v1alpha1.BundleDeploymentConditionReady)
+						mc.SetError(&bd.Status, "Cluster offline", fmt.Errorf("cluster is offline"))
+						//cond.LastUpdated(status, time.Now().UTC().Format(time.RFC3339))
+					}
+
+					logger.Info("[DEBUG] updating bundle deployment status", "cluster", cluster.Name, "bundledeployment", bd.Name)
+
+					return c.Status().Update(ctx, t)
+				})
+				if err != nil {
+					logger.Error(
+						err,
+						"Failed to update bundle deployment status for offline cluster",
+						"bundledeployment",
+						bd.Name,
+						"cluster",
+						cluster.Name,
+						"namespace",
+						cluster.Status.Namespace,
+					)
+				}
+			}
+		}
+	}
 }

--- a/internal/cmd/controller/operator.go
+++ b/internal/cmd/controller/operator.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/reugn/go-quartz/quartz"
 
@@ -241,7 +240,7 @@ func start(
 	}
 
 	setupLog.Info("starting cluster status monitor")
-	go clustermonitor.Run(ctx, mgr.GetClient(), 15*time.Second) // TODO load or hard-code sensible value
+	go clustermonitor.Run(ctx, mgr.GetClient())
 
 	setupLog.Info("starting job scheduler")
 	jobCtx, cancel := context.WithCancel(ctx)

--- a/internal/cmd/controller/operator.go
+++ b/internal/cmd/controller/operator.go
@@ -240,17 +240,23 @@ func start(
 		return err
 	}
 
-	if shardID == "" { // only one instance of the cluster status monitor needs to run.
+	cfg := fleetcfg.Get()
+
+	if cfg.ClusterMonitor.Enabled && shardID == "" { // only one instance of the cluster status monitor needs to run.
 		setupLog.Info("starting cluster status monitor")
-		cfg := fleetcfg.Get()
 		// No need to run a similar check on the threshold, since its minimum value will be a multiple of the agent check-in
 		// interval anyway.
-		if cfg.ClusterMonitorInterval.Seconds() == 0 {
+		if cfg.ClusterMonitor.Interval.Seconds() == 0 {
 			err := errors.New("cluster status monitor interval cannot be 0")
 			setupLog.Error(err, "cannot start cluster status monitor")
 			return err
 		}
-		go clustermonitor.Run(ctx, mgr.GetClient(), cfg.ClusterMonitorInterval.Duration, cfg.ClusterMonitorThreshold.Duration)
+		go clustermonitor.Run(
+			ctx,
+			mgr.GetClient(),
+			cfg.ClusterMonitor.Interval.Duration,
+			cfg.ClusterMonitor.Threshold.Duration,
+		)
 	}
 
 	setupLog.Info("starting job scheduler")

--- a/internal/cmd/controller/reconciler/cluster_controller.go
+++ b/internal/cmd/controller/reconciler/cluster_controller.go
@@ -4,6 +4,7 @@ package reconciler
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
 	"slices"
@@ -19,6 +20,7 @@ import (
 	"github.com/rancher/fleet/pkg/sharding"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/rancher/fleet/internal/cmd/agent/deployer/monitor"
 	fleetutil "github.com/rancher/fleet/internal/cmd/controller/errorutil"
 	"github.com/rancher/wrangler/v3/pkg/condition"
 
@@ -86,6 +88,10 @@ func (r *ClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 						return true
 					}
 					if n.Status.AppliedDeploymentID != o.Status.AppliedDeploymentID {
+						return true
+					}
+					if summary.MessageFromCondition(fleet.ClusterConditionReady, n.Status.Conditions) !=
+						summary.MessageFromCondition(fleet.ClusterConditionReady, o.Status.Conditions) {
 						return true
 					}
 					if n.Status.Ready != o.Status.Ready {
@@ -198,6 +204,7 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 	gitRepos := map[types.NamespacedName]bool{}
 	helmOps := map[types.NamespacedName]bool{}
+	isClusterOffline := false
 	for _, bd := range bundleDeployments {
 		state := summary.GetDeploymentState(&bd)
 		summary.IncrementState(&cluster.Status.Summary, bd.Name, state, summary.MessageFromDeployment(&bd), bd.Status.ModifiedStatus, bd.Status.NonReadyStatus)
@@ -221,6 +228,22 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			// a helmOp is ready if its bundledeployments are ready, take previous state into account
 			helmOpKey := types.NamespacedName{Namespace: ns, Name: helmOpName}
 			helmOps[helmOpKey] = (state == fleet.Ready) || helmOps[helmOpKey]
+		}
+
+		if isClusterOffline {
+			continue
+		}
+
+		if summary.MessageFromCondition(fleet.ClusterConditionReady, bd.Status.Conditions) == fleet.ClusterOfflineMsg {
+			isClusterOffline = true
+
+			ready := monitor.Cond(fleet.ClusterConditionReady)
+			ready.SetError(&cluster.Status, "Cluster offline", errors.New(fleet.ClusterOfflineMsg))
+			ready.Unknown(&cluster.Status)
+
+			reconciled := monitor.Cond("Reconciled")
+			reconciled.SetError(&cluster.Status, "Cluster offline", errors.New(fleet.ClusterOfflineMsg))
+			reconciled.Unknown(&cluster.Status)
 		}
 	}
 
@@ -250,7 +273,9 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		}
 	}
 
-	summary.SetReadyConditions(&cluster.Status, "Bundle", cluster.Status.Summary)
+	if !isClusterOffline {
+		summary.SetReadyConditions(&cluster.Status, "Bundle", cluster.Status.Summary)
+	}
 
 	// Calculate display status fields
 	cluster.Status.Display.ReadyBundles = fmt.Sprintf("%d/%d",

--- a/internal/cmd/controller/reconciler/cluster_controller.go
+++ b/internal/cmd/controller/reconciler/cluster_controller.go
@@ -64,7 +64,18 @@ type ClusterReconciler struct {
 // SetupWithManager sets up the controller with the Manager.
 func (r *ClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&fleet.Cluster{}).
+		For(&fleet.Cluster{},
+			builder.WithPredicates(
+				// do not trigger for cluster status changes (except for cache sync)
+				predicate.Or(
+					TypedResourceVersionUnchangedPredicate[client.Object]{},
+					predicate.GenerationChangedPredicate{},
+					predicate.AnnotationChangedPredicate{},
+					predicate.LabelChangedPredicate{},
+				),
+				sharding.FilterByShardID(r.ShardID),
+			),
+		).
 		// Watch bundledeployments so we can update the status fields
 		Watches(
 			&fleet.BundleDeployment{},

--- a/internal/cmd/controller/reconciler/cluster_controller.go
+++ b/internal/cmd/controller/reconciler/cluster_controller.go
@@ -43,6 +43,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
+var offlineConds = []string{
+	fleet.ClusterConditionReady,
+	"Reconciled",
+}
+
 var LongRetry = wait.Backoff{
 	Steps:    5,
 	Duration: 5 * time.Second,
@@ -241,20 +246,26 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			helmOps[helmOpKey] = (state == fleet.Ready) || helmOps[helmOpKey]
 		}
 
-		if isClusterOffline {
-			continue
-		}
-
 		if summary.MessageFromCondition(fleet.ClusterConditionReady, bd.Status.Conditions) == fleet.ClusterOfflineMsg {
+			// bundle deployment offline, mark cluster offline
+			if isClusterOffline {
+				continue
+			}
+
 			isClusterOffline = true
 
-			ready := monitor.Cond(fleet.ClusterConditionReady)
-			ready.SetError(&cluster.Status, "Cluster offline", errors.New(fleet.ClusterOfflineMsg))
-			ready.Unknown(&cluster.Status)
+			for _, c := range offlineConds {
+				cond := monitor.Cond(c)
+				cond.SetError(&cluster.Status, "Cluster offline", errors.New(fleet.ClusterOfflineMsg))
+				cond.Unknown(&cluster.Status)
+			}
 
-			reconciled := monitor.Cond("Reconciled")
-			reconciled.SetError(&cluster.Status, "Cluster offline", errors.New(fleet.ClusterOfflineMsg))
-			reconciled.Unknown(&cluster.Status)
+		} else if summary.MessageFromCondition(fleet.ClusterConditionReady, cluster.Status.Conditions) == fleet.ClusterOfflineMsg {
+			// bundle deployment online, mark offline cluster back online
+			for _, c := range offlineConds {
+				cond := monitor.Cond(c)
+				cond.SetError(&cluster.Status, "", nil)
+			}
 		}
 	}
 

--- a/internal/cmd/controller/reconciler/cluster_controller.go
+++ b/internal/cmd/controller/reconciler/cluster_controller.go
@@ -248,24 +248,18 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 		if summary.MessageFromCondition(fleet.ClusterConditionReady, bd.Status.Conditions) == fleet.ClusterOfflineMsg {
 			// bundle deployment offline, mark cluster offline
-			if isClusterOffline {
-				continue
-			}
-
 			isClusterOffline = true
+		}
+	}
 
-			for _, c := range offlineConds {
-				cond := monitor.Cond(c)
-				cond.SetError(&cluster.Status, "Cluster offline", errors.New(fleet.ClusterOfflineMsg))
-				cond.Unknown(&cluster.Status)
-			}
-
-		} else if summary.MessageFromCondition(fleet.ClusterConditionReady, cluster.Status.Conditions) == fleet.ClusterOfflineMsg {
-			// bundle deployment online, mark offline cluster back online
-			for _, c := range offlineConds {
-				cond := monitor.Cond(c)
-				cond.SetError(&cluster.Status, "", nil)
-			}
+	for _, c := range offlineConds {
+		cond := monitor.Cond(c)
+		if isClusterOffline {
+			cond.SetError(&cluster.Status, "Cluster offline", errors.New(fleet.ClusterOfflineMsg))
+			cond.Unknown(&cluster.Status)
+		} else {
+			// bundle deployments all online, mark offline cluster back online
+			cond.SetError(&cluster.Status, "", nil)
 		}
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -154,14 +154,8 @@ type Config struct {
 	// AgentWorkers specifies the maximum number of workers for each agent reconciler.
 	AgentWorkers AgentWorkers `json:"agentWorkers,omitzero"`
 
-	// ClusterMonitorInterval determines how often the cluster monitor will check for offline downstream clusters.
-	ClusterMonitorInterval metav1.Duration `json:"clusterMonitorInterval,omitempty"`
-
-	// ClusterMonitorThreshold determines how long must have elapsed since a downstream cluster's Fleet agent last
-	// reported its status to the management cluster, before that downstream cluster is considered offline.
-	// If this configured value is shorter than three times the agent check-in interval, then that check-in
-	// interval-based value will be used instead to prevent false positives.
-	ClusterMonitorThreshold metav1.Duration `json:"clusterMonitorThreshold.omitempty"`
+	// ClusterMonitor represents configuration for the cluster monitor, including its enabled or disabled state.
+	ClusterMonitor ClusterMonitor `json:"clusterMonitor,omitempty"`
 }
 
 type AgentWorkers struct {
@@ -181,6 +175,20 @@ type Bootstrap struct {
 	Secret string `json:"secret,omitempty"`
 	Paths  string `json:"paths,omitempty"`
 	Branch string `json:"branch,omitempty"`
+}
+
+type ClusterMonitor struct {
+	// Enabled determines whether the cluster monitor should be instantiated.
+	Enabled bool `json:"enabled,omitempty"`
+
+	// Interval determines how often the cluster monitor will check for offline downstream clusters.
+	Interval metav1.Duration `json:"interval,omitempty"`
+
+	// Threshold determines how long must have elapsed since a downstream cluster's Fleet agent last reported its
+	// status to the management cluster, before that downstream cluster is considered offline. If this configured value
+	// is shorter than three times the agent check-in interval, then that check-in interval-based value will be used
+	// instead to prevent false positives.
+	Threshold metav1.Duration `json:"threshold.omitempty"`
 }
 
 // OnChange is used by agentmanagement to react to config changes. The callback is triggered by 'Set' via

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -153,6 +153,15 @@ type Config struct {
 
 	// AgentWorkers specifies the maximum number of workers for each agent reconciler.
 	AgentWorkers AgentWorkers `json:"agentWorkers,omitzero"`
+
+	// ClusterMonitorInterval determines how often the cluster monitor will check for offline downstream clusters.
+	ClusterMonitorInterval metav1.Duration `json:"clusterMonitorInterval.omitempty"`
+
+	// ClusterMonitorThreshold determines how long must have elapsed since a downstream cluster's Fleet agent last
+	// reported its status to the management cluster, before that downstream cluster is considered offline.
+	// If this configured value is shorter than three times the agent check-in interval, then that check-in
+	// interval-based value will be used instead to prevent false positives.
+	ClusterMonitorThreshold metav1.Duration `json:"clusterMonitorThreshold.omitempty"`
 }
 
 type AgentWorkers struct {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -155,7 +155,7 @@ type Config struct {
 	AgentWorkers AgentWorkers `json:"agentWorkers,omitzero"`
 
 	// ClusterMonitorInterval determines how often the cluster monitor will check for offline downstream clusters.
-	ClusterMonitorInterval metav1.Duration `json:"clusterMonitorInterval.omitempty"`
+	ClusterMonitorInterval metav1.Duration `json:"clusterMonitorInterval,omitempty"`
 
 	// ClusterMonitorThreshold determines how long must have elapsed since a downstream cluster's Fleet agent last
 	// reported its status to the management cluster, before that downstream cluster is considered offline.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -155,7 +155,7 @@ type Config struct {
 	AgentWorkers AgentWorkers `json:"agentWorkers,omitzero"`
 
 	// ClusterMonitor represents configuration for the cluster monitor, including its enabled or disabled state.
-	ClusterMonitor ClusterMonitor `json:"clusterMonitor,omitempty"`
+	ClusterMonitor ClusterMonitor `json:"clusterMonitor,omitzero"`
 }
 
 type AgentWorkers struct {
@@ -182,13 +182,13 @@ type ClusterMonitor struct {
 	Enabled bool `json:"enabled,omitempty"`
 
 	// Interval determines how often the cluster monitor will check for offline downstream clusters.
-	Interval metav1.Duration `json:"interval,omitempty"`
+	Interval metav1.Duration `json:"interval,omitzero"`
 
 	// Threshold determines how long must have elapsed since a downstream cluster's Fleet agent last reported its
 	// status to the management cluster, before that downstream cluster is considered offline. If this configured value
 	// is shorter than three times the agent check-in interval, then that check-in interval-based value will be used
 	// instead to prevent false positives.
-	Threshold metav1.Duration `json:"threshold.omitempty"`
+	Threshold metav1.Duration `json:"threshold,omitzero"`
 }
 
 // OnChange is used by agentmanagement to react to config changes. The callback is triggered by 'Set' via

--- a/pkg/apis/fleet.cattle.io/v1alpha1/cluster_types.go
+++ b/pkg/apis/fleet.cattle.io/v1alpha1/cluster_types.go
@@ -45,6 +45,8 @@ var (
 
 	// ClusterManagementLabel can be used to specify a custom cluster manager
 	ClusterManagementLabel = "fleet.cattle.io/cluster-management"
+
+	ClusterOfflineMsg = "cluster is offline"
 )
 
 // +genclient


### PR DESCRIPTION
This adds a cluster status monitor to the Fleet controller, which checks when each cluster last saw its agent online. If more than the expected interval elapses, that cluster is considered offline, and the monitor updates its bundle deployments' statuses to reflect that. This will trigger status updates to bundles, `GitRepo`s, clusters and cluster groups.

Refers to #594.

Open points:
* how far, and how fine-grained, do we want to make bundle deployment status updates for offline clusters? This currently takes a fairly basic approach, updating both `Ready` and `Monitored` conditions while clearing modified and non-ready statuses, to prevent outdated messages from appearing in a bundle deployment's display status and further up the chain of status updates (to bundles, then upwards to `GitRepo`s, etc)
* should we make the frequency of monitoring configurable?
* do we have a way to exclude the local/management cluster from agent-last-seen checks?


### Update 2026-03
* the cluster controller checks for offline bundle deployments, to mark the corresponding cluster as offline. It also supports the opposite, namely marking a cluster back online when its bundle deployments are detected as such.
* this is covered by integration tests, not involving the cluster monitor, while end-to-end tests validate this behaviour when the cluster monitor is involved.