### PR TITLE
Fix integration test issue with git tests

### DIFF
--- a/integrationtests/gitjob/git/git_test.go
+++ b/integrationtests/gitjob/git/git_test.go
@@ -359,6 +359,12 @@ func createGogsContainer(ctx context.Context, tmpDir string) (testcontainers.Con
 	if err != nil {
 		return nil, "", err
 	}
+
+	err = os.Chmod(filepath.Join(tmpDir, "git", ".ssh"), 0700)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to change permissions for .ssh directory: %w", err)
+	}
+
 	req := testcontainers.ContainerRequest{
 		Image:        "gogs/gogs:0.13",
 		ExposedPorts: []string{"3000/tcp", "22/tcp"},


### PR DESCRIPTION
The issue seems to be specific to Ubuntu (or possibly other Linux distributions) as I have had it for both my Ubuntu machines.

Fixes
```
--- FAIL: TestLatestCommitSSH (4.68s)
    git_test.go:272: 
            Error Trace:    /home/user/src/fleet/integrationtests/gitjob/git/git_test.go:272
            Error:          Received unexpected error:
                            ssh: handshake failed: ssh: unable to authenticate, attempted methods [none publickey], no supported methods remain
            Test:           TestLatestCommitSSH
    --- FAIL: TestLatestCommitSSH/private_repo_without_known_hosts (0.04s)
        testing.go:1679: test executed panic(nil) or runtime.Goexit: subtest may have called FailNow on a parent test
```

<!-- Specify the issue ID that this pull request is solving -->
<!-- Make sure that the referenced issue provides steps to reproduce it -->

<!-- Describe the changes introduced by this pull request -->

<!--
  Please provide a unit, integration (`./integrationtests/`) or e2e (`./e2e/`) test if possible.
-->