### PR TITLE
Delete both, statefulset and deployment on agent update

### DIFF
--- a/charts/fleet-crd/templates/crds.yaml
+++ b/charts/fleet-crd/templates/crds.yaml
@@ -5632,7 +5632,7 @@ spec:
                   nullable: true
                   type: string
                 hostNetwork:
-                  description: 'HostNetwork sets the agent StatefulSet to use hostNetwork:
+                  description: 'HostNetwork sets the agent Deployment to use hostNetwork:
                     true setting.
 
                     Allows for provisioning of network related bundles (CNI configuration).'

--- a/internal/cmd/controller/agentmanagement/controllers/cluster/import.go
+++ b/internal/cmd/controller/agentmanagement/controllers/cluster/import.go
@@ -200,6 +200,10 @@ func (i *importHandler) deleteOldAgent(cluster *fleet.Cluster, kc kubernetes.Int
 	if err := kc.AppsV1().StatefulSets(namespace).Delete(i.ctx, config.AgentConfigName, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
 		return err
 	}
+	if err := kc.AppsV1().DaemonSets(namespace).Delete(i.ctx, config.AgentConfigName, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+		return err
+	}
+
 	logrus.Infof("Deleted old agent for cluster (%s/%s) in namespace %s", cluster.Namespace, cluster.Name, namespace)
 
 	return nil

--- a/pkg/apis/fleet.cattle.io/v1alpha1/cluster_types.go
+++ b/pkg/apis/fleet.cattle.io/v1alpha1/cluster_types.go
@@ -128,7 +128,7 @@ type ClusterSpec struct {
 
 	// +nullable
 	// +optional
-	// HostNetwork sets the agent StatefulSet to use hostNetwork: true setting.
+	// HostNetwork sets the agent Deployment to use hostNetwork: true setting.
 	// Allows for provisioning of network related bundles (CNI configuration).
 	HostNetwork *bool `json:"hostNetwork,omitempty"`
 }


### PR DESCRIPTION
even though the agent is not a statefulset anymore, but the user could be upgrading from an older fleet version.

<!-- Specify the issue ID that this pull request is solving -->
Refers to https://github.com/rancher/rancher/issues/49428

<!-- Make sure that the referenced issue provides steps to reproduce it -->

<!-- Describe the changes introduced by this pull request -->

<!--
  Please provide a unit, integration (`./integrationtests/`) or e2e (`./e2e/`) test if possible.
-->