### PR TITLE
Fix default state for GitRepo resources

### DIFF
--- a/internal/resourcestatus/resourcekey.go
+++ b/internal/resourcestatus/resourcekey.go
@@ -81,9 +81,11 @@ func toType(apiVersion, kind string) string {
 	return group + strings.ToLower(kind)
 }
 
+// resourceDefaultState calculates the state for items in the status.Resources list.
+// This default state may be replaced individually for each resource with the information from NonReadyStatus and ModifiedStatus fields.
 func resourcesDefaultState(bd *fleet.BundleDeployment) string {
 	switch bdState := summary.GetDeploymentState(bd); bdState {
-	// NotReady and Modified BD states are inferred from resource statuses, so it's incorrect to used that to calculate resource states
+	// NotReady and Modified BD states are inferred from resource statuses, so it's incorrect to use that to calculate resource states
 	case fleet.NotReady, fleet.Modified:
 		if bd.Status.IncompleteState {
 			return "Unknown"

--- a/internal/resourcestatus/resourcekey.go
+++ b/internal/resourcestatus/resourcekey.go
@@ -81,10 +81,24 @@ func toType(apiVersion, kind string) string {
 	return group + strings.ToLower(kind)
 }
 
+func resourcesDefaultState(bd *fleet.BundleDeployment) string {
+	switch bdState := summary.GetDeploymentState(bd); bdState {
+	// NotReady and Modified BD states are inferred from resource statuses, so it's incorrect to used that to calculate resource states
+	case fleet.NotReady, fleet.Modified:
+		if bd.Status.IncompleteState {
+			return "Unknown"
+		} else {
+			return string(fleet.Ready)
+		}
+	default:
+		return string(bdState)
+	}
+}
+
 func bundleDeploymentResources(bd fleet.BundleDeployment) map[fleet.ResourceKey]resourceStateEntry {
 	clusterID := bd.Labels[fleet.ClusterNamespaceLabel] + "/" + bd.Labels[fleet.ClusterLabel]
-	defaultState := string(summary.GetDeploymentState(&bd))
 	incomplete := bd.Status.IncompleteState
+	defaultState := resourcesDefaultState(&bd)
 
 	resources := make(map[fleet.ResourceKey]resourceStateEntry, len(bd.Status.Resources))
 	for _, bdResource := range bd.Status.Resources {


### PR DESCRIPTION
Follow up to #3209
Found while testing https://github.com/rancher/dashboard/pull/13244

#3209 changed the default state for resources from the Bundle summary state to use the BundleDeployment, but I didn't take into account that this is sometimes calculated from the resource states (when it's not `WaitApplied` or `ErrApplied`).
This change prevents that, and provides resources with correct default state assumptions.