### PR TITLE
Fix integrationtest for drift correction

### DIFF
--- a/e2e/single-cluster/sharding_test.go
+++ b/e2e/single-cluster/sharding_test.go
@@ -97,7 +97,7 @@ var _ = Describe("Filtering events by shard", Label("sharding"), func() {
 					shardLabelValue, err := k.Get(
 						"bundle",
 						bundleName,
-						`-o jsonpath='{.metadata.labels.fleet\.cattle\.io/shard-ref}'`,
+						`-o=jsonpath={.metadata.labels.fleet\.cattle\.io/shard-ref}`,
 					)
 					g.Expect(err).ToNot(HaveOccurred())
 					g.Expect(shardLabelValue).To(Equal(shard))
@@ -109,7 +109,7 @@ var _ = Describe("Filtering events by shard", Label("sharding"), func() {
 					"local",
 					"-n",
 					"fleet-local",
-					`-o=jsonpath='{.status.namespace}'`,
+					`-o=jsonpath={.status.namespace}`,
 				)
 				Expect(err).ToNot(HaveOccurred())
 
@@ -119,7 +119,7 @@ var _ = Describe("Filtering events by shard", Label("sharding"), func() {
 						bundleName,
 						"-n",
 						clusterNS,
-						`-o=jsonpath='{.metadata.labels.fleet\.cattle\.io/shard-ref}'`,
+						`-o=jsonpath={.metadata.labels.fleet\.cattle\.io/shard-ref}`,
 					)
 					g.Expect(err).ToNot(HaveOccurred())
 					g.Expect(shardLabelValue).To(Equal(shard))

--- a/integrationtests/agent/assets/deployment-v1.yaml
+++ b/integrationtests/agent/assets/deployment-v1.yaml
@@ -14,12 +14,21 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
+  name: svc-ext
+spec:
+  type: ExternalName
+  externalName: svc-ext
+---
+apiVersion: v1
+kind: Service
+metadata:
   name: svc-finalizer
   finalizers:
   - kubernetes
 spec:
   selector:
     app.kubernetes.io/name: MyApp
+  externalName: svc-finalizer
   ports:
     - protocol: TCP
       port: 80
@@ -30,5 +39,6 @@ kind: ConfigMap
 metadata:
   name: cm-test
 data:
+  foo: bar
   test.properties: |
     foo=bar

--- a/integrationtests/agent/bundle_deployment_status_test.go
+++ b/integrationtests/agent/bundle_deployment_status_test.go
@@ -84,14 +84,14 @@ var _ = Describe("BundleDeployment status", Ordered, func() {
 			bd := &v1alpha1.BundleDeployment{}
 			err := k8sClient.Get(ctx, types.NamespacedName{Namespace: clusterNS, Name: name}, bd)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(bd.Status.Resources).To(HaveLen(3))
+			Expect(bd.Status.Resources).To(HaveLen(4))
 			ts := bd.Status.Resources[0].CreatedAt
 			Expect(ts.Time).ToNot(BeZero())
 			Expect(bd.Status.Resources).To(ContainElement(v1alpha1.BundleDeploymentResource{
 				Kind:       "Service",
 				APIVersion: "v1",
 				Namespace:  namespace,
-				Name:       "svc-test",
+				Name:       svcName,
 				CreatedAt:  ts,
 			}))
 		})
@@ -111,7 +111,7 @@ var _ = Describe("BundleDeployment status", Ordered, func() {
 						Kind:       "Service",
 						APIVersion: "v1",
 						Namespace:  namespace,
-						Name:       "svc-test",
+						Name:       svcName,
 						Create:     false,
 						Delete:     false,
 						Patch:      "{\"spec\":{\"selector\":{\"app.kubernetes.io/name\":\"MyApp\"}}}",
@@ -157,7 +157,7 @@ var _ = Describe("BundleDeployment status", Ordered, func() {
 						Kind:       "Service",
 						APIVersion: "v1",
 						Namespace:  namespace,
-						Name:       "svc-finalizer",
+						Name:       svcFinalizerName,
 						Create:     false,
 						Delete:     true,
 						Patch:      "",
@@ -198,7 +198,7 @@ var _ = Describe("BundleDeployment status", Ordered, func() {
 						Kind:       "Service",
 						APIVersion: "v1",
 						Namespace:  namespace,
-						Name:       "svc-test",
+						Name:       svcName,
 						Create:     true,
 						Delete:     false,
 						Patch:      "",
@@ -253,14 +253,14 @@ var _ = Describe("BundleDeployment status", Ordered, func() {
 			bd := &v1alpha1.BundleDeployment{}
 			err := k8sClient.Get(ctx, types.NamespacedName{Namespace: clusterNS, Name: name}, bd)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(bd.Status.Resources).To(HaveLen(3))
+			Expect(bd.Status.Resources).To(HaveLen(4))
 			ts := bd.Status.Resources[0].CreatedAt
 			Expect(ts.Time).ToNot(BeZero())
 			Expect(bd.Status.Resources).To(ContainElement(v1alpha1.BundleDeploymentResource{
 				Kind:       "Service",
 				APIVersion: "v1",
 				Namespace:  namespace,
-				Name:       "svc-test",
+				Name:       svcName,
 				CreatedAt:  ts,
 			}))
 		})
@@ -280,7 +280,7 @@ var _ = Describe("BundleDeployment status", Ordered, func() {
 						Kind:       "Service",
 						APIVersion: "v1",
 						Namespace:  namespace,
-						Name:       "svc-test",
+						Name:       svcName,
 						Create:     false,
 						Delete:     false,
 						Patch:      "{\"spec\":{\"selector\":{\"app.kubernetes.io/name\":\"MyApp\"}}}",
@@ -326,7 +326,7 @@ var _ = Describe("BundleDeployment status", Ordered, func() {
 						Kind:       "Service",
 						APIVersion: "v1",
 						Namespace:  namespace,
-						Name:       "svc-finalizer",
+						Name:       svcFinalizerName,
 						Create:     false,
 						Delete:     true,
 						Patch:      "",
@@ -367,7 +367,7 @@ var _ = Describe("BundleDeployment status", Ordered, func() {
 						Kind:       "Service",
 						APIVersion: "v1",
 						Namespace:  namespace,
-						Name:       "svc-test",
+						Name:       svcName,
 						Create:     true,
 						Delete:     false,
 						Patch:      "",

--- a/integrationtests/agent/suite_test.go
+++ b/integrationtests/agent/suite_test.go
@@ -59,7 +59,7 @@ var (
 const (
 	clusterNS  = "cluster-test-id"
 	assetsPath = "assets"
-	timeout    = 30 * time.Second
+	timeout    = 60 * time.Second
 )
 
 var resources = map[string][]v1alpha1.BundleResource{}


### PR DESCRIPTION
After applying ginkgolinter fixes, several tests failed. Some tests where not effective, as they were missing `Should(Succeed())`.

This fixes test expectations and relaxes some tests.

It seems `UpdateStatus` sometimes overwrites the Ready error message or resets the conditions. The  error appears in either Ready or Deployed as "modified" or "cannot patch".