### PR TITLE
Use setup-go in release-against-charts.yaml

### DIFF
--- a/.github/workflows/release-against-charts.yml
+++ b/.github/workflows/release-against-charts.yml
@@ -43,6 +43,9 @@ jobs:
           repository: rancher/charts
           ref: ${{github.event.inputs.charts_ref}}
           path: charts
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.22.*'
       - name: Install dependencies
         run: sudo snap install yq --channel=v4/stable
       - name: Run release script


### PR DESCRIPTION
because the self-hosted seem to miss go?

https://github.com/rancher/fleet/actions/runs/11554501554/job/32157846848