### PR TITLE
Small refactor for setting resource statuses

### DIFF
--- a/internal/cmd/controller/gitops/reconciler/status_controller.go
+++ b/internal/cmd/controller/gitops/reconciler/status_controller.go
@@ -154,7 +154,7 @@ func setStatus(list *fleet.BundleDeploymentList, gitrepo *fleet.GitRepo) error {
 		return err
 	}
 
-	resourcestatus.SetResources(list, &gitrepo.Status.StatusBase)
+	resourcestatus.SetResources(list.Items, &gitrepo.Status.StatusBase)
 
 	summary.SetReadyConditions(&gitrepo.Status, "Bundle", gitrepo.Status.Summary)
 

--- a/internal/cmd/controller/helmops/reconciler/helmapp_status.go
+++ b/internal/cmd/controller/helmops/reconciler/helmapp_status.go
@@ -121,7 +121,7 @@ func setStatusHelm(list *fleet.BundleDeploymentList, helmapp *fleet.HelmApp) err
 		return err
 	}
 
-	resourcestatus.SetResources(list, &helmapp.Status.StatusBase)
+	resourcestatus.SetResources(list.Items, &helmapp.Status.StatusBase)
 
 	summary.SetReadyConditions(&helmapp.Status, "Bundle", helmapp.Status.Summary)
 

