### PR TITLE
Exports Metrics URLs to test with external IPs

### DIFF
--- a/dev/env.single-cluster-defaults
+++ b/dev/env.single-cluster-defaults
@@ -10,4 +10,7 @@ export CI_OCI_USERNAME=fleet-ci
 export CI_OCI_PASSWORD=foo
 export CI_OCI_CERTS_DIR=FleetCI-RootCA/
 
-export HELM_PATH=/usr/bin/helm
+# File with custom environment
+if [[ -f "$CUSTOM_ENV_FILE" ]]; then
+    source "$CUSTOM_ENV_FILE"
+fi

--- a/dev/env.single-cluster-defaults
+++ b/dev/env.single-cluster-defaults
@@ -10,7 +10,3 @@ export CI_OCI_USERNAME=fleet-ci
 export CI_OCI_PASSWORD=foo
 export CI_OCI_CERTS_DIR=FleetCI-RootCA/
 
-# File with custom environment
-if [[ -f "$CUSTOM_ENV_FILE" ]]; then
-    source "$CUSTOM_ENV_FILE"
-fi

--- a/dev/setup-k3d
+++ b/dev/setup-k3d
@@ -7,6 +7,14 @@ docker_mirror=${docker_mirror-}
 name=${1-upstream}
 i=${2-0}
 
+if [ ! -z METRICS_CONTROLLER_PORT ]; then
+    args="$args -p "${METRICS_CONTROLLER_PORT}:${METRICS_CONTROLLER_PORT}@server:0""
+fi
+
+if [ ! -z METRICS_GITJOB_PORT ]; then
+    args="$args -p "${METRICS_GITJOB_PORT}:${METRICS_GITJOB_PORT}@server:0""
+fi
+
 if [ -n "$docker_mirror" ]; then
   TMP_CONFIG="$(mktemp)"
   trap "rm -f $TMP_CONFIG" EXIT

--- a/e2e/metrics/gitrepo_test.go
+++ b/e2e/metrics/gitrepo_test.go
@@ -67,7 +67,9 @@ var _ = Describe("GitRepo Metrics", Label("gitrepo"), func() {
 		It("should have exactly one metric of each type for the gitrepo", func() {
 			Eventually(func() error {
 				metrics, err := etGitjob.Get()
-				Expect(err).ToNot(HaveOccurred())
+				if err != nil {
+					return err
+				}
 				for _, metricName := range gitrepoMetricNames {
 					metric, err := etGitjob.FindOneMetric(
 						metrics,
@@ -105,7 +107,9 @@ var _ = Describe("GitRepo Metrics", Label("gitrepo"), func() {
 				// Expect still no metrics to be duplicated.
 				Eventually(func() error {
 					metrics, err := etGitjob.Get()
-					Expect(err).ToNot(HaveOccurred())
+					if err != nil {
+						return err
+					}
 					for _, metricName := range gitrepoMetricNames {
 						metric, err = etGitjob.FindOneMetric(
 							metrics,
@@ -132,7 +136,9 @@ var _ = Describe("GitRepo Metrics", Label("gitrepo"), func() {
 
 				Eventually(func() error {
 					metrics, err := etGitjob.Get()
-					Expect(err).ToNot(HaveOccurred())
+					if err != nil {
+						return err
+					}
 					for _, metricName := range gitrepoMetricNames {
 						_, err := etGitjob.FindOneMetric(
 							metrics,

--- a/e2e/single-cluster/oci_registry_test.go
+++ b/e2e/single-cluster/oci_registry_test.go
@@ -144,6 +144,8 @@ var _ = Describe("Single Cluster Deployments using OCI registry", Label("oci-reg
 
 	JustBeforeEach(func() {
 		updateExperimentalFlagValue(k, experimentalValue)
+		Expect(os.Getenv("CI_OCI_USERNAME")).NotTo(BeEmpty())
+		Expect(os.Getenv("CI_OCI_PASSWORD")).NotTo(BeEmpty())
 		out, err := k.Create(
 			"secret", "generic", "oci-secret",
 			"--from-literal=username="+os.Getenv("CI_OCI_USERNAME"),

--- a/e2e/testenv/githelper/git.go
+++ b/e2e/testenv/githelper/git.go
@@ -304,8 +304,8 @@ func BuildGitHostname(ns string) (string, error) {
 // GetExternalRepoAddr retrieves the external URL where our local git server can be reached, based on the provided port
 // and repo name.
 func GetExternalRepoAddr(env *testenv.Env, port int, repoName string) (string, error) {
-	if v := os.Getenv("CI_GIT_REPO_URL"); v != "" {
-		return fmt.Sprintf("%s/%s", v, repoName), nil
+	if v := os.Getenv("external_ip"); v != "" {
+		return fmt.Sprintf("http://%s:8080/%s", v, repoName), nil
 	}
 
 	systemk := env.Kubectl.Namespace(env.Namespace)


### PR DESCRIPTION
It also deletes the HELM_PATH env variable as it is no longer used.

Fixes errors in metrics tests when the test is trying to check for metrics when the service exporting them it's still not fully up.

Adds a custom file to add extra env variables (This was added so the `dev/env.single-cluster-defaults` is not changed and to avoid pushing changes to it by mistake)  

Adds an extra check in OCI e2 tests to verify that the `CI_OCI_USERNAME` and `CI_OCI_PASSWORD` are set.

Deletes the `CI_GIT_REPO_URL` env variable and uses the already existing `external_ip`.


### Example on how to run `e2e` tests with services exported to external IPs (useful for testing under MAC OS)

1. Create a file with your custom environment
 ```bash
## YOUR IP HERE
export external_ip=192.168.1.47

## PORTS FOR EXPORTING METRICS IN E2E TESTS
## IF YOU DON'T SET THESE PORTS THE DEFAULT IS TO 
## CREATE A RANDOM PORT FOR EACH EXECUTION AND YOU 
## WON'T BE ABLE TO ACCESS.
## WHEN ENABLING THESE VARIABLES K3D WILL EXPORT THESE PORTS
export METRICS_CONTROLLER_PORT=8083
export METRICS_GITJOB_PORT=8084
```
2. Setup the cluster
```bash
export CUSTOM_ENV_FILE=PATH_TO_YOUR_CUSTOM_ENV
source dev/setup-single-cluster
``` 

3. Run the tests
```bash
export CUSTOM_ENV_FILE=PATH_TO_YOUR_CUSTOM_ENV
source dev/env.single-cluster-defaults
ginkgo --github-output e2e/metrics
ginkgo --github-output e2e/single-cluster
```
