### PR TITLE
Fix Rancher CA bundle mount after GitRepo update

### DIFF
--- a/internal/cmd/controller/gitops/reconciler/gitjob_controller.go
+++ b/internal/cmd/controller/gitops/reconciler/gitjob_controller.go
@@ -441,12 +441,12 @@ func (r *GitJobReconciler) createCABundleSecret(ctx context.Context, gitrepo *v1
 		return false, err
 	}
 	data := secret.StringData
-	res, err := controllerutil.CreateOrUpdate(ctx, r.Client, secret, func() error {
+	_, err := controllerutil.CreateOrUpdate(ctx, r.Client, secret, func() error {
 		secret.StringData = data // Supports update case, if the secret already exists.
 		return nil
 	})
 
-	return res == controllerutil.OperationResultCreated || res == controllerutil.OperationResultUpdated, err
+	return true, err
 }
 
 func (r *GitJobReconciler) validateExternalSecretExist(ctx context.Context, gitrepo *v1alpha1.GitRepo) error {

--- a/internal/cmd/controller/gitops/reconciler/gitjob_controller.go
+++ b/internal/cmd/controller/gitops/reconciler/gitjob_controller.go
@@ -7,6 +7,7 @@ import (
 	"math/rand/v2"
 	"os"
 	"reflect"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -430,7 +431,7 @@ func (r *GitJobReconciler) createCABundleSecret(ctx context.Context, gitrepo *v1
 
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: gitrepo.ObjectMeta.Namespace,
+			Namespace: gitrepo.Namespace,
 			Name:      name,
 		},
 		Data: map[string][]byte{
@@ -626,14 +627,7 @@ func (r *GitJobReconciler) newGitJob(ctx context.Context, obj *v1alpha1.GitRepo)
 	// Look for a `--ca-bundle-file` arg to the git cloner. This applies to cases where the GitRepo's `Spec.CABundle` is
 	// specified, but also to cases where a CA bundle secret has been created instead, with data from Rancher
 	// secrets.
-	hasCABundleArg := false
-	for _, arg := range initContainer.Args {
-		if arg == "--ca-bundle-file" {
-			hasCABundleArg = true
-			break
-		}
-	}
-	if hasCABundleArg {
+	if slices.Contains(initContainer.Args, "--ca-bundle-file") {
 		job.Spec.Template.Spec.Volumes = append(job.Spec.Template.Spec.Volumes, corev1.Volume{
 			Name: bundleCAVolumeName,
 			VolumeSource: corev1.VolumeSource{


### PR DESCRIPTION
 This fixes a bug whereby, once a `GitRepo` had been created, subsequent reconciles would not detect a Rancher secret as the source of CA bundle data.
 
 Relevant information for the controller is whether a secret created in the `GitRepo`'s namespace, duplicating a Rancher CA bundle secret, _exists_, not whether it was created or updated.

Refers to #2750.
Follow-up to #3233.