### PR TITLE
Slightly speed up end-to-end test runs 

### DIFF
--- a/dev/setup-single-cluster
+++ b/dev/setup-single-cluster
@@ -6,16 +6,21 @@ export CUSTOM_CONFIG_FILE="env.single-cluster"
 # shellcheck source=dev/setup-cluster-config
 source ./dev/setup-cluster-config
 
-# Cleans with settings sourced, so it should be rather selective.
-./dev/k3d-clean
+if [ $1 = "--reuse" ]; then
+    ./dev/remove-fleet
+else
+    # Cleans with settings sourced, so it should be rather selective.
+    ./dev/k3d-clean
 
-PORT_OFFSET=0
-if [ -z "$external_ip" ];
-then
- PORT_OFFSET=$(( RANDOM % 10001 ))
+    PORT_OFFSET=0
+    if [ -z "$external_ip" ];
+    then
+     PORT_OFFSET=$(( RANDOM % 10001 ))
+    fi
+
+    ./dev/setup-k3d "${FLEET_E2E_CLUSTER#k3d-}" "$PORT_OFFSET"
 fi
 
-./dev/setup-k3d "${FLEET_E2E_CLUSTER#k3d-}" "$PORT_OFFSET"
 ./dev/build-fleet
 ./dev/import-images-k3d
 ./dev/setup-fleet "${FLEET_E2E_CLUSTER#k3d-}" '[
@@ -39,5 +44,6 @@ fi
 # needed for gitrepo tests
 ./dev/import-images-tests-k3d
 ./dev/create-zot-certs 'FleetCI-RootCA' # for OCI tests
+set +e # keep going if secrets already exist
 ./dev/create-secrets 'FleetCI-RootCA'
 go run ./e2e/testenv/infra/main.go setup

