### PR TITLE
Refactor bundle deployment status integration tests

### DIFF
--- a/integrationtests/agent/bundle_deployment_drift_test.go
+++ b/integrationtests/agent/bundle_deployment_drift_test.go
@@ -85,15 +85,15 @@ var _ = Describe("BundleDeployment drift correction", Ordered, func() {
 		})
 
 		Context("Modifying externalName in service resource", func() {
-			It("Receives a modification on a service", func() {
+			It("Leaves the bundle deployment untouched", func() {
+				By("Receiving a modification on a service")
 				svc, err := env.getService("svc-ext")
 				Expect(err).NotTo(HaveOccurred())
 				patchedSvc := svc.DeepCopy()
 				patchedSvc.Spec.ExternalName = "modified"
 				Expect(k8sClient.Patch(ctx, patchedSvc, client.StrategicMergeFrom(&svc))).NotTo(HaveOccurred())
-			})
 
-			It("Preserves the modification on the service", func() {
+				By("Preserving the modification on the service")
 				Consistently(func(g Gomega) {
 					svc, err := env.getService("svc-ext")
 					g.Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
This ensures that bundle deployments are only created as often as necessary. It replaces `It` blocks, which would call the whole setup logic again, creating a new bundle deployment, with `By` statements illustrating mere steps of a testing context.

Logic under test is not affected; this is merely an optimisation of test drivers.

Example result on my machine:
* Before:
```                                                                                
Running Suite: Fleet Suite - /home/tan/Dev/fleet3/integrationtests/agent
========================================================================                                                                
Random Seed: 1741096567                                                                                                                 
                                                                                                                                        
Will run 53 of 53 specs
[...]
Ginkgo ran 1 suite in 2m35.561931079s                                                                                                   
Test Suite Passed
```
After:
```
Running Suite: Fleet Suite - /home/tan/Dev/fleet3/integrationtests/agent
========================================================================
Random Seed: 1741097877

Will run 31 of 31 specs
[...]
Ginkgo ran 1 suite in 2m27.184308843s
Test Suite Passed
```