### PR TITLE
Adds new gitops poller controller

### DIFF
--- a/charts/fleet-crd/templates/crds.yaml
+++ b/charts/fleet-crd/templates/crds.yaml
@@ -6662,6 +6662,15 @@ spec:
                   description: PerClusterResourceCounts contains the number of resources
                     in each state over all bundles, per cluster.
                   type: object
+                pollerCommit:
+                  description: PollerCommit is the latest Git commit gathered by the
+                    GitRepo poller
+                  type: string
+                pollerGeneration:
+                  description: PollerGeneration is the latest generation value processed
+                    by the GitRepo poller
+                  format: int64
+                  type: integer
                 readyClusters:
                   description: 'ReadyClusters is the lowest number of clusters that
                     are ready over

--- a/integrationtests/gitjob/controller/gitrepo_test.go
+++ b/integrationtests/gitjob/controller/gitrepo_test.go
@@ -59,6 +59,7 @@ var _ = Describe("GitRepo", func() {
 		})
 
 		It("updates the gitrepo status", func() {
+			// simulate job was successful
 			org := gitrepo.ResourceVersion
 			Eventually(func(g Gomega) {
 				_ = k8sClient.Get(ctx, types.NamespacedName{Name: gitrepoName, Namespace: namespace}, gitrepo)
@@ -67,7 +68,10 @@ var _ = Describe("GitRepo", func() {
 				g.Expect(gitrepo.Status.Display.Error).To(BeFalse())
 				g.Expect(len(gitrepo.Status.Conditions)).To(Equal(5))
 				g.Expect(checkCondition(gitrepo, "GitPolling", corev1.ConditionTrue, "")).To(BeTrue())
-				g.Expect(checkCondition(gitrepo, "Reconciling", corev1.ConditionTrue, "")).To(BeTrue())
+				// check only if it's set for Reconciling.
+				// After the polling mechanism has been moved away from the main controller
+				// we could have Reconciling set to true or false depending on how fast the job is started
+				g.Expect(checkConditionIsSet(gitrepo, "Reconciling")).To(BeTrue())
 				g.Expect(checkCondition(gitrepo, "Stalled", corev1.ConditionFalse, "")).To(BeTrue())
 				g.Expect(checkCondition(gitrepo, "Ready", corev1.ConditionTrue, "")).To(BeTrue())
 				g.Expect(checkCondition(gitrepo, "Accepted", corev1.ConditionTrue, "")).To(BeTrue())

--- a/integrationtests/gitjob/controller/suite_test.go
+++ b/integrationtests/gitjob/controller/suite_test.go
@@ -110,7 +110,6 @@ var _ = BeforeSuite(func() {
 		Image:      "image",
 		Scheduler:  sched,
 		GitFetcher: fetcherMock,
-		Clock:      reconciler.RealClock{},
 		Recorder:   mgr.GetEventRecorderFor("gitjob-controller"),
 	}).SetupWithManager(mgr)
 	Expect(err).ToNot(HaveOccurred())
@@ -118,6 +117,15 @@ var _ = BeforeSuite(func() {
 	err = (&reconciler.StatusReconciler{
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
+	}).SetupWithManager(mgr)
+	Expect(err).ToNot(HaveOccurred())
+
+	err = (&reconciler.PollerReconciler{
+		Client:     mgr.GetClient(),
+		Scheme:     mgr.GetScheme(),
+		GitFetcher: fetcherMock,
+		Clock:      reconciler.RealClock{},
+		Recorder:   mgr.GetEventRecorderFor("gitjob-controller"),
 	}).SetupWithManager(mgr)
 	Expect(err).ToNot(HaveOccurred())
 

--- a/internal/cmd/controller/gitops/reconciler/gitjob_test.go
+++ b/internal/cmd/controller/gitops/reconciler/gitjob_test.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"os"
 	"testing"
-	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"go.uber.org/mock/gomock"
@@ -16,9 +15,9 @@ import (
 	"github.com/rancher/fleet/internal/cmd/controller/finalize"
 	"github.com/rancher/fleet/internal/mocks"
 	fleetv1 "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
+	fleetevent "github.com/rancher/fleet/pkg/event"
 	"github.com/rancher/wrangler/v3/pkg/genericcondition"
 
-	fleetevent "github.com/rancher/fleet/pkg/event"
 	gitmocks "github.com/rancher/fleet/pkg/git/mocks"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -42,13 +41,6 @@ func getCondition(gitrepo *fleetv1.GitRepo, condType string) (genericcondition.G
 	}
 	return genericcondition.GenericCondition{}, false
 }
-
-type ClockMock struct {
-	t time.Time
-}
-
-func (m ClockMock) Now() time.Time                  { return m.t }
-func (m ClockMock) Since(t time.Time) time.Duration { return m.t.Sub(t) }
 
 // gitRepoMatcher implements a gomock matcher that checks for gitrepos.
 // It only checks for the expected name and namespace so far
@@ -78,15 +70,6 @@ func (m gitRepoPointerMatcher) Matches(x interface{}) bool {
 
 func (m gitRepoPointerMatcher) String() string {
 	return ""
-}
-
-func getGitPollingCondition(gitrepo *fleetv1.GitRepo) (genericcondition.GenericCondition, bool) {
-	for _, cond := range gitrepo.Status.Conditions {
-		if cond.Type == gitPollingCondition {
-			return cond, true
-		}
-	}
-	return genericcondition.GenericCondition{}, false
 }
 
 func TestReconcile_ReturnsAndRequeuesAfterAddingFinalizer(t *testing.T) {
@@ -127,7 +110,6 @@ func TestReconcile_ReturnsAndRequeuesAfterAddingFinalizer(t *testing.T) {
 		Scheme:     scheme,
 		Image:      "",
 		GitFetcher: fetcher,
-		Clock:      RealClock{},
 	}
 
 	ctx := context.TODO()
@@ -139,297 +121,6 @@ func TestReconcile_ReturnsAndRequeuesAfterAddingFinalizer(t *testing.T) {
 	}
 	if !res.Requeue {
 		t.Errorf("expecting Requeue set to true, it was false")
-	}
-}
-
-func TestReconcile_LatestCommitErrorIsSetInConditions(t *testing.T) {
-	mockCtrl := gomock.NewController(t)
-	defer mockCtrl.Finish()
-	scheme := runtime.NewScheme()
-	utilruntime.Must(batchv1.AddToScheme(scheme))
-	gitRepo := fleetv1.GitRepo{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "gitrepo",
-			Namespace: "default",
-		},
-	}
-	namespacedName := types.NamespacedName{Name: gitRepo.Name, Namespace: gitRepo.Namespace}
-	client := mocks.NewMockClient(mockCtrl)
-	statusClient := mocks.NewMockSubResourceWriter(mockCtrl)
-	client.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(nil)
-	client.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).DoAndReturn(
-		func(ctx context.Context, req types.NamespacedName, gitrepo *fleetv1.GitRepo, opts ...interface{}) error {
-			gitrepo.Name = gitRepo.Name
-			gitrepo.Namespace = gitRepo.Namespace
-			gitrepo.Spec.Repo = "repo"
-			controllerutil.AddFinalizer(gitrepo, finalize.GitRepoFinalizer)
-			return nil
-		},
-	)
-	client.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(nil)
-	client.EXPECT().Status().Return(statusClient).Times(1)
-	fetcher := gitmocks.NewMockGitFetcher(mockCtrl)
-	fetcher.EXPECT().LatestCommit(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return("", fmt.Errorf("TEST ERROR"))
-	statusClient.EXPECT().Update(gomock.Any(), gomock.Any(), gomock.Any()).Do(
-		func(ctx context.Context, repo *fleetv1.GitRepo, opts ...interface{}) {
-			cond, found := getGitPollingCondition(repo)
-			if !found {
-				t.Errorf("expecting Condition %s to be found", gitPollingCondition)
-			}
-			if cond.Message != "TEST ERROR" {
-				t.Errorf("expecting condition message [TEST ERROR], got [%s]", cond.Message)
-			}
-			if cond.Type != gitPollingCondition {
-				t.Errorf("expecting condition type [%s], got [%s]", gitPollingCondition, cond.Type)
-			}
-			if cond.Status != "False" {
-				t.Errorf("expecting condition Status [False], got [%s]", cond.Type)
-			}
-		},
-	).Times(1)
-
-	recorderMock := mocks.NewMockEventRecorder(mockCtrl)
-	recorderMock.EXPECT().Event(
-		&gitRepoMatcher{gitRepo},
-		fleetevent.Warning,
-		"FailedToCheckCommit",
-		"TEST ERROR",
-	)
-	r := GitJobReconciler{
-		Client:     client,
-		Scheme:     scheme,
-		Image:      "",
-		GitFetcher: fetcher,
-		Clock:      RealClock{},
-		Recorder:   recorderMock,
-	}
-
-	ctx := context.TODO()
-
-	// second call is the one calling LatestCommit
-	_, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: namespacedName})
-	if err != nil {
-		t.Errorf("unexpected error %v", err)
-	}
-}
-
-func TestReconcile_LatestCommitIsOkay(t *testing.T) {
-	mockCtrl := gomock.NewController(t)
-	defer mockCtrl.Finish()
-	scheme := runtime.NewScheme()
-	utilruntime.Must(batchv1.AddToScheme(scheme))
-	gitRepo := fleetv1.GitRepo{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "gitrepo",
-			Namespace: "default",
-		},
-	}
-	namespacedName := types.NamespacedName{Name: gitRepo.Name, Namespace: gitRepo.Namespace}
-	client := mocks.NewMockClient(mockCtrl)
-	statusClient := mocks.NewMockSubResourceWriter(mockCtrl)
-	client.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(nil)
-	client.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).DoAndReturn(
-		func(ctx context.Context, req types.NamespacedName, gitrepo *fleetv1.GitRepo, opts ...interface{}) error {
-			gitrepo.Name = gitRepo.Name
-			gitrepo.Namespace = gitRepo.Namespace
-			gitrepo.Spec.Repo = "repo"
-			controllerutil.AddFinalizer(gitrepo, finalize.GitRepoFinalizer)
-			return nil
-		},
-	)
-	client.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(nil)
-	client.EXPECT().Status().Return(statusClient).Times(1)
-
-	fetcher := gitmocks.NewMockGitFetcher(mockCtrl)
-	commit := "1883fd54bc5dfd225acf02aecbb6cb8020458e33"
-	fetcher.EXPECT().LatestCommit(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(commit, nil)
-	statusClient.EXPECT().Update(gomock.Any(), gomock.Any(), gomock.Any()).Do(
-		func(ctx context.Context, repo *fleetv1.GitRepo, opts ...interface{}) {
-			cond, found := getGitPollingCondition(repo)
-			if !found {
-				t.Errorf("expecting Condition %s to be found", gitPollingCondition)
-			}
-			if cond.Message != "" {
-				t.Errorf("expecting condition message empty, got [%s]", cond.Message)
-			}
-			if cond.Type != gitPollingCondition {
-				t.Errorf("expecting condition type [%s], got [%s]", gitPollingCondition, cond.Type)
-			}
-			if cond.Status != "True" {
-				t.Errorf("expecting condition Status [True], got [%s]", cond.Type)
-			}
-			if repo.Status.Commit != commit {
-				t.Errorf("expecting commit %s, got %s", commit, repo.Status.Commit)
-			}
-		},
-	).Times(1)
-
-	recorderMock := mocks.NewMockEventRecorder(mockCtrl)
-	recorderMock.EXPECT().Event(
-		&gitRepoMatcher{gitRepo},
-		fleetevent.Normal,
-		"GotNewCommit",
-		"1883fd54bc5dfd225acf02aecbb6cb8020458e33",
-	)
-
-	r := GitJobReconciler{
-		Client:     client,
-		Scheme:     scheme,
-		Image:      "",
-		GitFetcher: fetcher,
-		Clock:      RealClock{},
-		Recorder:   recorderMock,
-	}
-
-	ctx := context.TODO()
-
-	// second call is the one calling LatestCommit
-	_, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: namespacedName})
-	if err != nil {
-		t.Errorf("unexpected error %v", err)
-	}
-}
-
-func TestReconcile_LatestCommitNotCalledYet(t *testing.T) {
-	mockCtrl := gomock.NewController(t)
-	defer mockCtrl.Finish()
-	scheme := runtime.NewScheme()
-	utilruntime.Must(batchv1.AddToScheme(scheme))
-	gitRepo := fleetv1.GitRepo{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "gitrepo",
-			Namespace: "default",
-		},
-	}
-	namespacedName := types.NamespacedName{Name: gitRepo.Name, Namespace: gitRepo.Namespace}
-	client := mocks.NewMockClient(mockCtrl)
-	statusClient := mocks.NewMockSubResourceWriter(mockCtrl)
-	client.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(nil)
-	client.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).DoAndReturn(
-		func(ctx context.Context, req types.NamespacedName, gitrepo *fleetv1.GitRepo, opts ...interface{}) error {
-			gitrepo.Name = gitRepo.Name
-			gitrepo.Namespace = gitRepo.Namespace
-			gitrepo.Spec.Repo = "repo"
-			controllerutil.AddFinalizer(gitrepo, finalize.GitRepoFinalizer)
-
-			// set last polling time to now...
-			// default gitrepo polling time is 15 seconds, so it won't call LatestCommit this time
-			gitrepo.Status.LastPollingTime.Time = time.Now()
-			return nil
-		},
-	)
-	client.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(nil)
-	client.EXPECT().Status().Return(statusClient).Times(1)
-	statusClient.EXPECT().Update(gomock.Any(), gomock.Any(), gomock.Any()).Do(
-		func(ctx context.Context, repo *fleetv1.GitRepo, opts ...interface{}) {
-			if repo.Status.Commit != "" {
-				t.Errorf("expecting gitrepo empty commit, got [%s]", repo.Status.Commit)
-			}
-			cond, found := getGitPollingCondition(repo)
-			if found {
-				t.Errorf("not expecting Condition %s to be found. Got [%s]", gitPollingCondition, cond)
-			}
-		},
-	).Times(1)
-
-	fetcher := gitmocks.NewMockGitFetcher(mockCtrl)
-	r := GitJobReconciler{
-		Client:     client,
-		Scheme:     scheme,
-		Image:      "",
-		GitFetcher: fetcher,
-		Clock:      RealClock{},
-	}
-
-	ctx := context.TODO()
-
-	// second call is the one calling LatestCommit
-	_, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: namespacedName})
-	if err != nil {
-		t.Errorf("unexpected error %v", err)
-	}
-}
-
-func TestReconcile_LatestCommitShouldBeCalled(t *testing.T) {
-	mockCtrl := gomock.NewController(t)
-	defer mockCtrl.Finish()
-	scheme := runtime.NewScheme()
-	utilruntime.Must(batchv1.AddToScheme(scheme))
-	gitRepo := fleetv1.GitRepo{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "gitrepo",
-			Namespace: "default",
-		},
-	}
-	namespacedName := types.NamespacedName{Name: gitRepo.Name, Namespace: gitRepo.Namespace}
-	client := mocks.NewMockClient(mockCtrl)
-	statusClient := mocks.NewMockSubResourceWriter(mockCtrl)
-	client.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(nil)
-	fetcher := gitmocks.NewMockGitFetcher(mockCtrl)
-	commit := "1883fd54bc5dfd225acf02aecbb6cb8020458e33"
-	fetcher.EXPECT().LatestCommit(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(commit, nil)
-	client.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).DoAndReturn(
-		func(ctx context.Context, req types.NamespacedName, gitrepo *fleetv1.GitRepo, opts ...interface{}) error {
-			gitrepo.Name = gitRepo.Name
-			gitrepo.Namespace = gitRepo.Namespace
-			gitrepo.Spec.Repo = "repo"
-			controllerutil.AddFinalizer(gitrepo, finalize.GitRepoFinalizer)
-
-			// set last polling time to now less 15 seconds (which is the default)
-			// that should trigger the polling job now
-			now := time.Now()
-			gitrepo.Status.LastPollingTime.Time = now.Add(time.Duration(-15) * time.Second)
-			// commit is something different to what we expect after this reconcile
-			gitrepo.Status.Commit = "dd45c7ad68e10307765104fea4a1f5997643020f"
-			return nil
-		},
-	)
-	client.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(nil)
-	client.EXPECT().Status().Return(statusClient).Times(1)
-	statusClient.EXPECT().Update(gomock.Any(), gomock.Any(), gomock.Any()).Do(
-		func(ctx context.Context, repo *fleetv1.GitRepo, opts ...interface{}) {
-			cond, found := getGitPollingCondition(repo)
-			if !found {
-				t.Errorf("expecting Condition %s to be found", gitPollingCondition)
-			}
-			if cond.Message != "" {
-				t.Errorf("expecting condition message empty, got [%s]", cond.Message)
-			}
-			if cond.Type != gitPollingCondition {
-				t.Errorf("expecting condition type [%s], got [%s]", gitPollingCondition, cond.Type)
-			}
-			if cond.Status != "True" {
-				t.Errorf("expecting condition Status [True], got [%s]", cond.Type)
-			}
-			if repo.Status.Commit != commit {
-				t.Errorf("expecting commit %s, got %s", commit, repo.Status.Commit)
-			}
-		},
-	).Times(1)
-
-	recorderMock := mocks.NewMockEventRecorder(mockCtrl)
-	recorderMock.EXPECT().Event(
-		&gitRepoMatcher{gitRepo},
-		fleetevent.Normal,
-		"GotNewCommit",
-		"1883fd54bc5dfd225acf02aecbb6cb8020458e33",
-	)
-
-	r := GitJobReconciler{
-		Client:     client,
-		Scheme:     scheme,
-		Image:      "",
-		GitFetcher: fetcher,
-		Clock:      RealClock{},
-		Recorder:   recorderMock,
-	}
-
-	ctx := context.TODO()
-
-	// second call is the one calling LatestCommit
-	_, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: namespacedName})
-	if err != nil {
-		t.Errorf("unexpected error %v", err)
 	}
 }
 
