### PR TITLE
Set registered cluster name before running Fleet tests

### DIFF
--- a/.github/workflows/e2e-rancher-upgrade-fleet-to-head-ci.yml
+++ b/.github/workflows/e2e-rancher-upgrade-fleet-to-head-ci.yml
@@ -171,6 +171,7 @@ jobs:
           FLEET_E2E_NS_DOWNSTREAM: fleet-default
         run: |
           kubectl config use-context k3d-upstream
+          export CI_REGISTERED_CLUSTER=$(kubectl get clusters.fleet.cattle.io -n $FLEET_E2E_NS_DOWNSTREAM -o jsonpath='{..name}')
           ginkgo --github-output e2e/multi-cluster
       -
         name: Dump Failed Downstream Environment


### PR DESCRIPTION
This prevents failures in CI job `rancher-fleet-integration` caused by cluster `second` not existing.

See runs [before](https://github.com/rancher/fleet/actions/runs/12222044318) vs [after](https://github.com/rancher/fleet/actions/runs/12235629253/job/34127316931).