### PR TITLE
Adds message context to fleet apply errors

### DIFF
--- a/integrationtests/cli/apply/helm_test.go
+++ b/integrationtests/cli/apply/helm_test.go
@@ -186,7 +186,7 @@ func testHelmRepo(path, port string) {
 				return err.Error()
 			}).Should(
 				And(
-					ContainSubstring("processing bundle"),
+					ContainSubstring("failed to process bundle: failed to add auth to request for"),
 					ContainSubstring(
 						fmt.Sprintf(
 							"repo=%s chart=%s version=%s: error parsing regexp: missing closing ): `a(b`",

--- a/integrationtests/cli/apply/helm_test.go
+++ b/integrationtests/cli/apply/helm_test.go
@@ -184,13 +184,19 @@ func testHelmRepo(path, port string) {
 				})
 				Expect(err).To(HaveOccurred())
 				return err.Error()
-			}).Should(Equal(
-				fmt.Sprintf(
-					"repo=%s chart=%s version=%s: error parsing regexp: missing closing ): `a(b`",
-					fy.Helm.Repo,
-					fy.Helm.Chart,
-					fy.Helm.Version,
-				)))
+			}).Should(
+				And(
+					ContainSubstring("processing bundle"),
+					ContainSubstring(
+						fmt.Sprintf(
+							"repo=%s chart=%s version=%s: error parsing regexp: missing closing ): `a(b`",
+							fy.Helm.Repo,
+							fy.Helm.Chart,
+							fy.Helm.Version,
+						),
+					),
+				),
+			)
 		})
 	})
 

