### PR TITLE
[v0.12] Disable jobs cleanup cronjob if gitOps is disabled

### DIFF
--- a/charts/fleet/templates/job_cleanup_gitrepojobs.yaml
+++ b/charts/fleet/templates/job_cleanup_gitrepojobs.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.migrations.gitrepoJobsCleanup }}
+{{- if and .Values.migrations.gitrepoJobsCleanup .Values.gitops.enabled }}
 ---
 apiVersion: batch/v1
 kind: CronJob


### PR DESCRIPTION
This skips the cronjob responsible for cleaning up `fleet apply` Kubernetes jobs when no such jobs have run because Fleet has been installed with gitOps disabled.

Refers to #3128
Forward-port of #3125 to `main`.