### PR TITLE
Fix docs link in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,4 +12,5 @@ Refers to #XXX
 
 ### Checklist
 
-- [ ] <!-- If applicable,--> I have updated the documentation via pull request in [website](https://github.com/updatecli/website) repository.
+- [ ] <!-- If applicable,--> I have updated the documentation via a pull request in the
+[fleet-docs](https://github.com/rancher/fleet-docs) repository.


### PR DESCRIPTION
Follow-up to #3448.

The sources for the Fleet documentation website [2] live in `rancher/fleet-docs` [1].

[1]: https://github.com/rancher/fleet-docs
[2]: https://fleet.rancher.io/