--- a/internal/bundlereader/read.go
+++ b/internal/bundlereader/read.go
@@ -51,7 +51,7 @@ func Open(ctx context.Context, name, baseDir, file string, opts *Options) (*flee
 	if file == "-" {
 		b, s, err := mayCompress(ctx, name, baseDir, os.Stdin, opts)
 		if err != nil {
-			return b, s, fmt.Errorf("%s: %w", errorContext, err)
+			return b, s, fmt.Errorf("failed to process bundle from STDIN: %w", err)
 		}
 	}
 

--- a/internal/bundlereader/read.go
+++ b/internal/bundlereader/read.go
@@ -42,8 +42,6 @@ type Options struct {
 // Then it reads/downloads all referenced resources. It returns the populated
 // bundle and any existing imagescans.
 func Open(ctx context.Context, name, baseDir, file string, opts *Options) (*fleet.Bundle, []*fleet.ImageScan, error) {
-	errorContext := fmt.Sprintf("processing bundle %s", name)
-
 	if baseDir == "" {
 		baseDir = "."
 	}
@@ -61,7 +59,7 @@ func Open(ctx context.Context, name, baseDir, file string, opts *Options) (*flee
 
 	if file == "" {
 		if file, err := setupIOReader(baseDir); err != nil {
-			return nil, nil, fmt.Errorf("%s: %w", errorContext, err)
+			return nil, nil, fmt.Errorf("failed to open existing fleet.yaml in %q: %w", baseDir, err)
 		} else if file != nil {
 			in = file
 			defer file.Close()
@@ -72,7 +70,7 @@ func Open(ctx context.Context, name, baseDir, file string, opts *Options) (*flee
 	} else {
 		f, err := os.Open(filepath.Join(baseDir, file))
 		if err != nil {
-			return nil, nil, fmt.Errorf("%s: %w", errorContext, err)
+			return nil, nil, fmt.Errorf("failed to open file %q: %w", file, err)
 		}
 		defer f.Close()
 		in = f
@@ -80,7 +78,7 @@ func Open(ctx context.Context, name, baseDir, file string, opts *Options) (*flee
 
 	b, s, err := mayCompress(ctx, name, baseDir, in, opts)
 	if err != nil {
-		return b, s, fmt.Errorf("%s: %w", errorContext, err)
+		return b, s, fmt.Errorf("failed to process bundle: %w", err)
 	}
 
 	return b, s, nil

--- a/internal/bundlereader/resources.go
+++ b/internal/bundlereader/resources.go
@@ -128,12 +128,12 @@ func generateValues(base string, chart *fleet.HelmOptions) (valuesMap *fleet.Gen
 	for _, value := range chart.ValuesFiles {
 		valuesByte, err := os.ReadFile(base + "/" + value)
 		if err != nil {
-			return nil, fmt.Errorf("%s: %w", fmt.Sprintf("reading values file: %s/%s", base, value), err)
+			return nil, fmt.Errorf("reading values file: %s/%s: %w", base, value, err)
 		}
 		tmpDataOpt := &fleet.GenericMap{}
 		err = yaml.Unmarshal(valuesByte, tmpDataOpt)
 		if err != nil {
-			return nil, fmt.Errorf("%s: %w", fmt.Sprintf("reading values file: %s/%s", base, value), err)
+			return nil, fmt.Errorf("reading values file: %s/%s: %w", base, value, err)
 		}
 		valuesMap = mergeGenericMap(valuesMap, tmpDataOpt)
 	}
@@ -154,7 +154,7 @@ func addRemoteCharts(directories []directory, base string, charts []*fleet.HelmO
 		if _, err := os.Stat(filepath.Join(base, chart.Chart)); os.IsNotExist(err) || chart.Repo != "" {
 			shouldAddAuthToRequest, err := shouldAddAuthToRequest(helmRepoURLRegex, chart.Repo, chart.Chart)
 			if err != nil {
-				return nil, fmt.Errorf("%s: %w", downloadChartError(*chart), err)
+				return nil, fmt.Errorf("failed to add auth to request for %s: %w", downloadChartError(*chart), err)
 			}
 			if !shouldAddAuthToRequest {
 				auth = Auth{}
@@ -162,7 +162,7 @@ func addRemoteCharts(directories []directory, base string, charts []*fleet.HelmO
 
 			chartURL, err := chartURL(*chart, auth)
 			if err != nil {
-				return nil, fmt.Errorf("%s: %w", downloadChartError(*chart), err)
+				return nil, fmt.Errorf("failed to resolve URL of %s: %w", downloadChartError(*chart), err)
 			}
 
 			directories = append(directories, directory{
@@ -225,7 +225,7 @@ func loadDirectories(ctx context.Context, compress bool, disableDepsUpdate bool,
 			defer sem.Release(1)
 			resources, err := loadDirectory(ctx, compress, disableDepsUpdate, dir.prefix, dir.base, dir.source, dir.version, dir.auth)
 			if err != nil {
-				return fmt.Errorf("%s: %w", fmt.Sprintf("loading directory %s, %s", dir.prefix, dir.base), err)
+				return fmt.Errorf("loading directory %s, %s: %w", dir.prefix, dir.base, err)
 			}
 
 			key := dir.key

--- a/internal/bundlereader/resources.go
+++ b/internal/bundlereader/resources.go
@@ -128,12 +128,12 @@ func generateValues(base string, chart *fleet.HelmOptions) (valuesMap *fleet.Gen
 	for _, value := range chart.ValuesFiles {
 		valuesByte, err := os.ReadFile(base + "/" + value)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("%s: %w", fmt.Sprintf("reading values file: %s/%s", base, value), err)
 		}
 		tmpDataOpt := &fleet.GenericMap{}
 		err = yaml.Unmarshal(valuesByte, tmpDataOpt)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("%s: %w", fmt.Sprintf("reading values file: %s/%s", base, value), err)
 		}
 		valuesMap = mergeGenericMap(valuesMap, tmpDataOpt)
 	}
@@ -154,7 +154,7 @@ func addRemoteCharts(directories []directory, base string, charts []*fleet.HelmO
 		if _, err := os.Stat(filepath.Join(base, chart.Chart)); os.IsNotExist(err) || chart.Repo != "" {
 			shouldAddAuthToRequest, err := shouldAddAuthToRequest(helmRepoURLRegex, chart.Repo, chart.Chart)
 			if err != nil {
-				return nil, downloadChartError(*chart, err)
+				return nil, fmt.Errorf("%s: %w", downloadChartError(*chart), err)
 			}
 			if !shouldAddAuthToRequest {
 				auth = Auth{}
@@ -162,7 +162,7 @@ func addRemoteCharts(directories []directory, base string, charts []*fleet.HelmO
 
 			chartURL, err := chartURL(*chart, auth)
 			if err != nil {
-				return nil, downloadChartError(*chart, err)
+				return nil, fmt.Errorf("%s: %w", downloadChartError(*chart), err)
 			}
 
 			directories = append(directories, directory{
@@ -178,13 +178,12 @@ func addRemoteCharts(directories []directory, base string, charts []*fleet.HelmO
 	return directories, nil
 }
 
-func downloadChartError(c fleet.HelmOptions, e error) error {
-	return fmt.Errorf(
-		"repo=%s chart=%s version=%s: %w",
+func downloadChartError(c fleet.HelmOptions) string {
+	return fmt.Sprintf(
+		"repo=%s chart=%s version=%s",
 		c.Repo,
 		c.Chart,
 		c.Version,
-		e,
 	)
 }
 
@@ -226,7 +225,7 @@ func loadDirectories(ctx context.Context, compress bool, disableDepsUpdate bool,
 			defer sem.Release(1)
 			resources, err := loadDirectory(ctx, compress, disableDepsUpdate, dir.prefix, dir.base, dir.source, dir.version, dir.auth)
 			if err != nil {
-				return err
+				return fmt.Errorf("%s: %w", fmt.Sprintf("loading directory %s, %s", dir.prefix, dir.base), err)
 			}
 
 			key := dir.key

--- a/internal/cmd/cli/apply.go
+++ b/internal/cmd/cli/apply.go
@@ -98,11 +98,12 @@ func (a *Apply) Run(cmd *cobra.Command, args []string) error {
 		CorrectDriftKeepFailHistory: a.CorrectDriftKeepFailHistory,
 	}
 	if err := a.addAuthToOpts(&opts, os.ReadFile); err != nil {
-		return err
+		return fmt.Errorf("adding auth to opts: %w", err)
 	}
 	if err := a.addOCISpecToOpts(&opts, os.ReadFile); err != nil {
-		return err
+		return fmt.Errorf("adding oci spec to opts: %w", err)
 	}
+
 	if a.File == "-" {
 		opts.BundleReader = os.Stdin
 		if len(args) != 1 {

--- a/internal/cmd/cli/apply/apply.go
+++ b/internal/cmd/cli/apply/apply.go
@@ -105,14 +105,14 @@ func CreateBundles(ctx context.Context, client Getter, repoName string, baseDirs
 		for _, baseDir := range matches {
 			if i > 0 && opts.Output != nil {
 				if _, err := opts.Output.Write([]byte("\n---\n")); err != nil {
-					return err
+					return fmt.Errorf("writing to bundle output: %w", err)
 				}
 			}
 			err := filepath.Walk(baseDir, func(path string, info os.FileInfo, err error) error {
 				opts := opts
 				createBundle, e := shouldCreateBundleForThisPath(baseDir, path, info)
 				if e != nil {
-					return e
+					return fmt.Errorf("%s: %w", fmt.Sprintf("checking for bundle in path %s", path), err)
 				}
 				if !createBundle {
 					return nil
@@ -180,7 +180,7 @@ func readBundle(ctx context.Context, name, baseDir string, opts *Options) (*flee
 	if opts.BundleReader != nil {
 		var bundle *fleet.Bundle
 		if err := json.NewDecoder(opts.BundleReader).Decode(bundle); err != nil {
-			return nil, nil, err
+			return nil, nil, fmt.Errorf("%s: %w", fmt.Sprintf("decoding bundle %s", name), err)
 		}
 		return bundle, nil, nil
 	}

--- a/internal/cmd/cli/apply/apply.go
+++ b/internal/cmd/cli/apply/apply.go
@@ -112,7 +112,7 @@ func CreateBundles(ctx context.Context, client Getter, repoName string, baseDirs
 				opts := opts
 				createBundle, e := shouldCreateBundleForThisPath(baseDir, path, info)
 				if e != nil {
-					return fmt.Errorf("%s: %w", fmt.Sprintf("checking for bundle in path %s", path), err)
+					return fmt.Errorf("checking for bundle in path %q: %w", path, err)
 				}
 				if !createBundle {
 					return nil
@@ -180,7 +180,7 @@ func readBundle(ctx context.Context, name, baseDir string, opts *Options) (*flee
 	if opts.BundleReader != nil {
 		var bundle *fleet.Bundle
 		if err := json.NewDecoder(opts.BundleReader).Decode(bundle); err != nil {
-			return nil, nil, fmt.Errorf("%s: %w", fmt.Sprintf("decoding bundle %s", name), err)
+			return nil, nil, fmt.Errorf("decoding bundle %s: %w", name, err)
 		}
 		return bundle, nil, nil
 	}

--- a/internal/cmd/cli/gitcloner/cloner.go
+++ b/internal/cmd/cli/gitcloner/cloner.go
@@ -190,7 +190,7 @@ func createKnownHostsCallBack(knownHosts []byte) (ssh.HostKeyCallback, error) {
 
 func gitClonerErrorContext(opts *GitCloner) string {
 	return fmt.Sprintf(
-		"gitcloner: repo=[%s] branch=[%s] revision=[%s] path=[%s]",
+		"failed checkout of: repo=[%s] branch=[%s] revision=[%s] path=[%s]",
 		opts.Repo,
 		opts.Branch,
 		opts.Revision,

--- a/internal/cmd/cli/gitcloner/cloner_test.go
+++ b/internal/cmd/cli/gitcloner/cloner_test.go
@@ -128,7 +128,7 @@ udiSlDctMM/X3ZM2JN5M1rtAJ2WR3ZQtmWbOjZAbG2Eq
 				Username:     "user",
 			},
 			expectedCloneOpts: nil,
-			expectedErr:       errors.New("gitcloner: repo=[repo] branch=[master] revision=[] path=[]: file not found"),
+			expectedErr:       errors.New("failed checkout of: repo=[repo] branch=[master] revision=[] path=[]: file not found"),
 		},
 		"ca file does not exist": {
 			opts: &GitCloner{
@@ -137,7 +137,7 @@ udiSlDctMM/X3ZM2JN5M1rtAJ2WR3ZQtmWbOjZAbG2Eq
 				CABundleFile: "doesntexist",
 			},
 			expectedCloneOpts: nil,
-			expectedErr:       errors.New("gitcloner: repo=[repo] branch=[master] revision=[] path=[]: file not found"),
+			expectedErr:       errors.New("failed checkout of: repo=[repo] branch=[master] revision=[] path=[]: file not found"),
 		},
 		"ssh private key file does not exist": {
 			opts: &GitCloner{
@@ -146,7 +146,7 @@ udiSlDctMM/X3ZM2JN5M1rtAJ2WR3ZQtmWbOjZAbG2Eq
 				SSHPrivateKeyFile: "doesntexist",
 			},
 			expectedCloneOpts: nil,
-			expectedErr:       errors.New("gitcloner: repo=[repo] branch=[master] revision=[] path=[]: file not found"),
+			expectedErr:       errors.New("failed checkout of: repo=[repo] branch=[master] revision=[] path=[]: file not found"),
 		},
 	}
 

--- a/internal/cmd/controller/gitops/reconciler/gitjob_test.go
+++ b/internal/cmd/controller/gitops/reconciler/gitjob_test.go
@@ -711,9 +711,9 @@ func TestNewJob(t *testing.T) { // nolint:funlen
 			expectedInitContainers: []corev1.Container{
 				{
 					Command: []string{
-						"fleet",
+						"log.sh",
 					},
-					Args:  []string{"gitcloner", "repo", "/workspace", "--branch", "master"},
+					Args:  []string{"fleet", "gitcloner", "repo", "/workspace", "--branch", "master"},
 					Image: "test",
 					Name:  "gitcloner-initializer",
 					VolumeMounts: []corev1.VolumeMount{
@@ -754,9 +754,9 @@ func TestNewJob(t *testing.T) { // nolint:funlen
 			expectedInitContainers: []corev1.Container{
 				{
 					Command: []string{
-						"fleet",
+						"log.sh",
 					},
-					Args:  []string{"gitcloner", "repo", "/workspace", "--branch", "foo"},
+					Args:  []string{"fleet", "gitcloner", "repo", "/workspace", "--branch", "foo"},
 					Image: "test",
 					Name:  "gitcloner-initializer",
 					VolumeMounts: []corev1.VolumeMount{
@@ -797,9 +797,9 @@ func TestNewJob(t *testing.T) { // nolint:funlen
 			expectedInitContainers: []corev1.Container{
 				{
 					Command: []string{
-						"fleet",
+						"log.sh",
 					},
-					Args:  []string{"gitcloner", "repo", "/workspace", "--revision", "foo"},
+					Args:  []string{"fleet", "gitcloner", "repo", "/workspace", "--revision", "foo"},
 					Image: "test",
 					Name:  "gitcloner-initializer",
 					VolumeMounts: []corev1.VolumeMount{
@@ -840,9 +840,10 @@ func TestNewJob(t *testing.T) { // nolint:funlen
 			expectedInitContainers: []corev1.Container{
 				{
 					Command: []string{
-						"fleet",
+						"log.sh",
 					},
 					Args: []string{
+						"fleet",
 						"gitcloner",
 						"repo",
 						"/workspace",
@@ -915,9 +916,10 @@ func TestNewJob(t *testing.T) { // nolint:funlen
 			expectedInitContainers: []corev1.Container{
 				{
 					Command: []string{
-						"fleet",
+						"log.sh",
 					},
 					Args: []string{
+						"fleet",
 						"gitcloner",
 						"repo",
 						"/workspace",
@@ -991,9 +993,10 @@ func TestNewJob(t *testing.T) { // nolint:funlen
 			expectedInitContainers: []corev1.Container{
 				{
 					Command: []string{
-						"fleet",
+						"log.sh",
 					},
 					Args: []string{
+						"fleet",
 						"gitcloner",
 						"repo",
 						"/workspace",
@@ -1069,9 +1072,10 @@ func TestNewJob(t *testing.T) { // nolint:funlen
 			expectedInitContainers: []corev1.Container{
 				{
 					Command: []string{
-						"fleet",
+						"log.sh",
 					},
 					Args: []string{
+						"fleet",
 						"gitcloner",
 						"repo",
 						"/workspace",
@@ -1181,9 +1185,10 @@ func TestNewJob(t *testing.T) { // nolint:funlen
 			expectedInitContainers: []corev1.Container{
 				{
 					Command: []string{
-						"fleet",
+						"log.sh",
 					},
 					Args: []string{
+						"fleet",
 						"gitcloner",
 						"repo",
 						"/workspace",
@@ -1228,9 +1233,9 @@ func TestNewJob(t *testing.T) { // nolint:funlen
 			expectedInitContainers: []corev1.Container{
 				{
 					Command: []string{
-						"fleet",
+						"log.sh",
 					},
-					Args:  []string{"gitcloner", "repo", "/workspace", "--branch", "master"},
+					Args:  []string{"fleet", "gitcloner", "repo", "/workspace", "--branch", "master"},
 					Image: "test",
 					Name:  "gitcloner-initializer",
 					VolumeMounts: []corev1.VolumeMount{


### PR DESCRIPTION
Adds context to message in fleet apply. Specially to those running inside loops.

For example, when loading directories, remote charts, etc...

Contexts are wrapped in top of the previous one.

It also fixes the `gitjob` init container to use `log.sh` and redirect the errors to `/dev/termination-log` 

Related to: https://github.com/rancher/fleet/issues/3234

