### PR TITLE
Reduce flakiness in single-cluster end-to-end tests

### DIFF
--- a/e2e/single-cluster/oci_registry_test.go
+++ b/e2e/single-cluster/oci_registry_test.go
@@ -336,17 +336,19 @@ var _ = Describe("Single Cluster Deployments using OCI registry", Label("oci-reg
 				// look for failed pods with the name sample-xxxx-xxxx
 				r, _ := regexp.Compile("sample-([a-z0-9]+)-([a-z0-9]+)")
 				var failedJob string
-				Eventually(func() bool {
+				Eventually(func(g Gomega) {
 					failedPods, err := getFailedPodNames(k, "fleet-local")
-					Expect(err).ToNot(HaveOccurred())
+					failedJob = ""
+
+					g.Expect(err).ToNot(HaveOccurred())
 					for _, pod := range failedPods {
 						if r.MatchString(pod) {
 							failedJob = pod
-							return true
+							break
 						}
 					}
-					return false
-				}).Should(BeTrue())
+					g.Expect(failedJob).ToNot(BeEmpty())
+				}).Should(Succeed())
 
 				Expect(failedJob).ShouldNot(BeEmpty())
 				// check that the logs of the job reflect the bad OCI registry

--- a/e2e/single-cluster/sharding_test.go
+++ b/e2e/single-cluster/sharding_test.go
@@ -54,6 +54,37 @@ var _ = Describe("Filtering events by shard", Label("sharding"), func() {
 			})
 
 			It(fmt.Sprintf("deploys the gitrepo via the gitjob labeled with shard ID %s", shard), func() {
+				shardNodeSelector, err := k.Namespace("cattle-fleet-system").Get(
+					"deploy",
+					fmt.Sprintf("fleet-controller-shard-%s", shard),
+					"-o=jsonpath={.spec.template.spec.nodeSelector}",
+				)
+				Expect(err).ToNot(HaveOccurred())
+
+				By("checking the gitjob pod has the same nodeSelector as the sharded controller deployment")
+				Eventually(func(g Gomega) {
+					pods, err := k.Namespace("fleet-local").Get(
+						"pods",
+						"-o",
+						`jsonpath={range .items[*]}{.metadata.name}{"\t"}{.spec.nodeSelector}{"\n"}{end}`,
+					)
+					g.Expect(err).ToNot(HaveOccurred())
+					g.Expect(pods).ToNot(BeEmpty(), "no pod in namespace fleet-local")
+
+					var podNodeSelector string
+					for _, pod := range strings.Split(pods, "\n") {
+						fields := strings.Split(pod, "\t")
+						podName := fields[0]
+						if strings.HasPrefix(podName, "sharding-test") {
+							podNodeSelector = fields[1]
+							break
+						}
+					}
+
+					g.Expect(podNodeSelector).ToNot(BeEmpty(), "sharding-test* pod not found or has empty node selector")
+					g.Expect(podNodeSelector).To(Equal(shardNodeSelector))
+				}).Should(Succeed())
+
 				By("checking the configmap exists")
 				Eventually(func() string {
 					out, _ := k.Namespace(targetNamespace).Get("configmaps")
@@ -93,37 +124,6 @@ var _ = Describe("Filtering events by shard", Label("sharding"), func() {
 					g.Expect(err).ToNot(HaveOccurred())
 					g.Expect(shardLabelValue).To(Equal(shard))
 				})
-
-				By("checking the gitjob pod has the same nodeSelector as the sharded controller deployment")
-				Eventually(func(g Gomega) {
-					shardNodeSelector, err := k.Namespace("cattle-fleet-system").Get(
-						"deploy",
-						fmt.Sprintf("fleet-controller-shard-%s", shard),
-						"-o=jsonpath={.spec.template.spec.nodeSelector}",
-					)
-					g.Expect(err).ToNot(HaveOccurred())
-
-					pods, err := k.Namespace("fleet-local").Get(
-						"pods",
-						"-o",
-						`jsonpath={range .items[*]}{.metadata.name}{"\t"}{.spec.nodeSelector}{"\n"}{end}`,
-					)
-					g.Expect(err).ToNot(HaveOccurred())
-					g.Expect(pods).ToNot(BeEmpty(), "no pod in namespace fleet-local")
-
-					var podNodeSelector string
-					for _, pod := range strings.Split(pods, "\n") {
-						fields := strings.Split(pod, "\t")
-						podName := fields[0]
-						if strings.HasPrefix(podName, "sharding-test") {
-							podNodeSelector = fields[1]
-							break
-						}
-					}
-
-					g.Expect(podNodeSelector).ToNot(BeEmpty(), "sharding-test* pod not found or has empty node selector")
-					g.Expect(podNodeSelector).To(Equal(shardNodeSelector))
-				}).Should(Succeed())
 			})
 
 			AfterEach(func() {

--- a/e2e/single-cluster/sharding_test.go
+++ b/e2e/single-cluster/sharding_test.go
@@ -103,11 +103,13 @@ var _ = Describe("Filtering events by shard", Label("sharding"), func() {
 					)
 					g.Expect(err).ToNot(HaveOccurred())
 
-					pods, _ := k.Namespace("fleet-local").Get(
+					pods, err := k.Namespace("fleet-local").Get(
 						"pods",
 						"-o",
 						`jsonpath={range .items[*]}{.metadata.name}{"\t"}{.spec.nodeSelector}{"\n"}{end}`,
 					)
+					g.Expect(err).ToNot(HaveOccurred())
+					g.Expect(pods).ToNot(BeEmpty(), "no pod in namespace fleet-local")
 
 					var podNodeSelector string
 					for _, pod := range strings.Split(pods, "\n") {
@@ -119,7 +121,7 @@ var _ = Describe("Filtering events by shard", Label("sharding"), func() {
 						}
 					}
 
-					g.Expect(podNodeSelector).ToNot(BeEmpty())
+					g.Expect(podNodeSelector).ToNot(BeEmpty(), "sharding-test* pod not found or has empty node selector")
 					g.Expect(podNodeSelector).To(Equal(shardNodeSelector))
 				}).Should(Succeed())
 			})


### PR DESCRIPTION
Sharding end-to-end tests exhibited flakiness, caused by the git job pod
not being present in the cluster by the time checks were run to validate
its node selector against that of the relevant shard.
    
To prevent this, tests on the node selector are now run first, which
incidentally also prevents `Eventually` from running more loops waiting
for a config map to be deployed.