@@ -488,7 +179,6 @@ func TestReconcile_Error_WhenGitrepoRestrictionsAreNotMet(t *testing.T) {
 		Client:   mockClient,
 		Scheme:   scheme,
 		Image:    "",
-		Clock:    RealClock{},
 		Recorder: recorderMock,
 	}
 
@@ -528,9 +218,6 @@ func TestReconcile_Error_WhenGetGitJobErrors(t *testing.T) {
 		},
 	)
 	mockFetcher := gitmocks.NewMockGitFetcher(mockCtrl)
-	commit := "1883fd54bc5dfd225acf02aecbb6cb8020458e33"
-	mockFetcher.EXPECT().LatestCommit(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(commit, nil)
-
 	mockClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).DoAndReturn(
 		func(ctx context.Context, req types.NamespacedName, job *batchv1.Job, opts ...interface{}) error {
 			return fmt.Errorf("GITJOB ERROR")
@@ -538,12 +225,6 @@ func TestReconcile_Error_WhenGetGitJobErrors(t *testing.T) {
 	)
 
 	recorderMock := mocks.NewMockEventRecorder(mockCtrl)
-	recorderMock.EXPECT().Event(
-		&gitRepoMatcher{gitRepo},
-		fleetevent.Normal,
-		"GotNewCommit",
-		"1883fd54bc5dfd225acf02aecbb6cb8020458e33",
-	)
 	recorderMock.EXPECT().Event(
 		&gitRepoMatcher{gitRepo},
 		fleetevent.Warning,
@@ -555,7 +236,6 @@ func TestReconcile_Error_WhenGetGitJobErrors(t *testing.T) {
 		Client:     mockClient,
 		Scheme:     scheme,
 		Image:      "",
-		Clock:      RealClock{},
 		Recorder:   recorderMock,
 		GitFetcher: mockFetcher,
 	}
@@ -593,12 +273,11 @@ func TestReconcile_Error_WhenSecretDoesNotExist(t *testing.T) {
 			gitrepo.Spec.HelmSecretNameForPaths = "somevalue"
 			controllerutil.AddFinalizer(gitrepo, finalize.GitRepoFinalizer)
 			gitrepo.Status.Commit = "dd45c7ad68e10307765104fea4a1f5997643020f"
+			gitrepo.Status.PollerCommit = "1883fd54bc5dfd225acf02aecbb6cb8020458e33"
 			return nil
 		},
 	)
 	mockFetcher := gitmocks.NewMockGitFetcher(mockCtrl)
-	commit := "1883fd54bc5dfd225acf02aecbb6cb8020458e33"
-	mockFetcher.EXPECT().LatestCommit(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(commit, nil)
 
 	// we need to return a NotFound error, so the code tries to create it.
 	mockClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).DoAndReturn(
@@ -614,12 +293,6 @@ func TestReconcile_Error_WhenSecretDoesNotExist(t *testing.T) {
 	)
 
 	recorderMock := mocks.NewMockEventRecorder(mockCtrl)
-	recorderMock.EXPECT().Event(
-		&gitRepoMatcher{gitRepo},
-		fleetevent.Normal,
-		"GotNewCommit",
-		"1883fd54bc5dfd225acf02aecbb6cb8020458e33",
-	)
 	recorderMock.EXPECT().Event(
 		&gitRepoMatcher{gitRepo},
 		fleetevent.Warning,
@@ -645,7 +318,6 @@ func TestReconcile_Error_WhenSecretDoesNotExist(t *testing.T) {
 		Client:     mockClient,
 		Scheme:     scheme,
 		Image:      "",
-		Clock:      RealClock{},
 		Recorder:   recorderMock,
 		GitFetcher: mockFetcher,
 	}
@@ -1064,7 +736,6 @@ func TestNewJob(t *testing.T) { // nolint:funlen
 				Client: test.client,
 				Scheme: scheme,
 				Image:  "test",
-				Clock:  RealClock{},
 			}
 			job, err := r.newGitJob(ctx, test.gitrepo)
 			if err != nil {
@@ -1171,7 +842,6 @@ func TestGenerateJob_EnvVars(t *testing.T) {
 			r := GitJobReconciler{
 				Client: fake.NewFakeClient(),
 				Image:  "test",
-				Clock:  RealClock{},
 			}
 			for k, v := range test.osEnv {
 				err := os.Setenv(k, v)
@@ -1193,96 +863,6 @@ func TestGenerateJob_EnvVars(t *testing.T) {
 				err := os.Unsetenv(k)
 				if err != nil {
 					t.Errorf("unexpected error: %v", err)
-				}
-			}
-		})
-	}
-}
-
-func TestCheckforPollingTask(t *testing.T) {
-	tests := map[string]struct {
-		gitrepo        *fleetv1.GitRepo
-		timeNow        time.Time
-		expectedResult bool
-	}{
-		"LastPollingTime is not set": {
-			gitrepo:        &fleetv1.GitRepo{},
-			timeNow:        time.Now(), // time here is irrelevant
-			expectedResult: true,
-		},
-		"LastPollingTime is set but should still not trigger (1s away)": {
-			gitrepo: &fleetv1.GitRepo{
-				Status: fleetv1.GitRepoStatus{
-					LastPollingTime: metav1.Time{Time: time.Date(2024, time.July, 16, 15, 59, 59, 0, time.UTC)},
-				},
-				Spec: fleetv1.GitRepoSpec{
-					PollingInterval: &metav1.Duration{Duration: 10 * time.Second},
-				},
-			},
-			timeNow:        time.Date(2024, time.July, 16, 16, 0, 0, 0, time.UTC),
-			expectedResult: false,
-		},
-		"LastPollingTime is set and should trigger (10s away)": {
-			gitrepo: &fleetv1.GitRepo{
-				Status: fleetv1.GitRepoStatus{
-					LastPollingTime: metav1.Time{Time: time.Date(2024, time.July, 16, 15, 59, 50, 0, time.UTC)},
-				},
-				Spec: fleetv1.GitRepoSpec{
-					PollingInterval: &metav1.Duration{Duration: 10 * time.Second},
-				},
-			},
-			timeNow:        time.Date(2024, time.July, 16, 16, 0, 0, 0, time.UTC),
-			expectedResult: true,
-		},
-		"LastPollingTime is set but should still not trigger (1s away with default value)": {
-			gitrepo: &fleetv1.GitRepo{
-				Status: fleetv1.GitRepoStatus{
-					LastPollingTime: metav1.Time{Time: time.Date(2024, time.July, 16, 15, 59, 59, 0, time.UTC)},
-				},
-			},
-			timeNow:        time.Date(2024, time.July, 16, 16, 0, 0, 0, time.UTC),
-			expectedResult: false,
-		},
-		"LastPollingTime is set and should trigger (15s away with default value)": {
-			gitrepo: &fleetv1.GitRepo{
-				Status: fleetv1.GitRepoStatus{
-					LastPollingTime: metav1.Time{Time: time.Date(2024, time.July, 16, 15, 59, 45, 0, time.UTC)},
-				},
-			},
-			timeNow:        time.Date(2024, time.July, 16, 16, 0, 0, 0, time.UTC),
-			expectedResult: true,
-		},
-	}
-	for name, test := range tests {
-		t.Run(name, func(t *testing.T) {
-			mockCtrl := gomock.NewController(t)
-			defer mockCtrl.Finish()
-			fetcher := gitmocks.NewMockGitFetcher(mockCtrl)
-			commit := "1883fd54bc5dfd225acf02aecbb6cb8020458e33"
-			if test.expectedResult {
-				fetcher.EXPECT().LatestCommit(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(commit, nil)
-			}
-			r := GitJobReconciler{
-				Client:     fake.NewFakeClient(),
-				Image:      "test",
-				Clock:      ClockMock{t: test.timeNow},
-				GitFetcher: fetcher,
-			}
-			res, err := r.repoPolled(context.TODO(), test.gitrepo)
-			if res != test.expectedResult {
-				t.Errorf("unexpected result. Expecting %t, got %t", test.expectedResult, res)
-			}
-			if err != nil {
-				t.Errorf("not expecting to get an error, got [%v]", err)
-			}
-			if res {
-				// if the task was called, commit will be applied
-				if test.gitrepo.Status.Commit != commit {
-					t.Errorf("expecting commit: %s, got: %s", commit, test.gitrepo.Status.Commit)
-				}
-				// also LastPollingTime should be set to now
-				if test.gitrepo.Status.LastPollingTime.Time != test.timeNow {
-					t.Errorf("expecting LastPollingTime to be: %s, got: %s", test.timeNow, test.gitrepo.Status.LastPollingTime.Time)
 				}
 			}
 		})

--- a/internal/cmd/controller/gitops/reconciler/poller_controller.go
+++ b/internal/cmd/controller/gitops/reconciler/poller_controller.go
@@ -1,0 +1,184 @@
+package reconciler
+
+import (
+	"context"
+	"math/rand/v2"
+	"time"
+
+	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
+	v1alpha1 "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
+	fleetevent "github.com/rancher/fleet/pkg/event"
+	"github.com/rancher/fleet/pkg/sharding"
+	"github.com/rancher/wrangler/v3/pkg/condition"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+const requeueAlmostNow = 5 * time.Millisecond
+
+type RealClock struct{}
+
+func (RealClock) Now() time.Time                  { return time.Now() }
+func (RealClock) Since(t time.Time) time.Duration { return time.Since(t) }
+
+type PollerReconciler struct {
+	client.Client
+	Scheme     *runtime.Scheme
+	Workers    int
+	ShardID    string
+	GitFetcher GitFetcher
+	Clock      TimeGetter
+	Recorder   record.EventRecorder
+}
+
+func (r *PollerReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&v1alpha1.GitRepo{},
+			builder.WithPredicates(
+				predicate.GenerationChangedPredicate{},
+			),
+		).
+		Named("GitRepoPoller").
+		WithEventFilter(sharding.FilterByShardID(r.ShardID)).
+		WithOptions(controller.Options{MaxConcurrentReconciles: r.Workers}).
+		Complete(r)
+}
+
+// Reconcile implements a poller that triggers at the polling interval duration configured for a GitRepo
+func (r *PollerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx).WithName("gitops-poller")
+	gitrepo := &fleet.GitRepo{}
+
+	if err := r.Get(ctx, req.NamespacedName, gitrepo); err != nil && !errors.IsNotFound(err) {
+		return ctrl.Result{}, err
+	} else if errors.IsNotFound(err) {
+		return ctrl.Result{}, nil
+	}
+	gitrepoOrig := gitrepo.DeepCopy()
+
+	// Restrictions / Overrides, gitrepo reconciler is responsible for setting error in status
+	if err := AuthorizeAndAssignDefaults(ctx, r.Client, gitrepo); err != nil {
+		// the gitjob_controller will handle the error
+		return ctrl.Result{}, nil
+	}
+
+	if !gitrepo.DeletionTimestamp.IsZero() {
+		// the gitjob_controller will handle deletion
+		return ctrl.Result{}, nil
+	}
+
+	if gitrepo.Spec.Repo == "" {
+		return ctrl.Result{}, nil
+	}
+
+	logger = logger.WithValues(
+		"generation", gitrepo.Generation,
+		"pollerGeneration", gitrepo.Status.PollerGeneration,
+		"pollerCommit", gitrepo.Status.PollerCommit,
+		"pollerInterval", gitrepo.Spec.PollingInterval,
+		"lastPollingTime", gitrepo.Status.LastPollingTime,
+	)
+	ctx = log.IntoContext(ctx, logger)
+
+	logger.V(1).Info("Reconciling GitRepo poller")
+
+	result := reconcile.Result{RequeueAfter: getPollingIntervalDuration(gitrepo)}
+	result.RequeueAfter = addJitter(result.RequeueAfter)
+
+	if pollerGenerationChanged(gitrepo) {
+		// Generation changed.
+		// We reset the poller back to the initial state.
+		// We requeue with a 5ms value (short enough) so any pending
+		// event in the waiting to be processed queue is updated and processed.
+		// The internal queue updates a waiting event only if the new time is less
+		// than the time already queued.
+		// Example: we have an event waiting that should be processed at time X,
+		// if we enqueue another event that should be processed at time X+Y (greater) it
+		// will be ignored and the initial one would take precedence.
+		// We also reset the lastPollingTime value to zero to ensure that the event right after
+		// this call triggers the polling call.
+		gitrepo.Status.LastPollingTime = metav1.Time{}
+		result.RequeueAfter = requeueAlmostNow
+		logger.V(1).Info("generation changed")
+	} else {
+		oldCommit := gitrepo.Status.PollerCommit
+		if r.shouldRunPollingTask(gitrepo) {
+			logger.V(1).Info("polling")
+			gitrepo.Status.LastPollingTime.Time = r.Clock.Now()
+			commit, err := r.GitFetcher.LatestCommit(ctx, gitrepo, r.Client)
+			if err != nil {
+				r.Recorder.Event(gitrepo, fleetevent.Warning, "FailedToCheckCommit", err.Error())
+				logger.Info("Failed to check for latest commit", "error", err)
+			}
+			if oldCommit != commit {
+				r.Recorder.Event(gitrepo, fleetevent.Normal, "GotNewCommit", commit)
+				logger.Info("New commit from repository", "newCommit", commit)
+			}
+			condition.Cond(gitPollingCondition).SetError(&gitrepo.Status, "", err)
+			gitrepo.Status.PollerCommit = commit
+		}
+	}
+
+	gitrepo.Status.PollerGeneration = gitrepo.Generation
+
+	// Patch status, either to requeue after the configured poller interval
+	// or to requeue almost now because of generation changed
+	statusPatch := client.MergeFrom(gitrepoOrig)
+	err := r.Status().Patch(ctx, gitrepo, statusPatch)
+	if err != nil {
+		logger.V(1).Info("Reconcile failed patching gitrepo poller status", "status", gitrepo.Status, "error", err)
+		// if patching failed we requeue immediately
+		return ctrl.Result{}, err
+	}
+
+	nanos := result.RequeueAfter.Nanoseconds()
+	logger.V(1).Info("return result", "requeue", nanos)
+
+	return result, nil
+}
+
+func (r *PollerReconciler) shouldRunPollingTask(gitrepo *v1alpha1.GitRepo) bool {
+	if gitrepo.Spec.DisablePolling {
+		return false
+	}
+
+	t := gitrepo.Status.LastPollingTime
+
+	if t.IsZero() || (r.Clock.Since(t.Time) >= getPollingIntervalDuration(gitrepo)) {
+		return true
+	}
+
+	return false
+}
+
+func getPollingIntervalDuration(gitrepo *v1alpha1.GitRepo) time.Duration {
+	if gitrepo.Spec.PollingInterval == nil || gitrepo.Spec.PollingInterval.Duration == 0 {
+		return defaultPollingSyncInterval
+	}
+
+	return gitrepo.Spec.PollingInterval.Duration
+}
+
+// addJitter to the requeue time to avoid thundering herd
+// generate a random number between 0% and +10% of the duration
+func addJitter(d time.Duration) time.Duration {
+	if d <= 0 {
+		return d
+	}
+
+	return d + time.Duration(rand.Int64N(int64(d)/10)) // nolint:gosec // gosec G404 false positive, not used for crypto
+}
+
+func pollerGenerationChanged(r *v1alpha1.GitRepo) bool {
+	return r.Generation != r.Status.PollerGeneration
+}

--- a/internal/cmd/controller/gitops/reconciler/poller_test.go
+++ b/internal/cmd/controller/gitops/reconciler/poller_test.go
@@ -1,0 +1,527 @@
+//go:generate mockgen --build_flags=--mod=mod -destination=../../../../mocks/poller_mock.go -package=mocks github.com/rancher/fleet/internal/cmd/controller/gitops/reconciler GitPoller
+//go:generate mockgen --build_flags=--mod=mod -destination=../../../../mocks/client_mock.go -package=mocks sigs.k8s.io/controller-runtime/pkg/client Client,SubResourceWriter
+
+package reconciler
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/rancher/fleet/internal/cmd/controller/finalize"
+	"github.com/rancher/fleet/internal/mocks"
+	fleetv1 "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
+	fleetevent "github.com/rancher/fleet/pkg/event"
+	gitmocks "github.com/rancher/fleet/pkg/git/mocks"
+	"github.com/rancher/wrangler/v3/pkg/genericcondition"
+	"go.uber.org/mock/gomock"
+	batchv1 "k8s.io/api/batch/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+type ClockMock struct {
+	t time.Time
+}
+
+func (m ClockMock) Now() time.Time                  { return m.t }
+func (m ClockMock) Since(t time.Time) time.Duration { return m.t.Sub(t) }
+
+func getGitPollingCondition(gitrepo *fleetv1.GitRepo) (genericcondition.GenericCondition, bool) {
+	for _, cond := range gitrepo.Status.Conditions {
+		if cond.Type == gitPollingCondition {
+			return cond, true
+		}
+	}
+	return genericcondition.GenericCondition{}, false
+}
+
+func TestReconcile_LatestCommitErrorIsSetInConditions(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	scheme := runtime.NewScheme()
+	utilruntime.Must(batchv1.AddToScheme(scheme))
+	gitRepo := fleetv1.GitRepo{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "gitrepo",
+			Namespace: "default",
+		},
+	}
+	namespacedName := types.NamespacedName{Name: gitRepo.Name, Namespace: gitRepo.Namespace}
+	mockClient := mocks.NewMockClient(mockCtrl)
+	statusClient := mocks.NewMockSubResourceWriter(mockCtrl)
+	mockClient.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(nil)
+	mockClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).DoAndReturn(
+		func(ctx context.Context, req types.NamespacedName, gitrepo *fleetv1.GitRepo, opts ...interface{}) error {
+			gitrepo.Name = gitRepo.Name
+			gitrepo.Namespace = gitRepo.Namespace
+			gitrepo.Spec.Repo = "repo"
+			controllerutil.AddFinalizer(gitrepo, finalize.GitRepoFinalizer)
+			return nil
+		},
+	)
+	mockClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(nil)
+	mockClient.EXPECT().Status().Return(statusClient).Times(1)
+	fetcher := gitmocks.NewMockGitFetcher(mockCtrl)
+	fetcher.EXPECT().LatestCommit(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return("", fmt.Errorf("TEST ERROR"))
+	statusClient.EXPECT().Patch(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Do(
+		func(ctx context.Context, repo *fleetv1.GitRepo, patch client.Patch, opts ...interface{}) {
+			cond, found := getGitPollingCondition(repo)
+			if !found {
+				t.Errorf("expecting Condition %s to be found", gitPollingCondition)
+			}
+			if cond.Message != "TEST ERROR" {
+				t.Errorf("expecting condition message [TEST ERROR], got [%s]", cond.Message)
+			}
+			if cond.Type != gitPollingCondition {
+				t.Errorf("expecting condition type [%s], got [%s]", gitPollingCondition, cond.Type)
+			}
+			if cond.Status != "False" {
+				t.Errorf("expecting condition Status [False], got [%s]", cond.Type)
+			}
+		},
+	).Times(1)
+
+	recorderMock := mocks.NewMockEventRecorder(mockCtrl)
+	recorderMock.EXPECT().Event(
+		&gitRepoMatcher{gitRepo},
+		fleetevent.Warning,
+		"FailedToCheckCommit",
+		"TEST ERROR",
+	)
+	r := PollerReconciler{
+		Client:     mockClient,
+		Scheme:     scheme,
+		GitFetcher: fetcher,
+		Clock:      RealClock{},
+		Recorder:   recorderMock,
+	}
+
+	ctx := context.TODO()
+
+	// second call is the one calling LatestCommit
+	_, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: namespacedName})
+	if err != nil {
+		t.Errorf("unexpected error %v", err)
+	}
+}
+
+func TestReconcile_LatestCommitIsOkay(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	scheme := runtime.NewScheme()
+	utilruntime.Must(batchv1.AddToScheme(scheme))
+	gitRepo := fleetv1.GitRepo{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "gitrepo",
+			Namespace: "default",
+		},
+	}
+	namespacedName := types.NamespacedName{Name: gitRepo.Name, Namespace: gitRepo.Namespace}
+	mockClient := mocks.NewMockClient(mockCtrl)
+	statusClient := mocks.NewMockSubResourceWriter(mockCtrl)
+	mockClient.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(nil)
+	mockClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).DoAndReturn(
+		func(ctx context.Context, req types.NamespacedName, gitrepo *fleetv1.GitRepo, opts ...interface{}) error {
+			gitrepo.Name = gitRepo.Name
+			gitrepo.Namespace = gitRepo.Namespace
+			gitrepo.Spec.Repo = "repo"
+			controllerutil.AddFinalizer(gitrepo, finalize.GitRepoFinalizer)
+			return nil
+		},
+	)
+	mockClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(nil)
+	mockClient.EXPECT().Status().Return(statusClient).Times(1)
+
+	fetcher := gitmocks.NewMockGitFetcher(mockCtrl)
+	commit := "1883fd54bc5dfd225acf02aecbb6cb8020458e33"
+	fetcher.EXPECT().LatestCommit(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(commit, nil)
+	statusClient.EXPECT().Patch(gomock.Any(), gomock.Any(), gomock.Any()).Do(
+		func(ctx context.Context, repo *fleetv1.GitRepo, patch client.Patch, opts ...interface{}) {
+			cond, found := getGitPollingCondition(repo)
+			if !found {
+				t.Errorf("expecting Condition %s to be found", gitPollingCondition)
+			}
+			if cond.Message != "" {
+				t.Errorf("expecting condition message empty, got [%s]", cond.Message)
+			}
+			if cond.Type != gitPollingCondition {
+				t.Errorf("expecting condition type [%s], got [%s]", gitPollingCondition, cond.Type)
+			}
+			if cond.Status != "True" {
+				t.Errorf("expecting condition Status [True], got [%s]", cond.Type)
+			}
+			if repo.Status.PollerCommit != commit {
+				t.Errorf("expecting commit %s, got %s", commit, repo.Status.PollerCommit)
+			}
+		},
+	).Times(1)
+
+	recorderMock := mocks.NewMockEventRecorder(mockCtrl)
+	recorderMock.EXPECT().Event(
+		&gitRepoMatcher{gitRepo},
+		fleetevent.Normal,
+		"GotNewCommit",
+		"1883fd54bc5dfd225acf02aecbb6cb8020458e33",
+	)
+
+	r := PollerReconciler{
+		Client:     mockClient,
+		Scheme:     scheme,
+		GitFetcher: fetcher,
+		Clock:      RealClock{},
+		Recorder:   recorderMock,
+	}
+
+	ctx := context.TODO()
+
+	// second call is the one calling LatestCommit
+	_, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: namespacedName})
+	if err != nil {
+		t.Errorf("unexpected error %v", err)
+	}
+}
+
+func TestReconcile_LatestCommitNotCalledYet(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	scheme := runtime.NewScheme()
+	utilruntime.Must(batchv1.AddToScheme(scheme))
+	gitRepo := fleetv1.GitRepo{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "gitrepo",
+			Namespace: "default",
+		},
+	}
+	namespacedName := types.NamespacedName{Name: gitRepo.Name, Namespace: gitRepo.Namespace}
+	mockClient := mocks.NewMockClient(mockCtrl)
+	statusClient := mocks.NewMockSubResourceWriter(mockCtrl)
+	mockClient.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(nil)
+	mockClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).DoAndReturn(
+		func(ctx context.Context, req types.NamespacedName, gitrepo *fleetv1.GitRepo, opts ...interface{}) error {
+			gitrepo.Name = gitRepo.Name
+			gitrepo.Namespace = gitRepo.Namespace
+			gitrepo.Spec.Repo = "repo"
+			controllerutil.AddFinalizer(gitrepo, finalize.GitRepoFinalizer)
+
+			// set last polling time to now...
+			// default gitrepo polling time is 15 seconds, so it won't call LatestCommit this time
+			gitrepo.Status.LastPollingTime.Time = time.Now()
+			return nil
+		},
+	)
+	mockClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(nil)
+	mockClient.EXPECT().Status().Return(statusClient).Times(1)
+	statusClient.EXPECT().Patch(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Do(
+		func(ctx context.Context, repo *fleetv1.GitRepo, patch client.Patch, opts ...interface{}) {
+			if repo.Status.PollerCommit != "" {
+				t.Errorf("expecting gitrepo empty commit, got [%s]", repo.Status.PollerCommit)
+			}
+			cond, found := getGitPollingCondition(repo)
+			if found {
+				t.Errorf("not expecting Condition %s to be found. Got [%s]", gitPollingCondition, cond)
+			}
+		},
+	).Times(1)
+
+	fetcher := gitmocks.NewMockGitFetcher(mockCtrl)
+	r := PollerReconciler{
+		Client:     mockClient,
+		Scheme:     scheme,
+		GitFetcher: fetcher,
+		Clock:      RealClock{},
+	}
+
+	ctx := context.TODO()
+
+	// second call is the one calling LatestCommit
+	_, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: namespacedName})
+	if err != nil {
+		t.Errorf("unexpected error %v", err)
+	}
+}
+
+func TestReconcile_LatestCommitShouldBeCalled(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	scheme := runtime.NewScheme()
+	utilruntime.Must(batchv1.AddToScheme(scheme))
+	gitRepo := fleetv1.GitRepo{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "gitrepo",
+			Namespace: "default",
+		},
+	}
+	namespacedName := types.NamespacedName{Name: gitRepo.Name, Namespace: gitRepo.Namespace}
+	mockClient := mocks.NewMockClient(mockCtrl)
+	statusClient := mocks.NewMockSubResourceWriter(mockCtrl)
+	mockClient.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(nil)
+	fetcher := gitmocks.NewMockGitFetcher(mockCtrl)
+	commit := "1883fd54bc5dfd225acf02aecbb6cb8020458e33"
+	fetcher.EXPECT().LatestCommit(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(commit, nil)
+	mockClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).DoAndReturn(
+		func(ctx context.Context, req types.NamespacedName, gitrepo *fleetv1.GitRepo, opts ...interface{}) error {
+			gitrepo.Name = gitRepo.Name
+			gitrepo.Namespace = gitRepo.Namespace
+			gitrepo.Spec.Repo = "repo"
+			controllerutil.AddFinalizer(gitrepo, finalize.GitRepoFinalizer)
+
+			// set last polling time to now less 15 seconds (which is the default)
+			// that should trigger the polling job now
+			now := time.Now()
+			gitrepo.Status.LastPollingTime.Time = now.Add(time.Duration(-15) * time.Second)
+			// commit is something different to what we expect after this reconcile
+			gitrepo.Status.Commit = "dd45c7ad68e10307765104fea4a1f5997643020f"
+			return nil
+		},
+	)
+	mockClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(nil)
+	mockClient.EXPECT().Status().Return(statusClient).Times(1)
+	statusClient.EXPECT().Patch(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Do(
+		func(ctx context.Context, repo *fleetv1.GitRepo, patch client.Patch, opts ...interface{}) {
+			cond, found := getGitPollingCondition(repo)
+			if !found {
+				t.Errorf("expecting Condition %s to be found", gitPollingCondition)
+			}
+			if cond.Message != "" {
+				t.Errorf("expecting condition message empty, got [%s]", cond.Message)
+			}
+			if cond.Type != gitPollingCondition {
+				t.Errorf("expecting condition type [%s], got [%s]", gitPollingCondition, cond.Type)
+			}
+			if cond.Status != "True" {
+				t.Errorf("expecting condition Status [True], got [%s]", cond.Type)
+			}
+			if repo.Status.PollerCommit != commit {
+				t.Errorf("expecting commit %s, got %s", commit, repo.Status.PollerCommit)
+			}
+		},
+	).Times(1)
+
+	recorderMock := mocks.NewMockEventRecorder(mockCtrl)
+	recorderMock.EXPECT().Event(
+		&gitRepoMatcher{gitRepo},
+		fleetevent.Normal,
+		"GotNewCommit",
+		"1883fd54bc5dfd225acf02aecbb6cb8020458e33",
+	)
+
+	r := PollerReconciler{
+		Client:     mockClient,
+		Scheme:     scheme,
+		GitFetcher: fetcher,
+		Clock:      RealClock{},
+		Recorder:   recorderMock,
+	}
+
+	ctx := context.TODO()
+
+	// second call is the one calling LatestCommit
+	_, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: namespacedName})
+	if err != nil {
+		t.Errorf("unexpected error %v", err)
+	}
+}
+
+func TestReconcile_GenerationChanged(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	scheme := runtime.NewScheme()
+	utilruntime.Must(batchv1.AddToScheme(scheme))
+	gitRepo := fleetv1.GitRepo{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "gitrepo",
+			Namespace: "default",
+		},
+	}
+	namespacedName := types.NamespacedName{Name: gitRepo.Name, Namespace: gitRepo.Namespace}
+	mockClient := mocks.NewMockClient(mockCtrl)
+	statusClient := mocks.NewMockSubResourceWriter(mockCtrl)
+	mockClient.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(nil)
+	mockClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).DoAndReturn(
+		func(ctx context.Context, req types.NamespacedName, gitrepo *fleetv1.GitRepo, opts ...interface{}) error {
+			gitrepo.Name = gitRepo.Name
+			gitrepo.Namespace = gitRepo.Namespace
+			gitrepo.Spec.Repo = "repo"
+			controllerutil.AddFinalizer(gitrepo, finalize.GitRepoFinalizer)
+			gitrepo.Status.LastPollingTime.Time = time.Now()
+			gitrepo.Generation = 10
+			gitrepo.Status.PollerGeneration = 9
+			return nil
+		},
+	)
+	mockClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(nil)
+	mockClient.EXPECT().Status().Return(statusClient).Times(1)
+	statusClient.EXPECT().Patch(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Do(
+		func(ctx context.Context, repo *fleetv1.GitRepo, patch client.Patch, opts ...interface{}) {
+			if repo.Status.PollerCommit != "" {
+				t.Errorf("expecting gitrepo empty commit, got [%s]", repo.Status.PollerCommit)
+			}
+			cond, found := getGitPollingCondition(repo)
+			if found {
+				t.Errorf("not expecting Condition %s to be found. Got [%s]", gitPollingCondition, cond)
+			}
+			if repo.Status.PollerGeneration != repo.Generation {
+				t.Errorf("expecting pollerGeneration to be %d. Got [%d]", repo.Generation, repo.Status.PollerGeneration)
+			}
+		},
+	).Times(1)
+
+	fetcher := gitmocks.NewMockGitFetcher(mockCtrl)
+	r := PollerReconciler{
+		Client:     mockClient,
+		Scheme:     scheme,
+		GitFetcher: fetcher,
+		Clock:      RealClock{},
+	}
+
+	ctx := context.TODO()
+
+	// second call is the one calling LatestCommit
+	result, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: namespacedName})
+	if err != nil {
+		t.Errorf("unexpected error %v", err)
+	}
+
+	if result.RequeueAfter != time.Millisecond*5 {
+		t.Errorf("unexpected requeue after value %s", result.RequeueAfter)
+	}
+}
+
+func TestCheckforPollingTask(t *testing.T) {
+	tests := map[string]struct {
+		gitrepo        *fleetv1.GitRepo
+		timeNow        time.Time
+		expectedResult bool
+	}{
+		"LastPollingTime is not set": {
+			gitrepo:        &fleetv1.GitRepo{},
+			timeNow:        time.Now(), // time here is irrelevant
+			expectedResult: true,
+		},
+		"LastPollingTime is set but should still not trigger (1s away)": {
+			gitrepo: &fleetv1.GitRepo{
+				Status: fleetv1.GitRepoStatus{
+					LastPollingTime: metav1.Time{Time: time.Date(2024, time.July, 16, 15, 59, 59, 0, time.UTC)},
+				},
+				Spec: fleetv1.GitRepoSpec{
+					PollingInterval: &metav1.Duration{Duration: 10 * time.Second},
+				},
+			},
+			timeNow:        time.Date(2024, time.July, 16, 16, 0, 0, 0, time.UTC),
+			expectedResult: false,
+		},
+		"LastPollingTime is set and should trigger (10s away)": {
+			gitrepo: &fleetv1.GitRepo{
+				Status: fleetv1.GitRepoStatus{
+					LastPollingTime: metav1.Time{Time: time.Date(2024, time.July, 16, 15, 59, 50, 0, time.UTC)},
+				},
+				Spec: fleetv1.GitRepoSpec{
+					PollingInterval: &metav1.Duration{Duration: 10 * time.Second},
+				},
+			},
+			timeNow:        time.Date(2024, time.July, 16, 16, 0, 0, 0, time.UTC),
+			expectedResult: true,
+		},
+		"LastPollingTime is set but should still not trigger (1s away with default value)": {
+			gitrepo: &fleetv1.GitRepo{
+				Status: fleetv1.GitRepoStatus{
+					LastPollingTime: metav1.Time{Time: time.Date(2024, time.July, 16, 15, 59, 59, 0, time.UTC)},
+				},
+			},
+			timeNow:        time.Date(2024, time.July, 16, 16, 0, 0, 0, time.UTC),
+			expectedResult: false,
+		},
+		"LastPollingTime is set and should trigger (15s away with default value)": {
+			gitrepo: &fleetv1.GitRepo{
+				Status: fleetv1.GitRepoStatus{
+					LastPollingTime: metav1.Time{Time: time.Date(2024, time.July, 16, 15, 59, 45, 0, time.UTC)},
+				},
+			},
+			timeNow:        time.Date(2024, time.July, 16, 16, 0, 0, 0, time.UTC),
+			expectedResult: true,
+		},
+	}
+
+	fillTestGitRepo := func(gitrepo *fleetv1.GitRepo, testGitRepo *fleetv1.GitRepo) {
+		gitrepo.Name = "gitrepo"
+		gitrepo.Namespace = "ns"
+		gitrepo.Spec.Repo = "repo"
+		controllerutil.AddFinalizer(gitrepo, finalize.GitRepoFinalizer)
+		gitrepo.Status.LastPollingTime = testGitRepo.Status.LastPollingTime
+		gitrepo.Spec.PollingInterval = testGitRepo.Spec.PollingInterval
+	}
+
+	getTestGitRepo := func(testGitRepo *fleetv1.GitRepo) fleetv1.GitRepo {
+		gitrepo := &fleetv1.GitRepo{}
+		fillTestGitRepo(gitrepo, testGitRepo)
+		return *gitrepo
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			mockCtrl := gomock.NewController(t)
+			defer mockCtrl.Finish()
+			mockClient := mocks.NewMockClient(mockCtrl)
+			mockClient.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(nil)
+			mockClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).DoAndReturn(
+				func(ctx context.Context, req types.NamespacedName, gitrepo *fleetv1.GitRepo, opts ...interface{}) error {
+					fillTestGitRepo(gitrepo, test.gitrepo)
+					return nil
+				},
+			)
+			commit := "1883fd54bc5dfd225acf02aecbb6cb8020458e33"
+
+			statusClient := mocks.NewMockSubResourceWriter(mockCtrl)
+			mockClient.EXPECT().Status().Return(statusClient).Times(1)
+			statusClient.EXPECT().Patch(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Do(
+				func(ctx context.Context, repo *fleetv1.GitRepo, patch client.Patch, opts ...interface{}) {
+					if test.expectedResult {
+						if repo.Status.PollerCommit != commit {
+							t.Errorf("expecting commit %s, got %s", commit, repo.Status.PollerCommit)
+						}
+						// also LastPollingTime should be set to now
+						if repo.Status.LastPollingTime.Time != test.timeNow {
+							t.Errorf("expecting LastPollingTime to be: %s, got: %s", test.timeNow, repo.Status.LastPollingTime.Time)
+						}
+					} else {
+						// if polling was not executed lastPollingTime should be the same value
+						if repo.Status.LastPollingTime.Time != test.gitrepo.Status.LastPollingTime.Time {
+							t.Errorf("expecting LastPollingTime to be: %s, got: %s", test.gitrepo.Status.LastPollingTime.Time, repo.Status.LastPollingTime.Time)
+						}
+					}
+				},
+			).Times(1)
+			recorderMock := mocks.NewMockEventRecorder(mockCtrl)
+			fetcher := gitmocks.NewMockGitFetcher(mockCtrl)
+
+			if test.expectedResult {
+				fetcher.EXPECT().LatestCommit(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(commit, nil)
+				recorderMock.EXPECT().Event(
+					&gitRepoMatcher{getTestGitRepo(test.gitrepo)},
+					fleetevent.Normal,
+					"GotNewCommit",
+					commit,
+				)
+			}
+			r := PollerReconciler{
+				Client:     mockClient,
+				Clock:      ClockMock{t: test.timeNow},
+				GitFetcher: fetcher,
+				Recorder:   recorderMock,
+			}
+			// res, err := r.repoPolled(context.TODO(), test.gitrepo)
+			namespacedName := types.NamespacedName{}
+			_, err := r.Reconcile(context.TODO(), ctrl.Request{NamespacedName: namespacedName})
+			if err != nil {
+				t.Errorf("not expecting to get an error, got [%v]", err)
+			}
+		})
+	}
+}

