### PR TITLE
Add jitter and resync to polling

### DIFF
--- a/charts/fleet/templates/deployment_gitjob.yaml
+++ b/charts/fleet/templates/deployment_gitjob.yaml
@@ -83,6 +83,10 @@ spec:
             - name: NO_PROXY
               value: {{ $.Values.noProxy }}
           {{- end }}
+          {{- if $.Values.gitops.syncPeriod }}
+            - name: GITREPO_SYNC_PERIOD
+              value: {{ quote $.Values.gitops.syncPeriod }}
+          {{- end }}
           {{- if $.Values.controller.reconciler.workers.gitrepo }}
             - name: GITREPO_RECONCILER_WORKERS
               value: {{ quote $.Values.controller.reconciler.workers.gitrepo }}

--- a/charts/fleet/values.yaml
+++ b/charts/fleet/values.yaml
@@ -77,6 +77,9 @@ priorityClassName: ""
 
 gitops:
   enabled: true
+  # syncPeriod is used to pick up polling for lost gitrepo events.
+  # It should be larger than the largest gitrepo pollinginterval.
+  syncPeriod: 2h
 
 metrics:
   enabled: true

--- a/internal/cmd/agent/controller/bundledeployment_controller.go
+++ b/internal/cmd/agent/controller/bundledeployment_controller.go
@@ -59,6 +59,9 @@ func (r *BundleDeploymentReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		WithEventFilter(
 			// we do not trigger for status changes
 			predicate.Or(
+				// Note: These predicates prevent cache
+				// syncPeriod from triggering reconcile, since
+				// cache sync is an Update event.
 				predicate.GenerationChangedPredicate{},
 				predicate.AnnotationChangedPredicate{},
 				predicate.LabelChangedPredicate{},

--- a/internal/cmd/controller/gitops/reconciler/gitjob_controller.go
+++ b/internal/cmd/controller/gitops/reconciler/gitjob_controller.go
@@ -103,8 +103,9 @@ func (r *GitJobReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&v1alpha1.GitRepo{},
 			builder.WithPredicates(
-				// do not trigger for GitRepo status changes (except for commit changes)
+				// do not trigger for GitRepo status changes (except for commit changes and cache sync)
 				predicate.Or(
+					TypedResourceVersionUnchangedPredicate[client.Object]{},
 					predicate.GenerationChangedPredicate{},
 					predicate.AnnotationChangedPredicate{},
 					predicate.LabelChangedPredicate{},

--- a/internal/cmd/controller/gitops/reconciler/predicate.go
+++ b/internal/cmd/controller/gitops/reconciler/predicate.go
@@ -1,0 +1,51 @@
+package reconciler
+
+import (
+	"reflect"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+// TypedResourceVersionUnchangedPredicate implements a update predicate to
+// allow syncPeriod to trigger the reconciler
+type TypedResourceVersionUnchangedPredicate[T metav1.Object] struct {
+	predicate.TypedFuncs[T]
+}
+
+func isNil(arg any) bool {
+	if v := reflect.ValueOf(arg); !v.IsValid() || ((v.Kind() == reflect.Ptr ||
+		v.Kind() == reflect.Interface ||
+		v.Kind() == reflect.Slice ||
+		v.Kind() == reflect.Map ||
+		v.Kind() == reflect.Chan ||
+		v.Kind() == reflect.Func) && v.IsNil()) {
+		return true
+	}
+	return false
+}
+
+func (TypedResourceVersionUnchangedPredicate[T]) Create(e event.CreateEvent) bool {
+	return false
+}
+
+func (TypedResourceVersionUnchangedPredicate[T]) Delete(e event.DeleteEvent) bool {
+	return false
+}
+
+// Update implements default UpdateEvent filter for validating resource version change.
+func (TypedResourceVersionUnchangedPredicate[T]) Update(e event.TypedUpdateEvent[T]) bool {
+	if isNil(e.ObjectOld) {
+		return false
+	}
+	if isNil(e.ObjectNew) {
+		return false
+	}
+
+	return e.ObjectNew.GetResourceVersion() == e.ObjectOld.GetResourceVersion()
+}
+
+func (TypedResourceVersionUnchangedPredicate[T]) Generic(e event.GenericEvent) bool {
+	return false
+}

--- a/internal/cmd/controller/helmops/reconciler/helmapp_controller.go
+++ b/internal/cmd/controller/helmops/reconciler/helmapp_controller.go
@@ -51,6 +51,9 @@ func (r *HelmAppReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&fleet.HelmApp{},
 			builder.WithPredicates(
 				predicate.Or(
+					// Note: These predicates prevent cache
+					// syncPeriod from triggering reconcile, since
+					// cache sync is an Update event.
 					predicate.GenerationChangedPredicate{},
 					predicate.AnnotationChangedPredicate{},
 					predicate.LabelChangedPredicate{},

--- a/internal/cmd/controller/reconciler/config_controller.go
+++ b/internal/cmd/controller/reconciler/config_controller.go
@@ -58,6 +58,9 @@ func (r *ConfigReconciler) SetupWithManager(mgr ctrl.Manager) error {
 						object.GetName() == config.ManagerConfigName
 				}),
 				predicate.Or(
+					// Note: These predicates prevent cache
+					// syncPeriod from triggering reconcile, since
+					// cache sync is an Update event.
 					predicate.ResourceVersionChangedPredicate{},
 					predicate.GenerationChangedPredicate{},
 					predicate.AnnotationChangedPredicate{},

--- a/internal/cmd/controller/reconciler/imagescan_controller.go
+++ b/internal/cmd/controller/reconciler/imagescan_controller.go
@@ -40,6 +40,9 @@ func (r *ImageScanReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			predicate.And(
 				sharding.FilterByShardID(r.ShardID),
 				predicate.Or(
+					// Note: These predicates prevent cache
+					// syncPeriod from triggering reconcile, since
+					// cache sync is an Update event.
 					predicate.GenerationChangedPredicate{},
 					predicate.AnnotationChangedPredicate{},
 					predicate.LabelChangedPredicate{},


### PR DESCRIPTION
refers to https://github.com/rancher/fleet/issues/3138

* Add jitter to the pollingInterval of GitRepos, jitter is plus minus 1/10 the polling interval
* Gitops controller resyncs every hour, if gitrepos are lost from requeueAfter polling, resync should add them again.
* Since the 10h cache sync is an update event, change predicates like GenerationChanged, prevent the reconcile from running.