### PR TITLE
Fix fleet-agent chart validation

### DIFF
--- a/charts/fleet-agent/templates/validate.yaml
+++ b/charts/fleet-agent/templates/validate.yaml
@@ -1,9 +1,9 @@
 {{if ne .Release.Namespace .Values.internal.systemNamespace }}
-{{ fail (printf "This chart must be installed in the namespace %s as the release name fleet-agent" .Values.internal.systemNamespace) }}
+{{ fail (printf "This chart must be installed in the %s namespace" .Values.internal.systemNamespace) }}
 {{end}}
 
 {{if ne .Release.Name .Values.internal.managedReleaseName }}
-{{ fail (printf "This chart must be installed in the namespace %s as the release name fleet-agent" .Values.internal.managedReleaseName) }}
+{{ fail (printf "This chart must be installed with release name %s" .Values.internal.managedReleaseName) }}
 {{end}}
 
 {{if not .Values.apiServerURL }}


### PR DESCRIPTION
This fixes error messages shown in case of namespace or release name mismatch.