### PR TITLE
Add missing verb to RBAC

### DIFF
--- a/charts/fleet/templates/rbac.yaml
+++ b/charts/fleet/templates/rbac.yaml
@@ -43,6 +43,7 @@ rules:
   resources:
     - 'deployments'
   verbs:
+    - 'watch'
     - 'list'
     - 'get'
 ---


### PR DESCRIPTION
Fixes

```
│ fleet-agentmanagement E0304 16:38:51.311219       1 reflector.go:166] "Unhandled Error" err="pkg/mod/k8s.io/client-go@v0.32.1/tools/cache/reflector.go:251: Failed to watch *v1.Deployment: deployments.apps is forbidden: User \"system:serviceaccount:catt │
│ le-fleet-system:fleet-controller\" cannot watch resource \"deployments\" in API group \"apps\" at the cluster scope" logger="UnhandledError"                                                                                                                 │
```

Fix-up for #3313

<!-- Specify the issue ID that this pull request is solving -->
<!-- Make sure that the referenced issue provides steps to reproduce it -->

<!-- Describe the changes introduced by this pull request -->

<!--
  Please provide a unit, integration (`./integrationtests/`) or e2e (`./e2e/`) test if possible.
-->