### PR TITLE
[SURE-9419] Move agent registration into controller container

### DIFF
--- a/charts/fleet-agent/templates/deployment.yaml
+++ b/charts/fleet-agent/templates/deployment.yaml
@@ -11,43 +11,6 @@ spec:
       labels:
         app: fleet-agent
     spec:
-      initContainers:
-      - env:
-        - name: NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        {{- if $.Values.leaderElection.leaseDuration }}
-        - name: CATTLE_ELECTION_LEASE_DURATION
-          value: {{$.Values.leaderElection.leaseDuration}}
-        {{- end }}
-        {{- if $.Values.leaderElection.retryPeriod }}
-        - name: CATTLE_ELECTION_RETRY_PERIOD
-          value: {{$.Values.leaderElection.retryPeriod}}
-        {{- end }}
-        {{- if $.Values.leaderElection.renewDeadline }}
-        - name: CATTLE_ELECTION_RENEW_DEADLINE
-          value: {{$.Values.leaderElection.renewDeadline}}
-        {{- end }}
-        image: '{{ template "system_default_registry" . }}{{.Values.image.repository}}:{{.Values.image.tag}}'
-        name: fleet-agent-register
-        command:
-        - fleetagent
-        - register
-        {{- if .Values.debug }}
-        - --debug
-        - --debug-level
-        - {{ quote .Values.debugLevel }}
-        {{- end }}
-        {{- if not .Values.disableSecurityContext }}
-        securityContext:
-          allowPrivilegeEscalation: false
-          readOnlyRootFilesystem: true
-          privileged: false
-          capabilities:
-            drop:
-            - ALL
-        {{- end }}
       containers:
       - env:
         - name: NAMESPACE

