### PR TITLE
Add helm value to disable securityContext

### DIFF
--- a/charts/fleet/ci/debug-values.yaml
+++ b/charts/fleet/ci/debug-values.yaml
@@ -25,6 +25,7 @@ metrics:
 debug: true
 debugLevel: 4
 propagateDebugSettingsToAgents: true
+disableSecurityContext: true
 
 cpuPprof:
   period: "60s"

--- a/charts/fleet/templates/deployment.yaml
+++ b/charts/fleet/templates/deployment.yaml
@@ -101,7 +101,8 @@ spec:
         - --debug
         - --debug-level
         - {{ quote $.Values.debugLevel }}
-        {{- else }}
+        {{- end }}
+        {{- if not $.Values.disableSecurityContext }}
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
@@ -161,7 +162,8 @@ spec:
         - --debug
         - --debug-level
         - {{ quote $.Values.debugLevel }}
-        {{- else }}
+        {{- end }}
+        {{- if not $.Values.disableSecurityContext }}
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
@@ -206,7 +208,8 @@ spec:
         - --debug
         - --debug-level
         - {{ quote $.Values.debugLevel }}
-        {{- else }}
+        {{- end }}
+        {{- if not $.Values.disableSecurityContext }}
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
@@ -241,7 +244,7 @@ spec:
       priorityClassName: "{{$.Values.priorityClassName}}"
       {{- end }}
 
-{{- if not $.Values.debug }}
+{{- if not $.Values.disableSecurityContext }}
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000

--- a/charts/fleet/templates/deployment_gitjob.yaml
+++ b/charts/fleet/templates/deployment_gitjob.yaml
@@ -93,7 +93,8 @@ spec:
           {{- if $.Values.debug }}
             - name: CATTLE_DEV_MODE
               value: "true"
-          {{- else }}
+          {{- end }}
+          {{- if not $.Values.disableSecurityContext }}
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
@@ -122,7 +123,7 @@ spec:
       priorityClassName: "{{$.Values.priorityClassName}}"
       {{- end }}
 
-{{- if not $.Values.debug }}
+{{- if not $.Values.disableSecurityContext }}
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000

--- a/charts/fleet/values.yaml
+++ b/charts/fleet/values.yaml
@@ -84,6 +84,7 @@ metrics:
 debug: false
 debugLevel: 0
 propagateDebugSettingsToAgents: true
+disableSecurityContext: false
 
 ## Optional CPU pprof configuration. Profiles are collected continuously and saved every period
 ## Any valid volume configuration can be provided, the example below uses hostPath


### PR DESCRIPTION
The securityContext needs to be disabled to allow for debugging with a debugger.
However it should be possible to run debug logs with security contexts enabled.

