### PR TITLE
Change namespace for dev infrastructure

### DIFF
--- a/.github/scripts/create-secrets.sh
+++ b/.github/scripts/create-secrets.sh
@@ -3,7 +3,7 @@
 dir=${1-'FleetCI-RootCA'}
 
 # Create secret with certs, needed by test git server
-kubectl -n fleet-local create secret generic git-server-certs \
+kubectl -n default create secret generic git-server-certs \
     --from-file=./"$dir"/helm.crt \
     --from-file=./"$dir"/helm.key
 

--- a/.github/scripts/create-zot-certs.sh
+++ b/.github/scripts/create-zot-certs.sh
@@ -20,11 +20,6 @@ must_create_certs ()
     return $?
 }
 
-if [ -z $FLEET_E2E_NS ]; then
-    echo "Error: env var FLEET_E2E_NS is not set. Exiting."
-    exit 1
-fi
-
 must_create_certs
 if [ $? -eq 1 ]; then
     # generate private key for CA
@@ -43,9 +38,9 @@ if [ $? -eq 1 ]; then
     keyUsage = digitalSignature, nonRepudiation, keyEncipherment, dataEncipherment
     subjectAltName = @alt_names
     [alt_names]
-    DNS.1 = zot-service.$FLEET_E2E_NS.svc.cluster.local
-    DNS.2 = chartmuseum-service.$FLEET_E2E_NS.svc.cluster.local
-    DNS.3 = git-service.$FLEET_E2E_NS.svc.cluster.local
+    DNS.1 = zot-service.default.svc.cluster.local
+    DNS.2 = chartmuseum-service.default.svc.cluster.local
+    DNS.3 = git-service.default.svc.cluster.local
 EOF
 
     # sign Zot cert with CA root key

--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -103,8 +103,6 @@ jobs:
       -
         name: Create Zot certificates for OCI tests
         if: ${{ matrix.test_type.name == 'infra-setup' }}
-        env:
-          FLEET_E2E_NS: fleet-local
         run: |
           ./.github/scripts/create-zot-certs.sh "FleetCI-RootCA"
           ./.github/scripts/create-secrets.sh 'FleetCI-RootCA'

--- a/.github/workflows/e2e-nightly-ci.yml
+++ b/.github/workflows/e2e-nightly-ci.yml
@@ -76,8 +76,6 @@ jobs:
       -
         name: Create Zot certificates for OCI tests
         if: ${{ matrix.test_type == 'e2e-nosecrets' }}
-        env:
-          FLEET_E2E_NS: fleet-local
         run: |
           # Generate cert and key for TLS
           ./.github/scripts/create-zot-certs.sh "FleetCI-RootCA"

--- a/dev/README.md
+++ b/dev/README.md
@@ -224,10 +224,8 @@ To build and run the infra setup command do:
 ```
 dev/import-images-tests-k3d
 # ./dev/create-zot-certs 'FleetCI-RootCA'
-pushd e2e/testenv/infra
-  go build
-popd
-./e2e/testenv/infra/infra setup
+dev/create-secrets
+go run ./e2e/testenv/infra/main.go setup
 ```
 
 The resulting deployments use a loadbalancer service, which means the host must be able to reach the loadbalancer IP.

--- a/dev/create-secrets
+++ b/dev/create-secrets
@@ -1,14 +1,3 @@
 #!/bin/bash
 
-dir=${1-'FleetCI-RootCA'}
-
-# Create secret with certs, needed by test git server, uses the InfraNamespace
-kubectl -n "default" create secret generic git-server-certs \
-    --from-file=./"$dir"/helm.crt \
-    --from-file=./"$dir"/helm.key
-
-# Create cattle-system namespace
-kubectl create ns cattle-system
-
-# Create Rancher CA bundle secret
-kubectl -n cattle-system create secret generic tls-ca-additional --from-file=ca-additional.pem=./"$dir"/root.crt
+./.github/scripts/create-secrets.sh "$@"

--- a/dev/create-secrets
+++ b/dev/create-secrets
@@ -1,3 +1,14 @@
 #!/bin/bash
 
