### PR TITLE
docs:  remind to add documentation

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,3 +7,9 @@ Refers to #XXX
 <!--
   Please provide a unit, integration (`./integrationtests/`) or e2e (`./e2e/`) test if possible.
 -->
+
+## Additional Information
+
+### Checklist
+
+- [ ] <!-- If applicable,--> I have updated the documentation via pull request in [website](https://github.com/updatecli/website) repository.


### PR DESCRIPTION
As discussed in the retrospective, this pull request updates the pull request template to remind contributor to add documentation