### PR TITLE
Update gitcloner/fetcher error messages for SCP/SSH GitRepo URLs

### DIFF
--- a/internal/cmd/cli/gitcloner/cloner.go
+++ b/internal/cmd/cli/gitcloner/cloner.go
@@ -73,7 +73,7 @@ func (c *Cloner) CloneRepo(opts *GitCloner) error {
 
 func cloneBranch(opts *GitCloner, auth transport.AuthMethod, caBundle []byte) error {
 	_, err := plainClone(opts.Path, false, &git.CloneOptions{
-		URL:               opts.Repo,
+		URL:               normalizeRepo(opts.Repo),
 		Auth:              auth,
 		InsecureSkipTLS:   opts.InsecureSkipTLS,
 		CABundle:          caBundle,
@@ -90,7 +90,7 @@ func cloneBranch(opts *GitCloner, auth transport.AuthMethod, caBundle []byte) er
 
 func cloneRevision(opts *GitCloner, auth transport.AuthMethod, caBundle []byte) error {
 	r, err := plainClone(opts.Path, false, &git.CloneOptions{
-		URL:               opts.Repo,
+		URL:               normalizeRepo(opts.Repo),
 		Auth:              auth,
 		InsecureSkipTLS:   opts.InsecureSkipTLS,
 		CABundle:          caBundle,
@@ -113,6 +113,17 @@ func cloneRevision(opts *GitCloner, auth transport.AuthMethod, caBundle []byte) 
 	}
 
 	return nil
+}
+
+// normalizeRepo normalizes the repo URL to a canonical form. For example, it
+// will convert git@server to ssh://git@server.
+func normalizeRepo(repo string) string {
+
+	url, err := giturls.Parse(repo)
+	if err != nil {
+		return repo
+	}
+	return url.String()
 }
 
 func getCABundleFromFile(path string) ([]byte, error) {

--- a/internal/cmd/cli/gitcloner/cloner_test.go
+++ b/internal/cmd/cli/gitcloner/cloner_test.go
@@ -75,12 +75,12 @@ udiSlDctMM/X3ZM2JN5M1rtAJ2WR3ZQtmWbOjZAbG2Eq
 	}{
 		"branch no auth": {
 			opts: &GitCloner{
-				Repo:   "repo",
+				Repo:   "https://repo",
 				Path:   "path",
 				Branch: "master",
 			},
 			expectedCloneOpts: &git.CloneOptions{
-				URL:               "repo",
+				URL:               "https://repo",
 				SingleBranch:      true,
 				ReferenceName:     "master",
 				RecurseSubmodules: git.DefaultSubmoduleRecursionDepth,
@@ -88,14 +88,14 @@ udiSlDctMM/X3ZM2JN5M1rtAJ2WR3ZQtmWbOjZAbG2Eq
 		},
 		"branch basic auth": {
 			opts: &GitCloner{
-				Repo:         "repo",
+				Repo:         "https://repo",
 				Path:         "path",
 				Branch:       "master",
 				Username:     "user",
 				PasswordFile: passwordFile,
 			},
 			expectedCloneOpts: &git.CloneOptions{
-				URL:           "repo",
+				URL:           "https://repo",
 				SingleBranch:  true,
 				ReferenceName: "master",
 				Auth: &httpgit.BasicAuth{
@@ -122,31 +122,31 @@ udiSlDctMM/X3ZM2JN5M1rtAJ2WR3ZQtmWbOjZAbG2Eq
 		},
 		"password file does not exist": {
 			opts: &GitCloner{
-				Repo:         "repo",
+				Repo:         "https://repo",
 				Branch:       "master",
 				PasswordFile: "doesntexist",
 				Username:     "user",
 			},
 			expectedCloneOpts: nil,
-			expectedErr:       errors.New("failed checkout of: repo=[repo] branch=[master] revision=[] path=[]: file not found"),
+			expectedErr:       errors.New(`failed to create auth from options for repo="https://repo" branch="master" revision="" path="": file not found`),
 		},
 		"ca file does not exist": {
 			opts: &GitCloner{
-				Repo:         "repo",
+				Repo:         "https://repo",
 				Branch:       "master",
 				CABundleFile: "doesntexist",
 			},
 			expectedCloneOpts: nil,
-			expectedErr:       errors.New("failed checkout of: repo=[repo] branch=[master] revision=[] path=[]: file not found"),
+			expectedErr:       errors.New(`failed to read CA bundle from file for repo="https://repo" branch="master" revision="" path="": file not found`),
 		},
 		"ssh private key file does not exist": {
 			opts: &GitCloner{
-				Repo:              "repo",
+				Repo:              "https://repo",
 				Branch:            "master",
 				SSHPrivateKeyFile: "doesntexist",
 			},
 			expectedCloneOpts: nil,
-			expectedErr:       errors.New("failed checkout of: repo=[repo] branch=[master] revision=[] path=[]: file not found"),
+			expectedErr:       errors.New(`failed to create auth from options for repo="https://repo" branch="master" revision="" path="": file not found`),
 		},
 	}
 

--- a/pkg/git-urls/urls_test.go
+++ b/pkg/git-urls/urls_test.go
@@ -1,0 +1,59 @@
+package giturls_test
+
+import (
+	"testing"
+
+	giturls "github.com/rancher/fleet/pkg/git-urls"
+)
+
+func TestParse(t *testing.T) {
+	tests := []struct {
+		name string
+		url  string
+		want string
+	}{
+		{
+			name: "ssh",
+			url:  "ssh://example.com/foo/bar",
+			want: "ssh://example.com/foo/bar",
+		},
+		{
+			name: "git",
+			url:  "git://example.com/foo/bar",
+			want: "git://example.com/foo/bar",
+		},
+		{
+			name: "git+ssh",
+			url:  "git+ssh://example.com/foo/bar",
+			want: "git+ssh://example.com/foo/bar",
+		},
+		{
+			name: "http",
+			url:  "http://example.com/foo/bar",
+			want: "http://example.com/foo/bar",
+		},
+		{
+			name: "https",
+			url:  "https://example.com/foo/bar",
+
+			want: "https://example.com/foo/bar",
+		},
+		{
+			name: "scp",
+			url:  "git@example.com:foo/bar",
+			want: "ssh://git@example.com/foo/bar",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			u, err := giturls.Parse(tt.url)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if u.String() != tt.want {
+				t.Errorf("got %q, want %q", u.String(), tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Improve error messages when handling "scp-style" Git URLs: https://github.com/rancher/fleet/issues/2495 

*  ssh/scp style URLs only work when clientSecretName is used
  * cloner (job) works with scp-style URLs
  * fetcher (controller) works with scp-style URLs*
* made error messages in cloner more distinct

Note: The new require-secrets e2e tests needs `GIT_REPO_URL` to contain a scp-style URL, like `git@gitrepo.host:path`. Other e2e tests cannot be used, since our server runs on a non-standard port and "scp" syntax doesn't support ports...

(Updated description after comments)