### PR TITLE
Fall back to Rancher-configured CA bundles

### DIFF
--- a/.github/scripts/create-secrets.sh
+++ b/.github/scripts/create-secrets.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+dir=${1-'FleetCI-RootCA'}
+
+# Create secret with certs, needed by test git server
+kubectl -n fleet-local create secret generic git-server-certs \
+    --from-file=./"$dir"/helm.crt \
+    --from-file=./"$dir"/helm.key
+
+# Create cattle-system namespace
+kubectl create ns cattle-system
+
+# Create Rancher CA bundle secret
+kubectl -n cattle-system create secret generic tls-ca-additional --from-file=ca-additional.pem=./"$dir"/root.crt

--- a/.github/scripts/create-zot-certs.sh
+++ b/.github/scripts/create-zot-certs.sh
@@ -45,6 +45,7 @@ if [ $? -eq 1 ]; then
     [alt_names]
     DNS.1 = zot-service.$FLEET_E2E_NS.svc.cluster.local
     DNS.2 = chartmuseum-service.$FLEET_E2E_NS.svc.cluster.local
+    DNS.3 = git-service.$FLEET_E2E_NS.svc.cluster.local
 EOF
 
     # sign Zot cert with CA root key

--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -107,6 +107,7 @@ jobs:
           FLEET_E2E_NS: fleet-local
         run: |
           ./.github/scripts/create-zot-certs.sh "FleetCI-RootCA"
+          ./.github/scripts/create-secrets.sh 'FleetCI-RootCA'
       -
         name: E2E Infra Tests
         if: ${{ matrix.test_type.name == 'infra-setup' }}

--- a/.github/workflows/e2e-nightly-ci.yml
+++ b/.github/workflows/e2e-nightly-ci.yml
@@ -82,6 +82,7 @@ jobs:
         run: |
           # Generate cert and key for TLS
           ./.github/scripts/create-zot-certs.sh "FleetCI-RootCA"
+          ./.github/scripts/create-secrets.sh 'FleetCI-RootCA'
       -
         name: E2E Tests
         if: ${{ matrix.test_type == 'e2e-nosecrets' }}

--- a/dev/create-secrets
+++ b/dev/create-secrets
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+./.github/scripts/create-secrets.sh "$@"

--- a/dev/setup-multi-cluster
+++ b/dev/setup-multi-cluster
@@ -26,4 +26,5 @@ fi
 # needed for gitrepo tests
 ./dev/import-images-tests-k3d
 ./dev/create-zot-certs 'FleetCI-RootCA' # for OCI tests
+./dev/create-secrets 'FleetCI-RootCA'
 ./e2e/testenv/infra/infra setup

--- a/dev/setup-single-cluster
+++ b/dev/setup-single-cluster
@@ -39,4 +39,5 @@ fi
 # needed for gitrepo tests
 ./dev/import-images-tests-k3d
 ./dev/create-zot-certs 'FleetCI-RootCA' # for OCI tests
+./dev/create-secrets 'FleetCI-RootCA'
 ./e2e/testenv/infra/infra setup

--- a/e2e/assets/gitrepo/nginx_deployment.yaml
+++ b/e2e/assets/gitrepo/nginx_deployment.yaml
@@ -14,9 +14,23 @@ spec:
       labels:
         app: git-server
     spec:
+      volumes:
+        - name: git-certs
+          secret:
+            secretName: git-server-certs
+            items:
+              - key: helm.crt
+                path: helm.crt
+              - key: helm.key
+                path: helm.key
       containers:
         - name: git-server
           image: nginx-git:test
           imagePullPolicy: IfNotPresent
           ports:
+          - containerPort: 4343
           - containerPort: 8080
+          volumeMounts:
+            - name: git-certs
+              mountPath: "/etc/ssl/certs"
+              readOnly: true

