### PR TITLE
Fix nightly CI workflow

### DIFF
--- a/.github/workflows/e2e-nightly-ci.yml
+++ b/.github/workflows/e2e-nightly-ci.yml
@@ -99,8 +99,8 @@ jobs:
           ginkgo --github-output --label-filter='!infra-setup' e2e/single-cluster e2e/keep-resources
 
           # 2. Run tests for metrics
-          ginkgo --github-output e2e/metrics
-          SHARD=shard1 ginkgo --github-output e2e/metrics
+          ginkgo --github-output --label-filter='!oci-registry' e2e/metrics
+          SHARD=shard1 ginkgo --github-output --label-filter='!oci-registry' e2e/metrics
 
           # 3. Run tests requiring only the git server
           e2e/testenv/infra/infra setup --git-server=true
@@ -115,6 +115,7 @@ jobs:
           # 5. Run tests requiring an OCI registry
           e2e/testenv/infra/infra setup --oci-registry=true
           ginkgo --github-output --label-filter='oci-registry' e2e/single-cluster
+          ginkgo --github-output --label-filter='oci-registry' e2e/metrics
 
           # 6. Tear down all infra
           e2e/testenv/infra/infra teardown


### PR DESCRIPTION
This excludes metrics tests requiring an OCI registry to be set up, as is the case for new HelmApp tests, from the initial run which does not involve any test infrastructure.
Those tests are run once the OCI registry is up, as done in the regular end-to-end tests workflow.

This patch prevents failures such as [this one](https://github.com/rancher/fleet/actions/runs/12704848942/job/35414871763).