### PR TITLE
Retries in fleet apply and single patch in webhook

### DIFF
--- a/internal/cmd/controller/gitops/reconciler/gitjob_controller.go
+++ b/internal/cmd/controller/gitops/reconciler/gitjob_controller.go
@@ -779,7 +779,7 @@ func (r *GitJobReconciler) newJobSpec(ctx context.Context, gitrepo *v1alpha1.Git
 
 	saName := names.SafeConcatName("git", gitrepo.Name)
 	logger := log.FromContext(ctx)
-	args, envs := argsAndEnvs(gitrepo, logger.V(1).Enabled(), CACertsFilePathOverride)
+	args, envs := argsAndEnvs(gitrepo, logger, CACertsFilePathOverride)
 
 	return &batchv1.JobSpec{
 		BackoffLimit: &zero,
@@ -835,13 +835,13 @@ func (r *GitJobReconciler) newJobSpec(ctx context.Context, gitrepo *v1alpha1.Git
 	}, nil
 }
 
-func argsAndEnvs(gitrepo *v1alpha1.GitRepo, debug bool, CACertsPathOverride string) ([]string, []corev1.EnvVar) {
+func argsAndEnvs(gitrepo *v1alpha1.GitRepo, logger logr.Logger, CACertsPathOverride string) ([]string, []corev1.EnvVar) {
 	args := []string{
 		"fleet",
 		"apply",
 	}
 
-	if debug {
+	if logger.V(1).Enabled() {
 		args = append(args, "--debug", "--debug-level", "9")
 	}
 
@@ -877,6 +877,10 @@ func argsAndEnvs(gitrepo *v1alpha1.GitRepo, debug bool, CACertsPathOverride stri
 		}
 	}
 
+	fleetApplyRetries, err := fleetcli.GetOnConflictRetries()
+	if err != nil {
+		logger.Error(err, "failed parsing env variable, using defaults", "env_var_name", fleetcli.FleetApplyConflictRetriesEnv)
+	}
 	env := []corev1.EnvVar{
 		{
 			Name:  "HOME",
@@ -884,7 +888,7 @@ func argsAndEnvs(gitrepo *v1alpha1.GitRepo, debug bool, CACertsPathOverride stri
 		},
 		{
 			Name:  fleetcli.FleetApplyConflictRetriesEnv,
-			Value: strconv.Itoa(fleetcli.GetOnConflictRetries()),
+			Value: strconv.Itoa(fleetApplyRetries),
 		},
 	}
 	if gitrepo.Spec.HelmSecretNameForPaths != "" {

--- a/internal/cmd/controller/gitops/reconciler/gitjob_controller.go
+++ b/internal/cmd/controller/gitops/reconciler/gitjob_controller.go
@@ -15,6 +15,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/reugn/go-quartz/quartz"
 
+	fleetcli "github.com/rancher/fleet/internal/cmd/cli"
 	fleetutil "github.com/rancher/fleet/internal/cmd/controller/errorutil"
 	"github.com/rancher/fleet/internal/cmd/controller/finalize"
 	"github.com/rancher/fleet/internal/cmd/controller/imagescan"
@@ -880,6 +881,10 @@ func argsAndEnvs(gitrepo *v1alpha1.GitRepo, debug bool, CACertsPathOverride stri
 		{
 			Name:  "HOME",
 			Value: fleetHomeDir,
+		},
+		{
+			Name:  fleetcli.FleetApplyConflictRetriesEnv,
+			Value: strconv.Itoa(fleetcli.GetOnConflictRetries()),
 		},
 	}
 	if gitrepo.Spec.HelmSecretNameForPaths != "" {

--- a/internal/cmd/controller/gitops/reconciler/gitjob_test.go
+++ b/internal/cmd/controller/gitops/reconciler/gitjob_test.go
@@ -1393,6 +1393,10 @@ func TestGenerateJob_EnvVars(t *testing.T) {
 					Value: "/fleet-home",
 				},
 				{
+					Name:  "FLEET_APPLY_CONFLICT_RETRIES",
+					Value: "1",
+				},
+				{
 					Name:  "GIT_SSH_COMMAND",
 					Value: "ssh -o stricthostkeychecking=accept-new",
 				},
@@ -1413,6 +1417,10 @@ func TestGenerateJob_EnvVars(t *testing.T) {
 				{
 					Name:  "HOME",
 					Value: "/fleet-home",
+				},
+				{
+					Name:  "FLEET_APPLY_CONFLICT_RETRIES",
+					Value: "1",
 				},
 				{
 					Name:  "COMMIT",

--- a/internal/cmd/controller/gitops/reconciler/gitjob_test.go
+++ b/internal/cmd/controller/gitops/reconciler/gitjob_test.go
@@ -1447,6 +1447,52 @@ func TestGenerateJob_EnvVars(t *testing.T) {
 			},
 			osEnv: map[string]string{"HTTP_PROXY": "httpProxy", "HTTPS_PROXY": "httpsProxy"},
 		},
+		"retries_valid": {
+			gitrepo: &fleetv1.GitRepo{
+				Spec: fleetv1.GitRepoSpec{},
+				Status: fleetv1.GitRepoStatus{
+					Commit: "commit",
+				},
+			},
+			expectedContainerEnvVars: []corev1.EnvVar{
+				{
+					Name:  "HOME",
+					Value: "/fleet-home",
+				},
+				{
+					Name:  "FLEET_APPLY_CONFLICT_RETRIES",
+					Value: "3",
+				},
+				{
+					Name:  "COMMIT",
+					Value: "commit",
+				},
+			},
+			osEnv: map[string]string{"FLEET_APPLY_CONFLICT_RETRIES": "3"},
+		},
+		"retries_not_valid": {
+			gitrepo: &fleetv1.GitRepo{
+				Spec: fleetv1.GitRepoSpec{},
+				Status: fleetv1.GitRepoStatus{
+					Commit: "commit",
+				},
+			},
+			expectedContainerEnvVars: []corev1.EnvVar{
+				{
+					Name:  "HOME",
+					Value: "/fleet-home",
+				},
+				{
+					Name:  "FLEET_APPLY_CONFLICT_RETRIES",
+					Value: "1",
+				},
+				{
+					Name:  "COMMIT",
+					Value: "commit",
+				},
+			},
+			osEnv: map[string]string{"FLEET_APPLY_CONFLICT_RETRIES": "this_is_not_an_int"},
+		},
 	}
 
 	for name, test := range tests {

--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -385,16 +385,12 @@ func TestGitHubRightSecretAndCommitUpdated(t *testing.T) {
 
 	// Status().Update() mock call
 	mockClient.EXPECT().Status().Return(statusClient).Times(1)
-	statusClient.EXPECT().Update(gomock.Any(), gomock.Any(), gomock.Any()).Do(
-		func(ctx context.Context, repo *v1alpha1.GitRepo, opts ...interface{}) {
+	statusClient.EXPECT().Patch(gomock.Any(), gomock.Any(), gomock.Any()).Do(
+		func(ctx context.Context, repo *v1alpha1.GitRepo, _ client.Patch, opts ...interface{}) {
 			// check that the commit is the expected one
 			if repo.Status.WebhookCommit != expectedCommit {
 				t.Errorf("expecting gitrepo webhook commit %s, got %s", expectedCommit, repo.Status.WebhookCommit)
 			}
-		},
-	).Times(1)
-	mockClient.EXPECT().Patch(gomock.Any(), gomock.Any(), gomock.Any()).Do(
-		func(ctx context.Context, repo *v1alpha1.GitRepo, _ client.Patch, opts ...interface{}) {
 			if repo.Spec.PollingInterval.Duration != time.Hour {
 				t.Errorf("expecting gitrepo polling interval 1h, got %s", repo.Spec.PollingInterval.Duration)
 			}


### PR DESCRIPTION
Adds a retry mechanism to `fleet apply` after observing several errors due to conflicts under high loads. As the job created is not retrying by itself the `GitRepo` gets hung.

Also changes from 1 Status Update and Patch to one single patch in the webhook handling to mitigate conflicts and possible race conditions.

Refers to: https://github.com/rancher/fleet/issues/3067

