### PR TITLE
Bundledeployment controller does not write metrics on error

### DIFF
--- a/internal/cmd/controller/reconciler/bundledeployment_controller.go
+++ b/internal/cmd/controller/reconciler/bundledeployment_controller.go
@@ -110,11 +110,12 @@ func (r *BundleDeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	err = r.Status().Update(ctx, bd)
 	if err != nil {
 		logger.V(1).Error(err, "Reconcile failed update to bundle deployment status, requeueing", "status", bd.Status)
+		return ctrl.Result{}, err
 	}
 
 	metrics.BundleDeploymentCollector.Collect(ctx, bd)
 
-	return ctrl.Result{}, err
+	return ctrl.Result{}, nil
 }
 
 // bundleDeploymentStatusChangedPredicate returns true if the bundledeployment


### PR DESCRIPTION
Follow up to https://github.com/rancher/fleet/pull/2998

Accidentally changed when metrics are generated.