### PR TITLE
Prune BundleDeployments when GitRepo/Bundle targets change

### DIFF
--- a/integrationtests/gitjob/controller/suite_test.go
+++ b/integrationtests/gitjob/controller/suite_test.go
@@ -170,6 +170,13 @@ var _ = BeforeSuite(func() {
 	}).SetupWithManager(mgr)
 	Expect(err).ToNot(HaveOccurred(), "failed to set up manager")
 
+	err = (&ctrlreconciler.BundleDeploymentReconciler{
+		Client:  mgr.GetClient(),
+		Scheme:  mgr.GetScheme(),
+		Workers: 50,
+	}).SetupWithManager(mgr)
+	Expect(err).ToNot(HaveOccurred(), "failed to set up manager")
+
 	go func() {
 		defer GinkgoRecover()
 		defer ctlr.Finish()

--- a/integrationtests/helmops/controller/suite_test.go
+++ b/integrationtests/helmops/controller/suite_test.go
@@ -100,6 +100,13 @@ var _ = BeforeSuite(func() {
 	}).SetupWithManager(mgr)
 	Expect(err).ToNot(HaveOccurred(), "failed to set up manager")
 
+	err = (&ctrlreconciler.BundleDeploymentReconciler{
+		Client:  mgr.GetClient(),
+		Scheme:  mgr.GetScheme(),
+		Workers: 50,
+	}).SetupWithManager(mgr)
+	Expect(err).ToNot(HaveOccurred(), "failed to set up manager")
+
 	go func() {
 		defer GinkgoRecover()
 		defer ctlr.Finish()

--- a/internal/cmd/controller/finalize/finalize.go
+++ b/internal/cmd/controller/finalize/finalize.go
@@ -2,7 +2,6 @@ package finalize
 
 import (
 	"context"
-	"errors"
 	"slices"
 	"strings"
 
@@ -63,35 +62,6 @@ func PurgeBundles(ctx context.Context, c client.Client, gitrepo types.Namespaced
 	}
 
 	return nil
-}
-
-// PurgeBundleDeployments deletes all BundleDeployments related with the given Bundle namespaced name.
-func PurgeBundleDeployments(ctx context.Context, c client.Client, bundle types.NamespacedName) error {
-	list := &v1alpha1.BundleDeploymentList{}
-	err := c.List(
-		ctx,
-		list,
-		client.MatchingLabels{
-			v1alpha1.BundleLabel:          bundle.Name,
-			v1alpha1.BundleNamespaceLabel: bundle.Namespace,
-		},
-	)
-	if err != nil {
-		return err
-	}
-	var errs []error
-	for _, bd := range list.Items {
-		if bd.DeletionTimestamp != nil {
-			// already being deleted
-			continue
-		}
-		// Mark the object for deletion. The BundleDeployment reconciler will react to that calling PurgeContent and finally removing the finalizer
-		if err := c.Delete(ctx, &bd); client.IgnoreNotFound(err) != nil {
-			errs = append(errs, err)
-		}
-	}
-
-	return errors.Join(errs...)
 }
 
 // PurgeContent tries to delete the content resource related with the given bundle deployment.

--- a/internal/cmd/controller/reconciler/bundle_controller.go
+++ b/internal/cmd/controller/reconciler/bundle_controller.go
@@ -525,7 +525,7 @@ func (r *BundleReconciler) cleanupOrphanedBundleDeployments(ctx context.Context,
 		return err
 	}
 	toDelete := slices.DeleteFunc(list, func(bd fleet.BundleDeployment) bool {
-		return uidsToKeep.Has(bd.ObjectMeta.UID)
+		return uidsToKeep.Has(bd.UID)
 	})
 	return batchDeleteBundleDeployments(ctx, r.Client, toDelete)
 }

--- a/internal/cmd/controller/reconciler/bundle_controller.go
+++ b/internal/cmd/controller/reconciler/bundle_controller.go
@@ -284,14 +284,14 @@ func (r *BundleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		}
 	}
 
