### PR TITLE
Retry reconcile when we cannot add finalizer to content resource

### DIFF
--- a/internal/cmd/agent/controller/bundledeployment_controller.go
+++ b/internal/cmd/agent/controller/bundledeployment_controller.go
@@ -134,6 +134,7 @@ func (r *BundleDeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Req
 
 		merr = append(merr, fmt.Errorf("failed deploying bundle: %w", err))
 	} else {
+		logger.V(1).Info("Bundle deployed", "status", status)
 		bd.Status = setCondition(status, nil, monitor.Cond(fleetv1.BundleDeploymentConditionDeployed))
 	}
 

--- a/internal/cmd/agent/deployer/monitor/updatestatus.go
+++ b/internal/cmd/agent/deployer/monitor/updatestatus.go
@@ -67,6 +67,8 @@ func isAgent(bd *fleet.BundleDeployment) bool {
 	return strings.HasPrefix(bd.Name, "fleet-agent")
 }
 
+// ShouldUpdateStatus skips resource and ready status updates if the bundle
+// deployment is unchanged or not installed yet.
 func ShouldUpdateStatus(bd *fleet.BundleDeployment) bool {
 	if bd.Spec.DeploymentID != bd.Status.AppliedDeploymentID {
 		return false
@@ -81,6 +83,9 @@ func ShouldUpdateStatus(bd *fleet.BundleDeployment) bool {
 	return true
 }
 
+// UpdateStatus sets the status of the bundledeployment based on the resources from the helm release history and the live state.
+// In the status it updates: Ready, NonReadyStatus, IncompleteState, NonReadyStatus, NonModified, ModifiedStatus, Resources and ResourceCounts fields.
+// Additionally it sets the Ready condition either from the NonReadyStatus or the NonModified status field.
 func (m *Monitor) UpdateStatus(ctx context.Context, bd *fleet.BundleDeployment, resources *helmdeployer.Resources) (fleet.BundleDeploymentStatus, error) {
 	logger := log.FromContext(ctx).WithName("update-status")
 	ctx = log.IntoContext(ctx, logger)
@@ -101,14 +106,16 @@ func (m *Monitor) UpdateStatus(ctx context.Context, bd *fleet.BundleDeployment, 
 
 		return origStatus, err
 	}
+
 	status := bd.Status
+	status.SyncGeneration = &bd.Spec.Options.ForceSyncGeneration
 
 	readyError := readyError(status)
 	Cond(fleet.BundleDeploymentConditionReady).SetError(&status, "", readyError)
-
-	status.SyncGeneration = &bd.Spec.Options.ForceSyncGeneration
 	if readyError != nil {
-		logger.Info("Status not ready", "error", readyError)
+		logger.Info("Status not ready according to nonModified and nonReady", "nonModified", status.NonModified, "nonReady", status.NonReadyStatus)
+	} else {
+		logger.V(1).Info("Status ready, Ready condition set to true")
 	}
 
 	removePrivateFields(&status)
@@ -149,6 +156,7 @@ func readyError(status fleet.BundleDeploymentStatus) error {
 
 // updateFromPreviousDeployment updates the status with information from the
 // helm release history and an apply dry run.
+// Modified resources are resources that have changed from the previous helm release.
 func (m *Monitor) updateFromPreviousDeployment(ctx context.Context, bd *fleet.BundleDeployment, resources *helmdeployer.Resources) error {
 	resourcesPreviousRelease, err := m.deployer.ResourcesFromPreviousReleaseVersion(bd.Name, bd.Status.Release)
 	if err != nil {

--- a/pkg/apis/fleet.cattle.io/v1alpha1/bundle_types.go
+++ b/pkg/apis/fleet.cattle.io/v1alpha1/bundle_types.go
@@ -312,9 +312,8 @@ const (
 	// BundleDeploymentConditionInstalled indicates the bundledeployment
 	// has been installed.
 	BundleDeploymentConditionInstalled = "Installed"
-	// BundleDeploymentConditionDeployed is used by the bundledeployment
-	// controller. It is true if the handler returns no error and false if
-	// an error is returned.
+	// BundleDeploymentConditionDeployed indicates whether the deployment
+	// succeeded.
 	BundleDeploymentConditionDeployed  = "Deployed"
 	BundleDeploymentConditionMonitored = "Monitored"
 )


### PR DESCRIPTION
Noticed while reading logs. Also makes bundledeployment creation logging visible at INFO.


```
// fleet-controller-686cbf94bb-7zbnm fleet-controller 2025-02-05T17:16:04Z	ERROR	bundle	Reconcile failed to add content finalizer	{"controller": "bundle", "controllerGroup": "fleet.cattle.io", "controllerKind": "Bundle", "Bundle": {"name":"bm-1-gitrepo-1-bundle-benchmarks-create-1-gitre-773b4","namespace":"fleet-local"}, "namespace": "fleet-local", "name": "bm-1-gitrepo-1-bundle-benchmarks-create-1-gitre-773b4", "reconcileID": "9a95535b-199b-4478-b77b-fa5fae945a93", "gitrepo": "bm-1-gitrepo-1-bundle", "commit": "faca22290f9659e491e9a329ab3f23e6c9681139", "content ID": "s-bacd6eda76a6e0fef955f1656ac4d4bab9e0027580f1865a36689f71ae75a", "error": "resource name may not be empty"}
```