### PR TITLE
[v0.11] Locks typos to version 1.27.3

### DIFF
--- a/.github/workflows/typos.yaml
+++ b/.github/workflows/typos.yaml
@@ -11,5 +11,5 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Check spelling of file.txt
-      uses: crate-ci/typos@master
+      uses: crate-ci/typos@v1.27.3
 


### PR DESCRIPTION
Locks version of typos as version 1.28 requires extra changes