--- a/e2e/assets/gitrepo/nginx_git.conf
+++ b/e2e/assets/gitrepo/nginx_git.conf
@@ -1,8 +1,12 @@
 events {}
 http {
     server {
+        error_log stderr info;
         listen       80;
+        listen       443 ssl;
         server_name localhost;
+        ssl_certificate /etc/ssl/certs/helm.crt;
+        ssl_certificate_key /etc/ssl/certs/helm.key;
 
         # This is where the repositories live on the server
         root /srv/git;

--- a/e2e/assets/gitrepo/nginx_service.yaml
+++ b/e2e/assets/gitrepo/nginx_service.yaml
@@ -6,7 +6,12 @@ spec:
   selector:
     app: git-server
   ports:
-    - protocol: TCP
+    - name: http
+      protocol: TCP
       port: 8080
       targetPort: 80
+    - name: https
+      protocol: TCP
+      port: 4343
+      targetPort: 443
   type: LoadBalancer

--- a/e2e/testenv/githelper/git.go
+++ b/e2e/testenv/githelper/git.go
@@ -210,6 +210,9 @@ func (g *Git) Create(repodir string, from string, subdir string) (*git.Repositor
 		Progress: os.Stdout,
 		// Force push, so our initial state is deterministic
 		RefSpecs: []config.RefSpec{config.RefSpec("+refs/heads/master:refs/heads/" + g.Branch)},
+		// This prevents IP SANs from being needed on the git server cert; the TLS verification we are most
+		// interested in is the one happening in Fleet's controllers and jobs.
+		InsecureSkipTLS: true,
 	}
 	k, err := g.Auth.getKeys()
 	if err != nil {
@@ -246,6 +249,9 @@ func (g *Git) Update(repo *git.Repository) (string, error) {
 	po := git.PushOptions{
 		Progress: os.Stdout,
 		RefSpecs: []config.RefSpec{config.RefSpec("refs/heads/master:refs/heads/" + g.Branch)},
+		// This prevents IP SANs from being needed on the git server cert; the TLS verification we are most
+		// interested in is the one happening in Fleet's controllers and jobs.
+		InsecureSkipTLS: true,
 	}
 	k, err := g.Auth.getKeys()
 	if err != nil {

--- a/integrationtests/gitjob/controller/controller_test.go
+++ b/integrationtests/gitjob/controller/controller_test.go
@@ -102,15 +102,15 @@ var _ = Describe("GitJob controller", func() {
 
 				var sa corev1.ServiceAccount
 				g.Expect(k8sClient.Get(ctx, ns, &sa)).ToNot(HaveOccurred())
-				Expect(sa.ObjectMeta).To(beOwnedBy(gitRepoOwnerRef))
+				g.Expect(sa.ObjectMeta).To(beOwnedBy(gitRepoOwnerRef))
 
 				var ro rbacv1.Role
 				g.Expect(k8sClient.Get(ctx, ns, &ro)).ToNot(HaveOccurred())
-				Expect(ro.ObjectMeta).To(beOwnedBy(gitRepoOwnerRef))
+				g.Expect(ro.ObjectMeta).To(beOwnedBy(gitRepoOwnerRef))
 
 				var rb rbacv1.RoleBinding
 				g.Expect(k8sClient.Get(ctx, ns, &rb)).ToNot(HaveOccurred())
-				Expect(rb.ObjectMeta).To(beOwnedBy(gitRepoOwnerRef))
+				g.Expect(rb.ObjectMeta).To(beOwnedBy(gitRepoOwnerRef))
 			}).Should(Succeed())
 		})
 
@@ -257,7 +257,7 @@ var _ = Describe("GitJob controller", func() {
 					data, ok := secret.Data["additional-ca.crt"]
 					g.Expect(ok).To(BeTrue())
 					g.Expect(data).To(Equal([]byte("foo")))
-					Expect(secret.ObjectMeta).To(beOwnedBy(gitRepoOwnerRef))
+					g.Expect(secret.ObjectMeta).To(beOwnedBy(gitRepoOwnerRef))
 				}, time.Second*5, time.Second*1).Should(Succeed())
 
 				By("creating a CA bundle secret for the Helm client")
@@ -271,7 +271,7 @@ var _ = Describe("GitJob controller", func() {
 					data, ok := secret.Data["cacerts"]
 					g.Expect(ok).To(BeTrue())
 					g.Expect(data).To(Equal([]byte("foo")))
-					Expect(secret.ObjectMeta).To(beOwnedBy(gitRepoOwnerRef))
+					g.Expect(secret.ObjectMeta).To(beOwnedBy(gitRepoOwnerRef))
 				}, time.Second*5, time.Second*1).Should(Succeed())
 
 				By("feeding the mounted CA bundle to the fleet apply command")
@@ -349,7 +349,7 @@ var _ = Describe("GitJob controller", func() {
 				Eventually(func(g Gomega) {
 					err := k8sClient.Get(ctx, ns, &secret)
 					g.Expect(err).ToNot(HaveOccurred())
-					Expect(secret.ObjectMeta).To(beOwnedBy(gitRepoOwnerRef))
+					g.Expect(secret.ObjectMeta).To(beOwnedBy(gitRepoOwnerRef))
 
 					data, ok := secret.Data["additional-ca.crt"]
 					g.Expect(ok).To(BeTrue())
@@ -392,7 +392,7 @@ var _ = Describe("GitJob controller", func() {
 				Eventually(func(g Gomega) {
 					err := k8sClient.Get(ctx, ns, &secret)
 					g.Expect(err).ToNot(HaveOccurred())
-					Expect(secret.ObjectMeta).To(beOwnedBy(gitRepoOwnerRef))
+					g.Expect(secret.ObjectMeta).To(beOwnedBy(gitRepoOwnerRef))
 
 					data, ok := secret.Data["additional-ca.crt"]
 					g.Expect(ok).To(BeTrue())

--- a/integrationtests/gitjob/controller/controller_test.go
+++ b/integrationtests/gitjob/controller/controller_test.go
@@ -260,6 +260,43 @@ var _ = Describe("GitJob controller", func() {
 					g.Expect(secret.ObjectMeta).To(beOwnedBy(gitRepoOwnerRef))
 				}, time.Second*5, time.Second*1).Should(Succeed())
 
+				By("feeding the mounted CA bundle to the fleet apply command for the git cloner")
+				Eventually(func(g Gomega) {
+					err := k8sClient.Get(ctx, types.NamespacedName{Name: jobName, Namespace: gitRepoNamespace}, &job)
+					// Ignore not-found errors in case the job has not yet been created
+					g.Expect(client.IgnoreNotFound(err)).ToNot(HaveOccurred())
+				})
+
+				volumes := job.Spec.Template.Spec.Volumes
+				Expect(volumes).ToNot(BeEmpty())
+
+				found := false
+				for _, v := range volumes {
+					if v.Name == "additional-ca" {
+						found = true
+						break
+					}
+				}
+				Expect(found).To(BeTrue())
+
+				initContainers := job.Spec.Template.Spec.InitContainers
+				Expect(initContainers).ToNot(BeEmpty())
+				Expect(strings.Join(initContainers[0].Args, " ")).
+					To(ContainSubstring("--ca-bundle-file /gitjob/cabundle/additional-ca.crt"))
+
+				volumeMounts := initContainers[0].VolumeMounts
+				Expect(volumeMounts).ToNot(BeEmpty())
+
+				found = false
+				for _, vm := range volumeMounts {
+					if vm.Name == "additional-ca" {
+						found = true
+						Expect(vm.MountPath).To(Equal("/gitjob/cabundle"))
+						break
+					}
+				}
+				Expect(found).To(BeTrue())
+
 				By("creating a CA bundle secret for the Helm client")
 				secretName = fmt.Sprintf("%s-rancher-cabundle", gitRepoName)
 				ns = types.NamespacedName{Name: secretName, Namespace: gitRepo.Namespace}
@@ -274,31 +311,19 @@ var _ = Describe("GitJob controller", func() {
 					g.Expect(secret.ObjectMeta).To(beOwnedBy(gitRepoOwnerRef))
 				}, time.Second*5, time.Second*1).Should(Succeed())
 
-				By("feeding the mounted CA bundle to the fleet apply command")
-				Eventually(func(g Gomega) {
-					err := k8sClient.Get(ctx, types.NamespacedName{Name: jobName, Namespace: gitRepoNamespace}, &job)
-					// Ignore not-found errors in case the job has not yet been created
-					g.Expect(client.IgnoreNotFound(err)).ToNot(HaveOccurred())
-				})
-
-				volumes := job.Spec.Template.Spec.Volumes
-				Expect(volumes).ToNot(BeEmpty())
-
-				found := false
+				By("feeding the mounted CA bundle to the fleet apply command for Helm")
+				found = false
 				for _, v := range volumes {
 					if v.Name == "helm-secret-cert" {
 						found = true
 						break
 					}
 				}
+
 				Expect(found).To(BeTrue())
-
 				containers := job.Spec.Template.Spec.Containers
-				Expect(containers).ToNot(BeEmpty())
+				volumeMounts = containers[0].VolumeMounts
 				Expect(strings.Join(containers[0].Args, " ")).To(ContainSubstring("--cacerts-file /etc/ssl/certs/cacerts"))
-
-				volumeMounts := containers[0].VolumeMounts
-				Expect(volumeMounts).ToNot(BeEmpty())
 
 				found = false
 				for _, vm := range volumeMounts {

--- a/integrationtests/gitjob/controller/controller_test.go
+++ b/integrationtests/gitjob/controller/controller_test.go
@@ -210,7 +210,7 @@ var _ = Describe("GitJob controller", func() {
 				Consistently(func(g Gomega) {
 					err := k8sClient.Get(ctx, ns, &secret)
 
-					g.Expect(err).ToNot(BeNil())
+					g.Expect(err).To(HaveOccurred())
 					g.Expect(errors.IsNotFound(err)).To(BeTrue(), err)
 				}, time.Second*5, time.Second*1).Should(Succeed())
 			})
@@ -993,7 +993,7 @@ var _ = Describe("GitJob controller", func() {
 				Consistently(func(g Gomega) {
 					err := k8sClient.Get(ctx, ns, &secret)
 
-					g.Expect(err).ToNot(BeNil())
+					g.Expect(err).To(HaveOccurred())
 					g.Expect(errors.IsNotFound(err)).To(BeTrue(), err)
 				}, time.Second*5, time.Second*1).Should(Succeed())
 			})

--- a/integrationtests/gitjob/controller/suite_test.go
+++ b/integrationtests/gitjob/controller/suite_test.go
@@ -151,7 +151,7 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 
 	DeferCleanup(func() {
-		k8sClient.Delete(ctx, &corev1.Namespace{
+		_ = k8sClient.Delete(ctx, &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "cattle-system",
 			},

--- a/integrationtests/gitjob/controller/suite_test.go
+++ b/integrationtests/gitjob/controller/suite_test.go
@@ -23,6 +23,7 @@ import (
 	v1alpha1 "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
 	"github.com/rancher/fleet/pkg/git/mocks"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -141,6 +142,21 @@ var _ = BeforeSuite(func() {
 		err = mgr.Start(ctx)
 		Expect(err).ToNot(HaveOccurred(), "failed to run manager")
 	}()
+
+	err = k8sClient.Create(ctx, &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cattle-system",
+		},
+	})
+	Expect(err).ToNot(HaveOccurred())
+
+	DeferCleanup(func() {
+		k8sClient.Delete(ctx, &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "cattle-system",
+			},
+		})
+	})
 })
 
 var _ = AfterSuite(func() {

--- a/integrationtests/gitjob/git/git_test.go
+++ b/integrationtests/gitjob/git/git_test.go
@@ -117,7 +117,9 @@ func TestLatestCommit_NoAuth(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			f := git.Fetch{}
 			client := mocks.NewMockClient(ctlr)
-			client.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).Return(kerrors.NewNotFound(schema.GroupResource{}, "notfound"))
+			// May be called multiple times, including calls to get Rancher CA bundle secrets
+			client.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).
+				Return(kerrors.NewNotFound(schema.GroupResource{}, "notfound")).AnyTimes()
 			latestCommit, err := f.LatestCommit(ctx, test.gitrepo, client)
 			if test.expectedErr == nil {
 				require.NoError(t, err)
@@ -343,7 +345,9 @@ func TestLatestCommit_Revision(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			f := git.Fetch{}
 			client := mocks.NewMockClient(ctlr)
-			client.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).Return(kerrors.NewNotFound(schema.GroupResource{}, "notfound"))
+			// May be called multiple times, including calls to get Rancher CA bundle secrets
+			client.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).
+				Return(kerrors.NewNotFound(schema.GroupResource{}, "notfound")).AnyTimes()
 			latestCommit, err := f.LatestCommit(ctx, test.gitrepo, client)
 			if test.expectedCommit != latestCommit {
 				t.Errorf("latestCommit doesn't match. got %s, expected %s", latestCommit, test.expectedCommit)

--- a/internal/cmd/controller/gitops/reconciler/gitjob_test.go
+++ b/internal/cmd/controller/gitops/reconciler/gitjob_test.go
@@ -675,12 +675,14 @@ func TestNewJob(t *testing.T) { // nolint:funlen
 	defer mockCtrl.Finish()
 	scheme := runtime.NewScheme()
 	utilruntime.Must(batchv1.AddToScheme(scheme))
+	utilruntime.Must(fleetv1.AddToScheme(scheme))
 	ctx := context.TODO()
 
 	tests := map[string]struct {
 		gitrepo                *fleetv1.GitRepo
 		client                 client.Client
 		expectedInitContainers []corev1.Container
+		expectedContainers     []corev1.Container
 		expectedVolumes        []corev1.Volume
 		expectedErr            error
 	}{
@@ -1020,6 +1022,121 @@ func TestNewJob(t *testing.T) { // nolint:funlen
 				Type: corev1.SecretTypeSSHAuth,
 			}),
 		},
+		"no custom CA but Rancher CA secret exists": {
+			gitrepo: &fleetv1.GitRepo{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-rancher-custom-ca",
+					Namespace: "test-ns",
+				},
+				Spec: fleetv1.GitRepoSpec{
+					Repo: "repo",
+				},
+			},
+			expectedInitContainers: []corev1.Container{
+				{
+					Command: []string{
+						"fleet",
+					},
+					Args: []string{
+						"gitcloner",
+						"repo",
+						"/workspace",
+						"--branch",
+						"master",
+						"--ca-bundle-file",
+						"/gitjob/cabundle/" + bundleCAFile,
+					},
+					Image: "test",
+					Name:  "gitcloner-initializer",
+					VolumeMounts: []corev1.VolumeMount{
+						{
+							Name:      gitClonerVolumeName,
+							MountPath: "/workspace",
+						},
+						{
+							Name:      emptyDirVolumeName,
+							MountPath: "/tmp",
+						},
+						{
+							Name:      bundleCAVolumeName,
+							MountPath: "/gitjob/cabundle",
+						},
+					},
+					SecurityContext: securityContext,
+				},
+			},
+			expectedVolumes: []corev1.Volume{
+				{
+					Name: gitClonerVolumeName,
+					VolumeSource: corev1.VolumeSource{
+						EmptyDir: &corev1.EmptyDirVolumeSource{},
+					},
+				},
+				{
+					Name: emptyDirVolumeName,
+					VolumeSource: corev1.VolumeSource{
+						EmptyDir: &corev1.EmptyDirVolumeSource{},
+					},
+				},
+				{
+					Name: bundleCAVolumeName,
+					VolumeSource: corev1.VolumeSource{
+						Secret: &corev1.SecretVolumeSource{
+							SecretName: "test-rancher-custom-ca-cabundle",
+						},
+					},
+				},
+				{
+					Name: "rancher-helm-secret-cert",
+					VolumeSource: corev1.VolumeSource{
+						Secret: &corev1.SecretVolumeSource{
+							SecretName: "test-rancher-custom-ca-rancher-cabundle",
+							Items: []corev1.KeyToPath{
+								{
+									Key:  "cacerts",
+									Path: "cacert.crt",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedContainers: []corev1.Container{
+				{
+					Args: []string{
+						"--cacerts-file",
+						"/etc/rancher/certs/cacerts",
+					},
+					Name: "fleet",
+					VolumeMounts: []corev1.VolumeMount{
+						{
+							Name:      "rancher-helm-secret-cert",
+							MountPath: "/etc/ssl/certs",
+						},
+					},
+				},
+			},
+			client: fake.NewFakeClient(
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "tls-ca-additional",
+						Namespace: "cattle-system",
+					},
+					Data: map[string][]byte{
+						"ca-additional.pem": []byte("foo"),
+					},
+				},
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-rancher-custom-ca-cabundle",
+						Namespace: "test-ns",
+					},
+					Data: map[string][]byte{
+						"additional-ca.crt": []byte("foo"),
+					},
+				},
+			),
+		},
 		"skip tls": {
 			gitrepo: &fleetv1.GitRepo{
 				Spec: fleetv1.GitRepoSpec{
@@ -1085,8 +1202,50 @@ func TestNewJob(t *testing.T) { // nolint:funlen
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
+
 			if !cmp.Equal(job.Spec.Template.Spec.InitContainers, test.expectedInitContainers) {
-				t.Fatalf("expected initContainers: %v, got: %v", test.expectedInitContainers, job.Spec.Template.Spec.InitContainers)
+				t.Fatalf("expected initContainers:\n\t%v,\n got:\n\t%v", test.expectedInitContainers, job.Spec.Template.Spec.InitContainers)
+			}
+
+			for _, eCont := range test.expectedContainers {
+				found := false
+				for _, cont := range job.Spec.Template.Spec.Containers {
+					if cont.Name == eCont.Name {
+						found = true
+
+						for _, eArg := range eCont.Args {
+							argFound := false
+							for _, arg := range cont.Args {
+								if arg == eArg {
+									argFound = true
+									break
+								}
+							}
+							if !argFound {
+								t.Fatalf("expected arg %q not found in container %s with args %#v", eArg, eCont.Name, cont.Args)
+							}
+						}
+
+						for _, eVM := range eCont.VolumeMounts {
+							vmFound := false
+							for _, vm := range cont.VolumeMounts {
+								if vm.Name != eVM.Name {
+									continue
+								}
+								vmFound = true
+								if vm != eVM {
+									t.Fatalf("expected volume mount %v in container %s, got %v", eVM, eCont.Name, vm)
+								}
+							}
+							if !vmFound {
+								t.Fatalf("expected volume mount %v not found in container %s", eVM, eCont.Name)
+							}
+						}
+					}
+				}
+				if !found {
+					t.Fatalf("expected container %s not found", eCont.Name)
+				}
 			}
 
 			for _, evol := range test.expectedVolumes {
@@ -1098,7 +1257,7 @@ func TestNewJob(t *testing.T) { // nolint:funlen
 					}
 				}
 				if !found {
-					t.Fatalf("volume %v not found in %v", evol, job.Spec.Template.Spec.Volumes)
+					t.Fatalf("volume %v not found in \n\t%v", evol, job.Spec.Template.Spec.Volumes)
 				}
 			}
 		})

--- a/internal/cmd/controller/gitops/reconciler/gitjob_test.go
+++ b/internal/cmd/controller/gitops/reconciler/gitjob_test.go
@@ -945,6 +945,10 @@ func TestNewJob(t *testing.T) { // nolint:funlen
 		},
 		"custom CA": {
 			gitrepo: &fleetv1.GitRepo{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-custom-ca",
+					Namespace: "test-ns",
+				},
 				Spec: fleetv1.GitRepoSpec{
 					CABundle: []byte("ca"),
 					Repo:     "repo",
@@ -1000,11 +1004,21 @@ func TestNewJob(t *testing.T) { // nolint:funlen
 					Name: bundleCAVolumeName,
 					VolumeSource: corev1.VolumeSource{
 						Secret: &corev1.SecretVolumeSource{
-							SecretName: "-cabundle",
+							SecretName: "test-custom-ca-cabundle",
 						},
 					},
 				},
 			},
+			client: fake.NewFakeClient(&corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-custom-ca-cabundle",
+					Namespace: "test-ns",
+				},
+				Data: map[string][]byte{
+					"cacerts": []byte("foo"),
+				},
+				Type: corev1.SecretTypeSSHAuth,
+			}),
 		},
 		"skip tls": {
 			gitrepo: &fleetv1.GitRepo{
@@ -1055,6 +1069,7 @@ func TestNewJob(t *testing.T) { // nolint:funlen
 					},
 				},
 			},
+			client: fake.NewFakeClient(),
 		},
 	}
 

--- a/pkg/cert/cabundle.go
+++ b/pkg/cert/cabundle.go
@@ -1,0 +1,44 @@
+package cert
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const rancherNS = "cattle-system"
+
+func GetRancherCABundle(ctx context.Context, c client.Client) ([]byte, error) {
+	secret := &corev1.Secret{}
+
+	err := c.Get(ctx, types.NamespacedName{Namespace: rancherNS, Name: "tls-ca"}, secret)
+	if client.IgnoreNotFound(err) != nil {
+		return nil, err
+	}
+
+	caBundle, ok := secret.Data["cacerts.pem"] // TODO check that the path is right, with an actual Rancher install
+	if !errors.IsNotFound(err) && !ok {
+		return nil, fmt.Errorf("no field cacerts.pem found in secret tls-ca")
+	}
+
+	err = c.Get(ctx, types.NamespacedName{Namespace: rancherNS, Name: "tls-ca-additional"}, secret)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return caBundle, nil
+		}
+
+		return nil, err
+	}
+
+	field, ok := secret.Data["ca-additional.pem"] // TODO check that the path is right, with an actual Rancher install
+	if !ok {
+		return nil, fmt.Errorf("no field ca-additional.pem found in secret tls-ca-additional")
+	}
+	caBundle = append(caBundle, field...)
+
+	return caBundle, nil
+}

--- a/pkg/cert/cabundle_test.go
+++ b/pkg/cert/cabundle_test.go
@@ -1,0 +1,221 @@
+package cert_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"go.uber.org/mock/gomock"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/rancher/fleet/internal/mocks"
+	"github.com/rancher/fleet/pkg/cert"
+)
+
+func TestGetRancherCABundle(t *testing.T) {
+	notFoundErr := &k8serrors.StatusError{ErrStatus: metav1.Status{Reason: metav1.StatusReasonNotFound}}
+	testCases := []struct {
+		name           string
+		secretGets     func(c *mocks.MockClient)
+		expectedBundle []byte
+		expectedErr    error
+	}{
+		{
+			name: "no secrets found",
+			secretGets: func(c *mocks.MockClient) {
+				c.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+					func(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+						// nothing done: object stays nil
+						return notFoundErr
+					}).Times(2)
+			},
+			expectedBundle: nil,
+			expectedErr:    nil,
+		},
+		{
+			name: "tls-ca exists but tls-ca-additional does not",
+			secretGets: func(c *mocks.MockClient) {
+				c.EXPECT().Get(
+					gomock.Any(),
+					types.NamespacedName{Namespace: "cattle-system", Name: "tls-ca"},
+					gomock.Any(),
+				).DoAndReturn(
+					func(ctx context.Context, key client.ObjectKey, secret *corev1.Secret, opts ...client.GetOption) error {
+						secret.Data = map[string][]byte{"cacerts.pem": []byte("foo")}
+						return nil
+					})
+
+				c.EXPECT().Get(
+					gomock.Any(),
+					types.NamespacedName{Namespace: "cattle-system", Name: "tls-ca-additional"},
+					gomock.Any(),
+				).DoAndReturn(
+					func(ctx context.Context, key client.ObjectKey, secret *corev1.Secret, opts ...client.GetOption) error {
+						return notFoundErr
+					})
+			},
+			expectedBundle: []byte("foo"),
+			expectedErr:    nil,
+		},
+		{
+			name: "tls-ca does not exist but tls-ca-additional does",
+			secretGets: func(c *mocks.MockClient) {
+				c.EXPECT().Get(
+					gomock.Any(),
+					types.NamespacedName{Namespace: "cattle-system", Name: "tls-ca"},
+					gomock.Any(),
+				).DoAndReturn(
+					func(ctx context.Context, key client.ObjectKey, secret *corev1.Secret, opts ...client.GetOption) error {
+						return notFoundErr
+					})
+
+				c.EXPECT().Get(
+					gomock.Any(),
+					types.NamespacedName{Namespace: "cattle-system", Name: "tls-ca-additional"},
+					gomock.Any(),
+				).DoAndReturn(
+					func(ctx context.Context, key client.ObjectKey, secret *corev1.Secret, opts ...client.GetOption) error {
+						secret.Data = map[string][]byte{"ca-additional.pem": []byte("foo")}
+						return nil
+					})
+			},
+			expectedBundle: []byte("foo"),
+			expectedErr:    nil,
+		},
+		{
+			name: "tls-ca and tls-ca-additional both exist",
+			secretGets: func(c *mocks.MockClient) {
+				c.EXPECT().Get(
+					gomock.Any(),
+					types.NamespacedName{Namespace: "cattle-system", Name: "tls-ca"},
+					gomock.Any(),
+				).DoAndReturn(
+					func(ctx context.Context, key client.ObjectKey, secret *corev1.Secret, opts ...client.GetOption) error {
+						secret.Data = map[string][]byte{"cacerts.pem": []byte("foo")}
+						return nil
+					})
+
+				c.EXPECT().Get(
+					gomock.Any(),
+					types.NamespacedName{Namespace: "cattle-system", Name: "tls-ca-additional"},
+					gomock.Any(),
+				).DoAndReturn(
+					func(ctx context.Context, key client.ObjectKey, secret *corev1.Secret, opts ...client.GetOption) error {
+						secret.Data = map[string][]byte{"ca-additional.pem": []byte("bar")}
+						return nil
+					})
+			},
+			expectedBundle: []byte("foobar"),
+			expectedErr:    nil,
+		},
+		{
+			name: "tls-ca is malformed",
+			secretGets: func(c *mocks.MockClient) {
+				c.EXPECT().Get(
+					gomock.Any(),
+					types.NamespacedName{Namespace: "cattle-system", Name: "tls-ca"},
+					gomock.Any(),
+				).DoAndReturn(
+					func(ctx context.Context, key client.ObjectKey, secret *corev1.Secret, opts ...client.GetOption) error {
+						secret.Data = map[string][]byte{"certs.pem": []byte("foo")}
+						return nil
+					})
+			},
+			expectedBundle: nil,
+			expectedErr:    fmt.Errorf("no field cacerts.pem found in secret tls-ca"),
+		},
+		{
+			name: "tls-ca and tls-ca-additional both exist, but tls-ca-additional is malformed",
+			secretGets: func(c *mocks.MockClient) {
+				c.EXPECT().Get(
+					gomock.Any(),
+					types.NamespacedName{Namespace: "cattle-system", Name: "tls-ca"},
+					gomock.Any(),
+				).DoAndReturn(
+					func(ctx context.Context, key client.ObjectKey, secret *corev1.Secret, opts ...client.GetOption) error {
+						secret.Data = map[string][]byte{"cacerts.pem": []byte("foo")}
+						return nil
+					})
+
+				c.EXPECT().Get(
+					gomock.Any(),
+					types.NamespacedName{Namespace: "cattle-system", Name: "tls-ca-additional"},
+					gomock.Any(),
+				).DoAndReturn(
+					func(ctx context.Context, key client.ObjectKey, secret *corev1.Secret, opts ...client.GetOption) error {
+						secret.Data = map[string][]byte{"moar-ca.pem": []byte("bar")}
+						return nil
+					})
+			},
+			expectedBundle: nil,
+			expectedErr:    fmt.Errorf("no field ca-additional.pem found in secret tls-ca-additional"),
+		},
+		{
+			name: "client fails to get tls-ca secret",
+			secretGets: func(c *mocks.MockClient) {
+				c.EXPECT().Get(
+					gomock.Any(),
+					types.NamespacedName{Namespace: "cattle-system", Name: "tls-ca"},
+					gomock.Any(),
+				).DoAndReturn(
+					func(ctx context.Context, key client.ObjectKey, secret *corev1.Secret, opts ...client.GetOption) error {
+						return fmt.Errorf("something happened")
+					})
+			},
+			expectedBundle: nil,
+			expectedErr:    fmt.Errorf("something happened"),
+		},
+		{
+			name: "client fails to get tls-ca-additional secret",
+			secretGets: func(c *mocks.MockClient) {
+				c.EXPECT().Get(
+					gomock.Any(),
+					types.NamespacedName{Namespace: "cattle-system", Name: "tls-ca"},
+					gomock.Any(),
+				).DoAndReturn(
+					func(ctx context.Context, key client.ObjectKey, secret *corev1.Secret, opts ...client.GetOption) error {
+						secret.Data = map[string][]byte{"cacerts.pem": []byte("foo")}
+						return nil
+					})
+
+				c.EXPECT().Get(
+					gomock.Any(),
+					types.NamespacedName{Namespace: "cattle-system", Name: "tls-ca-additional"},
+					gomock.Any(),
+				).DoAndReturn(
+					func(ctx context.Context, key client.ObjectKey, secret *corev1.Secret, opts ...client.GetOption) error {
+						return fmt.Errorf("something happened")
+					})
+			},
+			expectedBundle: nil,
+			expectedErr:    fmt.Errorf("something happened"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+
+			ctlr := gomock.NewController(t)
+			mockClient := mocks.NewMockClient(ctlr)
+
+			tc.secretGets(mockClient)
+
+			bundle, err := cert.GetRancherCABundle(context.Background(), mockClient)
+			if tc.expectedErr == nil && err != nil {
+				t.Errorf("expected nil error, got %q", err.Error())
+			} else if tc.expectedErr != nil && err == nil {
+				t.Errorf("expected error %q, got nil", tc.expectedErr.Error())
+			} else if err != nil && tc.expectedErr != nil && err.Error() != tc.expectedErr.Error() {
+				t.Errorf("expected %q, got %q", tc.expectedErr.Error(), err.Error())
+			}
+
+			if string(bundle) != string(tc.expectedBundle) { // XXX: should we compare byte by byte instead?
+				t.Errorf("expected %q, got %q", tc.expectedBundle, bundle)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This enables Fleet to rely on Rancher-configured CA bundle [secrets](https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade/installation-references/helm-chart-options#additional-trusted-cas) in the following clients:
* git remote lister and cloner: those CA bundles no longer need to be provided in a `GitRepo`'s spec. Fleet will extract CA bundle data from Rancher secrets if (and only if) no CA bundle is provided for a `GitRepo`.
* Helm client: Fleet will extract, populate and mount Rancher CA bundles in the following cases:
    * no `HelmSecretName` nor `HelmSecretNameForPaths` secret is provided on a `GitRepo`
    * one of those secrets is provided, but only specifies username(s) and password(s), without a CA bundle

This is tested through a combination of:
* unit tests for common Rancher CA bundle data extraction logic
* integration tests for mounting and use of that data by the gitOps controller
* end-to-end tests for successful deployment of workloads with git repositories and Helm charts hosted on infrastructure using a custom CA. Those tests required adapting configuration and deployment of our test git server to support HTTPS beside HTTP and make use of already generated custom certificates.

## Limitations

This does not cover imagescan (pending further discussion on the future of that feature), nor the HelmOps controller.

Falling back to Rancher CA bundles in HelmOps would require reading the HelmApp's `HelmSecretName` field, and populating a CA bundle if that field is empty or if the referenced secret does not contain any CA bundle.

How this should be done to support both [version handling](https://github.com/rancher/fleet/blob/main/internal/cmd/controller/helmops/reconciler/helmapp_controller.go#L294) in the controller and chart downloads from the agent, is unclear for now: should an empty `HelmSecretName` be overwritten by the HelmOps controller, or an incomplete secret edited to add a Rancher CA bundle? This could be handled in a follow-up patch.
    
Refers to #2750
Related docs PR: https://github.com/rancher/fleet-docs/pull/212