--- a/e2e/single-cluster/helm_options_test.go
+++ b/e2e/single-cluster/helm_options_test.go
@@ -31,18 +31,17 @@ var _ = Describe("Helm deploy options", func() {
 		BeforeEach(func() {
 			asset = "single-cluster/helm-options-disabledns.yaml"
 		})
-		When("is false", func() {
-			bundleName := "helm-options-disabledns-helm-disable-dns-not-set"
-			It("enables DNS when invoking helm", func() {
+		When("toggling DisableDNS", func() {
+			It("honors DisableDNS", func() {
+				By("enabling DNS when invoking helm if DisableDNS is false")
+				bundleName := "helm-options-disabledns-helm-disable-dns-not-set"
 				Eventually(func() string {
 					out, _ := k.Get("bundle", bundleName, `-o=jsonpath={.status.conditions[?(@.type=="Ready")].status}`)
 					return out
 				}).Should(Equal("True"))
-			})
-		})
-		When("is true", func() {
-			bundleName := "helm-options-disabledns-helm-disable-dns-set"
-			It("does not enable DNS when invoking helm", func() {
+
+				By("not enabling DNS when invoking helm if DisableDNS is true")
+				bundleName = "helm-options-disabledns-helm-disable-dns-set"
 				Eventually(func() string {
 					out, _ := k.Get("bundle", bundleName, `-o=jsonpath='{.status.conditions[?(@.type=="Ready")].message}'`)
 					return out
@@ -55,18 +54,17 @@ var _ = Describe("Helm deploy options", func() {
 		BeforeEach(func() {
 			asset = "single-cluster/helm-options-skip-schema-validation.yaml"
 		})
-		When("is false", func() {
-			bundleName := "helm-options-skip-schema-val-helm-schemas-not-set"
-			It("fails when schema validation does not pass", func() {
+		When("toggling SkipSchemaValidation", func() {
+			It("honors SkipSchemaValidation", func() {
+				By("enabling SkipSchemaValidation and failing when schema validation does not pass")
+				bundleName := "helm-options-skip-schema-val-helm-schemas-not-set"
 				Eventually(func() string {
 					out, _ := k.Get("bundle", bundleName, `-o=jsonpath='{.status.conditions[?(@.type=="Ready")].message}'`)
 					return out
 				}).Should(ContainSubstring("values don't meet the specifications of the schema"))
-			})
-		})
-		When("is true", func() {
-			bundleName := "helm-options-skip-schema-val-helm-schemas-set"
-			It("completely skips the schema validation", func() {
+
+				By("completely skipping schema validation when disabled")
+				bundleName = "helm-options-skip-schema-val-helm-schemas-set"
 				Eventually(func() string {
 					out, _ := k.Get("bundle", bundleName, `-o=jsonpath={.status.conditions[?(@.type=="Ready")].status}`)
 					return out

--- a/e2e/single-cluster/release_cleanup_test.go
+++ b/e2e/single-cluster/release_cleanup_test.go
@@ -59,7 +59,8 @@ var _ = Describe("Monitoring Helm releases along GitRepo/bundle namespace update
 	})
 
 	When("updating a bundle's namespace", func() {
-		It("creates a new release in the new namespace", func() {
+		It("properly manages releases", func() {
+			By("creating a new release in the new namespace")
 			out, err := k.Patch(
 				"gitrepo",
 				gitrepoName,
@@ -70,9 +71,8 @@ var _ = Describe("Monitoring Helm releases along GitRepo/bundle namespace update
 			Expect(err).ToNot(HaveOccurred(), out)
 
 			checkRelease(newNamespace, fmt.Sprintf("%s-%s", gitrepoName, path))
-		})
 
-		It("deletes the old release in the previous namespace", func() {
+			By("deleting the old release in the previous namespace")
 			Eventually(func(g Gomega) {
 				cmd := exec.Command("helm", "list", "-q", "-n", oldNamespace)
 				out, err := cmd.CombinedOutput()

--- a/e2e/single-cluster/status_test.go
+++ b/e2e/single-cluster/status_test.go
@@ -66,7 +66,8 @@ var _ = Describe("Checks status updates happen for a simple deployment", Ordered
 			targetNamespace = "my-custom-namespace"
 		})
 
-		It("correctly sets the status values for GitRepos", func() {
+		It("correctly sets status values", func() {
+			By("correctly updating status values for GitRepos")
 			Eventually(func(g Gomega) {
 				out, err := k.Get("gitrepo", "my-gitrepo", "-n", "fleet-local", "-o", "jsonpath='{.status.summary}'")
 				g.Expect(err).ToNot(HaveOccurred(), out)
@@ -78,9 +79,8 @@ var _ = Describe("Checks status updates happen for a simple deployment", Ordered
 				g.Expect(err).ToNot(HaveOccurred(), out)
 				g.Expect(out).Should(ContainSubstring("\"readyBundleDeployments\":\"1/1\""))
 			}).Should(Succeed())
-		})
 
-		It("correctly sets the status values for Clusters", func() {
+			By("correctly updating status values for Clusters")
 			Eventually(func(g Gomega) {
 				out, err := k.Get("cluster", "local", "-n", "fleet-local", "-o", "jsonpath='{.status.display.readyBundles}'")
 				g.Expect(err).ToNot(HaveOccurred(), out)
@@ -88,9 +88,8 @@ var _ = Describe("Checks status updates happen for a simple deployment", Ordered
 				// Expected 2 bundles instead of just 1 because fleet-agent is also included here
 				g.Expect(out).Should(Equal("'2/2'"))
 			}).Should(Succeed())
-		})
 
-		It("correctly sets the status values for ClusterGroups", func() {
+			By("correctly updating status values for ClusterGroups")
 			Eventually(func(g Gomega) {
 				out, err := k.Get("clustergroup", "default", "-n", "fleet-local", "-o", "jsonpath='{.status.display.readyBundles}'")
 				g.Expect(err).ToNot(HaveOccurred(), out)
@@ -100,9 +99,8 @@ var _ = Describe("Checks status updates happen for a simple deployment", Ordered
 				g.Expect(err).ToNot(HaveOccurred(), out)
 				g.Expect(out).Should(Equal("'1/1'"))
 			}).Should(Succeed())
-		})
 
-		It("correctly sets the status values for bundle", func() {
+			By("correctly updating status values for bundles")
 			Eventually(func(g Gomega) {
 				out, err := k.Get("bundle", "my-gitrepo-helm-verify", "-n", "fleet-local", "-o", "jsonpath='{.status.summary}'")
 				g.Expect(err).ToNot(HaveOccurred(), out)
@@ -236,15 +234,15 @@ var _ = Describe("Checks that template errors are shown in bundles and gitrepos"
 			targetNamespace = testenv.NewNamespaceName("target", r)
 		})
 
-		It("should have an error in the bundle", func() {
+		It("should exhibit the error", func() {
+			By("showing the error in the bundle")
 			_, _ = ensureClusterHasNoLabelFoo()
 			Eventually(func(g Gomega) {
 				status := getBundleStatus(g, k, gitrepoName+"-examples")
 				expectTargetingError(g, status.Conditions)
 			}).Should(Succeed())
-		})
 
-		It("should have an error in the gitrepo", func() {
+			By("showing the error in the gitrepo")
 			_, _ = ensureClusterHasNoLabelFoo()
 			Eventually(func(g Gomega) {
 				status := getGitRepoStatus(g, k, gitrepoName)


### PR DESCRIPTION
This improves a couple of points to speed up running end-to-end tests:
* `dev/setup-single-cluster` supports a `--reuse` flag to reuse an existing cluster and uninstall Fleet from it, instead of deleting and re-creating the cluster
* redundant `It` blocks test cases are replaced with `By` statements to enable common setup logic to be run only as many times as necessary