### PR TITLE
Incorporate kube-version and rancher-version annotations in chart

### DIFF
--- a/charts/fleet-agent/Chart.yaml
+++ b/charts/fleet-agent/Chart.yaml
@@ -1,10 +1,12 @@
 annotations:
   catalog.cattle.io/certified: rancher
   catalog.cattle.io/hidden: "true"
+  catalog.cattle.io/kube-version: '>= 1.28.0-0 < 1.33.0-0'
   catalog.cattle.io/namespace: cattle-fleet-system
-  catalog.cattle.io/release-name: fleet-agent
   catalog.cattle.io/os: linux
   catalog.cattle.io/permits-os: linux,windows
+  catalog.cattle.io/rancher-version: '>= 2.11.0-0 < 2.12.0-0'
+  catalog.cattle.io/release-name: fleet-agent
 apiVersion: v2
 appVersion: 0.0.0
 description: Fleet Agent - GitOps at Scale

--- a/charts/fleet/Chart.yaml
+++ b/charts/fleet/Chart.yaml
@@ -3,10 +3,12 @@ annotations:
   catalog.cattle.io/certified: rancher
   catalog.cattle.io/experimental: "true"
   catalog.cattle.io/hidden: "true"
+  catalog.cattle.io/kube-version: '>= 1.28.0-0 < 1.33.0-0'
   catalog.cattle.io/namespace: cattle-fleet-system
   catalog.cattle.io/os: linux
   catalog.cattle.io/permits-os: linux,windows
   catalog.cattle.io/provides-gvr: clusters.fleet.cattle.io/v1alpha1
+  catalog.cattle.io/rancher-version: '>= 2.11.0-0 < 2.12.0-0'
   catalog.cattle.io/release-name: fleet
 apiVersion: v2
 appVersion: 0.0.0


### PR DESCRIPTION
to get rid of the generated patches in the charts repo.

E.G.: https://github.com/rancher/charts/blob/dev-v2.11/packages/fleet/fleet-agent/generated-changes/patch/Chart.yaml.patch
