### PR TITLE
Remove fix for agent redeployment

### DIFF
--- a/e2e/multi-cluster/installation/suite_test.go
+++ b/e2e/multi-cluster/installation/suite_test.go
@@ -20,11 +20,10 @@ func TestE2E(t *testing.T) {
 }
 
 var (
-	env      *testenv.Env
-	ku       kubectl.Command
-	kd       kubectl.Command
-	config   string
-	strategy string
+	env    *testenv.Env
+	ku     kubectl.Command
+	kd     kubectl.Command
+	config string
 )
 
 var _ = BeforeSuite(func() {
@@ -45,29 +44,6 @@ var _ = BeforeSuite(func() {
 		"jsonpath={.data.config}")
 	Expect(err).ToNot(HaveOccurred(), cfg)
 
-	// Save initial state of `fleet-agent` deployment
-	strategy, err = kd.Get(
-		"deployment",
-		"fleet-agent",
-		"-n",
-		"cattle-fleet-system",
-		"-o",
-		"jsonpath={.spec.strategy}",
-	)
-	Expect(err).ToNot(HaveOccurred(), cfg)
-
-	// Patch `fleet-agent` deployment to use Recreate strategy
-	out, err := kd.Patch(
-		"deployment",
-		"fleet-agent",
-		"-n",
-		"cattle-fleet-system",
-		"--type=merge",
-		"-p",
-		`{"spec":{"strategy":{"type":"Recreate", "rollingUpdate":null}}}`,
-	)
-	Expect(err).ToNot(HaveOccurred(), string(out))
-
 	cfg = strings.ReplaceAll(cfg, `"`, `\"`)
 	config = strings.ReplaceAll(cfg, "\n", "")
 })
@@ -82,18 +58,6 @@ var _ = AfterSuite(func() {
 		"--type=merge",
 		"-p",
 		fmt.Sprintf(`{"data":{"config":"%s"}}`, config),
-	)
-	Expect(err).ToNot(HaveOccurred(), string(out))
-
-	// Restore initial state of deployment
-	out, err = kd.Patch(
-		"deployment",
-		"fleet-agent",
-		"-n",
-		"cattle-fleet-system",
-		"--type=merge",
-		"-p",
-		fmt.Sprintf(`{"spec":{"strategy":%s}}`, strategy),
 	)
 	Expect(err).ToNot(HaveOccurred(), string(out))
 })


### PR DESCRIPTION
as it appears to be unnecessary.

Unfortunately, those changes seem to cause many issues in the `AfterSuite` code path when the tests have actually succeeded. This will fix test issues we have in `e2e-fleet-mc-test`.

IIRC, those adaptations were necessary for having leader election in every of the three containers of the pod, but now we have a single container in the pod. I was not able to verify that this produces less issues in general, but it will remove the issues we have repeatedly seen recently, since the error occurs in the code removed, which was added by me and just in for a few weeks. When I adapted that test, it fixed the original, but now the original works without this addition.

<!-- Specify the issue ID that this pull request is solving -->
Refers to #XXX
<!-- Make sure that the referenced issue provides steps to reproduce it -->

<!-- Describe the changes introduced by this pull request -->

<!--
  Please provide a unit, integration (`./integrationtests/`) or e2e (`./e2e/`) test if possible.
-->

## Additional Information

### Checklist

- [ ] <!-- If applicable,--> I have updated the documentation via pull request in [website](https://github.com/updatecli/website) repository.
