### PR TITLE
Use UTC for timestamps

### DIFF
--- a/e2e/testenv/githelper/git.go
+++ b/e2e/testenv/githelper/git.go
@@ -276,7 +276,7 @@ func author() *object.Signature {
 	return &object.Signature{
 		Name:  "CI",
 		Email: "fleet@example.org",
-		When:  time.Now(),
+		When:  time.Now().UTC(),
 	}
 }
 

--- a/internal/cmd/agent/deployer/summary/summarizers.go
+++ b/internal/cmd/agent/deployer/summary/summarizers.go
@@ -353,7 +353,7 @@ func checkInitializing(obj data.Object, conditions []Condition, summary fleetv1.
 	if summary.State == "" && hasConditions && len(conditions) == 0 && strings.Contains(apiVersion, "cattle.io") {
 		val := obj.String("metadata", "created")
 		if i, err := convert.ToTimestamp(val); err == nil {
-			if time.Unix(i/1000, 0).Add(5 * time.Second).After(time.Now()) {
+			if time.Unix(i/1000, 0).Add(5 * time.Second).After(time.Now().UTC()) {
 				summary.State = "initializing"
 				summary.Transitioning = true
 			}
@@ -393,7 +393,7 @@ func checkRemoving(obj data.Object, conditions []Condition, summary fleetv1.Summ
 
 	summary.Message = append(summary.Message, "waiting on "+f)
 	if i, err := convert.ToTimestamp(removed); err == nil {
-		if time.Unix(i/1000, 0).Add(5 * time.Minute).Before(time.Now()) {
+		if time.Unix(i/1000, 0).Add(5 * time.Minute).Before(time.Now().UTC()) {
 			summary.Error = true
 		}
 	}

--- a/internal/cmd/controller/agentmanagement/controllers/clusterregistrationtoken/handler.go
+++ b/internal/cmd/controller/agentmanagement/controllers/clusterregistrationtoken/handler.go
@@ -271,7 +271,7 @@ func (h *handler) deleteExpired(token *fleet.ClusterRegistrationToken) (bool, er
 		return false, nil
 	}
 	expire := token.CreationTimestamp.Add(ttl.Duration)
-	if time.Now().After(expire) {
+	if time.Now().UTC().After(expire) {
 		return true, h.clusterRegistrationTokens.Delete(token.Namespace, token.Name, nil)
 	}
 

--- a/internal/cmd/controller/gitops/reconciler/gitjob_controller.go
+++ b/internal/cmd/controller/gitops/reconciler/gitjob_controller.go
@@ -81,7 +81,7 @@ type TimeGetter interface {
 
 type RealClock struct{}
 
-func (RealClock) Now() time.Time                  { return time.Now() }
+func (RealClock) Now() time.Time                  { return time.Now().UTC() }
 func (RealClock) Since(t time.Time) time.Duration { return time.Since(t) }
 
 // CronJobReconciler reconciles a GitRepo resource to create a git cloning k8s job

--- a/internal/cmd/controller/imagescan/gitcommit_job.go
+++ b/internal/cmd/controller/imagescan/gitcommit_job.go
@@ -365,7 +365,7 @@ func commitAllAndPush(ctx context.Context, repo *gogit.Repository, auth transpor
 		Author: &object.Signature{
 			Name:  commit.AuthorName,
 			Email: commit.AuthorEmail,
-			When:  time.Now(),
+			When:  time.Now().UTC(),
 		},
 	}); err != nil {
 		return "", err

--- a/internal/cmd/controller/imagescan/gitcommit_job.go
+++ b/internal/cmd/controller/imagescan/gitcommit_job.go
@@ -219,7 +219,7 @@ func (j *GitCommitJob) cloneAndReplace(ctx context.Context) {
 	if interval == nil || interval.Seconds() == 0.0 {
 		interval = &DefaultInterval
 	}
-	gitrepo.Status.LastSyncedImageScanTime = metav1.NewTime(time.Now())
+	gitrepo.Status.LastSyncedImageScanTime = metav1.NewTime(time.Now().UTC())
 
 	// update gitrepo status
 	condition.Cond(fleet.ImageScanSyncCondition).SetError(&gitrepo.Status, "", nil)

--- a/internal/cmd/controller/imagescan/tagscan_job.go
+++ b/internal/cmd/controller/imagescan/tagscan_job.go
@@ -139,7 +139,7 @@ func (j *TagScanJob) updateImageTags(ctx context.Context) {
 		return
 	}
 
-	image.Status.LastScanTime = metav1.NewTime(time.Now())
+	image.Status.LastScanTime = metav1.NewTime(time.Now().UTC())
 
 	latestTag, err := latestTag(image.Spec.Policy, tags)
 	if err != nil {


### PR DESCRIPTION
This brings consistency to the use of `time.Now()` timestamps for resource creation, deletion, last sync, etc.
It should limit the risks of confusion and timestamp-related bugs.