### PR TITLE
Propagate tolerations from values to jobs

### DIFF
--- a/charts/fleet/templates/job_cleanup_clusterregistrations.yaml
+++ b/charts/fleet/templates/job_cleanup_clusterregistrations.yaml
@@ -37,5 +37,8 @@ spec:
         - clusterregistration
       nodeSelector: {{ include "linux-node-selector" . | nindent 8 }}
       tolerations: {{ include "linux-node-tolerations" . | nindent 8 }}
+{{- if $.Values.tolerations }}
+{{ toYaml $.Values.tolerations | indent 8 }}
+{{- end }}
   backoffLimit: 1
 {{- end }}

--- a/charts/fleet/templates/job_cleanup_gitrepojobs.yaml
+++ b/charts/fleet/templates/job_cleanup_gitrepojobs.yaml
@@ -40,5 +40,8 @@ spec:
             - gitjob
           nodeSelector: {{ include "linux-node-selector" . | nindent 12 }}
           tolerations: {{ include "linux-node-tolerations" . | nindent 12 }}
+{{- if $.Values.tolerations }}
+{{ toYaml $.Values.tolerations | indent 12 }}
+{{- end }}
       backoffLimit: 1
 {{- end }}


### PR DESCRIPTION
This fixes a bug which would prevent jobs from running on a cluster where all nodes are tainted, leading to failures to install Fleet charts.

<!-- Specify the issue ID that this pull request is solving -->
Refers to #3280
<!-- Make sure that the referenced issue provides steps to reproduce it -->

<!-- Describe the changes introduced by this pull request -->

<!--
  Please provide a unit, integration (`./integrationtests/`) or e2e (`./e2e/`) test if possible.
-->