### PR TITLE
[CI/e2e] Adds definition of helmops metrics port

### DIFF
--- a/dev/setup-k3d
+++ b/dev/setup-k3d
@@ -13,6 +13,7 @@ unique_api_port=${unique_api_port-36443}
 unique_tls_port=${unique_tls_port-443}
 METRICS_GITJOB_PORT=${METRICS_GITJOB_PORT-}
 METRICS_CONTROLLER_PORT=${METRICS_CONTROLLER_PORT-}
+METRICS_HELMOPS_PORT=${METRICS_HELMOPS_PORT-}
 
 name=${1-upstream}
 offs=${2-0}
@@ -23,6 +24,10 @@ fi
 
 if [ -n "$METRICS_GITJOB_PORT" ]; then
     args="$args -p "${METRICS_GITJOB_PORT}:${METRICS_GITJOB_PORT}@server:0""
+fi
+
+if [ -n "$METRICS_HELMOPS_PORT" ]; then
+    args="$args -p "${METRICS_HELMOPS_PORT}:${METRICS_HELMOPS_PORT}@server:0""
 fi
 
 if [ -n "$docker_mirror" ]; then

--- a/e2e/metrics/suite_test.go
+++ b/e2e/metrics/suite_test.go
@@ -53,6 +53,12 @@ func getMetricsPort(app string) int64 {
 			Expect(err).ToNot(HaveOccurred())
 			return i
 		}
+	case "helmops":
+		if port := os.Getenv("METRICS_HELMOPS_PORT"); port != "" {
+			i, err := strconv.ParseInt(port, 10, 64)
+			Expect(err).ToNot(HaveOccurred())
+			return i
+		}
 	}
 	rs := rand.NewSource(time.Now().UnixNano())
 	return rs.Int63()%1000 + 30000


### PR DESCRIPTION
This is added to be able to define the port used when setting up the metrics service for helmops Helps also to be able to run e2e tests in conjunction with an external ip (and to run e2e test on Mac OS)