--- a/e2e/multi-cluster/installation/agent_test.go
+++ b/e2e/multi-cluster/installation/agent_test.go
@@ -42,7 +42,7 @@ var _ = Describe("Fleet installation with TLS agent modes", func() {
 	})
 
 	Context("with non-strict agent TLS mode", func() {
-		When("fetching fleet-agent-register logs", func() {
+		When("fetching fleet-agent logs", func() {
 			BeforeEach(func() {
 				agentMode = "system-store"
 			})
@@ -53,7 +53,7 @@ var _ = Describe("Fleet installation with TLS agent modes", func() {
 						"-l",
 						"app=fleet-agent",
 						"-c",
-						"fleet-agent-register",
+						"fleet-agent",
 						"--tail=-1",
 					)
 					if err != nil {
@@ -69,7 +69,7 @@ var _ = Describe("Fleet installation with TLS agent modes", func() {
 	})
 
 	Context("with strict agent TLS mode", func() {
-		When("fetching fleet-agent-register logs", func() {
+		When("fetching fleet-agent logs", func() {
 			BeforeEach(func() {
 				agentMode = "strict"
 			})
@@ -80,7 +80,7 @@ var _ = Describe("Fleet installation with TLS agent modes", func() {
 						"-l",
 						"app=fleet-agent",
 						"-c",
-						"fleet-agent-register",
+						"fleet-agent",
 						"--tail=-1",
 					)
 					if err != nil {

--- a/internal/cmd/agent/operator.go
+++ b/internal/cmd/agent/operator.go
@@ -59,9 +59,9 @@ func start(
 	agentScope string,
 	workersOpts AgentReconcilerWorkers,
 ) error {
-	// Registration is done in an init container. If we are here, we are already registered.
-	// Retrieve the existing config from the registration.
-	// Cannot start without kubeconfig for upstream cluster:
+	// Registration is done before start is called. If we are here, we are already registered.
+	// Retrieve the existing config from the registration.  Cannot start without kubeconfig for
+	// upstream cluster:
 	upstreamConfig, agentConfig, fleetNamespace, clusterName, err := loadRegistration(ctx, systemNamespace, localConfig)
 	if err != nil {
 		setupLog.Error(err, "unable to load registration and start manager")

--- a/internal/cmd/agent/register.go
+++ b/internal/cmd/agent/register.go
@@ -2,17 +2,7 @@ package agent
 
 import (
 	"context"
-	"fmt"
-	"os"
 
-	"github.com/spf13/cobra"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/leaderelection"
-	"k8s.io/client-go/tools/leaderelection/resourcelock"
-
-	command "github.com/rancher/fleet/internal/cmd"
 	"github.com/rancher/fleet/internal/cmd/agent/register"
 
 	"github.com/rancher/wrangler/v3/pkg/kubeconfig"
@@ -22,36 +12,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
-func NewRegister() *cobra.Command {
-	cmd := command.Command(&Register{}, cobra.Command{
-		Use:   "register [flags]",
-		Short: "Register agent with an upstream cluster",
-	})
-	return cmd
-}
-
 type Register struct {
-	command.DebugConfig
 	UpstreamOptions
 }
 
-// HelpFunc hides the global agent-scope flag from the help output
-func (c *Register) HelpFunc(cmd *cobra.Command, strings []string) {
-	_ = cmd.Flags().MarkHidden("agent-scope")
-	cmd.Parent().HelpFunc()(cmd, strings)
-}
-
-func (r *Register) PersistentPre(cmd *cobra.Command, _ []string) error {
-	if err := r.SetupDebug(); err != nil {
-		return fmt.Errorf("failed to setup debug logging: %w", err)
-	}
-	zopts = r.OverrideZapOpts(zopts)
-	return nil
-}
-
-func (r *Register) Run(cmd *cobra.Command, args []string) error {
+func (r *Register) RegisterAgent(ctx context.Context) error {
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(zopts)))
-	ctx := log.IntoContext(cmd.Context(), ctrl.Log)
+	ctx = log.IntoContext(ctx, ctrl.Log)
 
 	clientConfig := kubeconfig.GetNonInteractiveClientConfig(r.Kubeconfig)
 	kc, err := clientConfig.ClientConfig()
@@ -59,82 +26,32 @@ func (r *Register) Run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	localClient, err := kubernetes.NewForConfig(kc)
-	if err != nil {
-		return fmt.Errorf("failed to create local client: %w", err)
-	}
+	setupLog.Info("starting registration on upstream cluster", "namespace", r.Namespace)
 
-	identifier, err := getUniqueIdentifier()
-	if err != nil {
-		return fmt.Errorf("failed to get unique identifier: %w", err)
-	}
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
 
-	lock := resourcelock.LeaseLock{
-		LeaseMeta: metav1.ObjectMeta{
-			Name:      leaseLockNameRegister,
-			Namespace: r.Namespace,
-		},
-		Client: localClient.CoordinationV1(),
-		LockConfig: resourcelock.ResourceLockConfig{
-			Identity: identifier,
-		},
-	}
-
-	leaderOpts, err := command.NewLeaderElectionOptions()
+	// try to register with upstream fleet controller by obtaining
+	// a kubeconfig for the upstream cluster
+	agentInfo, err := register.Register(ctx, r.Namespace, kc)
 	if err != nil {
+		setupLog.Error(err, "failed to register with upstream cluster")
 		return err
 	}
 
-	leaderElectionConfig := leaderelection.LeaderElectionConfig{
-		Lock:          &lock,
-		LeaseDuration: *leaderOpts.LeaseDuration,
-		RetryPeriod:   *leaderOpts.RetryPeriod,
-		RenewDeadline: *leaderOpts.RenewDeadline,
-		Callbacks: leaderelection.LeaderCallbacks{
-			OnStartedLeading: func(ctx context.Context) {
-				setupLog.Info("starting registration on upstream cluster", "namespace", r.Namespace)
-
-				ctx, cancel := context.WithCancel(ctx)
-				defer cancel()
-
-				// try to register with upstream fleet controller by obtaining
-				// a kubeconfig for the upstream cluster
-				agentInfo, err := register.Register(ctx, r.Namespace, kc)
-				if err != nil {
-					setupLog.Error(err, "failed to register with upstream cluster")
-					return
-				}
-
-				ns, _, err := agentInfo.ClientConfig.Namespace()
-				if err != nil {
-					setupLog.Error(err, "failed to get namespace from upstream cluster")
-					return
-				}
-
-				_, err = agentInfo.ClientConfig.ClientConfig()
-				if err != nil {
-					setupLog.Error(err, "failed to get kubeconfig from upstream cluster")
-					return
-				}
-
-				setupLog.Info("successfully registered with upstream cluster", "namespace", ns)
-				os.Exit(0)
-			},
-			OnStoppedLeading: func() {
-				setupLog.Info("stopped leading")
-				os.Exit(1)
-			},
-			OnNewLeader: func(identity string) {
-				if identity == identifier {
-					setupLog.Info("renewed leader", "identity", identity)
-				} else {
-					setupLog.Info("new leader", "identity", identity)
-				}
-			},
-		},
+	ns, _, err := agentInfo.ClientConfig.Namespace()
+	if err != nil {
+		setupLog.Error(err, "failed to get namespace from upstream cluster")
+		return err
 	}
 
-	leaderelection.RunOrDie(ctx, leaderElectionConfig)
+	_, err = agentInfo.ClientConfig.ClientConfig()
+	if err != nil {
+		setupLog.Error(err, "failed to get kubeconfig from upstream cluster")
+		return err
+	}
+
+	setupLog.Info("successfully registered with upstream cluster", "namespace", ns)
 
 	return nil
 }

--- a/internal/cmd/controller/agentmanagement/agent/manifest.go
+++ b/internal/cmd/controller/agentmanagement/agent/manifest.go
@@ -164,30 +164,6 @@ func agentApp(namespace string, agentScope string, opts ManifestOptions) *appsv1
 				},
 				Spec: corev1.PodSpec{
 					ServiceAccountName: serviceAccount,
-					InitContainers: []corev1.Container{
-						{
-							Name:            name + "-register",
-							Image:           image,
-							ImagePullPolicy: corev1.PullPolicy(opts.AgentImagePullPolicy),
-							Env: []corev1.EnvVar{
-								{
-									Name: "NAMESPACE",
-									ValueFrom: &corev1.EnvVarSource{
-										FieldRef: &corev1.ObjectFieldSelector{
-											FieldPath: "metadata.namespace",
-										},
-									},
-								},
-								{Name: "CATTLE_ELECTION_LEASE_DURATION", Value: electionLeaseDuration},
-								{Name: "CATTLE_ELECTION_RETRY_PERIOD", Value: electionRetryPeriod},
-								{Name: "CATTLE_ELECTION_RENEW_DEADLINE", Value: electionRenewDeadline},
-							},
-							Command: []string{
-								"fleetagent",
-								"register",
-							},
-						},
-					},
 					Containers: []corev1.Container{
 						{
 							Name:            name,


### PR DESCRIPTION
Since we have changed the agent from using a StatefulSet to a Deployment, we also needed and have implemented leader election for every container of the agent pod. This ensures that
- only  one cluster registration is created at a time from one downstream cluster,
- one agent is running on a downstream cluster at a time and
- one container is updating the status at at time,

even if the replicas are temporarily (as in a rollout) or permanently (as in replica size) above one.

Now, if replicas are to be set to anything above one, this will currently lead to the agent of the second pod to perform the cluster registration, even though the agent cannot run after it completed the registration. The cluster registration will complete, but the controller will wait for the lease. This state potentially leads to confusion, as there are cluster registrations in the upstream cluster that have never and may never be used. Apparently this state is also considered inconsistent with the UI. Lastly, we use more leases than necessary.

While theoretically possible that the name for the lease is the same for the cluster registration container as well as for the agent controller, this may lead to extended waiting times, as the leases need to be acquired. Also, it is not guaranteed that the agent controller of the same pod will get the lease after the cluster registration container has let go of the lease , potentially leading to the same problem with unused cluster registrations (imagine replica size 3 from 1).

For those reasons the agent registration is to be moved into the controller container.

Part of #3377 

<!-- Specify the issue ID that this pull request is solving -->
<!-- Make sure that the referenced issue provides steps to reproduce it -->

<!-- Describe the changes introduced by this pull request -->

<!--
  Please provide a unit, integration (`./integrationtests/`) or e2e (`./e2e/`) test if possible.
-->