### PR TITLE
Don't force requeuing after adding finalizer in GitRepo controller

### DIFF
--- a/internal/cmd/controller/gitops/reconciler/gitjob_controller.go
+++ b/internal/cmd/controller/gitops/reconciler/gitjob_controller.go
@@ -158,7 +158,7 @@ func (r *GitJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		}
 
 		// requeue as adding the finalizer changes the spec
-		return ctrl.Result{Requeue: true}, nil
+		return ctrl.Result{}, nil
 	}
 
 	logger = logger.WithValues("generation", gitrepo.Generation, "commit", gitrepo.Status.Commit).WithValues("conditions", gitrepo.Status.Conditions)


### PR DESCRIPTION
This change is meant to avoid an extra `Reconcile` call when adding the finalizer to `GitRepo`. The reconciler will get called anyway because generation changes and, also because generation changes, we'll avoid an extra call to the polling function.

See below the difference of with and without the change. I've added a new extra log lines to show the difference (that are not part of this pull request)

**without change**
```bash
2025-01-30T13:45:49Z	INFO	gitjob	TESTFINALIZER Reconciling GitRepo	{"controller": "gitrepo", "controllerGroup": "fleet.cattle.io", "controllerKind": "GitRepo", "GitRepo": {"name":"simple","namespace":"fleet-local"}, "namespace": "fleet-local", "name": "simple", "reconcileID": "5517b2f5-2d4e-415b-b0e5-859cc070d9af"}
2025-01-30T13:45:49Z	INFO	gitjob	TESTFINALIZER -- finalizer added	{"controller": "gitrepo", "controllerGroup": "fleet.cattle.io", "controllerKind": "GitRepo", "GitRepo": {"name":"simple","namespace":"fleet-local"}, "namespace": "fleet-local", "name": "simple", "reconcileID": "5517b2f5-2d4e-415b-b0e5-859cc070d9af"}
2025-01-30T13:45:49Z	INFO	gitjob	TESTFINALIZER Reconciling GitRepo	{"controller": "gitrepo", "controllerGroup": "fleet.cattle.io", "controllerKind": "GitRepo", "GitRepo": {"name":"simple","namespace":"fleet-local"}, "namespace": "fleet-local", "name": "simple", "reconcileID": "94d228b5-c018-46af-9b69-b04b17ed976a"}
2025-01-30T13:45:49Z	INFO	gitjob	TESTFINALIZER --- GitRepo polled	{"controller": "gitrepo", "controllerGroup": "fleet.cattle.io", "controllerKind": "GitRepo", "GitRepo": {"name":"simple","namespace":"fleet-local"}, "namespace": "fleet-local", "name": "simple", "reconcileID": "94d228b5-c018-46af-9b69-b04b17ed976a", "generation": 2, "commit": "", "conditions": null}
2025-01-30T13:45:49Z	INFO	gitjob	TESTFINALIZER Reconciling GitRepo	{"controller": "gitrepo", "controllerGroup": "fleet.cattle.io", "controllerKind": "GitRepo", "GitRepo": {"name":"simple","namespace":"fleet-local"}, "namespace": "fleet-local", "name": "simple", "reconcileID": "1c71ae46-ea6b-452c-8896-704293f24584"}
2025-01-30T13:45:49Z	INFO	gitjob	TESTFINALIZER --- GitRepo polled	{"controller": "gitrepo", "controllerGroup": "fleet.cattle.io", "controllerKind": "GitRepo", "GitRepo": {"name":"simple","namespace":"fleet-local"}, "namespace": "fleet-local", "name": "simple", "reconcileID": "1c71ae46-ea6b-452c-8896-704293f24584", "generation": 2, "commit": "", "conditions": [{"type":"Ready","status":"True","lastUpdateTime":"2025-01-30T13:45:49Z"}]}
```

`GitRepo` is polled twice. 

**with change**
```bash
2025-01-30T13:54:19Z	INFO	gitjob	TESTFINALIZER Reconciling GitRepo	{"controller": "gitrepo", "controllerGroup": "fleet.cattle.io", "controllerKind": "GitRepo", "GitRepo": {"name":"simple","namespace":"fleet-local"}, "namespace": "fleet-local", "name": "simple", "reconcileID": "4cb52a70-d552-4cda-85f7-058a9d129e1f"}
2025-01-30T13:54:19Z	INFO	gitjob	TESTFINALIZER -- finalizer added	{"controller": "gitrepo", "controllerGroup": "fleet.cattle.io", "controllerKind": "GitRepo", "GitRepo": {"name":"simple","namespace":"fleet-local"}, "namespace": "fleet-local", "name": "simple", "reconcileID": "4cb52a70-d552-4cda-85f7-058a9d129e1f"}
2025-01-30T13:54:19Z	INFO	gitjob	TESTFINALIZER Reconciling GitRepo	{"controller": "gitrepo", "controllerGroup": "fleet.cattle.io", "controllerKind": "GitRepo", "GitRepo": {"name":"simple","namespace":"fleet-local"}, "namespace": "fleet-local", "name": "simple", "reconcileID": "52cce150-c17c-4242-acb8-6b05ba3ecd58"}
2025-01-30T13:54:19Z	INFO	gitjob	TESTFINALIZER --- GitRepo polled	{"controller": "gitrepo", "controllerGroup": "fleet.cattle.io", "controllerKind": "GitRepo", "GitRepo": {"name":"simple","namespace":"fleet-local"}, "namespace": "fleet-local", "name": "simple", "reconcileID": "52cce150-c17c-4242-acb8-6b05ba3ecd58", "generation": 2, "commit": "", "conditions": null}
```

`GitRepo` is only polled 1 time 
