### PR TITLE
[v0.10] Skip chart release for hotfixes

### DIFF
--- a/.github/workflows/release-fleet.yml
+++ b/.github/workflows/release-fleet.yml
@@ -113,6 +113,7 @@ jobs:
           GORELEASER_CURRENT_TAG: ${{ github.ref_name }}
 
       - name: Upload charts to release
+        if: ${{ env.IS_HOTFIX == 'false' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           repo: "rancher"


### PR DESCRIPTION
These steps are not needed when building hotfixes, only the image.
([also for the 0.11 branch](https://github.com/rancher/fleet/pull/3405))