### PR TITLE
Inject registered cluster name into multi-cluster tests

### DIFF
--- a/.github/workflows/e2e-multicluster-ci.yml
+++ b/.github/workflows/e2e-multicluster-ci.yml
@@ -185,6 +185,9 @@ jobs:
           FLEET_E2E_NS: fleet-local
           FLEET_E2E_NS_DOWNSTREAM: fleet-default
         run: |
+          # Force use of non-managed downstream cluster for portability
+          export CI_REGISTERED_CLUSTER=$(kubectl get clusters.fleet.cattle.io -n $FLEET_E2E_NS_DOWNSTREAM -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}' | grep -v second)
+
           kubectl config use-context k3d-upstream
           ginkgo --github-output e2e/multi-cluster
       -

--- a/.github/workflows/e2e-test-fleet-in-rancher.yml
+++ b/.github/workflows/e2e-test-fleet-in-rancher.yml
@@ -219,6 +219,9 @@ jobs:
         run: |
           kubectl config use-context k3d-upstream
           ginkgo --github-output e2e/acceptance/single-cluster-examples
+
+          export CI_REGISTERED_CLUSTER=$(kubectl get clusters.fleet.cattle.io -n $FLEET_E2E_NS_DOWNSTREAM -o jsonpath='{..name}')
+
           ginkgo --github-output e2e/multi-cluster
 
       -

--- a/.github/workflows/release-against-test-charts.yml
+++ b/.github/workflows/release-against-test-charts.yml
@@ -12,7 +12,7 @@ on:
       charts_base_branch:
         description: "Use the following rancher/charts branch as a base (e.g. dev-v2.7)"
         required: true
-        default: "dev-v2.9"
+        default: "dev-v2.10"
       charts_repo:
         description: "Push to the following Rancher charts repo (which must exist)"
         required: true
@@ -41,7 +41,7 @@ jobs:
           ref=${tmp:-${{github.ref}}}
 
           tmp=${{github.event.inputs.charts_base_branch}}
-          charts_base_branch=${tmp:-'dev-v2.8'}
+          charts_base_branch=${tmp:-'dev-v2.10'}
 
           tmp=${{github.event.inputs.charts_repo}}
           charts_repo=${tmp:-fleetrepoci/charts}

--- a/e2e/multi-cluster/not_matching_targets_delete_bd_test.go
+++ b/e2e/multi-cluster/not_matching_targets_delete_bd_test.go
@@ -50,7 +50,7 @@ var _ = Describe("Target clusters by label", func() {
 			asset = "multi-cluster/bundle-deployment-labels.yaml"
 			data = TemplateData{env.ClusterRegistrationNamespace, namespace}
 			// set the expected label
-			out, err := k.Namespace(env.ClusterRegistrationNamespace).Label("clusters", dsCluster, "envlabels=test")
+			out, err := k.Namespace(env.ClusterRegistrationNamespace).Label("cluster.fleet.cattle.io", dsCluster, "envlabels=test")
 			Expect(err).ToNot(HaveOccurred(), out)
 		})
 
@@ -65,7 +65,7 @@ var _ = Describe("Target clusters by label", func() {
 			}).Should(ContainSubstring("simple-config"))
 
 			// delete the label (bundledeployment should be deleted and resources in cluster deleted)
