### PR TITLE
Fix base Fleet chart version resolution for test release

### DIFF
--- a/.github/workflows/release-against-test-charts.yml
+++ b/.github/workflows/release-against-test-charts.yml
@@ -157,16 +157,16 @@ jobs:
 
       - name: Run release script
         run: |
-          fleet_version=9.9.9
+          fleet_test_version=9.9.9
 
-          prev_chart=$(ls -1 ./charts/charts/fleet | tail -n 1)
-          prev_fleet=${prev_chart#*+up}
-          prev_chart=${prev_chart/+*}
+          latest_chart=$(grep '^version: ' ./charts/packages/fleet/fleet/package.yaml | cut -d' ' -f2)
+          latest_fleet=$(ls -1 ./charts/charts/fleet/ | grep $latest_chart)
+          latest_fleet=${latest_fleet#*+up}
 
           ./fleet/.github/scripts/release-against-test-charts.sh \
-            $prev_fleet \
-            $fleet_version \
-            $prev_chart \
+            $latest_fleet \
+            $fleet_test_version \
+            $latest_chart \
             999.9.9 \
             ${{ steps.uuid.outputs.uuid }}
 


### PR DESCRIPTION
When releasing test Fleet charts, the test release workflow looks for the latest existing Fleet release, to use it as a base before making a few edits.

The previous logic used to find the latest available chart was buggy, in that it would list releases in alphabetical order, which could differ from semver. For instance, chart version `103.1.10+up0.9.11` would be listed between versions `103.1.0+up0.9.0` and `103.1.2+up0.9.2`.

Instead, this commit simplifies resolution by first looking at the `package.yaml` file, extracting the chart version from there and looking for the corresponding Fleet version in the charts repository. Resolution would then fail if no corresponding version is found in the repository, but that is far less likely to happen than with the previous logic and would typically be a symptom of a broken state of the charts repository.

Tested with [this job](https://github.com/rancher/fleet/actions/runs/11783388018/job/32820424351) (previous failure example [here](https://github.com/rancher/fleet/actions/runs/11779327385/job/32807550017)).

Refers to #1640