### PR TITLE
Don't check for ResourceVersion on Status tests

### DIFF
--- a/integrationtests/gitjob/controller/gitrepo_test.go
+++ b/integrationtests/gitjob/controller/gitrepo_test.go
@@ -59,10 +59,8 @@ var _ = Describe("GitRepo", func() {
 		})
 
 		It("updates the gitrepo status", func() {
-			org := gitrepo.ResourceVersion
 			Eventually(func(g Gomega) {
 				_ = k8sClient.Get(ctx, types.NamespacedName{Name: gitrepoName, Namespace: namespace}, gitrepo)
-				g.Expect(gitrepo.ResourceVersion > org).To(BeTrue())
 				g.Expect(gitrepo.Status.Display.ReadyBundleDeployments).To(Equal("0/0"))
 				g.Expect(gitrepo.Status.Display.Error).To(BeFalse())
 				g.Expect(gitrepo.Status.Conditions).To(HaveLen(5))


### PR DESCRIPTION
The test already checks for meaningful status fields and `ResourceVersion` is part of the kubernetes engine. The test is flaky because the value of the original `ResourceVersion` could be already updated when it reads it.

