### PR TITLE
[v0.10] Converts the delete gitjobs to one-time job

### DIFF
--- a/charts/fleet/templates/job_cleanup_gitrepojobs.yaml
+++ b/charts/fleet/templates/job_cleanup_gitrepojobs.yaml
@@ -1,47 +1,41 @@
 {{- if .Values.migrations.gitrepoJobsCleanup }}
 ---
 apiVersion: batch/v1
-kind: CronJob
+kind: Job
 metadata:
   name: fleet-cleanup-gitrepo-jobs
   annotations:
     "helm.sh/hook": post-install, post-upgrade
     "helm.sh/hook-delete-policy": hook-succeeded, before-hook-creation
 spec:
-  schedule: "@daily"
-  concurrencyPolicy: Forbid
-  successfulJobsHistoryLimit: 0
-  failedJobsHistoryLimit: 1
-  jobTemplate:
+  template:
+    metadata:
+      labels:
+        app: fleet-job
     spec:
-      template:
-        metadata:
-          labels:
-            app: fleet-job
-        spec:
-          serviceAccountName: fleet-controller
-          restartPolicy: Never
-          securityContext:
-            runAsNonRoot: true
-            runAsGroup: 1000
-            runAsUser: 1000
-          containers:
-          - name: cleanup
-            image: "{{ template "system_default_registry" . }}{{.Values.image.repository}}:{{.Values.image.tag}}"
-            imagePullPolicy: {{ .Values.global.imagePullPolicy }}
-            securityContext:
-              allowPrivilegeEscalation: false
-              capabilities:
-                drop:
-                - ALL
-              readOnlyRootFilesystem: false
-              privileged: false
-            command:
-            - fleet
-            args:
-            - cleanup
-            - gitjob
-          nodeSelector: {{ include "linux-node-selector" . | nindent 12 }}
-          tolerations: {{ include "linux-node-tolerations" . | nindent 12 }}
-      backoffLimit: 1
+      serviceAccountName: gitjob
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        runAsGroup: 1000
+        runAsUser: 1000
+      containers:
+      - name: cleanup
+        image: "{{ template "system_default_registry" . }}{{.Values.image.repository}}:{{.Values.image.tag}}"
+        imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: false
+          privileged: false
+        command:
+        - fleet
+        args:
+        - cleanup
+        - gitjob
+      nodeSelector: {{ include "linux-node-selector" . | nindent 8 }}
+      tolerations: {{ include "linux-node-tolerations" . | nindent 8 }}
+  backoffLimit: 1
 {{- end }}

--- a/charts/fleet/templates/rbac.yaml
+++ b/charts/fleet/templates/rbac.yaml
@@ -38,7 +38,6 @@ rules:
     - 'events'
   verbs:
     - '*'
-
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
The job also deletes all completed gitjobs, not leaving the last one active, as https://github.com/rancher/fleet/pull/2903 was merged.

Also fixes the ServiceAccount to be able to list and delete jobs.

Refers to: https://github.com/rancher/fleet/issues/2935
Backport of: https://github.com/rancher/fleet/pull/2928
