### PR TITLE
[v0.11] - Adds tolerations from fleet-controller Deployment

### DIFF
--- a/charts/fleet/templates/rbac.yaml
+++ b/charts/fleet/templates/rbac.yaml
@@ -38,6 +38,13 @@ rules:
     - 'events'
   verbs:
     - '*'
+- apiGroups:
+    - "apps"
+  resources:
+    - 'deployments'
+  verbs:
+    - 'list'
+    - 'get'
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/charts/fleet/templates/rbac_gitjob.yaml
+++ b/charts/fleet/templates/rbac_gitjob.yaml
@@ -91,7 +91,14 @@ rules:
       - rolebindings
     verbs:
       - create
-
+  - apiGroups:
+      - "apps"
+    resources:
+      - 'deployments'
+    verbs:
+      - 'list'
+      - 'get'
+      - 'watch'
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/integrationtests/gitjob/controller/suite_test.go
+++ b/integrationtests/gitjob/controller/suite_test.go
@@ -14,6 +14,8 @@ import (
 	gomegatypes "github.com/onsi/gomega/types"
 	"github.com/reugn/go-quartz/quartz"
 	"go.uber.org/mock/gomock"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 
 	"github.com/rancher/fleet/internal/cmd/controller/gitops/reconciler"
 	ctrlreconciler "github.com/rancher/fleet/internal/cmd/controller/reconciler"
@@ -99,19 +101,53 @@ var _ = BeforeSuite(func() {
 		},
 	)
 
+	// fleet-controller deployment
+	err = k8sClient.Create(ctx, &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      config.ManagerConfigName,
+			Namespace: "default",
+		},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app": "fleet-controller",
+				},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"app": "fleet-controller",
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "test",
+							Image: "test", // value is required. but we don't need a real deployment for the test
+
+						},
+					},
+				},
+			},
+		},
+	})
+	Expect(err).ToNot(HaveOccurred())
+
 	sched := quartz.NewStdScheduler()
 	Expect(sched).ToNot(BeNil())
 
 	config.Set(&config.Config{})
 
 	err = (&reconciler.GitJobReconciler{
-		Client:     mgr.GetClient(),
-		Scheme:     mgr.GetScheme(),
-		Image:      "image",
-		Scheduler:  sched,
-		GitFetcher: fetcherMock,
-		Clock:      reconciler.RealClock{},
-		Recorder:   mgr.GetEventRecorderFor("gitjob-controller"),
+		Client:          mgr.GetClient(),
+		Scheme:          mgr.GetScheme(),
+		Image:           "image",
+		Scheduler:       sched,
+		GitFetcher:      fetcherMock,
+		Clock:           reconciler.RealClock{},
+		Recorder:        mgr.GetEventRecorderFor("gitjob-controller"),
+		Workers:         50,
+		SystemNamespace: "default",
 	}).SetupWithManager(mgr)
 	Expect(err).ToNot(HaveOccurred())
 

--- a/internal/cmd/controller/gitops/operator.go
+++ b/internal/cmd/controller/gitops/operator.go
@@ -146,6 +146,7 @@ func (g *GitOperator) Run(cmd *cobra.Command, args []string) error {
 		GitFetcher:      &git.Fetch{},
 		Clock:           reconciler.RealClock{},
 		Recorder:        mgr.GetEventRecorderFor(fmt.Sprintf("fleet-gitops%s", shardIDSuffix)),
+		SystemNamespace: namespace,
 	}
 
 	statusReconciler := &reconciler.StatusReconciler{

--- a/internal/cmd/controller/gitops/reconciler/gitjob_controller.go
+++ b/internal/cmd/controller/gitops/reconciler/gitjob_controller.go
@@ -18,6 +18,7 @@ import (
 	fleetutil "github.com/rancher/fleet/internal/cmd/controller/errorutil"
 	"github.com/rancher/fleet/internal/cmd/controller/finalize"
 	"github.com/rancher/fleet/internal/cmd/controller/imagescan"
+	"github.com/rancher/fleet/internal/config"
 	"github.com/rancher/fleet/internal/metrics"
 	"github.com/rancher/fleet/internal/names"
 	"github.com/rancher/fleet/internal/ociwrapper"
@@ -29,6 +30,7 @@ import (
 	"github.com/rancher/wrangler/v3/pkg/genericcondition"
 	"github.com/rancher/wrangler/v3/pkg/kstatus"
 
+	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -97,6 +99,7 @@ type GitJobReconciler struct {
 	GitFetcher      GitFetcher
 	Clock           TimeGetter
 	Recorder        record.EventRecorder
+	SystemNamespace string
 }
 
 func (r *GitJobReconciler) SetupWithManager(mgr ctrl.Manager) error {
@@ -547,7 +550,19 @@ func (r *GitJobReconciler) newGitJob(ctx context.Context, obj *v1alpha1.GitRepo)
 	if err != nil {
 		return nil, err
 	}
+	var fleetControllerDeployment appsv1.Deployment
+	if err := r.Get(ctx, types.NamespacedName{
+		Namespace: r.SystemNamespace,
+		Name:      config.ManagerConfigName,
+	}, &fleetControllerDeployment); err != nil {
+		return nil, err
+	}
 
+	// add tolerations from the fleet-controller deployment
+	jobSpec.Template.Spec.Tolerations = append(
+		jobSpec.Template.Spec.Tolerations,
+		fleetControllerDeployment.Spec.Template.Spec.Tolerations...,
+	)
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: map[string]string{


### PR DESCRIPTION
Adding the toleration needed to the helm chart in Fleet is not enough when running the agent and the fleet apply job.

This PR adds the tolerations found in the `fleet-controller` deployment to the agent and to the fleet apply job.

Refers to: https://github.com/rancher/fleet/issues/3313