### PR TITLE
Remove reconcile error from retry

### DIFF
--- a/internal/cmd/controller/gitops/reconciler/status_controller.go
+++ b/internal/cmd/controller/gitops/reconciler/status_controller.go
@@ -114,7 +114,7 @@ func (r *StatusReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	err = r.Client.Status().Update(ctx, gitrepo)
 	if err != nil {
 		logger.Error(err, "Reconcile failed update to git repo status", "status", gitrepo.Status)
-		return ctrl.Result{RequeueAfter: durations.GitRepoStatusDelay}, err
+		return ctrl.Result{RequeueAfter: durations.GitRepoStatusDelay}, nil
 	}
 
 	return ctrl.Result{}, nil


### PR DESCRIPTION

Refers to #3045


Addresses this warning seen when updating a `GitRepo`:
```
"Warning: Reconciler returned both a non-zero result and a non-nil error.
The result will always be ignored if the error is non-nil and the non-nil error causes 
reqeueuing with exponential backoff. For more details, 
see: https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/reconcile#Reconciler"
```

<!--
  Please provide a unit, integration (`./integrationtests/`) or e2e (`./e2e/`) test if possible.
-->