-./.github/scripts/create-secrets.sh "$@"
+dir=${1-'FleetCI-RootCA'}
+
+# Create secret with certs, needed by test git server, uses the InfraNamespace
+kubectl -n "default" create secret generic git-server-certs \
+    --from-file=./"$dir"/helm.crt \
+    --from-file=./"$dir"/helm.key
+
+# Create cattle-system namespace
+kubectl create ns cattle-system
+
+# Create Rancher CA bundle secret
+kubectl -n cattle-system create secret generic tls-ca-additional --from-file=ca-additional.pem=./"$dir"/root.crt

--- a/dev/create-zot-certs
+++ b/dev/create-zot-certs
@@ -1,4 +1,3 @@
 #!/bin/bash
 
-export FLEET_E2E_NS=default
 ./.github/scripts/create-zot-certs.sh "$@"

--- a/dev/create-zot-certs
+++ b/dev/create-zot-certs
@@ -1,3 +1,4 @@
 #!/bin/bash
 
+export FLEET_E2E_NS=default
 ./.github/scripts/create-zot-certs.sh "$@"

--- a/dev/setup-cluster-config
+++ b/dev/setup-cluster-config
@@ -3,7 +3,7 @@
 set -ex
 
 if [ "$1" = "teardown" ]; then
-    ./e2e/testenv/infra/infra teardown
+    go run ./e2e/testenv/infra/main.go teardown
     exit 0
 fi
 

--- a/dev/setup-multi-cluster
+++ b/dev/setup-multi-cluster
@@ -27,4 +27,4 @@ fi
 ./dev/import-images-tests-k3d
 ./dev/create-zot-certs 'FleetCI-RootCA' # for OCI tests
 ./dev/create-secrets 'FleetCI-RootCA'
-./e2e/testenv/infra/infra setup
+go run ./e2e/testenv/infra/main.go setup

--- a/dev/setup-single-cluster
+++ b/dev/setup-single-cluster
@@ -40,4 +40,4 @@ fi
 ./dev/import-images-tests-k3d
 ./dev/create-zot-certs 'FleetCI-RootCA' # for OCI tests
 ./dev/create-secrets 'FleetCI-RootCA'
-./e2e/testenv/infra/infra setup
+go run ./e2e/testenv/infra/main.go setup

--- a/e2e/assets/helm/repo/http-with-auth-chart-path/fleet.yaml
+++ b/e2e/assets/helm/repo/http-with-auth-chart-path/fleet.yaml
@@ -9,7 +9,7 @@ helm:
   # The release name to use. If empty a generated release name will be used
   releaseName: sleeper-chart
 
-  chart: "https://chartmuseum-service.fleet-local.svc.cluster.local:8081/charts/sleeper-chart-0.1.0.tgz"
+  chart: "https://chartmuseum-service.default.svc.cluster.local:8081/charts/sleeper-chart-0.1.0.tgz"
 
   # Used if repo is set to look up the version of the chart
   version: "0.1.0"

--- a/e2e/assets/helm/repo/http-with-auth-repo-path/fleet.yaml
+++ b/e2e/assets/helm/repo/http-with-auth-repo-path/fleet.yaml
@@ -10,7 +10,7 @@ helm:
   releaseName: sleeper-chart
 
   chart: "sleeper-chart"
-  repo: "https://chartmuseum-service.fleet-local.svc.cluster.local:8081"
+  repo: "https://chartmuseum-service.default.svc.cluster.local:8081"
 
   # Used if repo is set to look up the version of the chart
   version: "0.1.0"

--- a/e2e/assets/helm/repo/oci-with-auth/fleet.yaml
+++ b/e2e/assets/helm/repo/oci-with-auth/fleet.yaml
@@ -12,7 +12,7 @@ helm:
   # The directory of the chart in the repo.  Any valid go-getter supported
   # URL can also be used here to specify where to download the chart from.
   # If repo below is set, this value is the chart name in the repo.
-  chart: "oci://zot-service.fleet-local.svc.cluster.local:8082/sleeper-chart"
+  chart: "oci://zot-service.default.svc.cluster.local:8082/sleeper-chart"
 
   # Used if repo is set to look up the version of the chart
   version: "0.1.0"

