### PR TITLE
Limit git clone to latest commit

### DIFF
--- a/internal/cmd/cli/gitcloner/cloner.go
+++ b/internal/cmd/cli/gitcloner/cloner.go
@@ -79,6 +79,7 @@ func cloneBranch(opts *GitCloner, auth transport.AuthMethod, caBundle []byte) er
 		CABundle:          caBundle,
 		SingleBranch:      true,
 		ReferenceName:     plumbing.ReferenceName(opts.Branch),
+		Depth:             1,
 		RecurseSubmodules: git.DefaultSubmoduleRecursionDepth,
 	})
 

--- a/internal/cmd/cli/gitcloner/cloner_test.go
+++ b/internal/cmd/cli/gitcloner/cloner_test.go
@@ -87,6 +87,7 @@ udiSlDctMM/X3ZM2JN5M1rtAJ2WR3ZQtmWbOjZAbG2Eq
 				SingleBranch:      true,
 				ReferenceName:     "master",
 				RecurseSubmodules: git.DefaultSubmoduleRecursionDepth,
+				Depth:             1,
 			},
 		},
 		"branch basic auth": {
@@ -106,6 +107,7 @@ udiSlDctMM/X3ZM2JN5M1rtAJ2WR3ZQtmWbOjZAbG2Eq
 					Password: passwordFileContent,
 				},
 				RecurseSubmodules: git.DefaultSubmoduleRecursionDepth,
+				Depth:             1,
 			},
 		},
 		"branch ssh auth": {
@@ -121,6 +123,7 @@ udiSlDctMM/X3ZM2JN5M1rtAJ2WR3ZQtmWbOjZAbG2Eq
 				ReferenceName:     "master",
 				Auth:              sshAuth,
 				RecurseSubmodules: git.DefaultSubmoduleRecursionDepth,
+				Depth:             1,
 			},
 		},
 		"password file does not exist": {


### PR DESCRIPTION
This should speed up git cloning.
A follow-up to this could implement filtering by path once [this go-git PR](https://github.com/go-git/go-git/pull/1108) is merged upstream.