### PR TITLE
Change ImageScanCommit in GitRepo spec to a pointer

### DIFF
--- a/internal/cmd/controller/imagescan/gitcommit_job.go
+++ b/internal/cmd/controller/imagescan/gitcommit_job.go
@@ -206,7 +206,7 @@ func (j *GitCommitJob) cloneAndReplace(ctx context.Context) {
 		}
 	}
 
-	commit, err := commitAllAndPush(context.Background(), repo, auth, gitrepo.Spec.ImageScanCommit)
+	commit, err := commitAllAndPush(context.Background(), repo, auth, *gitrepo.Spec.ImageScanCommit)
 	if err != nil {
 		err = j.updateErrorStatus(ctx, gitrepo, err)
 		logger.V(1).Info("Cannot commit and push to repo", "error", err)

--- a/pkg/apis/fleet.cattle.io/v1alpha1/gitrepo_types.go
+++ b/pkg/apis/fleet.cattle.io/v1alpha1/gitrepo_types.go
@@ -121,7 +121,7 @@ type GitRepoSpec struct {
 	ImageSyncInterval *metav1.Duration `json:"imageScanInterval,omitempty"`
 
 	// Commit specifies how to commit to the git repo when a new image is scanned and written back to git repo.
-	ImageScanCommit CommitSpec `json:"imageScanCommit,omitempty"`
+	ImageScanCommit *CommitSpec `json:"imageScanCommit,omitempty"`
 
 	// KeepResources specifies if the resources created must be kept after deleting the GitRepo.
 	KeepResources bool `json:"keepResources,omitempty"`

--- a/pkg/apis/fleet.cattle.io/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/fleet.cattle.io/v1alpha1/zz_generated.deepcopy.go
@@ -1510,7 +1510,11 @@ func (in *GitRepoSpec) DeepCopyInto(out *GitRepoSpec) {
 		*out = new(v1.Duration)
 		**out = **in
 	}
-	out.ImageScanCommit = in.ImageScanCommit
+	if in.ImageScanCommit != nil {
+		in, out := &in.ImageScanCommit, &out.ImageScanCommit
+		*out = new(CommitSpec)
+		**out = **in
+	}
 	if in.CorrectDrift != nil {
 		in, out := &in.CorrectDrift, &out.CorrectDrift
 		*out = new(CorrectDrift)


### PR DESCRIPTION
As ImageScanCommit is an optional field inside the GitRepo spec this PR changes it to be a pointer.

Not doing so means that the veru first time the `GitRepo` is stored in the cluster default values will be created and generation will be incresed, which means a double polling for the `GitRepo` when it is created.

The first time the `GitRepo` is polled because the `LastPollingTime` is not set. The second time it is polled because of the generation change mentioned above.

Aside from double polling in a short period of time this PR also tries to prevent an extra reconciler call that is not needed.

**Before the change**
```bash
2025-02-05T17:00:39Z    INFO    gitjob  DUAL POLLING TEST -- Reconciling GitRepo        {"controller": "gitrepo", "controllerGroup": "fleet.cattle.io", "controllerKind": "GitRepo", "GitRepo": {"name":"simple","namespace":"fleet-local"}, "namespace": "fleet-local", "name": "simple", "reconcileID": "e92c1baf-1889-41ac-9213-7d8d924815cf"}
2025-02-05T17:00:39Z    INFO    gitjob  DUAL POLLING TEST -- Reconciling GitRepo        {"controller": "gitrepo", "controllerGroup": "fleet.cattle.io", "controllerKind": "GitRepo", "GitRepo": {"name":"simple","namespace":"fleet-local"}, "namespace": "fleet-local", "name": "simple", "reconcileID": "9dce24dd-c643-4f8b-86ed-4b8397ca3588"}
2025-02-05T17:00:39Z    INFO    gitjob  DUAL POLLING TEST -- GitRepo Polled     {"controller": "gitrepo", "controllerGroup": "fleet.cattle.io", "controllerKind": "GitRepo", "GitRepo": {"name":"simple","namespace":"fleet-local"}, "namespace": "fleet-local", "name": "simple", "reconcileID": "9dce24dd-c643-4f8b-86ed-4b8397ca3588", "generation": 2, "commit": "", "conditions": [{"type":"Ready","status":"True","lastUpdateTime":"2025-02-05T17:00:39Z"}]}
2025-02-05T17:00:39Z    INFO    gitjob  DUAL POLLING TEST -- Reconciling GitRepo        {"controller": "gitrepo", "controllerGroup": "fleet.cattle.io", "controllerKind": "GitRepo", "GitRepo": {"name":"simple","namespace":"fleet-local"}, "namespace": "fleet-local", "name": "simple", "reconcileID": "cedb6284-f877-4bb6-b287-912118ec044f"}
2025-02-05T17:00:40Z    INFO    gitjob  DUAL POLLING TEST -- GitRepo Polled     {"controller": "gitrepo", "controllerGroup": "fleet.cattle.io", "controllerKind": "GitRepo", "GitRepo": {"name":"simple","namespace":"fleet-local"}, "namespace": "fleet-local", "name": "simple", "reconcileID": "cedb6284-f877-4bb6-b287-912118ec044f", "generation": 2, "commit": "", "conditions": [{"type":"Ready","status":"True","lastUpdateTime":"2025-02-05T17:00:39Z"}]}
```

**After the change**
```bash
2025-02-05T17:14:27Z    INFO    gitjob  DUAL POLLING TEST -- Reconciling GitRepo        {"controller": "gitrepo", "controllerGroup": "fleet.cattle.io", "controllerKind": "GitRepo", "GitRepo": {"name":"simple","namespace":"fleet-local"}, "namespace": "fleet-local", "name": "simple", "reconcileID": "61c6eac7-3df7-44df-86d5-ad9686b1ff71"}
2025-02-05T17:14:27Z    INFO    gitjob  DUAL POLLING TEST -- Reconciling GitRepo        {"controller": "gitrepo", "controllerGroup": "fleet.cattle.io", "controllerKind": "GitRepo", "GitRepo": {"name":"simple","namespace":"fleet-local"}, "namespace": "fleet-local", "name": "simple", "reconcileID": "86269817-c347-4b31-bb00-aeff6ee801ad"}
2025-02-05T17:14:28Z    INFO    gitjob  DUAL POLLING TEST -- GitRepo Polled     {"controller": "gitrepo", "controllerGroup": "fleet.cattle.io", "controllerKind": "GitRepo", "GitRepo": {"name":"simple","namespace":"fleet-local"}, "namespace": "fleet-local", "name": "simple", "reconcileID": "86269817-c347-4b31-bb00-aeff6ee801ad", "generation": 1, "commit": "", "conditions": [{"type":"Ready","status":"True","lastUpdateTime":"2025-02-05T17:14:27Z"}]}
```