### PR TITLE
Remove tmate step from Fleet-in-Rancher test workflow

### DIFF
--- a/.github/workflows/e2e-test-fleet-in-rancher.yml
+++ b/.github/workflows/e2e-test-fleet-in-rancher.yml
@@ -22,11 +22,6 @@ on:
       fleet_version:
         description: Fleet version to install in Rancher
         type: string
-      enable_tmate:
-        description: Enable debugging via tmate
-        required: false
-        default: false
-        type: boolean
   workflow_call:
     # Variables to set when calling this reusable workflow
     inputs:
@@ -152,14 +147,6 @@ jobs:
             --k3s-arg '--kubelet-arg=eviction-minimum-reclaim=imagefs.available=1%,nodefs.available=1%@agent:*' \
             --network "nw01" \
             --image docker.io/rancher/k3s:${{ env.SETUP_K3S_VERSION }}
-
-      -
-        name: Set Up Tmate Debug Session
-        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.enable_tmate == 'true' }}
-        uses: mxschmitt/action-tmate@v3
-        timeout-minutes: 15
-        with:
-          limit-access-to-actor: true
 
       -
         name: Set up latest Rancher

--- a/dev/README.md
+++ b/dev/README.md
@@ -392,21 +392,6 @@ container image and simply re-used it. You can remove it yourself, either by
 
 This container image will have `act` in his name.
 
-#### Using `act` fails
-
-**Error: The runs.using key in action.yml must be one of: [composite docker node12 node16], got node20**
-
-[action-tmate](https://github.com/mxschmitt/action-tmate) was updated recently
-and switched the value of `runs.using` from `node16` in version
-[3.16](https://github.com/mxschmitt/action-tmate/blob/v3.16/action.yml) to
-`node20` in version
-[3.17](https://github.com/mxschmitt/action-tmate/blob/v3.17/action.yml#L7),
-which is not yet supported by `act`! But an issue for act with a [corresponding
-PR](https://github.com/nektos/act/pull/1988) already exists.
-
-A temporary workaround is to comment the step in the workflow file out which
-includes `tmate`.
-
 ## Monitoring
 
 This sections describes how to add a monitoring stack to your development


### PR DESCRIPTION
That step uses a Github action which is no longer allowed in the Rancher org.

Refers to #1640
Follow-up to #2804.