### PR TITLE
Remove "fleet apply" config files from bundle resources

### DIFF
--- a/e2e/single-cluster/single_cluster_test.go
+++ b/e2e/single-cluster/single_cluster_test.go
@@ -73,14 +73,6 @@ var _ = Describe("Single Cluster Deployments", func() {
 				_, _ = k.Delete("ns", "test-fleet-mp-service")
 			})
 
-			It("sets status fields for gitrepo on deployment", func() {
-				Eventually(func() bool {
-					out, err := k.Get("gitrepo", "multiple-paths", "-n", "fleet-local", "-o", "jsonpath='{.status.summary}'")
-					Expect(err).ToNot(HaveOccurred(), out)
-					return strings.Contains(out, "\"ready\":2")
-				}).Should(BeTrue())
-			})
-
 			It("deploys bundles from all the paths", func() {
 				Eventually(func() string {
 					out, _ := k.Namespace("fleet-local").Get("bundles")
@@ -89,6 +81,12 @@ var _ = Describe("Single Cluster Deployments", func() {
 					ContainSubstring("multiple-paths-multiple-paths-config"),
 					ContainSubstring("multiple-paths-multiple-paths-service"),
 				))
+
+				Eventually(func() bool {
+					out, err := k.Get("gitrepo", "multiple-paths", "-n", "fleet-local", "-o", "jsonpath='{.status.summary}'")
+					Expect(err).ToNot(HaveOccurred(), out)
+					return strings.Contains(out, "\"ready\":2")
+				}).Should(BeTrue())
 
 				Eventually(func(g Gomega) {
 					out, err := k.Get(

--- a/integrationtests/cli/apply/apply_online_test.go
+++ b/integrationtests/cli/apply/apply_online_test.go
@@ -67,7 +67,7 @@ var _ = Describe("Fleet apply online", Label("online"), func() {
 					Name:      "test_labels",
 				},
 			}
-			//bundle in the fleet.yaml file; some values are autofilled in the implementation (this is why there are not only the labels)
+			// bundle in the cm.yaml file; some values are autofilled in the implementation (this is why there are not only the labels)
 			newBundle = &fleet.Bundle{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
@@ -79,8 +79,14 @@ var _ = Describe("Fleet apply online", Label("online"), func() {
 				Spec: fleet.BundleSpec{
 					Resources: []fleet.BundleResource{
 						{
-							Name:    "fleet.yaml",
-							Content: "labels:\n  new: fleet-label2",
+							Name: "cm.yaml",
+							Content: `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cm3
+data:
+  test: "value23"
+`,
 						},
 					},
 					Targets: []fleet.BundleTarget{

--- a/integrationtests/cli/apply/helm_test.go
+++ b/integrationtests/cli/apply/helm_test.go
@@ -235,7 +235,6 @@ func verifyResourcesArePresent() bool {
 	paths, err := getAllResourcesPathFromTheHelmRelease()
 	Expect(err).NotTo(HaveOccurred())
 	Expect(paths).Should(HaveLen(numberOfFilesInHelmConfigChart))
-	// should contain all resources plus the fleet.yaml
 	Expect(bundle.Spec.Resources).Should(HaveLen(numberOfFilesInHelmConfigChart))
 	for _, path := range paths {
 		present, err := cli.IsResourcePresentInBundle(path, bundle.Spec.Resources)

--- a/integrationtests/cli/apply/helm_test.go
+++ b/integrationtests/cli/apply/helm_test.go
@@ -236,7 +236,7 @@ func verifyResourcesArePresent() bool {
 	Expect(err).NotTo(HaveOccurred())
 	Expect(paths).Should(HaveLen(numberOfFilesInHelmConfigChart))
 	// should contain all resources plus the fleet.yaml
-	Expect(bundle.Spec.Resources).Should(HaveLen(numberOfFilesInHelmConfigChart + 1))
+	Expect(bundle.Spec.Resources).Should(HaveLen(numberOfFilesInHelmConfigChart))
 	for _, path := range paths {
 		present, err := cli.IsResourcePresentInBundle(path, bundle.Spec.Resources)
 		Expect(err).NotTo(HaveOccurred(), "validating resource: "+path)

--- a/integrationtests/cli/assets/labels_update/cm.yaml
+++ b/integrationtests/cli/assets/labels_update/cm.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cm3
+data:
+  test: "value23"

--- a/integrationtests/cli/assets/nested_mixed_two_levels/nested/deploymentC/cm.yaml
+++ b/integrationtests/cli/assets/nested_mixed_two_levels/nested/deploymentC/cm.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cm1
+data:
+  test: "value123"

--- a/integrationtests/cli/assets/targets/override/cm.yaml
+++ b/integrationtests/cli/assets/targets/override/cm.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cm1
+data:
+  test: "value123"

--- a/integrationtests/cli/assets/targets/simple/cm.yaml
+++ b/integrationtests/cli/assets/targets/simple/cm.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cm2
+data:
+  test: "value1234"

--- a/internal/bundlereader/helm.go
+++ b/internal/bundlereader/helm.go
@@ -36,7 +36,16 @@ func GetManifestFromHelmChart(ctx context.Context, c client.Client, bd *fleet.Bu
 		return nil, err
 	}
 
-	resources, err := loadDirectory(ctx, false, false, checksum(helm), temp, chartURL, helm.Version, auth)
+	resources, err := loadDirectory(ctx,
+		loadOpts{},
+		directory{
+			prefix:  checksum(helm),
+			base:    temp,
+			source:  chartURL,
+			version: helm.Version,
+			auth:    auth,
+		},
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/bundlereader/helm.go
+++ b/internal/bundlereader/helm.go
@@ -11,7 +11,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// GetManifestFromHelmChart downloads the given helm chart and creates a manifest with its contents
+// GetManifestFromHelmChart downloads the given helm chart and creates a
+// manifest with its contents. This is used by the agent to deploy HelmApps.
 func GetManifestFromHelmChart(ctx context.Context, c client.Client, bd *fleet.BundleDeployment) (*manifest.Manifest, error) {
 	helm := bd.Spec.Options.Helm
 

--- a/internal/bundlereader/loaddirectory.go
+++ b/internal/bundlereader/loaddirectory.go
@@ -182,17 +182,17 @@ func readFleetIgnore(path string) ([]string, error) {
 	return ignored, nil
 }
 
-func loadDirectory(ctx context.Context, compress bool, disableDepsUpdate bool, prefix, base, source, version string, auth Auth) ([]fleet.BundleResource, error) {
+func loadDirectory(ctx context.Context, opts loadOpts, dir directory) ([]fleet.BundleResource, error) {
 	var resources []fleet.BundleResource
 
-	files, err := GetContent(ctx, base, source, version, auth, disableDepsUpdate)
+	files, err := GetContent(ctx, dir.base, dir.source, dir.version, dir.auth, opts.disableDepsUpdate)
 	if err != nil {
 		return nil, err
 	}
 
 	for name, data := range files {
 		r := fleet.BundleResource{Name: name}
-		if compress || !utf8.Valid(data) {
+		if opts.compress || !utf8.Valid(data) {
 			content, err := content.Base64GZ(data)
 			if err != nil {
 				return nil, err
@@ -202,8 +202,8 @@ func loadDirectory(ctx context.Context, compress bool, disableDepsUpdate bool, p
 		} else {
 			r.Content = string(data)
 		}
-		if prefix != "" {
-			r.Name = filepath.Join(prefix, name)
+		if dir.prefix != "" {
+			r.Name = filepath.Join(dir.prefix, name)
 		}
 		resources = append(resources, r)
 	}

--- a/internal/bundlereader/loaddirectory_test.go
+++ b/internal/bundlereader/loaddirectory_test.go
@@ -37,6 +37,20 @@ func TestGetContent(t *testing.T) {
 				name:  "no-fleetignore",
 				children: []fsNode{
 					{
+						name:     "fleet.yaml",
+						contents: "foo",
+					},
+					{
+						name:  "chart",
+						isDir: true,
+						children: []fsNode{
+							{
+								name:     "myvalues.yaml",
+								contents: "bar",
+							},
+						},
+					},
+					{
 						name:     "something.yaml",
 						contents: "foo",
 					},
@@ -52,6 +66,10 @@ func TestGetContent(t *testing.T) {
 				isDir: true,
 				name:  "empty-fleetignore",
 				children: []fsNode{
+					{
+						name:     "fleet.yaml",
+						contents: "foo",
+					},
 					{
 						name:     "something.yaml",
 						contents: "foo",
@@ -529,12 +547,14 @@ func TestGetContent(t *testing.T) {
 
 	defer os.RemoveAll(base)
 
+	ignoreApplyConfigs := []string{"fleet.yaml", "chart/myvalues.yaml"}
+
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 
 			root := createDirStruct(t, base, c.directoryStructure)
 
-			files, err := bundlereader.GetContent(context.Background(), root, root, "", bundlereader.Auth{}, false)
+			files, err := bundlereader.GetContent(context.Background(), root, root, "", bundlereader.Auth{}, false, ignoreApplyConfigs)
 			assert.NoError(t, err)
 
 			assert.Equal(t, len(c.expectedFiles), len(files))
@@ -617,7 +637,7 @@ func TestGetContentOCI(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			result, err := bundlereader.GetContent(context.Background(), base, c.source, c.version, bundlereader.Auth{}, false)
+			result, err := bundlereader.GetContent(context.Background(), base, c.source, c.version, bundlereader.Auth{}, false, []string{})
 			if c.expectedErr == "" {
 				assert.NoError(err)
 				for k := range result {

--- a/internal/bundlereader/resources.go
+++ b/internal/bundlereader/resources.go
@@ -82,14 +82,20 @@ type loadOpts struct {
 	disableDepsUpdate bool
 }
 
+// directory represents a directory to load resources from. The directory can
+// be created from an external Helm chart, or a local path.
+// One bundle can consist of multiple directories.
 type directory struct {
-	key string
-
-	prefix  string
-	base    string
-	source  string
+	// prefix is the generated top level dir of the chart, e.g. '.chart/1234'
+	prefix string
+	// base is the directory on disk to load the files from
+	base string
+	// source is the chart URL to download the chart from
+	source string
+	// version is the version of the chart
 	version string
-	auth    Auth
+	// auth is the auth to use for the chart URL
+	auth Auth
 }
 
 func addDirectory(base, customDir, defaultDir string) ([]directory, error) {
@@ -107,7 +113,6 @@ func addDirectory(base, customDir, defaultDir string) ([]directory, error) {
 		prefix: defaultDir,
 		base:   base,
 		source: customDir,
-		key:    defaultDir,
 	}}, nil
 }
 
@@ -175,7 +180,6 @@ func addRemoteCharts(directories []directory, base string, charts []*fleet.HelmO
 				prefix:  checksum(chart),
 				base:    base,
 				source:  chartURL,
-				key:     checksum(chart),
 				auth:    auth,
 				version: chart.Version,
 			})
@@ -234,7 +238,7 @@ func loadDirectories(ctx context.Context, opts loadOpts, directories ...director
 				return fmt.Errorf("loading directory %s, %s: %w", dir.prefix, dir.base, err)
 			}
 
-			key := dir.key
+			key := dir.prefix
 			if key == "" {
 				key = dir.source
 			}

--- a/internal/cmd/controller/agentmanagement/agent/agent.go
+++ b/internal/cmd/controller/agentmanagement/agent/agent.go
@@ -68,11 +68,12 @@ func AgentWithConfig(ctx context.Context, agentNamespace, controllerNamespace, a
 		return objs, err
 	}
 
+	// keep in sync with manageagent.go
 	mo := opts.ManifestOptions
 	mo.AgentImage = cfg.AgentImage
-	mo.SystemDefaultRegistry = cfg.SystemDefaultRegistry
 	mo.AgentImagePullPolicy = cfg.AgentImagePullPolicy
 	mo.CheckinInterval = cfg.AgentCheckinInterval.Duration.String()
+	mo.SystemDefaultRegistry = cfg.SystemDefaultRegistry
 	mo.BundleDeploymentWorkers = cfg.AgentWorkers.BundleDeployment
 	mo.DriftWorkers = cfg.AgentWorkers.Drift
 

--- a/internal/cmd/controller/agentmanagement/controllers/cluster/import.go
+++ b/internal/cmd/controller/agentmanagement/controllers/cluster/import.go
@@ -320,16 +320,14 @@ func (i *importHandler) importCluster(cluster *fleet.Cluster, status fleet.Clust
 				AgentTLSMode:              cfg.AgentTLSMode,
 				GarbageCollectionInterval: cfg.GarbageCollectionInterval,
 			},
+			// keep in sync with manageagent.go
 			ManifestOptions: agent.ManifestOptions{
-				AgentEnvVars:            cluster.Spec.AgentEnvVars,
-				AgentTolerations:        cluster.Spec.AgentTolerations,
-				CheckinInterval:         cfg.AgentCheckinInterval.Duration.String(),
-				PrivateRepoURL:          cluster.Spec.PrivateRepoURL,
-				AgentAffinity:           cluster.Spec.AgentAffinity,
-				AgentResources:          cluster.Spec.AgentResources,
-				HostNetwork:             *cmp.Or(cluster.Spec.HostNetwork, ptr.To(false)),
-				BundleDeploymentWorkers: cfg.AgentWorkers.BundleDeployment,
-				DriftWorkers:            cfg.AgentWorkers.Drift,
+				AgentEnvVars:     cluster.Spec.AgentEnvVars,
+				AgentTolerations: cluster.Spec.AgentTolerations,
+				PrivateRepoURL:   cluster.Spec.PrivateRepoURL,
+				AgentAffinity:    cluster.Spec.AgentAffinity,
+				AgentResources:   cluster.Spec.AgentResources,
+				HostNetwork:      *cmp.Or(cluster.Spec.HostNetwork, ptr.To(false)),
 			},
 		})
 	if err != nil {

--- a/internal/cmd/controller/agentmanagement/controllers/manageagent/manageagent.go
+++ b/internal/cmd/controller/agentmanagement/controllers/manageagent/manageagent.go
@@ -261,16 +261,19 @@ func (h *handler) newAgentBundle(ns string, cluster *fleet.Cluster) (runtime.Obj
 	objs := agent.Manifest(
 		agentNamespace, cluster.Spec.AgentNamespace,
 		agent.ManifestOptions{
-			AgentEnvVars:            cluster.Spec.AgentEnvVars,
+			// keep in sync with cluster/import.go
+			AgentEnvVars:     cluster.Spec.AgentEnvVars,
+			AgentTolerations: cluster.Spec.AgentTolerations,
+			PrivateRepoURL:   cluster.Spec.PrivateRepoURL,
+			AgentAffinity:    cluster.Spec.AgentAffinity,
+			AgentResources:   cluster.Spec.AgentResources,
+			HostNetwork:      *cmp.Or(cluster.Spec.HostNetwork, ptr.To(false)),
+
+			// keep in sync with agent/agent.go
 			AgentImage:              cfg.AgentImage,
 			AgentImagePullPolicy:    cfg.AgentImagePullPolicy,
-			AgentTolerations:        cluster.Spec.AgentTolerations,
 			CheckinInterval:         cfg.AgentCheckinInterval.Duration.String(),
-			PrivateRepoURL:          cluster.Spec.PrivateRepoURL,
 			SystemDefaultRegistry:   cfg.SystemDefaultRegistry,
-			AgentAffinity:           cluster.Spec.AgentAffinity,
-			AgentResources:          cluster.Spec.AgentResources,
-			HostNetwork:             *cmp.Or(cluster.Spec.HostNetwork, ptr.To(false)),
 			BundleDeploymentWorkers: cfg.AgentWorkers.BundleDeployment,
 			DriftWorkers:            cfg.AgentWorkers.Drift,
 		},

--- a/internal/ociwrapper/ociwrapper_test.go
+++ b/internal/ociwrapper/ociwrapper_test.go
@@ -14,16 +14,16 @@ import (
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"oras.land/oras-go/v2"
 	"oras.land/oras-go/v2/content"
+	orasmemory "oras.land/oras-go/v2/content/memory"
 	"oras.land/oras-go/v2/registry/remote/auth"
 	"oras.land/oras-go/v2/registry/remote/retry"
 
+	"github.com/rancher/fleet/internal/manifest"
+	"github.com/rancher/fleet/internal/mocks"
 	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/rancher/fleet/internal/manifest"
-	"github.com/rancher/fleet/internal/mocks"
-	orasmemory "oras.land/oras-go/v2/content/memory"
 )
 
 type MockOrasOperator struct {
@@ -120,24 +120,6 @@ var _ = Describe("OCIUtils tests", func() {
 		}
 		err := oci.PushManifest(context.Background(), opts, "123", manifest)
 		Expect(err.Error()).To(Equal("ERROR PACKING"))
-	})
-	It("returns an error when is unable to connect to the registry", func() {
-		oci := NewOCIWrapper()
-		opts := OCIOpts{
-			Reference: "127.0.0.0:2334",
-		}
-		manifest := &manifest.Manifest{
-			Commit: "123456",
-			Resources: []fleet.BundleResource{
-				{
-					Name:     "resource1",
-					Content:  "Content1",
-					Encoding: "encoding1",
-				},
-			},
-		}
-		err := oci.PushManifest(context.Background(), opts, "123", manifest)
-		Expect(err.Error()).To(Or(ContainSubstring("connection refused"), ContainSubstring("i/o timeout")))
 	})
 	It("returns an OCI repository with the expected values when using basic HTTP", func() {
 		opts := OCIOpts{


### PR DESCRIPTION
Fleet apply has several "config" files inside of a bundle, like "fleet.yaml". After running "fleet apply" these files are not needed anymore and there is no reason to add them to the `Bundle.Spec.Resources` list.