### PR TITLE
[v0.11] - Change ImageScanCommit in GitRepo spec to a pointer (#3302)

### DIFF
--- a/internal/cmd/controller/imagescan/gitcommit_job.go
+++ b/internal/cmd/controller/imagescan/gitcommit_job.go
@@ -206,7 +206,7 @@ func (j *GitCommitJob) cloneAndReplace(ctx context.Context) {
 		}
 	}
 
-	commit, err := commitAllAndPush(context.Background(), repo, auth, gitrepo.Spec.ImageScanCommit)
+	commit, err := commitAllAndPush(context.Background(), repo, auth, *gitrepo.Spec.ImageScanCommit)
 	if err != nil {
 		err = j.updateErrorStatus(ctx, gitrepo, err)
 		logger.V(1).Info("Cannot commit and push to repo", "error", err)

--- a/pkg/apis/fleet.cattle.io/v1alpha1/gitrepo_types.go
+++ b/pkg/apis/fleet.cattle.io/v1alpha1/gitrepo_types.go
@@ -122,7 +122,7 @@ type GitRepoSpec struct {
 	ImageSyncInterval *metav1.Duration `json:"imageScanInterval,omitempty"`
 
 	// Commit specifies how to commit to the git repo when a new image is scanned and written back to git repo.
-	ImageScanCommit CommitSpec `json:"imageScanCommit,omitempty"`
+	ImageScanCommit *CommitSpec `json:"imageScanCommit,omitempty"`
 
 	// KeepResources specifies if the resources created must be kept after deleting the GitRepo.
 	KeepResources bool `json:"keepResources,omitempty"`

--- a/pkg/apis/fleet.cattle.io/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/fleet.cattle.io/v1alpha1/zz_generated.deepcopy.go
@@ -1521,7 +1521,11 @@ func (in *GitRepoSpec) DeepCopyInto(out *GitRepoSpec) {
 		*out = new(v1.Duration)
 		**out = **in
 	}
-	out.ImageScanCommit = in.ImageScanCommit
+	if in.ImageScanCommit != nil {
+		in, out := &in.ImageScanCommit, &out.ImageScanCommit
+		*out = new(CommitSpec)
+		**out = **in
+	}
 	if in.CorrectDrift != nil {
 		in, out := &in.CorrectDrift, &out.CorrectDrift
 		*out = new(CorrectDrift)


### PR DESCRIPTION
As ImageScanCommit is an optional field inside the GitRepo spec this PR changes it to be a pointer.

Not doing so means that the veru first time the `GitRepo` is stored in the cluster default values will be created and generation will be incresed, which means a double polling for the `GitRepo` when it is created.

The first time the `GitRepo` is polled because the `LastPollingTime` is not set. The second time it is polled because of the generation change mentioned above.

Aside from double polling in a short period of time this PR also tries to prevent an extra reconciler call that is not needed.

Backport of https://github.com/rancher/fleet/pull/3302