### PR TITLE
During release reference api tag directly if available

### DIFF
--- a/.github/scripts/release-against-rancher.sh
+++ b/.github/scripts/release-against-rancher.sh
@@ -11,7 +11,7 @@ BUMP_API="$3"             # bump api if `true`
 bump_fleet_api() {
     COMMIT=$1
 
-    go get -u "github.com/rancher/fleet/pkg/apis@${COMMIT}"
+    go get -u "github.com/rancher/fleet/pkg/apis@v${NEW_FLEET_VERSION}" || go get -u "github.com/rancher/fleet/pkg/apis@${COMMIT}"
     go mod tidy
 }
 


### PR DESCRIPTION
most of the time the tag was automatically recognized from the commit, but since this is flaky, we now first try the tag and then fallback to the commit, if there is none.

Result before: https://github.com/rancher/rancher/pull/47687/files
Result after: https://github.com/rancher/rancher/pull/47689