### PR TITLE
[v0.11] Bump Go to 1.23.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/rancher/fleet
 
 go 1.23.0
 
-toolchain go1.23.2
+toolchain go1.23.6
 
 replace (
 	github.com/imdario/mergo => github.com/imdario/mergo v0.3.16


### PR DESCRIPTION
https://artifacthub.io/packages/helm/fleet/fleet/0.11.4-rc.1?modal=security-report

The link will work soon, the helm cart pr was just merged recently.