-			out, err := k.Namespace(env.ClusterRegistrationNamespace).Label("clusters", dsCluster, "envlabels-")
+			out, err := k.Namespace(env.ClusterRegistrationNamespace).Label("cluster.fleet.cattle.io", dsCluster, "envlabels-")
 			Expect(err).ToNot(HaveOccurred(), out)
 
 			Eventually(func() string {
@@ -78,7 +78,7 @@ var _ = Describe("Target clusters by label", func() {
 			}).ShouldNot(ContainSubstring("simple-config"))
 
 			// re-apply the label (bundledeployment should be created and applied again)
-			out, err = k.Namespace(env.ClusterRegistrationNamespace).Label("clusters", dsCluster, "envlabels=test")
+			out, err = k.Namespace(env.ClusterRegistrationNamespace).Label("cluster.fleet.cattle.io", dsCluster, "envlabels=test")
 			Expect(err).ToNot(HaveOccurred(), out)
 
 			Eventually(func() string {

--- a/e2e/multi-cluster/not_matching_targets_delete_bd_test.go
+++ b/e2e/multi-cluster/not_matching_targets_delete_bd_test.go
@@ -50,7 +50,7 @@ var _ = Describe("Target clusters by label", func() {
 			asset = "multi-cluster/bundle-deployment-labels.yaml"
 			data = TemplateData{env.ClusterRegistrationNamespace, namespace}
 			// set the expected label
-			out, err := k.Namespace(env.ClusterRegistrationNamespace).Label("clusters", "second", "envlabels=test")
+			out, err := k.Namespace(env.ClusterRegistrationNamespace).Label("clusters", dsCluster, "envlabels=test")
 			Expect(err).ToNot(HaveOccurred(), out)
 		})
 
@@ -65,7 +65,7 @@ var _ = Describe("Target clusters by label", func() {
 			}).Should(ContainSubstring("simple-config"))
 
 			// delete the label (bundledeployment should be deleted and resources in cluster deleted)
-			out, err := k.Namespace(env.ClusterRegistrationNamespace).Label("clusters", "second", "envlabels-")
+			out, err := k.Namespace(env.ClusterRegistrationNamespace).Label("clusters", dsCluster, "envlabels-")
 			Expect(err).ToNot(HaveOccurred(), out)
 
 			Eventually(func() string {
@@ -78,7 +78,7 @@ var _ = Describe("Target clusters by label", func() {
 			}).ShouldNot(ContainSubstring("simple-config"))
 
 			// re-apply the label (bundledeployment should be created and applied again)
-			out, err = k.Namespace(env.ClusterRegistrationNamespace).Label("clusters", "second", "envlabels=test")
+			out, err = k.Namespace(env.ClusterRegistrationNamespace).Label("clusters", dsCluster, "envlabels=test")
 			Expect(err).ToNot(HaveOccurred(), out)
 
 			Eventually(func() string {

--- a/e2e/multi-cluster/not_matching_targets_delete_bd_test.go
+++ b/e2e/multi-cluster/not_matching_targets_delete_bd_test.go
@@ -31,7 +31,7 @@ var _ = Describe("Target clusters by label", func() {
 
 	BeforeEach(func() {
 		k = env.Kubectl.Context(env.Upstream)
-		kd = env.Kubectl.Context(env.ManagedDownstream)
+		kd = env.Kubectl.Context(env.Downstream)
 	})
 
 	JustBeforeEach(func() {

--- a/e2e/multi-cluster/suite_test.go
+++ b/e2e/multi-cluster/suite_test.go
@@ -2,6 +2,7 @@
 package multicluster_test
 
 import (
+	"os"
 	"testing"
 
 	"github.com/rancher/fleet/e2e/testenv"
@@ -16,7 +17,8 @@ func TestE2E(t *testing.T) {
 }
 
 var (
-	env *testenv.Env
+	env       *testenv.Env
+	dsCluster = "second"
 )
 
 var _ = BeforeSuite(func() {
@@ -24,4 +26,8 @@ var _ = BeforeSuite(func() {
 	testenv.SetRoot("../..")
 
 	env = testenv.New()
+
+	if dsClusterEnvVar := os.Getenv("CI_REGISTERED_CLUSTER"); dsClusterEnvVar != "" {
+		dsCluster = dsClusterEnvVar
+	}
 })


### PR DESCRIPTION
Depending on the context in which multi-cluster end-to-end tests are
run, there may not be any registered downstream cluster called `second`,
reachable through context `k3d-managed-downstream`.

In such cases, such as when testing Fleet in Rancher the CI workflow
computes the name of the registered cluster and exports it as an
environment variable, for the tests to use instead of `second`.

To make the multi-cluster end-to-end test suite compatible between workflows, it no longer relies on context `k3d-managed-downstream`, labeling the cluster registered in non-managed mode instead to use it for label-based targeting.

This also takes the opportunity to use `dev-v2.10` as the new default `rancher/charts` base branch for Fleet charts, in line with the most recent releases.

Tested with [this run](https://github.com/rancher/fleet/actions/runs/11799083224/job/32866938600) and [this one](https://github.com/rancher/fleet/actions/runs/11833951826/job/32973842549) with test Fleet charts built from the `dev-v1.10` branch of `rancher/charts`.

Depends on #3068.
Refers to #1640