### PR TITLE
Add logging around drift correction and disable test

### DIFF
--- a/integrationtests/agent/assets/deployment-v1.yaml
+++ b/integrationtests/agent/assets/deployment-v1.yaml
@@ -28,7 +28,6 @@ metadata:
 spec:
   selector:
     app.kubernetes.io/name: MyApp
-  externalName: svc-finalizer
   ports:
     - protocol: TCP
       port: 80

--- a/integrationtests/agent/bundle_deployment_diffs_test.go
+++ b/integrationtests/agent/bundle_deployment_diffs_test.go
@@ -128,7 +128,6 @@ var _ = Describe("BundleDeployment diff", func() {
 						context.TODO(),
 						types.NamespacedName{Namespace: clusterNS, Name: name},
 						bd,
-						&client.GetOptions{},
 					)
 					g.Expect(err).NotTo(HaveOccurred())
 					g.Expect(bd.Status.NonModified).To(BeTrue())
@@ -155,7 +154,6 @@ var _ = Describe("BundleDeployment diff", func() {
 						context.TODO(),
 						types.NamespacedName{Namespace: clusterNS, Name: name},
 						bd,
-						&client.GetOptions{},
 					)
 					g.Expect(err).NotTo(HaveOccurred())
 					g.Expect(bd.Status.NonModified).To(BeTrue())

--- a/integrationtests/agent/suite_test.go
+++ b/integrationtests/agent/suite_test.go
@@ -69,6 +69,7 @@ func TestFleet(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 	SetDefaultEventuallyTimeout(timeout)
+	SetDefaultEventuallyPollingInterval(1 * time.Second)
 
 	ctx, cancel = context.WithCancel(context.TODO())
 	testEnv = utils.NewEnvTest("../..")
@@ -257,7 +258,7 @@ type specEnv struct {
 
 func (se specEnv) isNotReadyAndModified(g Gomega, name string, modifiedStatus v1alpha1.ModifiedStatus, message string) {
 	bd := &v1alpha1.BundleDeployment{}
-	err := k8sClient.Get(context.TODO(), types.NamespacedName{Namespace: clusterNS, Name: name}, bd, &client.GetOptions{})
+	err := k8sClient.Get(context.TODO(), types.NamespacedName{Namespace: clusterNS, Name: name}, bd)
 
 	g.Expect(err).ToNot(HaveOccurred())
 
@@ -269,7 +270,7 @@ func (se specEnv) isNotReadyAndModified(g Gomega, name string, modifiedStatus v1
 
 func (se specEnv) isBundleDeploymentReadyAndNotModified(name string) bool {
 	bd := &v1alpha1.BundleDeployment{}
-	err := k8sClient.Get(context.TODO(), types.NamespacedName{Namespace: clusterNS, Name: name}, bd, &client.GetOptions{})
+	err := k8sClient.Get(context.TODO(), types.NamespacedName{Namespace: clusterNS, Name: name}, bd)
 	if err != nil {
 		return false
 	}


### PR DESCRIPTION
The test for switching on forced drift correction after a failed drift correction attempt is flaky.
