### PR TITLE
Fix status conflict between agent and fleetcontroller

### DIFF
--- a/internal/cmd/controller/reconciler/bundledeployment_controller.go
+++ b/internal/cmd/controller/reconciler/bundledeployment_controller.go
@@ -107,21 +107,12 @@ func (r *BundleDeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		State:     string(summary.GetDeploymentState(bd)),
 	}
 
-	var t *fleet.BundleDeployment
-	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		t = &fleet.BundleDeployment{}
-		err := r.Get(ctx, req.NamespacedName, t)
-		if err != nil {
-			return err
-		}
-		t.Status = bd.Status
-		return r.Status().Update(ctx, t)
-	})
+	err = r.Status().Update(ctx, bd)
 	if err != nil {
-		logger.V(1).Error(err, "Reconcile failed final update to bundle deployment status", "status", bd.Status)
-	} else {
-		metrics.BundleDeploymentCollector.Collect(ctx, t)
+		logger.V(1).Error(err, "Reconcile failed update to bundle deployment status, requeueing", "status", bd.Status)
 	}
+
+	metrics.BundleDeploymentCollector.Collect(ctx, bd)
 
 	return ctrl.Result{}, err
 }


### PR DESCRIPTION
refers to SURE-9104

fleetcontroller was updating the whole status, instead of the changed fields.
