### PR TITLE
Adds tolerations to GitRepo

### DIFF
--- a/charts/fleet-crd/templates/crds.yaml
+++ b/charts/fleet-crd/templates/crds.yaml
@@ -6604,6 +6604,63 @@ spec:
                         type: string
                     type: object
                   type: array
+                tolerations:
+                  description: Tolerations specifies tolerations to be added when
+                    running fleet apply
+                  items:
+                    description: 'The pod this Toleration is attached to tolerates
+                      any taint that matches
+
+                      the triple <key,value,effect> using the matching operator <operator>.'
+                    properties:
+                      effect:
+                        description: 'Effect indicates the taint effect to match.
+                          Empty means match all taint effects.
+
+                          When specified, allowed values are NoSchedule, PreferNoSchedule
+                          and NoExecute.'
+                        type: string
+                      key:
+                        description: 'Key is the taint key that the toleration applies
+                          to. Empty means match all taint keys.
+
+                          If the key is empty, operator must be Exists; this combination
+                          means to match all values and all keys.'
+                        type: string
+                      operator:
+                        description: 'Operator represents a key''s relationship to
+                          the value.
+
+                          Valid operators are Exists and Equal. Defaults to Equal.
+
+                          Exists is equivalent to wildcard for value, so that a pod
+                          can
+
+                          tolerate all taints of a particular category.'
+                        type: string
+                      tolerationSeconds:
+                        description: 'TolerationSeconds represents the period of time
+                          the toleration (which must be
+
+                          of effect NoExecute, otherwise this field is ignored) tolerates
+                          the taint. By default,
+
+                          it is not set, which means tolerate the taint forever (do
+                          not evict). Zero and
+
+                          negative values will be treated as 0 (evict immediately)
+                          by the system.'
+                        format: int64
+                        type: integer
+                      value:
+                        description: 'Value is the taint value the toleration matches
+                          to.
+
+                          If the operator is Exists, the value should be empty, otherwise
+                          just a regular string.'
+                        type: string
+                    type: object
+                  type: array
               type: object
             status:
               properties:

--- a/internal/cmd/controller/gitops/reconciler/gitjob_controller.go
+++ b/internal/cmd/controller/gitops/reconciler/gitjob_controller.go
@@ -536,6 +536,9 @@ func (r *GitJobReconciler) newGitJob(ctx context.Context, obj *v1alpha1.GitRepo)
 		return nil, err
 	}
 
+	// Add user defined tolerations
+	jobSpec.Template.Spec.Tolerations = append(jobSpec.Template.Spec.Tolerations, obj.Spec.Tolerations...)
+
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: map[string]string{

--- a/pkg/apis/fleet.cattle.io/v1alpha1/gitrepo_types.go
+++ b/pkg/apis/fleet.cattle.io/v1alpha1/gitrepo_types.go
@@ -1,6 +1,7 @@
 package v1alpha1
 
 import (
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -134,6 +135,9 @@ type GitRepoSpec struct {
 
 	// Disables git polling. When enabled only webhooks will be used.
 	DisablePolling bool `json:"disablePolling,omitempty"`
+
+	// Tolerations specifies tolerations to be added when running fleet apply
+	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
 
 	// OCIRegistry specifies the OCI registry related parameters
 	OCIRegistry *OCIRegistrySpec `json:"ociRegistry,omitempty"`

--- a/pkg/apis/fleet.cattle.io/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/fleet.cattle.io/v1alpha1/zz_generated.deepcopy.go
@@ -1520,6 +1520,13 @@ func (in *GitRepoSpec) DeepCopyInto(out *GitRepoSpec) {
 		*out = new(CorrectDrift)
 		**out = **in
 	}
+	if in.Tolerations != nil {
+		in, out := &in.Tolerations, &out.Tolerations
+		*out = make([]corev1.Toleration, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	if in.OCIRegistry != nil {
 		in, out := &in.OCIRegistry, &out.OCIRegistry
 		*out = new(OCIRegistrySpec)


### PR DESCRIPTION
When applying a `GitRepo` in a cluster where all the nodes are tainted the pod created to call `fleet apply` remans waiting as Pending.

This PR adds tolerations to the `GitRepo` spec. Those tolerations will be added to the job spec when running `fleet apply` so the pod is scheduled.

Refers to: https://github.com/rancher/fleet/issues/3313