### PR TITLE
Increase runner CPUs for nightly CI workflow

### DIFF
--- a/.github/workflows/e2e-nightly-ci.yml
+++ b/.github/workflows/e2e-nightly-ci.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   e2e-fleet-nightly-test:
-    runs-on: runs-on,runner=8cpu-linux-x64,mem=16,run-id=${{ github.run_id }}
+    runs-on: runs-on,runner=16cpu-linux-x64,mem=16,run-id=${{ github.run_id }}
 
     strategy:
       matrix:

--- a/e2e/single-cluster/oci_registry_test.go
+++ b/e2e/single-cluster/oci_registry_test.go
@@ -291,7 +291,7 @@ var _ = Describe("Single Cluster Deployments using OCI registry", Label("oci-reg
 
 					// check for contentsID
 					contentsID, err := k.Namespace("fleet-local").Get("bundle", "sample-simple-chart-oci", `-o=jsonpath={.spec.contentsId}`)
-					Expect(err).ToNot(HaveOccurred())
+					g.Expect(err).ToNot(HaveOccurred())
 					g.Expect(contentsID).To(BeEmpty())
 
 					GinkgoWriter.Printf("ContentsID: %s\n", contentsID)


### PR DESCRIPTION
This aligns runner specs with the regular end-to-end tests CI workflow, which runs against pull requests.

It may fix end-to-end test failures which, while not related to sharding, only happen with sharding enabled.

Refers to #3215