### PR TITLE
DeleteCRDResources overrides existing annotations

### DIFF
--- a/internal/helmdeployer/postrender.go
+++ b/internal/helmdeployer/postrender.go
@@ -83,13 +83,18 @@ func (p *postRender) Run(renderedManifests *bytes.Buffer) (modifiedManifests *by
 		if err != nil {
 			return nil, err
 		}
+
 		objAnnotations := mergeMaps(m.GetAnnotations(), annotations)
-		if !p.opts.DeleteCRDResources &&
-			obj.GetObjectKind().GroupVersionKind().Kind == CRDKind {
-			objAnnotations[kube.ResourcePolicyAnno] = kube.KeepPolicy
+		if obj.GetObjectKind().GroupVersionKind().Kind == CRDKind {
+			if !p.opts.DeleteCRDResources { // keep CRD resources
+				objAnnotations[kube.ResourcePolicyAnno] = kube.KeepPolicy
+			} else {
+				delete(objAnnotations, kube.ResourcePolicyAnno)
+			}
 		}
-		m.SetLabels(mergeMaps(m.GetLabels(), labels))
 		m.SetAnnotations(objAnnotations)
+
+		m.SetLabels(mergeMaps(m.GetLabels(), labels))
 
 		if p.opts.TargetNamespace != "" {
 			if p.mapper != nil {

--- a/internal/helmdeployer/postrender_test.go
+++ b/internal/helmdeployer/postrender_test.go
@@ -44,9 +44,7 @@ func TestPostRenderer_Run_DeleteCRDs(t *testing.T) {
 					APIVersion: "apiextensions.k8s.io/v1",
 				},
 			},
-			opts: v1alpha1.BundleDeploymentOptions{
-				DeleteCRDResources: true,
-			},
+			opts: v1alpha1.BundleDeploymentOptions{DeleteCRDResources: true},
 			expectedAnnotations: map[string]string{
 				"objectset.rio.cattle.io/id": "-",
 			},
@@ -58,25 +56,73 @@ func TestPostRenderer_Run_DeleteCRDs(t *testing.T) {
 					APIVersion: "apiextensions.k8s.io/v1",
 				},
 			},
-			opts: v1alpha1.BundleDeploymentOptions{
-				DeleteCRDResources: false,
-			},
+			opts: v1alpha1.BundleDeploymentOptions{DeleteCRDResources: false},
 			expectedAnnotations: map[string]string{
 				kube.ResourcePolicyAnno:      kube.KeepPolicy,
 				"objectset.rio.cattle.io/id": "-",
 			},
 		},
-		"Annotation not added for non CRDs resources": {
+		"Annotation not added to non CRDs resources": {
 			obj: &corev1.Pod{
 				TypeMeta: metav1.TypeMeta{
 					Kind: "Pod",
 				},
 			},
-			opts: v1alpha1.BundleDeploymentOptions{
-				DeleteCRDResources: false,
-			},
+			opts: v1alpha1.BundleDeploymentOptions{DeleteCRDResources: false},
 			expectedAnnotations: map[string]string{
 				"objectset.rio.cattle.io/id": "-",
+			},
+		},
+		"Policy exists, DeleteCRDResources is set, policy is removed": {
+			obj: &apiextensionsv1.CustomResourceDefinition{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       CRDKind,
+					APIVersion: "apiextensions.k8s.io/v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						kube.ResourcePolicyAnno: kube.KeepPolicy,
+					},
+				},
+			},
+			opts: v1alpha1.BundleDeploymentOptions{DeleteCRDResources: true},
+			expectedAnnotations: map[string]string{
+				"objectset.rio.cattle.io/id": "-",
+			},
+		},
+		"Policy exists, DeleteCRDResources is not set, no change": {
+			obj: &apiextensionsv1.CustomResourceDefinition{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       CRDKind,
+					APIVersion: "apiextensions.k8s.io/v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						kube.ResourcePolicyAnno: kube.KeepPolicy,
+					},
+				},
+			},
+			opts: v1alpha1.BundleDeploymentOptions{DeleteCRDResources: false},
+			expectedAnnotations: map[string]string{
+				kube.ResourcePolicyAnno:      kube.KeepPolicy,
+				"objectset.rio.cattle.io/id": "-",
+			},
+		},
+		"Policy exists, DeleteCRDResources is not set, no change on non CRDs resources": {
+			obj: &corev1.Pod{
+				TypeMeta: metav1.TypeMeta{
+					Kind: "Pod",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						kube.ResourcePolicyAnno: kube.KeepPolicy,
+					},
+				},
+			},
+			opts: v1alpha1.BundleDeploymentOptions{DeleteCRDResources: false},
+			expectedAnnotations: map[string]string{
+				"objectset.rio.cattle.io/id": "-",
+				kube.ResourcePolicyAnno:      kube.KeepPolicy,
 			},
 		},
 	}


### PR DESCRIPTION
Refers to https://github.com/rancher/fleet/issues/2860


Since updates work, I'm closing this. Overriding labels from the template folder of the user's chart could be  feature in the future.