### PR TITLE
Deletes no longer valid comment in infra

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -1,6 +1,7 @@
 [files]
 extend-exclude = [
   "go.mod",
+  "go.sum",
   "ssh_host_ecdsa_key",
   "cloner_test.go",
   "netutils_test.go",

--- a/e2e/testenv/infra/cmd/setup.go
+++ b/e2e/testenv/infra/cmd/setup.go
@@ -166,7 +166,6 @@ var setupCmd = &cobra.Command{
 				return "", nil
 			})
 
-			// TODO enable this when the Helm library supports `--insecure-skip-tls-verify`
 			chartArchive, err := os.ReadFile("sleeper-chart-0.1.0.tgz")
 			if err != nil {
 				fail(fmt.Errorf("reading helm chart: %v", err))


### PR DESCRIPTION
It also adds `go.sum` to the list of excluded files for `typos` after `v1.28` was released 