--- a/internal/resourcestatus/resourcekey_test.go
+++ b/internal/resourcestatus/resourcekey_test.go
@@ -12,139 +12,137 @@ import (
 )
 
 func TestSetResources(t *testing.T) {
-	list := &fleet.BundleDeploymentList{
-		Items: []fleet.BundleDeployment{
-			{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "bd1",
-					Namespace: "ns1-cluster1-ns",
-					Labels: map[string]string{
-						fleet.ClusterLabel:          "cluster1",
-						fleet.ClusterNamespaceLabel: "c-ns1",
-					},
-				},
-				Spec: fleet.BundleDeploymentSpec{
-					DeploymentID: "id2",
-				},
-				Status: fleet.BundleDeploymentStatus{
-					Ready:               false,
-					NonModified:         true,
-					AppliedDeploymentID: "id1",
-					Resources: []fleet.BundleDeploymentResource{
-						{
-							Kind:       "Deployment",
-							APIVersion: "v1",
-							Name:       "web",
-							Namespace:  "default",
-						},
-						{
-							// extra service for one cluster
-							Kind:       "Service",
-							APIVersion: "v1",
-							Name:       "web-svc",
-							Namespace:  "default",
-						},
-					},
-					ResourceCounts: fleet.ResourceCounts{
-						DesiredReady: 2,
-						WaitApplied:  2,
-					},
+	list := []fleet.BundleDeployment{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "bd1",
+				Namespace: "ns1-cluster1-ns",
+				Labels: map[string]string{
+					fleet.ClusterLabel:          "cluster1",
+					fleet.ClusterNamespaceLabel: "c-ns1",
 				},
 			},
-			{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "bd1",
-					Namespace: "ns1-cluster2-ns",
-					Labels: map[string]string{
-						fleet.ClusterLabel:          "cluster2",
-						fleet.ClusterNamespaceLabel: "c-ns1",
+			Spec: fleet.BundleDeploymentSpec{
+				DeploymentID: "id2",
+			},
+			Status: fleet.BundleDeploymentStatus{
+				Ready:               false,
+				NonModified:         true,
+				AppliedDeploymentID: "id1",
+				Resources: []fleet.BundleDeploymentResource{
+					{
+						Kind:       "Deployment",
+						APIVersion: "v1",
+						Name:       "web",
+						Namespace:  "default",
+					},
+					{
+						// extra service for one cluster
+						Kind:       "Service",
+						APIVersion: "v1",
+						Name:       "web-svc",
+						Namespace:  "default",
 					},
 				},
-				Status: fleet.BundleDeploymentStatus{
-					Ready:       true,
-					NonModified: true,
-					Resources: []fleet.BundleDeploymentResource{
-						{
-							Kind:       "Deployment",
-							APIVersion: "v1",
-							Name:       "web",
-							Namespace:  "default",
-						},
-					},
-					ResourceCounts: fleet.ResourceCounts{
-						DesiredReady: 1,
-						Ready:        1,
-					},
+				ResourceCounts: fleet.ResourceCounts{
+					DesiredReady: 2,
+					WaitApplied:  2,
 				},
 			},
-			{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "bd2",
-					Namespace: "ns1-cluster2-ns",
-					Labels: map[string]string{
-						fleet.ClusterLabel:          "cluster2",
-						fleet.ClusterNamespaceLabel: "c-ns1",
-					},
-				},
-				Status: fleet.BundleDeploymentStatus{
-					Ready:       true,
-					NonModified: true,
-					Resources: []fleet.BundleDeploymentResource{
-						{
-							Kind:       "ConfigMap",
-							APIVersion: "v1",
-							Name:       "cm-web",
-							Namespace:  "default",
-						},
-					},
-					ResourceCounts: fleet.ResourceCounts{
-						DesiredReady: 1,
-						Ready:        1,
-					},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "bd1",
+				Namespace: "ns1-cluster2-ns",
+				Labels: map[string]string{
+					fleet.ClusterLabel:          "cluster2",
+					fleet.ClusterNamespaceLabel: "c-ns1",
 				},
 			},
-			{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "bd1",
-					Namespace: "ns2-cluster1",
-					Labels: map[string]string{
-						fleet.ClusterLabel:          "cluster1",
-						fleet.ClusterNamespaceLabel: "c-ns2",
+			Status: fleet.BundleDeploymentStatus{
+				Ready:       true,
+				NonModified: true,
+				Resources: []fleet.BundleDeploymentResource{
+					{
+						Kind:       "Deployment",
+						APIVersion: "v1",
+						Name:       "web",
+						Namespace:  "default",
 					},
 				},
-				Spec: fleet.BundleDeploymentSpec{
-					DeploymentID: "id2",
+				ResourceCounts: fleet.ResourceCounts{
+					DesiredReady: 1,
+					Ready:        1,
 				},
-				Status: fleet.BundleDeploymentStatus{
-					Ready:               false,
-					NonModified:         true,
-					AppliedDeploymentID: "id1",
-					NonReadyStatus: []fleet.NonReadyStatus{
-						{
-							Kind:       "Deployment",
-							APIVersion: "v1",
-							Name:       "web",
-							Namespace:  "default",
-							Summary: summary.Summary{
-								State:         "Pending",
-								Error:         true,
-								Transitioning: true,
-								Message:       []string{"message1", "message2"},
-							},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "bd2",
+				Namespace: "ns1-cluster2-ns",
+				Labels: map[string]string{
+					fleet.ClusterLabel:          "cluster2",
+					fleet.ClusterNamespaceLabel: "c-ns1",
+				},
+			},
+			Status: fleet.BundleDeploymentStatus{
+				Ready:       true,
+				NonModified: true,
+				Resources: []fleet.BundleDeploymentResource{
+					{
+						Kind:       "ConfigMap",
+						APIVersion: "v1",
+						Name:       "cm-web",
+						Namespace:  "default",
+					},
+				},
+				ResourceCounts: fleet.ResourceCounts{
+					DesiredReady: 1,
+					Ready:        1,
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "bd1",
+				Namespace: "ns2-cluster1",
+				Labels: map[string]string{
+					fleet.ClusterLabel:          "cluster1",
+					fleet.ClusterNamespaceLabel: "c-ns2",
+				},
+			},
+			Spec: fleet.BundleDeploymentSpec{
+				DeploymentID: "id2",
+			},
+			Status: fleet.BundleDeploymentStatus{
+				Ready:               false,
+				NonModified:         true,
+				AppliedDeploymentID: "id1",
+				NonReadyStatus: []fleet.NonReadyStatus{
+					{
+						Kind:       "Deployment",
+						APIVersion: "v1",
+						Name:       "web",
+						Namespace:  "default",
+						Summary: summary.Summary{
+							State:         "Pending",
+							Error:         true,
+							Transitioning: true,
+							Message:       []string{"message1", "message2"},
 						},
 					},
-					Resources: []fleet.BundleDeploymentResource{
-						{
-							Kind:       "Deployment",
-							APIVersion: "v1",
-							Name:       "web",
-							Namespace:  "default",
-						},
+				},
+				Resources: []fleet.BundleDeploymentResource{
+					{
+						Kind:       "Deployment",
+						APIVersion: "v1",
+						Name:       "web",
+						Namespace:  "default",
 					},
-					ResourceCounts: fleet.ResourceCounts{
-						DesiredReady: 1,
-						NotReady:     1,
-					},
+				},
+				ResourceCounts: fleet.ResourceCounts{
+					DesiredReady: 1,
+					NotReady:     1,
 				},
 			},
 		},


### PR DESCRIPTION
<!-- Specify the issue ID that this pull request is solving -->
Refers to #3186

Also, changes `fromResources` to order BundleDeployments before processing instead of sorting the resulting resources, which should be more efficient while producing the same result.