### PR TITLE
Add manual trigger to Fleet release action

### DIFF
--- a/.github/workflows/release-fleet.yml
+++ b/.github/workflows/release-fleet.yml
@@ -5,6 +5,7 @@ on:
   push:
     tags:
       - v**
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
to be able to test newer implemenations without merging them before.