### PR TITLE
Add `templateValues` to HelmApp, Bundle, etc

### DIFF
--- a/charts/fleet-crd/templates/crds.yaml
+++ b/charts/fleet-crd/templates/crds.yaml
@@ -349,6 +349,24 @@ spec:
                           description: TakeOwnership makes helm skip the check for
                             its own annotations
                           type: boolean
+                        templateValues:
+                          additionalProperties:
+                            type: string
+                          description: 'Template Values passed to Helm. It is possible
+                            to specify the keys and values
+
+                            as go template strings. Unlike .values, content of each
+                            key will be templated
+
+                            first, before serializing to yaml. This allows to template
+                            complex values,
+
+                            like ranges and maps.
+
+                            templateValues keys have precedence over values keys in
+                            case of conflict.'
+                          nullable: true
+                          type: object
                         timeoutSeconds:
                           description: TimeoutSeconds is the time to wait for Helm
                             operations.
@@ -695,6 +713,24 @@ spec:
                           description: TakeOwnership makes helm skip the check for
                             its own annotations
                           type: boolean
+                        templateValues:
+                          additionalProperties:
+                            type: string
+                          description: 'Template Values passed to Helm. It is possible
+                            to specify the keys and values
+
+                            as go template strings. Unlike .values, content of each
+                            key will be templated
+
+                            first, before serializing to yaml. This allows to template
+                            complex values,
+
+                            like ranges and maps.
+
+                            templateValues keys have precedence over values keys in
+                            case of conflict.'
+                          nullable: true
+                          type: object
                         timeoutSeconds:
                           description: TimeoutSeconds is the time to wait for Helm
                             operations.
@@ -1568,6 +1604,24 @@ spec:
                       description: TakeOwnership makes helm skip the check for its
                         own annotations
                       type: boolean
+                    templateValues:
+                      additionalProperties:
+                        type: string
+                      description: 'Template Values passed to Helm. It is possible
+                        to specify the keys and values
+
+                        as go template strings. Unlike .values, content of each key
+                        will be templated
+
+                        first, before serializing to yaml. This allows to template
+                        complex values,
+
+                        like ranges and maps.
+
+                        templateValues keys have precedence over values keys in case
+                        of conflict.'
+                      nullable: true
+                      type: object
                     timeoutSeconds:
                       description: TimeoutSeconds is the time to wait for Helm operations.
                       type: integer
@@ -2433,6 +2487,24 @@ spec:
                             description: TakeOwnership makes helm skip the check for
                               its own annotations
                             type: boolean
+                          templateValues:
+                            additionalProperties:
+                              type: string
+                            description: 'Template Values passed to Helm. It is possible
+                              to specify the keys and values
+
+                              as go template strings. Unlike .values, content of each
+                              key will be templated
+
+                              first, before serializing to yaml. This allows to template
+                              complex values,
+
+                              like ranges and maps.
+
+                              templateValues keys have precedence over values keys
+                              in case of conflict.'
+                            nullable: true
+                            type: object
                           timeoutSeconds:
                             description: TimeoutSeconds is the time to wait for Helm
                               operations.
@@ -7307,6 +7379,24 @@ spec:
                       description: TakeOwnership makes helm skip the check for its
                         own annotations
                       type: boolean
+                    templateValues:
+                      additionalProperties:
+                        type: string
+                      description: 'Template Values passed to Helm. It is possible
+                        to specify the keys and values
+
+                        as go template strings. Unlike .values, content of each key
+                        will be templated
+
+                        first, before serializing to yaml. This allows to template
+                        complex values,
+
+                        like ranges and maps.
+
+                        templateValues keys have precedence over values keys in case
+                        of conflict.'
+                      nullable: true
+                      type: object
                     timeoutSeconds:
                       description: TimeoutSeconds is the time to wait for Helm operations.
                       type: integer
@@ -8191,6 +8281,24 @@ spec:
                             description: TakeOwnership makes helm skip the check for
                               its own annotations
                             type: boolean
+                          templateValues:
+                            additionalProperties:
+                              type: string
+                            description: 'Template Values passed to Helm. It is possible
+                              to specify the keys and values
+
+                              as go template strings. Unlike .values, content of each
+                              key will be templated
+
+                              first, before serializing to yaml. This allows to template
+                              complex values,
+
+                              like ranges and maps.
+
+                              templateValues keys have precedence over values keys
+                              in case of conflict.'
+                            nullable: true
+                            type: object
                           timeoutSeconds:
                             description: TimeoutSeconds is the time to wait for Helm
                               operations.

--- a/internal/cmd/controller/options/calculate.go
+++ b/internal/cmd/controller/options/calculate.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"maps"
 
 	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
 	"github.com/rancher/wrangler/v3/pkg/data"