--- a/pkg/apis/fleet.cattle.io/v1alpha1/gitrepo_types.go
+++ b/pkg/apis/fleet.cattle.io/v1alpha1/gitrepo_types.go
@@ -178,6 +178,10 @@ type GitRepoStatus struct {
 	LastSyncedImageScanTime metav1.Time `json:"lastSyncedImageScanTime,omitempty"`
 	// LastPollingTime is the last time the polling check was triggered
 	LastPollingTime metav1.Time `json:"lastPollingTriggered,omitempty"`
+	// PollerCommit is the latest Git commit gathered by the GitRepo poller
+	PollerCommit string `json:"pollerCommit,omitempty"`
+	// PollerGeneration is the latest generation value processed by the GitRepo poller
+	PollerGeneration int64 `json:"pollerGeneration,omitempty"`
 }
 
 type GitRepoDisplay struct {


### PR DESCRIPTION
Adds a new poller controller to avoid sharing events between the main `GitRepo` controller and the polling mechanism. New poller controller only does polling and resets its state upon generation change.

When a new commit is found by the poller controller it sets the `PollerCommit` field in the `GitRepo`'s status. The main controller watches for changes in that field and it is called to reflect the new commit in the `GitRepo`'s `Status.Commit` field.

A new `PollerGeneration` field is added so it does not interfere with the already existing `ObservedGeneration` used in the main `GitRepo` controller

### Changes in e2e tests
It now uses `BeforeAll` and `AfterAll` for OCI storage `e2e` tests and test are ordered. This is to avoid having to change the experimental env variable for almost each test. That was taking too much time and was being a source of errors. 

### Changes in integration tests
There is one integration test that was removed because it was passing because the poller inside the main controller was triggering an extra reconcile call. 
The test makes no sense as `gitjobs` are owned by the controller and we already look for the `succeded/failed` lifecycle


Refers to https://github.com/rancher/fleet/issues/3138