-	updateDisplay(&bundle.Status)
-	if err := r.updateStatus(ctx, bundleOrig, bundle); err != nil {
-		return ctrl.Result{}, err
-	}
-
 	// the targets configuration may have changed, leaving behind some BundleDeployments that are no longer needed
 	if err := r.cleanupOrphanedBundleDeployments(ctx, bundle, bundleDeploymentUIDs); err != nil {
 		logger.V(1).Error(err, "deleting orphaned bundle deployments", "bundle", bundle.GetName())
+	}
+
+	updateDisplay(&bundle.Status)
+	if err := r.updateStatus(ctx, bundleOrig, bundle); err != nil {
+		return ctrl.Result{}, err
 	}
 
 	return ctrl.Result{}, nil

--- a/internal/cmd/controller/reconciler/bundledeployment_controller.go
+++ b/internal/cmd/controller/reconciler/bundledeployment_controller.go
@@ -69,15 +69,14 @@ func (r *BundleDeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Req
 				return ctrl.Result{}, err
 			}
 			err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
-				t := &fleet.BundleDeployment{}
-				err := r.Get(ctx, req.NamespacedName, t)
+				err := r.Get(ctx, req.NamespacedName, bd)
 				if err != nil {
 					return err
 				}
 
-				controllerutil.RemoveFinalizer(t, finalize.BundleDeploymentFinalizer)
+				controllerutil.RemoveFinalizer(bd, finalize.BundleDeploymentFinalizer)
 
-				return r.Update(ctx, t)
+				return r.Update(ctx, bd)
 			})
 			if err != nil {
 				return ctrl.Result{}, err

--- a/internal/cmd/controller/reconciler/bundledeployment_controller.go
+++ b/internal/cmd/controller/reconciler/bundledeployment_controller.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"reflect"
 
+	"github.com/rancher/fleet/internal/cmd/controller/finalize"
 	"github.com/rancher/fleet/internal/cmd/controller/summary"
 	"github.com/rancher/fleet/internal/metrics"
 	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
@@ -66,6 +67,9 @@ func (r *BundleDeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	// The bundle reconciler takes care of adding the finalizer when creating a bundle deployment
 	if !bd.DeletionTimestamp.IsZero() {
 		if controllerutil.ContainsFinalizer(bd, bundleDeploymentFinalizer) {
+			if err := finalize.PurgeContent(ctx, r.Client, bd.Name, bd.Spec.DeploymentID); err != nil {
+				return ctrl.Result{}, err
+			}
 			err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
 				t := &fleet.BundleDeployment{}
 				err := r.Get(ctx, req.NamespacedName, t)

--- a/internal/cmd/controller/reconciler/bundledeployment_controller.go
+++ b/internal/cmd/controller/reconciler/bundledeployment_controller.go
@@ -25,8 +25,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
-const bundleDeploymentFinalizer = "fleet.cattle.io/bundle-deployment-finalizer"
-
 // BundleDeploymentReconciler reconciles a BundleDeployment object
 type BundleDeploymentReconciler struct {
 	client.Client
@@ -66,7 +64,7 @@ func (r *BundleDeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Req
 
 	// The bundle reconciler takes care of adding the finalizer when creating a bundle deployment
 	if !bd.DeletionTimestamp.IsZero() {
-		if controllerutil.ContainsFinalizer(bd, bundleDeploymentFinalizer) {
+		if controllerutil.ContainsFinalizer(bd, finalize.BundleDeploymentFinalizer) {
 			if err := finalize.PurgeContent(ctx, r.Client, bd.Name, bd.Spec.DeploymentID); err != nil {
 				return ctrl.Result{}, err
 			}
@@ -77,7 +75,7 @@ func (r *BundleDeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Req
 					return err
 				}
 
-				controllerutil.RemoveFinalizer(t, bundleDeploymentFinalizer)
+				controllerutil.RemoveFinalizer(t, finalize.BundleDeploymentFinalizer)
 
 				return r.Update(ctx, t)
 			})


### PR DESCRIPTION
Also changes/improves how the finalizers are handled, both for Bundles and BundleDeployments.

Refers to #3437

`BundleDeployments` are only being deleted on the `Cluster` reconciler, which can take considerable time to run and cause confusion in the status of resources.
Note: this PR was superseded by #3509 while still on review. However, I believe this implementation is cleaner, so some of the changes there are being replaced.