### PR TITLE
Schedule workflow releasing test charts

### DIFF
--- a/.github/workflows/e2e-test-fleet-in-rancher.yml
+++ b/.github/workflows/e2e-test-fleet-in-rancher.yml
@@ -2,9 +2,6 @@
 name: Test Fleet in Rancher
 
 on:
-  schedule:
-    # Run everyday at 1:00 PM
-    - cron:  '0 13 * * *'
   workflow_dispatch:
     inputs:
       ref:

--- a/.github/workflows/release-against-test-charts.yml
+++ b/.github/workflows/release-against-test-charts.yml
@@ -1,5 +1,8 @@
 name: Release Fleet against test Rancher charts repo
 on:
+  schedule:
+    # Run everyday at 1:00 PM
+    - cron:  '0 13 * * *'
   workflow_dispatch:
     inputs:
       ref:


### PR DESCRIPTION
Scheduling the workflow running end-to-end tests against Rancher would not work, as Rancher would be installed with an empty Fleet version setting, not find that Fleet version, and [time out](https://github.com/rancher/fleet/actions/runs/11480809015/job/31950035334).

Instead, this commit schedules the workflow releasing test charts for the head of `rancher/fleet`'s `main` branch, which then calls the test workflow with the right version, repo and branch parameters for Rancher to install those test charts.

<!-- Specify the issue ID that this pull request is solving -->
Refers to #1640
Follow-up to #2804.