### PR TITLE
Fix charts repo name in workflow call

### DIFF
--- a/.github/workflows/release-against-test-charts.yml
+++ b/.github/workflows/release-against-test-charts.yml
@@ -176,6 +176,6 @@ jobs:
     needs: push-test-rancher-charts
     with:
       ref: ${{ github.ref }}
-      charts_repo: ${{github.event.inputs.charts_repo}}
+      charts_repo: ${{ env.charts_repo }}
       charts_branch: ${{ needs.push-test-rancher-charts.outputs.target_branch }}
       fleet_version: 999.9.9+up9.9.9


### PR DESCRIPTION
When the test charts release workflow is triggered by scheduling, it cannot rely on input parameters as if it were triggered manually. Instead, the charts repo name must come from the environment, where it is computed precisely based on how the workflow is triggered.

Refers to #1640
Follow-up to #2804