### PR TITLE
Ensure same bundle is selected for non-ready status

### DIFF
--- a/internal/cmd/controller/gitops/reconciler/status_controller.go
+++ b/internal/cmd/controller/gitops/reconciler/status_controller.go
@@ -180,6 +180,7 @@ func (r StatusReconciler) setReadyStatusFromBundle(ctx context.Context, gitrepo 
 	}
 
 	// Make sure the bundles are always iterated in the same order
+	// The code below will pick the first element matching the condition, so successive executions should produce the same result.
 	sort.Slice(bList.Items, func(i, j int) bool {
 		return bList.Items[i].UID < bList.Items[j].UID
 	})

--- a/internal/cmd/controller/gitops/reconciler/status_controller.go
+++ b/internal/cmd/controller/gitops/reconciler/status_controller.go
@@ -179,6 +179,11 @@ func (r StatusReconciler) setReadyStatusFromBundle(ctx context.Context, gitrepo 
 		return err
 	}
 
+	// Make sure the bundles are always iterated in the same order
+	sort.Slice(bList.Items, func(i, j int) bool {
+		return bList.Items[i].UID < bList.Items[j].UID
+	})
+
 	found := false
 	// Find a ready status condition in a bundle which is not ready.
 	var condition genericcondition.GenericCondition


### PR DESCRIPTION
<!-- Specify the issue ID that this pull request is solving -->
Refers to #3484
<!-- Make sure that the referenced issue provides steps to reproduce it -->

<!-- Describe the changes introduced by this pull request -->
Adding a sort by UID for the bundle list, so the same bundle is selected to update the non ready state. 

## Additional Information
This only makes sure that the same bundle is always selected. But it still picks one (as long as it is the first and in non ready state). 
A follow-up could aggregate all the non-ready bundles on the message.
And also avoid overiding the status condition previously set at: https://github.com/rancher/fleet/blob/main/internal/cmd/controller/gitops/reconciler/status_controller.go#L159