--- a/e2e/single-cluster/gitrepo_polling_disabled_test.go
+++ b/e2e/single-cluster/gitrepo_polling_disabled_test.go
@@ -34,8 +34,7 @@ var _ = Describe("GitRepoPollingDisabled", Label("infra-setup"), func() {
 
 	JustBeforeEach(func() {
 		// Build git repo URL reachable _within_ the cluster, for the GitRepo
-		host, err := githelper.BuildGitHostname(env.Namespace)
-		Expect(err).ToNot(HaveOccurred())
+		host := githelper.BuildGitHostname()
 
 		addr, err := githelper.GetExternalRepoAddr(env, port, repoName)
 		Expect(err).ToNot(HaveOccurred())

--- a/e2e/single-cluster/gitrepo_test.go
+++ b/e2e/single-cluster/gitrepo_test.go
@@ -71,8 +71,7 @@ var _ = Describe("Monitoring Git repos via HTTP for change", Label("infra-setup"
 		JustBeforeEach(func() {
 
 			// Build git repo URL reachable _within_ the cluster, for the GitRepo
-			host, err := githelper.BuildGitHostname(env.Namespace)
-			Expect(err).ToNot(HaveOccurred())
+			host := githelper.BuildGitHostname()
 
 			addr, err := githelper.GetExternalRepoAddr(env, c.port, repoName)
 			Expect(err).ToNot(HaveOccurred())

--- a/e2e/single-cluster/gitrepo_test.go
+++ b/e2e/single-cluster/gitrepo_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/rancher/fleet/e2e/testenv"
 	"github.com/rancher/fleet/e2e/testenv/githelper"
+	"github.com/rancher/fleet/e2e/testenv/infra/cmd"
 	"github.com/rancher/fleet/e2e/testenv/kubectl"
 	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
 	"github.com/rancher/wrangler/v3/pkg/genericcondition"
@@ -236,9 +237,10 @@ var _ = Describe("Monitoring Git repos via HTTP for change", Label("infra-setup"
 				var (
 					out string
 					err error
+					kg  = k.Namespace(cmd.InfraNamespace)
 				)
 				Eventually(func() string {
-					out, err = k.Get("pod", "-l", "app=git-server", "-o", "name")
+					out, err = kg.Get("pod", "-l", "app=git-server", "-o", "name")
 					if err != nil {
 						fmt.Printf("%v\n", err)
 						return ""
@@ -259,7 +261,7 @@ var _ = Describe("Monitoring Git repos via HTTP for change", Label("infra-setup"
 				Expect(err).ToNot(HaveOccurred())
 
 				// Create a git repo, erasing a previous repo with the same name if any
-				out, err = k.Run(
+				out, err = kg.Run(
 					"exec",
 					gitServerPod,
 					"--",
@@ -276,13 +278,13 @@ var _ = Describe("Monitoring Git repos via HTTP for change", Label("infra-setup"
 				hookPathInRepo := fmt.Sprintf("/srv/git/%s/hooks/post-receive", repoName)
 
 				Eventually(func() error {
-					out, err = k.Run("cp", hookScript, fmt.Sprintf("%s:%s", gitServerPod, hookPathInRepo))
+					out, err = kg.Run("cp", hookScript, fmt.Sprintf("%s:%s", gitServerPod, hookPathInRepo))
 					return err
 				}).Should(Not(HaveOccurred()), out)
 
 				// Make hook script executable
 				Eventually(func() error {
-					out, err = k.Run("exec", gitServerPod, "--", "chmod", "+x", hookPathInRepo)
+					out, err = kg.Run("exec", gitServerPod, "--", "chmod", "+x", hookPathInRepo)
 					return err
 				}).ShouldNot(HaveOccurred(), out)
 

--- a/e2e/single-cluster/helm_auth_test.go
+++ b/e2e/single-cluster/helm_auth_test.go
@@ -25,13 +25,12 @@ var _ = Describe("GitRepo using Helm chart with auth", Label("infra-setup"), fun
 
 	JustBeforeEach(func() {
 		// Build git repo URL reachable _within_ the cluster, for the GitRepo
-		host, err := githelper.BuildGitHostname(env.Namespace)
-		Expect(err).ToNot(HaveOccurred())
+		host := githelper.BuildGitHostname()
 
 		inClusterRepoURL := gh.GetInClusterURL(host, port, repoName)
 
 		gitrepo := path.Join(tmpdir, "gitrepo.yaml")
-		err = testenv.Template(gitrepo, testenv.AssetPath("single-cluster/helm-with-auth.yaml"), struct {
+		err := testenv.Template(gitrepo, testenv.AssetPath("single-cluster/helm-with-auth.yaml"), struct {
 			Repo       string
 			Path       string
 			SecretName string

--- a/e2e/single-cluster/helm_dependencies_test.go
+++ b/e2e/single-cluster/helm_dependencies_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/rancher/fleet/e2e/testenv"
 	"github.com/rancher/fleet/e2e/testenv/githelper"
+	"github.com/rancher/fleet/e2e/testenv/infra/cmd"
 	"github.com/rancher/fleet/e2e/testenv/kubectl"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -22,7 +23,7 @@ func getChartMuseumExternalAddr(env *testenv.Env) string {
 	passwd := os.Getenv("GIT_HTTP_PASSWORD")
 	Expect(username).ToNot(Equal(""))
 	Expect(passwd).ToNot(Equal(""))
-	return fmt.Sprintf("https://%s:%s@chartmuseum-service.%s.svc.cluster.local:8081", username, passwd, env.Namespace)
+	return fmt.Sprintf("https://%s:%s@chartmuseum-service.%s.svc.cluster.local:8081", username, passwd, cmd.InfraNamespace)
 }
 
 func setupChartDepsInTmpDir(chartDir string, tmpDir string, namespace string, disableDependencyUpdate bool, env *testenv.Env) {
@@ -70,8 +71,7 @@ var _ = Describe("Helm dependency update tests", Label("infra-setup", "helm-regi
 	JustBeforeEach(func() {
 		k = env.Kubectl.Namespace(env.Namespace)
 		// Build git repo URL reachable _within_ the cluster, for the GitRepo
-		host, err := githelper.BuildGitHostname(env.Namespace)
-		Expect(err).ToNot(HaveOccurred())
+		host := githelper.BuildGitHostname()
 
 		addr, err := githelper.GetExternalRepoAddr(env, port, repoName)
 		Expect(err).ToNot(HaveOccurred())

--- a/e2e/single-cluster/imagescan_test.go
+++ b/e2e/single-cluster/imagescan_test.go
@@ -224,8 +224,7 @@ func setupRepo(k kubectl.Command, tmpdir, clonedir, repoDir string) (*git.Reposi
 	Expect(err).ToNot(HaveOccurred())
 
 	// Build git repo URL reachable _within_ the cluster, for the GitRepo
-	host, err := githelper.BuildGitHostname(env.Namespace)
-	Expect(err).ToNot(HaveOccurred())
+	host := githelper.BuildGitHostname()
 
 	inClusterRepoURL := gh.GetInClusterURL(host, port, repoName)
 

--- a/e2e/single-cluster/oci_registry_test.go
+++ b/e2e/single-cluster/oci_registry_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/rancher/fleet/e2e/testenv"
+	"github.com/rancher/fleet/e2e/testenv/infra/cmd"
 	"github.com/rancher/fleet/e2e/testenv/kubectl"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -129,7 +130,7 @@ var _ = Describe("Single Cluster Deployments using OCI registry", Label("oci-reg
 	BeforeEach(func() {
 		k = env.Kubectl.Namespace(env.Namespace)
 		tempDir = GinkgoT().TempDir()
-		externalIP, err := k.Get("service", "zot-service", "-o", "jsonpath={.status.loadBalancer.ingress[0].ip}")
+		externalIP, err := k.Namespace(cmd.InfraNamespace).Get("service", "zot-service", "-o", "jsonpath={.status.loadBalancer.ingress[0].ip}")
 		Expect(err).ToNot(HaveOccurred(), externalIP)
 		Expect(net.ParseIP(externalIP)).ShouldNot(BeNil())
 		ociRegistry = fmt.Sprintf("%s:8082", externalIP)

--- a/e2e/single-cluster/release_cleanup_test.go
+++ b/e2e/single-cluster/release_cleanup_test.go
@@ -121,8 +121,7 @@ var _ = Describe("Monitoring Helm releases along GitRepo/bundle release name upd
 
 	JustBeforeEach(func() {
 		// Build git repo URL reachable _within_ the cluster, for the GitRepo
-		host, err := githelper.BuildGitHostname(env.Namespace)
-		Expect(err).ToNot(HaveOccurred())
+		host := githelper.BuildGitHostname()
 
 		addr, err := githelper.GetExternalRepoAddr(env, port, repoName)
 		Expect(err).ToNot(HaveOccurred())

--- a/e2e/single-cluster/status_test.go
+++ b/e2e/single-cluster/status_test.go
@@ -139,8 +139,7 @@ var _ = Describe("Checks that template errors are shown in bundles and gitrepos"
 
 	JustBeforeEach(func() {
 		// Build git repo URL reachable _within_ the cluster, for the GitRepo
-		host, err := githelper.BuildGitHostname(env.Namespace)
-		Expect(err).ToNot(HaveOccurred())
+		host := githelper.BuildGitHostname()
 
 		addr, err := githelper.GetExternalRepoAddr(env, port, repoName)
 		Expect(err).ToNot(HaveOccurred())

--- a/e2e/single-cluster/suite_test.go
+++ b/e2e/single-cluster/suite_test.go
@@ -26,4 +26,6 @@ var _ = BeforeSuite(func() {
 	testenv.SetRoot("../..")
 
 	env = testenv.New()
+
+	Expect(env.Namespace).To(Equal("fleet-local"), "The single-cluster test assets target the default clustergroup and only work in fleet-local")
 })

--- a/e2e/testenv/infra/cmd/setup.go
+++ b/e2e/testenv/infra/cmd/setup.go
@@ -22,6 +22,8 @@ import (
 
 var timeoutDuration = 10 * time.Minute // default timeout duration
 
+const InfraNamespace = "default"
+
 func eventually(f func() (string, error)) string {
 	ctx, cancel := context.WithTimeout(context.Background(), timeoutDuration)
 	defer cancel()
@@ -84,7 +86,7 @@ var setupCmd = &cobra.Command{
 		// enables infra setup to be run from any location within the repo
 		testenv.SetRoot(strings.TrimSpace(string(repoRoot)))
 
-		k := env.Kubectl.Namespace(env.Namespace)
+		k := env.Kubectl.Namespace(InfraNamespace)
 
 		if err := packageHelmChart(); err != nil {
 			fail(fmt.Errorf("package Helm chart: %v", err))
@@ -114,7 +116,7 @@ var setupCmd = &cobra.Command{
 				fail(fmt.Errorf("create helm-tls secret: %s with error %v", out, err))
 			}
 
-			out, err = k.Create(
+			out, err = k.Namespace(env.Namespace).Create(
 				"secret", "generic", "helm-secret",
 				"--from-literal=username="+os.Getenv("CI_OCI_USERNAME"),
 				"--from-literal=password="+os.Getenv("CI_OCI_PASSWORD"),

--- a/e2e/testenv/infra/cmd/teardown.go
+++ b/e2e/testenv/infra/cmd/teardown.go
@@ -18,7 +18,7 @@ var teardownCmd = &cobra.Command{
 		fmt.Println("Tearing down test environment...")
 
 		env := testenv.New()
-		k := env.Kubectl.Namespace(env.Namespace)
+		k := env.Kubectl.Namespace(InfraNamespace)
 
 		// Only act on specified components, unless none is specified in which case all are affected.
 		if !withGitServer && !withHelmRegistry && !withOCIRegistry {
@@ -46,7 +46,7 @@ var teardownCmd = &cobra.Command{
 
 		if withHelmRegistry && withOCIRegistry {
 			_, _ = k.Delete("secret", "helm-tls")
-			_, _ = k.Delete("secret", "helm-secret")
+			_, _ = k.Namespace(env.Namespace).Delete("secret", "helm-secret")
 		}
 
 	},

--- a/e2e/testenv/zothelper/zothelper.go
+++ b/e2e/testenv/zothelper/zothelper.go
@@ -4,11 +4,12 @@ import (
 	"fmt"
 	"net"
 
+	"github.com/rancher/fleet/e2e/testenv/infra/cmd"
 	"github.com/rancher/fleet/e2e/testenv/kubectl"
 )
 
 func GetOCIReference(k kubectl.Command) (string, error) {
-	externalIP, err := k.Get("service", "zot-service", "-o", "jsonpath={.status.loadBalancer.ingress[0].ip}")
+	externalIP, err := k.Namespace(cmd.InfraNamespace).Get("service", "zot-service", "-o", "jsonpath={.status.loadBalancer.ingress[0].ip}")
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
The new namespace is default, so services are no longer started in the workspaces used for the tests.

This also makes sure, single-cluster tests run in "fleet-local", as their gitrepo resources use the default target.
