### PR TITLE
Prevent empty Patch updates

### DIFF
--- a/internal/cmd/agent/controller/bundledeployment_controller.go
+++ b/internal/cmd/agent/controller/bundledeployment_controller.go
@@ -194,6 +194,10 @@ func (r *BundleDeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Req
 
 func (r *BundleDeploymentReconciler) updateStatus(ctx context.Context, orig *fleetv1.BundleDeployment, obj *fleetv1.BundleDeployment) error {
 	statusPatch := client.MergeFrom(orig)
+	if patchData, err := statusPatch.Data(obj); err == nil && string(patchData) == "{}" {
+		// skip update if patch is empty
+		return nil
+	}
 	return r.Status().Patch(ctx, obj, statusPatch)
 }
 

--- a/internal/cmd/controller/reconciler/bundle_controller.go
+++ b/internal/cmd/controller/reconciler/bundle_controller.go
@@ -492,8 +492,12 @@ func experimentalHelmOpsEnabled() bool {
 func (r *BundleReconciler) updateStatus(ctx context.Context, orig *fleet.Bundle, bundle *fleet.Bundle) error {
 	logger := log.FromContext(ctx).WithName("bundle - updateStatus")
 	statusPatch := client.MergeFrom(orig)
-	err := r.Status().Patch(ctx, bundle, statusPatch)
-	if err != nil {
+
+	if patchData, err := statusPatch.Data(bundle); err == nil && string(patchData) == "{}" {
+		// skip update if patch is empty
+		return nil
+	}
+	if err := r.Status().Patch(ctx, bundle, statusPatch); err != nil {
 		logger.V(1).Info("Reconcile failed update to bundle status", "status", bundle.Status, "error", err)
 		return err
 	}


### PR DESCRIPTION
Refers to #3163

By adding additional logging to the BundleReconciler, I realized that (in my experiment), every operation was taking ~2.5s, and most of it was on the `updateStatus` function. It seems that the client implementation will perform the call besides producing an empty JSON patch (which BTW is correct in my opinion).

In order to prevent those spurious requests, we need to skip calling `Patch()`. This can be done at the cost of generating the diff twice, but it's still worth it.