### PR TITLE
[v0.10] Readd toolchain

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/rancher/fleet
 
 go 1.23.0
 
+toolchain go1.23.2
+
 replace (
 	github.com/imdario/mergo => github.com/imdario/mergo v0.3.16
 	github.com/rancher/fleet/pkg/apis => ./pkg/apis


### PR DESCRIPTION
otherwise the CVE's affecting Go 1.23.0 are not considered fixed.