### PR TITLE
Adds tolerations from fleet-controller Deployment

### DIFF
--- a/charts/fleet/templates/rbac.yaml
+++ b/charts/fleet/templates/rbac.yaml
@@ -38,6 +38,13 @@ rules:
     - 'events'
   verbs:
     - '*'
+- apiGroups:
+    - "apps"
+  resources:
+    - 'deployments'
+  verbs:
+    - 'list'
+    - 'get'
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/charts/fleet/templates/rbac_gitjob.yaml
+++ b/charts/fleet/templates/rbac_gitjob.yaml
@@ -99,7 +99,14 @@ rules:
       - list
       - watch
       - update
-
+  - apiGroups:
+      - "apps"
+    resources:
+      - 'deployments'
+    verbs:
+      - 'list'
+      - 'get'
+      - 'watch'
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/internal/cmd/controller/gitops/operator.go
+++ b/internal/cmd/controller/gitops/operator.go
@@ -144,6 +144,7 @@ func (g *GitOperator) Run(cmd *cobra.Command, args []string) error {
 		GitFetcher:      &git.Fetch{},
 		Clock:           reconciler.RealClock{},
 		Recorder:        mgr.GetEventRecorderFor(fmt.Sprintf("fleet-gitops%s", shardIDSuffix)),
+		SystemNamespace: namespace,
 	}
 
 	statusReconciler := &reconciler.StatusReconciler{

--- a/internal/cmd/controller/gitops/reconciler/gitjob_controller.go
+++ b/internal/cmd/controller/gitops/reconciler/gitjob_controller.go
@@ -18,6 +18,7 @@ import (
 	fleetutil "github.com/rancher/fleet/internal/cmd/controller/errorutil"
 	"github.com/rancher/fleet/internal/cmd/controller/finalize"
 	"github.com/rancher/fleet/internal/cmd/controller/imagescan"
+	"github.com/rancher/fleet/internal/config"
 	"github.com/rancher/fleet/internal/metrics"
 	"github.com/rancher/fleet/internal/names"
 	"github.com/rancher/fleet/internal/ociwrapper"
@@ -29,6 +30,7 @@ import (
 	"github.com/rancher/wrangler/v3/pkg/genericcondition"
 	"github.com/rancher/wrangler/v3/pkg/kstatus"
 
+	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -97,6 +99,7 @@ type GitJobReconciler struct {
 	GitFetcher      GitFetcher
 	Clock           TimeGetter
 	Recorder        record.EventRecorder
+	SystemNamespace string
 }
 
 func (r *GitJobReconciler) SetupWithManager(mgr ctrl.Manager) error {
@@ -535,7 +538,19 @@ func (r *GitJobReconciler) newGitJob(ctx context.Context, obj *v1alpha1.GitRepo)
 	if err != nil {
 		return nil, err
 	}
+	var fleetControllerDeployment appsv1.Deployment
+	if err := r.Get(ctx, types.NamespacedName{
+		Namespace: r.SystemNamespace,
+		Name:      config.ManagerConfigName,
+	}, &fleetControllerDeployment); err != nil {
+		return nil, err
+	}
 
+	// add tolerations from the fleet-controller deployment
+	jobSpec.Template.Spec.Tolerations = append(
+		jobSpec.Template.Spec.Tolerations,
+		fleetControllerDeployment.Spec.Template.Spec.Tolerations...,
+	)
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: map[string]string{


### PR DESCRIPTION
Adding the toleration needed to the helm chart in Fleet is not enough when running the agent and the fleet apply job.

This PR adds the tolerations found in the `fleet-controller` deployment to the agent and to the fleet apply job.

Refers to: https://github.com/rancher/fleet/issues/3313
