### PR TITLE
GitRepo resources list doesn't list resources multiple times

### DIFF
--- a/internal/cmd/controller/gitops/reconciler/resourcekey.go
+++ b/internal/cmd/controller/gitops/reconciler/resourcekey.go
@@ -32,6 +32,10 @@ func merge(resources []fleet.GitRepoResource) []fleet.GitRepoResource {
 	for _, resource := range merged {
 		result = append(result, resource)
 	}
+
+	sort.Slice(result, func(i, j int) bool {
+		return key(result[i]) < key(result[j])
+	})
 	return result
 }
 
@@ -77,9 +81,6 @@ func fromResources(list *fleet.BundleDeploymentList, summaryState string) ([]fle
 	}
 
 	sort.Strings(errors)
-	sort.Slice(resources, func(i, j int) bool {
-		return key(resources[i]) < key(resources[j])
-	})
 
 	return resources, errors
 }

--- a/internal/cmd/controller/gitops/reconciler/resourcekey_test.go
+++ b/internal/cmd/controller/gitops/reconciler/resourcekey_test.go
@@ -1,10 +1,9 @@
 package reconciler
 
 import (
-	"fmt"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
@@ -116,7 +115,6 @@ var _ = Describe("Resourcekey", func() {
 
 	It("returns a list", func() {
 		setResources(list, gitrepo)
-		fmt.Printf("%#v\n", gitrepo.Status.Resources)
 
 		Expect(gitrepo.Status.Resources).To(HaveLen(2))
 		Expect(gitrepo.Status.Resources).To(ContainElement(fleet.GitRepoResource{

--- a/internal/cmd/controller/gitops/reconciler/resourcekey_test.go
+++ b/internal/cmd/controller/gitops/reconciler/resourcekey_test.go
@@ -1,0 +1,175 @@
+package reconciler
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
+	"github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1/summary"
+)
+
+var _ = Describe("Resourcekey", func() {
+	var (
+		gitrepo *fleet.GitRepo
+		list    *fleet.BundleDeploymentList
+	)
+
+	BeforeEach(func() {
+		gitrepo = &fleet.GitRepo{
+			Status: fleet.GitRepoStatus{
+				Summary: fleet.BundleSummary{
+					Ready:       2,
+					WaitApplied: 1,
+				},
+			},
+		}
+		list = &fleet.BundleDeploymentList{
+			Items: []fleet.BundleDeployment{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "bd1",
+						Labels: map[string]string{
+							fleet.RepoLabel:             "gitrepo1",
+							fleet.ClusterLabel:          "cluster1",
+							fleet.ClusterNamespaceLabel: "c-ns1",
+						},
+					},
+					Status: fleet.BundleDeploymentStatus{
+						Resources: []fleet.BundleDeploymentResource{
+							{
+								Kind:       "Deployment",
+								APIVersion: "v1",
+								Name:       "web",
+								Namespace:  "default",
+							},
+							{
+								// extra service for one cluster
+								Kind:       "Service",
+								APIVersion: "v1",
+								Name:       "web-svc",
+								Namespace:  "default",
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "bd1",
+						Labels: map[string]string{
+							fleet.RepoLabel:             "gitrepo1",
+							fleet.ClusterLabel:          "cluster2",
+							fleet.ClusterNamespaceLabel: "c-ns1",
+						},
+					},
+					Status: fleet.BundleDeploymentStatus{
+						Resources: []fleet.BundleDeploymentResource{
+							{
+								Kind:       "Deployment",
+								APIVersion: "v1",
+								Name:       "web",
+								Namespace:  "default",
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "bd1",
+						Labels: map[string]string{
+							fleet.RepoLabel:             "gitrepo1",
+							fleet.ClusterLabel:          "cluster1",
+							fleet.ClusterNamespaceLabel: "c-ns2",
+						},
+					},
+					Status: fleet.BundleDeploymentStatus{
+						NonReadyStatus: []fleet.NonReadyStatus{
+							{
+								Kind:       "Deployment",
+								APIVersion: "v1",
+								Name:       "web",
+								Namespace:  "default",
+								Summary: summary.Summary{
+									State:         "Pending",
+									Error:         true,
+									Transitioning: true,
+									Message:       []string{"message1", "message2"},
+								},
+							},
+						},
+						Resources: []fleet.BundleDeploymentResource{
+							{
+								Kind:       "Deployment",
+								APIVersion: "v1",
+								Name:       "web",
+								Namespace:  "default",
+							},
+						},
+					},
+				},
+			},
+		}
+
+	})
+
+	It("returns a list", func() {
+		setResources(list, gitrepo)
+		fmt.Printf("%#v\n", gitrepo.Status.Resources)
+
+		Expect(gitrepo.Status.Resources).To(HaveLen(2))
+		Expect(gitrepo.Status.Resources).To(ContainElement(fleet.GitRepoResource{
+			APIVersion: "v1",
+			Kind:       "Deployment",
+			Type:       "deployment",
+			ID:         "default/web",
+
+			Namespace: "default",
+			Name:      "web",
+
+			IncompleteState: false,
+			State:           "WaitApplied",
+			Error:           false,
+			Transitioning:   false,
+			Message:         "",
+			PerClusterState: []fleet.ResourcePerClusterState{
+				{
+					State:         "Pending",
+					ClusterID:     "c-ns2/cluster1",
+					Error:         true,
+					Transitioning: true,
+					Message:       "message1; message2",
+					Patch:         nil,
+				},
+			},
+		}))
+		Expect(gitrepo.Status.Resources).To(ContainElement(fleet.GitRepoResource{
+			APIVersion: "v1",
+			Kind:       "Service",
+			Type:       "service",
+			ID:         "default/web-svc",
+
+			Namespace: "default",
+			Name:      "web-svc",
+
+			IncompleteState: false,
+			State:           "WaitApplied",
+			Error:           false,
+			Transitioning:   false,
+			Message:         "",
+			PerClusterState: []fleet.ResourcePerClusterState{},
+		}))
+
+		Expect(gitrepo.Status.ResourceErrors).To(BeEmpty())
+
+		Expect(gitrepo.Status.ResourceCounts.Ready).To(Equal(0))
+		Expect(gitrepo.Status.ResourceCounts.DesiredReady).To(Equal(4))
+		Expect(gitrepo.Status.ResourceCounts.WaitApplied).To(Equal(3))
+		Expect(gitrepo.Status.ResourceCounts.Modified).To(Equal(0))
+		Expect(gitrepo.Status.ResourceCounts.Orphaned).To(Equal(0))
+		Expect(gitrepo.Status.ResourceCounts.Missing).To(Equal(0))
+		Expect(gitrepo.Status.ResourceCounts.Unknown).To(Equal(0))
+		Expect(gitrepo.Status.ResourceCounts.NotReady).To(Equal(1))
+	})
+})

--- a/internal/cmd/controller/gitops/reconciler/suite_test.go
+++ b/internal/cmd/controller/gitops/reconciler/suite_test.go
@@ -1,0 +1,16 @@
+package reconciler
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestGitOpsReconciler(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "GitOps Reconciler Suite")
+}
+
+var _ = BeforeSuite(func() {
+})


### PR DESCRIPTION
Refers to https://github.com/rancher/dashboard/issues/11643

This is a hotfix to avoid a conflict with UI code, which multiplies the resources list per cluster. Multiplying a GitRepo's resources from all clusters with the number of clusters potentially freezes the UI.

With this PR `gitrepo.Status.Resources` reports resources only once, even if they are deployed to multiple clusters. If any cluster has a nonready/modified status for the resource, it is still added to the `PerClusterState` field. 

That means, it's no longer possible to tell if a resource was not deployed to a cluster, e.g. because it was excluded via helm chart values.

Future code needs to respect that some resources are not present in each bundledeployment.
Users can for example use targetCustomization to deploy resources only to some clusters. Additionally, popular charts install different resources depending on the k8s version of the cluster. Some charts even allow to deploy "extraObjects" via a helm chart value.


* https://github.com/rancher/dashboard/blob/master/shell/models/fleet.cattle.io.gitrepo.js#L334-L339
* https://github.com/rancher/fleet/blob/main/internal/cmd/controller/gitops/reconciler/resourcekey.go#L38-L54
