### PR TITLE
Use Docker digest instead of tag to attest provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -143,12 +143,15 @@ jobs:
           CURRENT_TAG: ${{ github.ref_name }}
         run: |
           for IMG_NAME in $(yq e '.dockers[].image_templates[0]' .goreleaser.yaml | grep PRIME_REGISTRY | sed "s/{{ .Env.PRIME_REGISTRY }}/${PRIME_REGISTRY}/g" | sed "s/{{ .Tag }}/${CURRENT_TAG}/g"); do
+            # Extract Docker image reference plus digest from local image
+            IMAGE=$(docker inspect --format='{{index .RepoDigests 0}}' ${IMG_NAME})
+
             max_retries=3
             retry_delay=5
             i=0
 
             while [ "${i}" -lt "${max_retries}" ]; do
-                if slsactl download provenance --format=slsav1 "${IMG_NAME}" > provenance-slsav1.json; then
+                if slsactl download provenance --format=slsav1 "${IMAGE}" > provenance-slsav1.json; then
                     break
                 fi
                 if [ "${i}" -eq "$(( max_retries - 1 ))" ]; then
@@ -159,7 +162,7 @@ jobs:
                 sleep "${retry_delay}"
             done
 
-            cosign attest --yes --predicate provenance-slsav1.json --type slsaprovenance1 "${IMG_NAME}"
+            cosign attest --yes --predicate provenance-slsav1.json --type slsaprovenance1 "${IMAGE}"
           done
 
       - name: Upload charts to release


### PR DESCRIPTION
<!-- Specify the issue ID that this pull request is solving -->
Refers to #3075 

To fix the warning:
```
WARNING: Image reference ***/***/fleet:v0.12.0-alpha.7-linux-amd64 uses a tag, not a digest, to identify the image to sign.
    This can lead you to sign a different image than the intended one. Please use a
    digest (example.com/ubuntu@sha256:abc123...) rather than tag
    (example.com/ubuntu:latest) for the input to cosign. The ability to refer to
    images by tag will be removed in a future release.
```

`docker inspect` in this form should only work if the image is locally available so there should be no real threat of mixing up images.

[Old Github Action output](https://github.com/rancher/fleet/actions/runs/13079222641/job/36498669332#step:22:114) vs [New Github Action output](https://github.com/rancher/fleet/actions/runs/13111778663/job/36577080927#step:16:1)