### PR TITLE
Fix call path in test charts release workflow

### DIFF
--- a/.github/workflows/release-against-test-charts.yml
+++ b/.github/workflows/release-against-test-charts.yml
@@ -172,7 +172,7 @@ jobs:
           git push -u origin $target_branch
 
   test-fleet-in-rancher:
-    uses: ./.github/workflows/e2e-rancher-upgrade-fleet-to-head-ci.yml
+    uses: ./.github/workflows/e2e-test-fleet-in-rancher.yml
     needs: push-test-rancher-charts
     with:
       ref: ${{ github.ref }}


### PR DESCRIPTION
The workflow testing Fleet in Rancher has been moved to a new file since the test charts release workflow last called it.

Tested with [this run](https://github.com/rancher/fleet/actions/runs/11553220782) (Failed) vs [this one](https://github.com/rancher/fleet/actions/runs/11553276955) (OK)

Follow-up to #2993.