### PR TITLE
[v0.10] Skip install loop for invalid patches

### DIFF
--- a/internal/cmd/agent/deployer/deployer.go
+++ b/internal/cmd/agent/deployer/deployer.go
@@ -264,6 +264,7 @@ func deployErrToStatus(err error, status fleet.BundleDeploymentStatus) (bool, fl
 			"(YAML parse error)|" + // YAML is broken in source files
 			"(Forbidden: updates to [0-9A-Za-z]+ spec for fields other than [0-9A-Za-z ']+ are forbidden)|" + // trying to update fields that cannot be updated
 			"(Forbidden: spec is immutable after creation)|" + // trying to modify immutable spec
+			"(cannot patch.*is invalid)|" + // trying to apply an invalid patch (eg. undoing a port edit on a Service)
 			"(chart requires kubeVersion: [0-9A-Za-z\\.\\-<>=]+ which is incompatible with Kubernetes)", // trying to deploy to incompatible Kubernetes
 	)
 	if re.MatchString(msg) {


### PR DESCRIPTION
When Helm, and hence Fleet, is unable to install a release, for instance to undo drift without force mode on a `Service`, this ensures that bundle deployment status resources will not be computed based on a failing Helm release.

That behaviour caused discrepancies between bundle and bundle deployment statuses, and eventually to bundles appearing as ready for drifting bundle deployments.

Tested manually with Rancher 2.9.3, using [this build](https://github.com/rancher/fleet/actions/runs/11613075014).

Refers to #2834