### PR TITLE
Dev scripts use same docker network 

### DIFF
--- a/dev/README.md
+++ b/dev/README.md
@@ -156,7 +156,7 @@ export FLEET_E2E_CLUSTER_DOWNSTREAM=k3d-upstream
 
 # running multi-cluster tests in k3d (setup-k3d;setup-k3ds-downstream)
 export FLEET_E2E_CLUSTER=k3d-upstream
-export FLEET_E2E_CLUSTER_DOWNSTREAM=k3d-downstream
+export FLEET_E2E_CLUSTER_DOWNSTREAM=k3d-downstream1
 
 # for running tests on darwin/arm64
 export GOARCH=arm64
@@ -222,11 +222,12 @@ The local infra setup creates pods for:
 To build and run the infra setup command do:
 
 ```
+dev/import-images-tests-k3d
+# ./dev/create-zot-certs 'FleetCI-RootCA'
 pushd e2e/testenv/infra
   go build
 popd
 ./e2e/testenv/infra/infra setup
-
 ```
 
 The resulting deployments use a loadbalancer service, which means the host must be able to reach the loadbalancer IP.

--- a/dev/env.multi-cluster-defaults
+++ b/dev/env.multi-cluster-defaults
@@ -2,7 +2,7 @@ export FLEET_E2E_NS=fleet-local
 export FLEET_E2E_NS_DOWNSTREAM=fleet-default
 
 export FLEET_E2E_CLUSTER=k3d-upstream
-export FLEET_E2E_CLUSTER_DOWNSTREAM=k3d-downstream
+export FLEET_E2E_CLUSTER_DOWNSTREAM=k3d-downstream1
 
 export GIT_HTTP_USER=fleet-ci
 export GIT_HTTP_PASSWORD=foo

--- a/dev/import-images-k3d
+++ b/dev/import-images-k3d
@@ -6,7 +6,7 @@ set -euxo pipefail
 upstream_ctx="${FLEET_E2E_CLUSTER-k3d-upstream}"
 
 # The single downstream cluster to import the agent image to.
-downstream_ctx="${FLEET_E2E_CLUSTER_DOWNSTREAM-k3d-downstream}"
+downstream_ctx="${FLEET_E2E_CLUSTER_DOWNSTREAM-k3d-downstream1}"
 
 # If multi-cluster is enabled, import the agent image to all downstream clusters.
 FLEET_E2E_DS_CLUSTER_COUNT="${FLEET_E2E_DS_CLUSTER_COUNT:-1}"

--- a/dev/remove-fleet
+++ b/dev/remove-fleet
@@ -2,7 +2,7 @@
 # Warning: do not use this script on a production system!
 
 upstream_ctx="${FLEET_E2E_CLUSTER-k3d-upstream}"
-downstream_ctx="${FLEET_E2E_CLUSTER_DOWNSTREAM-k3d-downstream}"
+downstream_ctx="${FLEET_E2E_CLUSTER_DOWNSTREAM-k3d-downstream1}"
 
 ctx=$(kubectl config current-context)
 

--- a/dev/setup-fleet-downstream
+++ b/dev/setup-fleet-downstream
@@ -9,7 +9,7 @@ if [ ! -d ./charts/fleet ]; then
 fi
 
 upstream_ctx="${FLEET_E2E_CLUSTER-k3d-upstream}"
-downstream_ctx="${FLEET_E2E_CLUSTER_DOWNSTREAM-k3d-downstream}"
+downstream_ctx="${FLEET_E2E_CLUSTER_DOWNSTREAM-k3d-downstream1}"
 ns="${FLEET_E2E_NS_DOWNSTREAM-fleet-local}"
 
 kubectl create ns "$ns"|| true

--- a/dev/setup-k3d
+++ b/dev/setup-k3d
@@ -7,7 +7,7 @@ set -euxo pipefail
 # https://hub.docker.com/r/rancher/k3s/tags
 # k3d_args="-i docker.io/rancher/k3s:v1.22.15-k3s1"
 
-args=${k3d_args-}
+args=${k3d_args---network fleet}
 docker_mirror=${docker_mirror-}
 unique_api_port=${unique_api_port-36443}
 unique_tls_port=${unique_tls_port-443}

--- a/dev/setup-rancher-clusters
+++ b/dev/setup-rancher-clusters
@@ -9,7 +9,7 @@ fi
 
 public_hostname="${public_hostname-172.18.0.1.sslip.io}"
 upstream_ctx="${FLEET_E2E_CLUSTER-k3d-upstream}"
-downstream_ctx="${FLEET_E2E_CLUSTER_DOWNSTREAM-k3d-downstream}"
+downstream_ctx="${FLEET_E2E_CLUSTER_DOWNSTREAM-k3d-downstream1}"
 rancherpassword="${RANCHER_PASSWORD-rancherpassword}"
 
 version="${1-}"

--- a/dev/setup-rancher-with-dev-fleet
+++ b/dev/setup-rancher-with-dev-fleet
@@ -22,7 +22,7 @@ ip=$(kubectl get service -n kube-system traefik -o jsonpath='{.status.loadBalanc
 #fi
 
 helm repo update
-helm install cert-manager jetstack/cert-manager \
+helm upgrade --install cert-manager jetstack/cert-manager \
     --namespace cert-manager \
     --create-namespace \
     --set crds.enabled=true \
@@ -63,6 +63,7 @@ until kubectl get bundles -n fleet-local | grep -q "fleet-agent-local.*1/1"; do 
 helm list -A
 
 export public_hostname=$ip.sslip.io
+export cluster_downstream="k3d-downstream1"
 
 ./.github/scripts/wait-for-loadbalancer.sh
 ./.github/scripts/register-downstream-clusters.sh


### PR DESCRIPTION
* use same docker network for upstream/downstream
* switch all defaults to "downstream1"
* dev/setup-rancher-with-dev-fleet idempotency