### PR TITLE
Avoid retries for bundle and content resources

### DIFF
--- a/internal/cmd/controller/reconciler/bundle_controller.go
+++ b/internal/cmd/controller/reconciler/bundle_controller.go
@@ -361,7 +361,9 @@ func (r *BundleReconciler) createBundleDeployment(
 			return client.IgnoreNotFound(err)
 		}
 
-		controllerutil.AddFinalizer(content, bd.Name)
+		if added := controllerutil.AddFinalizer(content, bd.Name); !added {
+			return nil
+		}
 
 		return r.Update(ctx, content)
 	})

--- a/internal/manifest/store.go
+++ b/internal/manifest/store.go
@@ -62,5 +62,5 @@ func (c *ContentStore) createContents(ctx context.Context, id string, manifest *
 		Content:   compressed,
 		SHA256Sum: digest,
 	})
-	return err
+	return client.IgnoreAlreadyExists(err)
 }


### PR DESCRIPTION
I observed some log messages when the agents were down.
When two reconciles try to create the same content resource, one will error, however content resources are meant to be shared between bundles.

We also don't need to update the content for a finalizer, when no finalizer was added.
