### PR TITLE
Fix desired ready with override targets

### DIFF
--- a/internal/cmd/controller/gitops/reconciler/gitjob.go
+++ b/internal/cmd/controller/gitops/reconciler/gitjob.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2021-2023 SUSE LLC
 
-package grutil
+package reconciler
 
 import (
 	corev1 "k8s.io/api/core/v1"
@@ -8,7 +8,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func NewServiceAccount(namespace string, name string) *corev1.ServiceAccount {
+func newServiceAccount(namespace string, name string) *corev1.ServiceAccount {
 	return &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -17,7 +17,7 @@ func NewServiceAccount(namespace string, name string) *corev1.ServiceAccount {
 	}
 }
 
-func NewRole(namespace string, name string) *rbacv1.Role {
+func newRole(namespace string, name string) *rbacv1.Role {
 	return &rbacv1.Role{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -43,7 +43,7 @@ func NewRole(namespace string, name string) *rbacv1.Role {
 	}
 }
 
-func NewRoleBinding(namespace string, name string) *rbacv1.RoleBinding {
+func newRoleBinding(namespace string, name string) *rbacv1.RoleBinding {
 	return &rbacv1.RoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,

--- a/internal/cmd/controller/gitops/reconciler/resourcekey.go
+++ b/internal/cmd/controller/gitops/reconciler/resourcekey.go
@@ -1,4 +1,4 @@
-package grutil
+package reconciler
 
 import (
 	"context"
@@ -6,12 +6,12 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
 	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
+
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func SetStatusFromResourceKey(ctx context.Context, c client.Client, gitrepo *fleet.GitRepo) {
+func setResourceKey(ctx context.Context, c client.Client, gitrepo *fleet.GitRepo) {
 	state := bundleErrorState(gitrepo.Status.Summary)
 	gitrepo.Status.Resources, gitrepo.Status.ResourceErrors = fromResourceKey(ctx, c, gitrepo.Namespace, gitrepo.Name, state)
 	gitrepo.Status = countResources(gitrepo.Status)
@@ -137,7 +137,7 @@ func addState(bd fleet.BundleDeployment, resources map[fleet.ResourceKey][]fleet
 		incomplete = true
 	}
 
-	cluster := bd.Labels[v1alpha1.ClusterNamespaceLabel] + "/" + bd.Labels[v1alpha1.ClusterLabel]
+	cluster := bd.Labels[fleet.ClusterNamespaceLabel] + "/" + bd.Labels[fleet.ClusterLabel]
 	for _, nonReady := range bd.Status.NonReadyStatus {
 		key := fleet.ResourceKey{
 			Kind:       nonReady.Kind,

--- a/internal/cmd/controller/gitops/reconciler/restrictions.go
+++ b/internal/cmd/controller/gitops/reconciler/restrictions.go
@@ -1,4 +1,4 @@
-package grutil
+package reconciler
 
 import (
 	"context"
@@ -11,8 +11,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// AuthorizeAndAssignDefaults applies restrictions and returns a new GitRepo if it passes the restrictions
-func AuthorizeAndAssignDefaults(ctx context.Context, c client.Client, gitrepo *fleet.GitRepo) (*fleet.GitRepo, error) {
+// authorizeAndAssignDefaults applies restrictions and returns a new GitRepo if it passes the restrictions
+func authorizeAndAssignDefaults(ctx context.Context, c client.Client, gitrepo *fleet.GitRepo) (*fleet.GitRepo, error) {
 	restrictions := &fleet.GitRepoRestrictionList{}
 	err := c.List(ctx, restrictions, client.InNamespace(gitrepo.Namespace))
 	if err != nil {

--- a/internal/cmd/controller/gitops/reconciler/targetsyaml.go
+++ b/internal/cmd/controller/gitops/reconciler/targetsyaml.go
@@ -1,4 +1,4 @@
-package grutil
+package reconciler
 
 import (
 	"encoding/json"
@@ -10,11 +10,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// NewTargetsConfigMap builds a config map, containing the GitTarget cluster matchers, converted to BundleTargets.
+// newTargetsConfigMap builds a config map, containing the GitTarget cluster matchers, converted to BundleTargets.
 // The BundleTargets are duplicated into TargetRestrictions. TargetRestrictions is a whilelist. A BundleDeployment
 // will be created for a Target just if it is inside a TargetRestrictions. If it is not inside TargetRestrictions a Target
 // is a TargetCustomization.
-func NewTargetsConfigMap(repo *fleet.GitRepo) (*corev1.ConfigMap, error) {
+func newTargetsConfigMap(repo *fleet.GitRepo) (*corev1.ConfigMap, error) {
 	spec := &fleet.BundleSpec{}
 	for _, target := range targetsOrDefault(repo.Spec.Targets) {
 		spec.Targets = append(spec.Targets, fleet.BundleTarget{

--- a/internal/metrics/bundle_metrics.go
+++ b/internal/metrics/bundle_metrics.go
@@ -113,7 +113,7 @@ func collectBundleMetrics(obj any, metrics map[string]prometheus.Collector) {
 		"name":       bundle.Name,
 		"namespace":  bundle.Namespace,
 		"commit":     bundle.ObjectMeta.Labels[fleet.CommitLabel],
-		"repo":       bundle.ObjectMeta.Labels[repoNameLabel],
+		"repo":       bundle.ObjectMeta.Labels[fleet.RepoLabel],
 		"generation": fmt.Sprintf("%d", bundle.ObjectMeta.Generation),
 		"state":      string(currentState),
 	}

--- a/internal/metrics/bundledeployment_metrics.go
+++ b/internal/metrics/bundledeployment_metrics.go
@@ -52,12 +52,12 @@ func collectBundleDeploymentMetrics(obj any, metrics map[string]prometheus.Colle
 	labels := prometheus.Labels{
 		"name":              bundleDep.Name,
 		"namespace":         bundleDep.Namespace,
-		"cluster_name":      bundleDep.ObjectMeta.Labels["fleet.cattle.io/cluster"],
-		"cluster_namespace": bundleDep.ObjectMeta.Labels["fleet.cattle.io/cluster-namespace"],
-		"repo":              bundleDep.ObjectMeta.Labels[repoNameLabel],
+		"cluster_name":      bundleDep.ObjectMeta.Labels[fleet.ClusterLabel],
+		"cluster_namespace": bundleDep.ObjectMeta.Labels[fleet.ClusterNamespaceLabel],
+		"repo":              bundleDep.ObjectMeta.Labels[fleet.RepoLabel],
 		"commit":            bundleDep.ObjectMeta.Labels[fleet.CommitLabel],
-		"bundle":            bundleDep.ObjectMeta.Labels["fleet.cattle.io/bundle-name"],
-		"bundle_namespace":  bundleDep.ObjectMeta.Labels["fleet.cattle.io/bundle-namespace"],
+		"bundle":            bundleDep.ObjectMeta.Labels[fleet.BundleLabel],
+		"bundle_namespace":  bundleDep.ObjectMeta.Labels[fleet.BundleNamespaceLabel],
 		"generation":        fmt.Sprintf("%d", bundleDep.ObjectMeta.Generation),
 		"state":             string(currentState),
 	}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -12,8 +12,7 @@ import (
 )
 
 const (
-	metricPrefix  = "fleet"
-	repoNameLabel = "fleet.cattle.io/repo-name"
+	metricPrefix = "fleet"
 )
 
 var (


### PR DESCRIPTION
GitRepo's readyClusters calculates directly from bundledeployments.

This fixes an issue with incorrect values when using overrideTargets in fleet.yaml


-> Doesn't work since the gitops controller doesn't trigger on bundledeployments, values would not update.