@@ -51,6 +52,11 @@ func Merge(base, custom fleet.BundleDeploymentOptions) fleet.BundleDeploymentOpt
 			result.Helm.Values = custom.Helm.Values
 		} else if custom.Helm.Values != nil {
 			result.Helm.Values.Data = data.MergeMaps(result.Helm.Values.Data, custom.Helm.Values.Data)
+		}
+		if result.Helm.TemplateValues == nil {
+			result.Helm.TemplateValues = custom.Helm.TemplateValues
+		} else if custom.Helm.TemplateValues != nil {
+			maps.Copy(result.Helm.TemplateValues, custom.Helm.TemplateValues)
 		}
 		if custom.Helm.ValuesFrom != nil {
 			result.Helm.ValuesFrom = append(result.Helm.ValuesFrom, custom.Helm.ValuesFrom...)

--- a/internal/cmd/controller/target/builder.go
+++ b/internal/cmd/controller/target/builder.go
@@ -2,8 +2,10 @@ package target
 
 import (
 	"bytes"
+	"cmp"
 	"context"
 	"fmt"
+	"maps"
 	"sort"
 	"strings"
 	"text/template"
@@ -182,10 +184,15 @@ func preprocessHelmValues(logger logr.Logger, opts *fleet.BundleDeploymentOption
 	}
 
 	opts.Helm = opts.Helm.DeepCopy()
-	if opts.Helm.Values == nil || opts.Helm.Values.Data == nil {
-		opts.Helm.Values = &fleet.GenericMap{
-			Data: map[string]interface{}{},
-		}
+	opts.Helm.Values = cmp.Or(opts.Helm.Values, &fleet.GenericMap{
+		Data: map[string]interface{}{},
+	})
+
+	if opts.Helm.Values.Data == nil {
+		opts.Helm.Values.Data = map[string]interface{}{}
+	}
+
+	if opts.Helm.TemplateValues == nil && len(opts.Helm.Values.Data) == 0 {
 		return nil
 	}
 
@@ -211,6 +218,14 @@ func preprocessHelmValues(logger logr.Logger, opts *fleet.BundleDeploymentOption
 		if err != nil {
 			return err
 		}
+
+		templatedData, err := processTemplateValuesData(opts.Helm.TemplateValues, values)
+		if err != nil {
+			return err
+		}
+
+		maps.Copy(opts.Helm.Values.Data, templatedData)
+
 		logger.V(4).Info("preProcess completed", "releaseName", opts.Helm.ReleaseName)
 	}
 
@@ -276,6 +291,38 @@ func tplFuncMap() template.FuncMap {
 	delete(f, "tpl")
 
 	return f
+}
+
+func processTemplateValuesData(helmTemplateData map[string]string, templateContext map[string]interface{}) (map[string]interface{}, error) {
+	renderedValues := make(map[string]interface{}, len(helmTemplateData))
+
+	for k, v := range helmTemplateData {
+		// fleet.yaml must be valid yaml, however '{}[]' are YAML control
+		// characters and will be interpreted as JSON data structures. This
+		// causes issues when parsing the fleet.yaml so we change the delims
+		// for templating to '${ }'
+		tmpl := template.New("values").Funcs(tplFuncMap()).Option("missingkey=error").Delims("${", "}")
+		tmpl, err := tmpl.Parse(v)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse helm values template: %w", err)
+		}
+
+		var b bytes.Buffer
+		err = tmpl.Execute(&b, templateContext)
+		if err != nil {
+			return nil, fmt.Errorf("failed to render helm values template: %w", err)
+		}
+
+		var value interface{}
+		err = kyaml.Unmarshal(b.Bytes(), &value)
+		if err != nil {
+			return nil, fmt.Errorf("failed to interpret rendered template as helm values: %s, %v", b.String(), err)
+		}
+
+		renderedValues[k] = value
+	}
+
+	return renderedValues, nil
 }
 
 func processTemplateValues(helmValues map[string]interface{}, templateContext map[string]interface{}) (map[string]interface{}, error) {

--- a/pkg/apis/fleet.cattle.io/v1alpha1/bundledeployment_types.go
+++ b/pkg/apis/fleet.cattle.io/v1alpha1/bundledeployment_types.go
@@ -211,6 +211,14 @@ type HelmOptions struct {
 	// +kubebuilder:validation:XPreserveUnknownFields
 	Values *GenericMap `json:"values,omitempty"`
 
+	// Template Values passed to Helm. It is possible to specify the keys and values
+	// as go template strings. Unlike .values, content of each key will be templated
+	// first, before serializing to yaml. This allows to template complex values,
+	// like ranges and maps.
+	// templateValues keys have precedence over values keys in case of conflict.
+	// +nullable
+	TemplateValues map[string]string `json:"templateValues,omitempty"`
+
 	// +nullable
 	// ValuesFrom loads the values from configmaps and secrets.
 	ValuesFrom []ValuesFrom `json:"valuesFrom,omitempty"`

--- a/pkg/apis/fleet.cattle.io/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/fleet.cattle.io/v1alpha1/zz_generated.deepcopy.go
@@ -1681,6 +1681,13 @@ func (in *HelmOptions) DeepCopyInto(out *HelmOptions) {
 		in, out := &in.Values, &out.Values
 		*out = (*in).DeepCopy()
 	}
+	if in.TemplateValues != nil {
+		in, out := &in.TemplateValues, &out.TemplateValues
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	if in.ValuesFrom != nil {
 		in, out := &in.ValuesFrom, &out.ValuesFrom
 		*out = make([]ValuesFrom, len(*in))


### PR DESCRIPTION
<!-- Specify the issue ID that this pull request is solving -->
Refers to #3266 
<!-- Make sure that the referenced issue provides steps to reproduce it -->

<!-- Describe the changes introduced by this pull request -->
Implement new field inside `Helm` options: `templateValues`, which performs templating of each individual value before converting data to yaml. This allows to use more complex template expressions then currently available to template string data, like creation of maps and lists.

<!--
  Please provide a unit, integration (`./integrationtests/`) or e2e (`./e2e/`) test if possible.
-->