### PR TITLE
New webhook secret handling

### DIFF
--- a/charts/fleet-crd/templates/crds.yaml
+++ b/charts/fleet-crd/templates/crds.yaml
@@ -6625,6 +6625,10 @@ spec:
                         type: string
                     type: object
                   type: array
+                webhookSecret:
+                  description: WebhookSecret contains the name of the secret to use
+                    for webhook parsing
+                  type: string
               type: object
             status:
               properties:

--- a/pkg/apis/fleet.cattle.io/v1alpha1/gitrepo_types.go
+++ b/pkg/apis/fleet.cattle.io/v1alpha1/gitrepo_types.go
@@ -137,6 +137,9 @@ type GitRepoSpec struct {
 
 	// OCIRegistry specifies the OCI registry related parameters
 	OCIRegistry *OCIRegistrySpec `json:"ociRegistry,omitempty"`
+
+	// WebhookSecret contains the name of the secret to use for webhook parsing
+	WebhookSecret string `json:"webhookSecret,omitempty"`
 }
 
 // GitTarget is a cluster or cluster group to deploy to.

--- a/pkg/webhook/parser.go
+++ b/pkg/webhook/parser.go
@@ -1,0 +1,159 @@
+package webhook
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/go-playground/webhooks/v6/azuredevops"
+	"gopkg.in/go-playground/webhooks.v5/bitbucket"
+	bitbucketserver "gopkg.in/go-playground/webhooks.v5/bitbucket-server"
+	"gopkg.in/go-playground/webhooks.v5/github"
+	"gopkg.in/go-playground/webhooks.v5/gitlab"
+	"gopkg.in/go-playground/webhooks.v5/gogs"
+	corev1 "k8s.io/api/core/v1"
+)
+
+const (
+	githubKey          = "github"
+	gitlabKey          = "gitlab"
+	bitbucketKey       = "bitbucket"
+	bitbucketServerKey = "bitbucket-server"
+	gogsKey            = "gogs"
+	azureUsername      = "azure-username"
+	azurePassword      = "azure-password"
+)
+
+func parseWebook(r *http.Request, secret *corev1.Secret) (interface{}, error) {
+	switch {
+	//Gogs needs to be checked before Github since it carries both Gogs and (incompatible) Github headers
+	case r.Header.Get("X-Gogs-Event") != "":
+		return parseGogs(r, secret)
+	case r.Header.Get("X-GitHub-Event") != "":
+		return parseGithub(r, secret)
+	case r.Header.Get("X-Gitlab-Event") != "":
+		return parseGitlab(r, secret)
+	case r.Header.Get("X-Hook-UUID") != "":
+		return parseBitbucket(r, secret)
+	case r.Header.Get("X-Event-Key") != "":
+		return parseBitbucketServer(r, secret)
+	case r.Header.Get("X-Vss-Activityid") != "" || r.Header.Get("X-Vss-Subscriptionid") != "":
+		return parseAzureDevops(r, secret)
+	}
+
+	return nil, nil
+}
+
+func getValue(secret corev1.Secret, key string) (string, error) {
+	value, ok := secret.Data[key]
+	if !ok {
+		return "", fmt.Errorf("secret key %q not found in secret %q", key, secret.Name)
+	}
+
+	return string(value), nil
+}
+
+func parseGogs(r *http.Request, secret *corev1.Secret) (interface{}, error) {
+	opts := []gogs.Option{}
+	if secret != nil {
+		value, error := getValue(*secret, gogsKey)
+		if error != nil {
+			return nil, error
+		}
+		opts = append(opts, gogs.Options.Secret(value))
+	}
+	p, err := gogs.New(opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	return p.Parse(r, gogs.PushEvent)
+}
+
+func parseGithub(r *http.Request, secret *corev1.Secret) (interface{}, error) {
+	opts := []github.Option{}
+	if secret != nil {
+		value, error := getValue(*secret, githubKey)
+		if error != nil {
+			return nil, error
+		}
+		opts = append(opts, github.Options.Secret(value))
+	}
+	p, err := github.New(opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	return p.Parse(r, github.PushEvent)
+}
+
+func parseGitlab(r *http.Request, secret *corev1.Secret) (interface{}, error) {
+	opts := []gitlab.Option{}
+	if secret != nil {
+		value, error := getValue(*secret, gitlabKey)
+		if error != nil {
+			return nil, error
+		}
+		opts = append(opts, gitlab.Options.Secret(value))
+	}
+	p, err := gitlab.New(opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	return p.Parse(r, gitlab.PushEvents, gitlab.TagEvents)
+}
+
+func parseBitbucket(r *http.Request, secret *corev1.Secret) (interface{}, error) {
+	opts := []bitbucket.Option{}
+	if secret != nil {
+		value, error := getValue(*secret, bitbucketKey)
+		if error != nil {
+			return nil, error
+		}
+		opts = append(opts, bitbucket.Options.UUID(value))
+	}
+	p, err := bitbucket.New(opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	return p.Parse(r, bitbucket.RepoPushEvent)
+}
+
+func parseBitbucketServer(r *http.Request, secret *corev1.Secret) (interface{}, error) {
+	opts := []bitbucketserver.Option{}
+	if secret != nil {
+		value, error := getValue(*secret, bitbucketServerKey)
+		if error != nil {
+			return nil, error
+		}
+		opts = append(opts, bitbucketserver.Options.Secret(value))
+	}
+	p, err := bitbucketserver.New(opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	return p.Parse(r, bitbucketserver.RepositoryReferenceChangedEvent)
+}
+
+func parseAzureDevops(r *http.Request, secret *corev1.Secret) (interface{}, error) {
+	opts := []azuredevops.Option{}
+	if secret != nil {
+		username, error := getValue(*secret, azureUsername)
+		if error != nil {
+			return nil, error
+		}
+		password, error := getValue(*secret, azurePassword)
+		if error != nil {
+			return nil, error
+		}
+		opts = append(opts, azuredevops.Options.BasicAuth(username, password))
+	}
+	p, err := azuredevops.New(opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	return p.Parse(r, azuredevops.GitPushEventType)
+}

--- a/pkg/webhook/parser.go
+++ b/pkg/webhook/parser.go
@@ -23,7 +23,7 @@ const (
 	azurePassword      = "azure-password"
 )
 
-func parseWebook(r *http.Request, secret *corev1.Secret) (interface{}, error) {
+func parseWebhook(r *http.Request, secret *corev1.Secret) (interface{}, error) {
 	switch {
 	//Gogs needs to be checked before Github since it carries both Gogs and (incompatible) Github headers
 	case r.Header.Get("X-Gogs-Event") != "":

--- a/pkg/webhook/parser_test.go
+++ b/pkg/webhook/parser_test.go
@@ -1,0 +1,1275 @@
+package webhook
+
+import (
+	"bytes"
+	"net/http"
+	"testing"
+
+	"github.com/go-playground/webhooks/v6/azuredevops"
+	gogsclient "github.com/gogits/go-gogs-client"
+	"gopkg.in/go-playground/webhooks.v5/bitbucket"
+	bitbucketserver "gopkg.in/go-playground/webhooks.v5/bitbucket-server"
+	"gopkg.in/go-playground/webhooks.v5/github"
+	"gopkg.in/go-playground/webhooks.v5/gitlab"
+	"gotest.tools/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/kubectl/pkg/scheme"
+)
+
+func TestParseGogs(t *testing.T) {
+	tests := map[string]struct {
+		secretData map[string][]byte
+		body       []byte
+		headers    map[string]string
+		wantErr    bool
+		wantErrMsg string
+		wantEvent  interface{}
+	}{
+		"valid-gogs-push-event-no-secret": {
+			secretData: nil,
+			body: []byte(`{
+				"ref": "refs/heads/main",
+				"after": "af69d162de5a276abc86e0686b2b44033cd3f442",
+				"repository": {
+					"html_url": "https://gogs.example.com/example/repo"
+				}
+			}`),
+			headers: map[string]string{
+				"X-Gogs-Event": "push",
+			},
+			wantErr: false,
+			wantEvent: gogsclient.PushPayload{
+				Ref:   "refs/heads/main",
+				After: "af69d162de5a276abc86e0686b2b44033cd3f442",
+				Repo: &gogsclient.Repository{
+					HTMLURL: "https://gogs.example.com/example/repo",
+				},
+			},
+		},
+		"valid-gogs-push-event-with-secret": {
+			secretData: map[string][]byte{
+				gogsKey: []byte("gogssecret"),
+			},
+			body: []byte(`{
+				"ref": "refs/heads/main",
+				"after": "af69d162de5a276abc86e0686b2b44033cd3f442",
+				"repository": {
+					"html_url": "https://gogs.example.com/example/repo"
+				}
+			}`),
+			headers: map[string]string{
+				"X-Gogs-Event":     "push",
+				"X-Gogs-Signature": "bd00de14f93a8bef25c89bb3c976a1320b3a535515cd66c91ec1e8b9f67a2259",
+			},
+			wantErr: false,
+			wantEvent: gogsclient.PushPayload{
+				Ref:   "refs/heads/main",
+				After: "af69d162de5a276abc86e0686b2b44033cd3f442",
+				Repo: &gogsclient.Repository{
+					HTMLURL: "https://gogs.example.com/example/repo",
+				},
+			},
+		},
+		"invalid-gogs-push-event-with-secret": {
+			secretData: map[string][]byte{
+				gogsKey: []byte("gogssecret"),
+			},
+			body: []byte(`{
+				"ref": "refs/heads/main",
+				"after": "af69d162de5a276abc86e0686b2b44033cd3f442",
+				"repository": {
+					"html_url": "https://gogs.example.com/example/repo"
+				}
+			}`),
+			headers: map[string]string{
+				"X-Gogs-Event":     "push",
+				"X-Gogs-Signature": "wrongsignature",
+			},
+			wantErr:    true,
+			wantErrMsg: "HMAC verification failed",
+			wantEvent:  nil,
+		},
+		"missing-gogs-secret": {
+			secretData: map[string][]byte{
+				"wrongkey": []byte("gogssecret"),
+			},
+			body: []byte(`{
+				"ref": "refs/heads/main",
+				"after": "af69d162de5a276abc86e0686b2b44033cd3f442",
+				"repository": {
+					"html_url": "https://gogs.example.com/example/repo"
+				}
+			}`),
+			headers: map[string]string{
+				"X-Gogs-Event":     "push",
+				"X-Gogs-Signature": "sha1=57968570459352679905f2372454008f9015101a",
+			},
+			wantErr:    true,
+			wantErrMsg: "secret key \"gogs\" not found in secret \"test-secret\"",
+			wantEvent:  nil,
+		},
+		"no-gogs-event": {
+			secretData: nil,
+			body: []byte(`{
+				"ref": "refs/heads/main",
+				"after": "af69d162de5a276abc86e0686b2b44033cd3f442",
+				"repository": {
+					"html_url": "https://gogs.example.com/example/repo"
+				}
+			}`),
+			headers:    map[string]string{},
+			wantErr:    true,
+			wantErrMsg: "missing X-Gogs-Event Header",
+			wantEvent:  nil,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			var secret *corev1.Secret
+			if tt.secretData != nil {
+				secret = &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-secret",
+						Namespace: "test-ns",
+					},
+					Data: tt.secretData,
+				}
+			}
+
+			req, err := http.NewRequest(http.MethodPost, "/", bytes.NewReader(tt.body))
+			if err != nil {
+				t.Fatalf("Failed to create HTTP request: %v", err)
+			}
+
+			for k, v := range tt.headers {
+				req.Header.Set(k, v)
+			}
+
+			got, err := parseGogs(req, secret)
+
+			if tt.wantErr {
+				assert.Error(t, err, tt.wantErrMsg)
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("parseGogs() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			if tt.wantEvent == nil {
+				if got != nil {
+					t.Fatalf("parseGogs() = %v, want %v", got, tt.wantEvent)
+				}
+			} else {
+				assert.DeepEqual(t, got, tt.wantEvent)
+			}
+		})
+	}
+}
+
+func TestParseGithub(t *testing.T) {
+	utilruntime.Must(corev1.AddToScheme(scheme.Scheme))
+
+	tests := map[string]struct {
+		secretData   map[string][]byte
+		body         []byte
+		headers      map[string]string
+		wantErr      bool
+		wantErrMsg   string
+		wantNilEvent bool
+		wantRef      string
+		wantAfter    string
+		wantRepoURL  string
+	}{
+		"valid-github-push-event-no-secret": {
+			secretData: nil,
+			body: []byte(`{
+				"ref": "refs/heads/main",
+				"after": "af69d162de5a276abc86e0686b2b44033cd3f442",
+				"repository": {
+					"html_url": "https://github.com/example/repo"
+				}
+			}`),
+			headers: map[string]string{
+				"X-GitHub-Event": "push",
+			},
+			wantErr:      false,
+			wantNilEvent: false,
+			wantRef:      "refs/heads/main",
+			wantAfter:    "af69d162de5a276abc86e0686b2b44033cd3f442",
+			wantRepoURL:  "https://github.com/example/repo",
+		},
+		"valid-github-push-event-with-secret": {
+			secretData: map[string][]byte{
+				githubKey: []byte("githubsecret"),
+			},
+			body: []byte(`{
+				"ref": "refs/heads/main",
+				"after": "af69d162de5a276abc86e0686b2b44033cd3f442",
+				"repository": {
+					"html_url": "https://github.com/example/repo"
+				}
+			}`),
+			headers: map[string]string{
+				"X-GitHub-Event":  "push",
+				"X-Hub-Signature": "sha1=dba820f85951e0f100549aa167ef67dcd989ca4a",
+			},
+			wantErr:      false,
+			wantNilEvent: false,
+			wantRef:      "refs/heads/main",
+			wantAfter:    "af69d162de5a276abc86e0686b2b44033cd3f442",
+			wantRepoURL:  "https://github.com/example/repo",
+		},
+		"invalid-github-push-event-with-secret": {
+			secretData: map[string][]byte{
+				githubKey: []byte("githubsecret"),
+			},
+			body: []byte(`{
+				"ref": "refs/heads/main",
+				"after": "af69d162de5a276abc86e0686b2b44033cd3f442",
+				"repository": {
+					"html_url": "https://github.com/example/repo"
+				}
+			}`),
+			headers: map[string]string{
+				"X-GitHub-Event":  "push",
+				"X-Hub-Signature": "sha1=wrongsignature",
+			},
+			wantErr:      true,
+			wantErrMsg:   "HMAC verification failed",
+			wantNilEvent: true,
+		},
+		"missing-github-secret": {
+			secretData: map[string][]byte{
+				"wrongkey": []byte("githubsecret"),
+			},
+			body: []byte(`{
+				"ref": "refs/heads/main",
+				"after": "af69d162de5a276abc86e0686b2b44033cd3f442",
+				"repository": {
+					"html_url": "https://github.com/example/repo"
+				}
+			}`),
+			headers: map[string]string{
+				"X-GitHub-Event":  "push",
+				"X-Hub-Signature": "sha1=57968570459352679905f2372454008f9015101a",
+			},
+			wantErr:      true,
+			wantNilEvent: true,
+			wantErrMsg:   "secret key \"github\" not found in secret \"test-secret\"",
+		},
+		"no-github-event": {
+			secretData: nil,
+			body: []byte(`{
+				"ref": "refs/heads/main",
+				"after": "af69d162de5a276abc86e0686b2b44033cd3f442",
+				"repository": {
+					"html_url": "https://github.com/example/repo"
+				}
+			}`),
+			headers:      map[string]string{},
+			wantErr:      true,
+			wantNilEvent: true,
+			wantErrMsg:   "missing X-GitHub-Event Header",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			var secret *corev1.Secret
+			if tt.secretData != nil {
+				secret = &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-secret",
+						Namespace: "test-ns",
+					},
+					Data: tt.secretData,
+				}
+			}
+
+			req, err := http.NewRequest(http.MethodPost, "/", bytes.NewReader(tt.body))
+			if err != nil {
+				t.Fatalf("Failed to create HTTP request: %v", err)
+			}
+
+			for k, v := range tt.headers {
+				req.Header.Set(k, v)
+			}
+
+			got, err := parseGithub(req, secret)
+
+			if tt.wantErr {
+				assert.Error(t, err, tt.wantErrMsg)
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("parseGithub() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			if tt.wantNilEvent {
+				if got != nil {
+					t.Fatalf("parseGithub() got %v, want nil", got)
+				}
+			} else {
+				if got == nil {
+					t.Fatalf("parseGithub() got nil, want not nil")
+				}
+				gotGH, ok := got.(github.PushPayload)
+				if !ok {
+					t.Fatalf("parseGithub() got %T, want github.PushPayload", got)
+				}
+
+				if gotGH.Ref != tt.wantRef {
+					t.Fatalf("parseGithub() got ref %s, want %s", gotGH.Ref, tt.wantRef)
+				}
+				if gotGH.After != tt.wantAfter {
+					t.Fatalf("parseGithub() got after %s, want %s", gotGH.After, tt.wantAfter)
+				}
+				if gotGH.Repository.HTMLURL != tt.wantRepoURL {
+					t.Fatalf("parseGithub() got repo URL %s, want %s", gotGH.Repository.HTMLURL, tt.wantRepoURL)
+				}
+			}
+		})
+	}
+}
+
+func TestParseGitlab(t *testing.T) {
+	utilruntime.Must(corev1.AddToScheme(scheme.Scheme))
+
+	tests := map[string]struct {
+		secretData map[string][]byte
+		body       []byte
+		headers    map[string]string
+		wantErr    bool
+		wantErrMsg string
+		wantEvent  interface{}
+	}{
+		"valid-gitlab-push-event-no-secret": {
+			secretData: nil,
+			body: []byte(`{
+				"ref": "refs/heads/main",
+				"checkout_sha": "af69d162de5a276abc86e0686b2b44033cd3f442",
+				"project": {
+					"web_url": "https://gitlab.example.com/example/repo"
+				}
+			}`),
+			headers: map[string]string{
+				"X-Gitlab-Event": "Push Hook",
+			},
+			wantErr: false,
+			wantEvent: gitlab.PushEventPayload{
+				Ref:         "refs/heads/main",
+				CheckoutSHA: "af69d162de5a276abc86e0686b2b44033cd3f442",
+				Project: gitlab.Project{
+					WebURL: "https://gitlab.example.com/example/repo",
+				},
+			},
+		},
+		"valid-gitlab-push-event-with-secret": {
+			secretData: map[string][]byte{
+				gitlabKey: []byte("gitlabsecret"),
+			},
+			body: []byte(`{
+				"ref": "refs/heads/main",
+				"checkout_sha": "af69d162de5a276abc86e0686b2b44033cd3f442",
+				"project": {
+					"web_url": "https://gitlab.example.com/example/repo"
+				}
+			}`),
+			headers: map[string]string{
+				"X-Gitlab-Event": "Push Hook",
+				"X-Gitlab-Token": "gitlabsecret",
+			},
+			wantErr: false,
+			wantEvent: gitlab.PushEventPayload{
+				Ref:         "refs/heads/main",
+				CheckoutSHA: "af69d162de5a276abc86e0686b2b44033cd3f442",
+				Project: gitlab.Project{
+					WebURL: "https://gitlab.example.com/example/repo",
+				},
+			},
+		},
+		"invalid-gitlab-push-event-with-secret": {
+			secretData: map[string][]byte{
+				gitlabKey: []byte("gitlabsecret"),
+			},
+			body: []byte(`{
+				"ref": "refs/heads/main",
+				"checkout_sha": "af69d162de5a276abc86e0686b2b44033cd3f442",
+				"project": {
+					"web_url": "https://gitlab.example.com/example/repo"
+				}
+			}`),
+			headers: map[string]string{
+				"X-Gitlab-Event": "Push Hook",
+				"X-Gitlab-Token": "wrongsecret",
+			},
+			wantErr:    true,
+			wantErrMsg: "X-Gitlab-Token validation failed",
+			wantEvent:  nil,
+		},
+		"missing-gitlab-secret": {
+			secretData: map[string][]byte{
+				"wrongkey": []byte("gitlabsecret"),
+			},
+			body: []byte(`{
+				"ref": "refs/heads/main",
+				"checkout_sha": "af69d162de5a276abc86e0686b2b44033cd3f442",
+				"project": {
+					"web_url": "https://gitlab.example.com/example/repo"
+				}
+			}`),
+			headers: map[string]string{
+				"X-Gitlab-Event": "Push Hook",
+				"X-Gitlab-Token": "gitlabsecret",
+			},
+			wantErr:    true,
+			wantErrMsg: "secret key \"gitlab\" not found in secret \"test-secret\"",
+			wantEvent:  nil,
+		},
+		"no-gitlab-event": {
+			secretData: nil,
+			body: []byte(`{
+				"ref": "refs/heads/main",
+				"checkout_sha": "af69d162de5a276abc86e0686b2b44033cd3f442",
+				"project": {
+					"web_url": "https://gitlab.example.com/example/repo"
+				}
+			}`),
+			headers:    map[string]string{},
+			wantErr:    true,
+			wantErrMsg: "missing X-Gitlab-Event Header",
+			wantEvent:  nil,
+		},
+		"valid-gitlab-tag-event-no-secret": {
+			secretData: nil,
+			body: []byte(`{
+				"ref": "refs/tags/v1.0.0",
+				"checkout_sha": "af69d162de5a276abc86e0686b2b44033cd3f442",
+				"project": {
+					"web_url": "https://gitlab.example.com/example/repo"
+				}
+			}`),
+			headers: map[string]string{
+				"X-Gitlab-Event": "Tag Push Hook",
+			},
+			wantErr: false,
+			wantEvent: gitlab.TagEventPayload{
+				Ref:         "refs/tags/v1.0.0",
+				CheckoutSHA: "af69d162de5a276abc86e0686b2b44033cd3f442",
+				Project: gitlab.Project{
+					WebURL: "https://gitlab.example.com/example/repo",
+				},
+			},
+		},
+		"valid-gitlab-tag-event-with-secret": {
+			secretData: map[string][]byte{
+				gitlabKey: []byte("gitlabsecret"),
+			},
+			body: []byte(`{
+				"ref": "refs/tags/v1.0.0",
+				"checkout_sha": "af69d162de5a276abc86e0686b2b44033cd3f442",
+				"project": {
+					"web_url": "https://gitlab.example.com/example/repo"
+				}
+			}`),
+			headers: map[string]string{
+				"X-Gitlab-Event": "Tag Push Hook",
+				"X-Gitlab-Token": "gitlabsecret",
+			},
+			wantErr: false,
+			wantEvent: gitlab.TagEventPayload{
+				Ref:         "refs/tags/v1.0.0",
+				CheckoutSHA: "af69d162de5a276abc86e0686b2b44033cd3f442",
+				Project: gitlab.Project{
+					WebURL: "https://gitlab.example.com/example/repo",
+				},
+			},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			var secret *corev1.Secret
+			if tt.secretData != nil {
+				secret = &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-secret",
+						Namespace: "test-ns",
+					},
+					Data: tt.secretData,
+				}
+			}
+
+			req, err := http.NewRequest(http.MethodPost, "/", bytes.NewReader(tt.body))
+			if err != nil {
+				t.Fatalf("Failed to create HTTP request: %v", err)
+			}
+
+			for k, v := range tt.headers {
+				req.Header.Set(k, v)
+			}
+
+			got, err := parseGitlab(req, secret)
+
+			if tt.wantErr {
+				assert.Error(t, err, tt.wantErrMsg)
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("parseGitlab() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			if tt.wantEvent == nil {
+				if got != nil {
+					t.Fatalf("parseGitlab() = %v, want %v", got, tt.wantEvent)
+				}
+			} else {
+				assert.DeepEqual(t, got, tt.wantEvent)
+			}
+		})
+	}
+}
+
+func TestParseBitbucket(t *testing.T) {
+	utilruntime.Must(corev1.AddToScheme(scheme.Scheme))
+
+	tests := map[string]struct {
+		secretData   map[string][]byte
+		body         []byte
+		headers      map[string]string
+		wantErr      bool
+		wantErrMsg   string
+		wantNilEvent bool
+		wantRepoURL  string
+		wantBranch   string
+		wantRevision string
+	}{
+		"valid-bitbucket-push-event-no-secret": {
+			secretData: nil,
+			body: []byte(`{
+				"push": {
+					"changes": [
+						{
+							"new": {
+								"type": "branch",
+								"name": "main",
+								"target": {
+									"hash": "af69d162de5a276abc86e0686b2b44033cd3f442"
+								}
+							}
+						}
+					]
+				},
+				"repository": {
+					"links": {
+						"html": {
+							"href": "https://bitbucket.org/example/repo"
+						}
+					}
+				}
+			}`),
+			headers: map[string]string{
+				"X-Hook-UUID": "some-uuid",
+				"X-Event-Key": "repo:push",
+			},
+			wantErr:      false,
+			wantNilEvent: false,
+			wantRepoURL:  "https://bitbucket.org/example/repo",
+			wantBranch:   "main",
+			wantRevision: "af69d162de5a276abc86e0686b2b44033cd3f442",
+		},
+		"valid-bitbucket-push-event-with-secret": {
+			secretData: map[string][]byte{
+				bitbucketKey: []byte("some-uuid"),
+			},
+			body: []byte(`{
+				"push": {
+					"changes": [
+						{
+							"new": {
+								"type": "branch",
+								"name": "main",
+								"target": {
+									"hash": "af69d162de5a276abc86e0686b2b44033cd3f442"
+								}
+							}
+						}
+					]
+				},
+				"repository": {
+					"links": {
+						"html": {
+							"href": "https://bitbucket.org/example/repo"
+						}
+					}
+				}
+			}`),
+			headers: map[string]string{
+				"X-Hook-UUID": "some-uuid",
+				"X-Event-Key": "repo:push",
+			},
+			wantErr:      false,
+			wantNilEvent: false,
+			wantRepoURL:  "https://bitbucket.org/example/repo",
+			wantBranch:   "main",
+			wantRevision: "af69d162de5a276abc86e0686b2b44033cd3f442",
+		},
+		"invalid-bitbucket-push-event-with-secret": {
+			secretData: map[string][]byte{
+				bitbucketKey: []byte("some-uuid"),
+			},
+			body: []byte(`{
+				"push": {
+					"changes": [
+						{
+							"new": {
+								"type": "branch",
+								"name": "main",
+								"target": {
+									"hash": "af69d162de5a276abc86e0686b2b44033cd3f442"
+								}
+							}
+						}
+					]
+				},
+				"repository": {
+					"links": {
+						"html": {
+							"href": "https://bitbucket.org/example/repo"
+						}
+					}
+				}
+			}`),
+			headers: map[string]string{
+				"X-Hook-UUID": "wrong-uuid",
+				"X-Event-Key": "repo:push",
+			},
+			wantErr:      true,
+			wantErrMsg:   "UUID verification failed",
+			wantNilEvent: true,
+		},
+		"missing-bitbucket-secret": {
+			secretData: map[string][]byte{
+				"wrongkey": []byte("some-uuid"),
+			},
+			body: []byte(`{
+				"push": {
+					"changes": [
+						{
+							"new": {
+								"type": "branch",
+								"name": "main",
+								"target": {
+									"hash": "af69d162de5a276abc86e0686b2b44033cd3f442"
+								}
+							}
+						}
+					]
+				},
+				"repository": {
+					"links": {
+						"html": {
+							"href": "https://bitbucket.org/example/repo"
+						}
+					}
+				}
+			}`),
+			headers: map[string]string{
+				"X-Hook-UUID": "some-uuid",
+				"X-Event-Key": "repo:push",
+			},
+			wantErr:      true,
+			wantNilEvent: true,
+			wantErrMsg:   "secret key \"bitbucket\" not found in secret \"test-secret\"",
+		},
+		"no-bitbucket-event": {
+			secretData:   nil,
+			body:         []byte(`{}`),
+			headers:      map[string]string{},
+			wantErr:      true,
+			wantErrMsg:   "missing X-Event-Key Header",
+			wantNilEvent: true,
+		},
+		"empty-changes": {
+			secretData: nil,
+			body: []byte(`{
+				"push": {
+					"changes": []
+				},
+				"repository": {
+					"links": {
+						"html": {
+							"href": "https://bitbucket.org/example/repo"
+						}
+					}
+				}
+			}`),
+			headers: map[string]string{
+				"X-Hook-UUID": "some-uuid",
+				"X-Event-Key": "repo:push",
+			},
+			wantErr:      false,
+			wantNilEvent: false,
+			wantRepoURL:  "https://bitbucket.org/example/repo",
+			wantBranch:   "",
+			wantRevision: "",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			var secret *corev1.Secret
+			if tt.secretData != nil {
+				secret = &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-secret",
+						Namespace: "test-ns",
+					},
+					Data: tt.secretData,
+				}
+			}
+
+			req, err := http.NewRequest(http.MethodPost, "/", bytes.NewReader(tt.body))
+			if err != nil {
+				t.Fatalf("Failed to create HTTP request: %v", err)
+			}
+
+			for k, v := range tt.headers {
+				req.Header.Set(k, v)
+			}
+
+			got, err := parseBitbucket(req, secret)
+
+			if tt.wantErr {
+				assert.Error(t, err, tt.wantErrMsg)
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("parseBitbucket() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			if tt.wantNilEvent {
+				if got != nil {
+					t.Fatalf("parseBitbucket() got %v, want nil", got)
+				}
+			} else {
+				if got == nil {
+					t.Fatalf("parseBitbucket() got nil, want not nil")
+				}
+				gotBB, ok := got.(bitbucket.RepoPushPayload)
+				if !ok {
+					t.Fatalf("parseBitbucket() got %T, want bitbucket.RepoPushPayload", got)
+				}
+
+				if gotBB.Repository.Links.HTML.Href != tt.wantRepoURL {
+					t.Fatalf("parseBitbucket() got repo URL %s, want %s", gotBB.Repository.Links.HTML.Href, tt.wantRepoURL)
+				}
+				if len(gotBB.Push.Changes) > 0 {
+					if gotBB.Push.Changes[0].New.Name != tt.wantBranch {
+						t.Fatalf("parseBitbucket() got branch %s, want %s", gotBB.Push.Changes[0].New.Name, tt.wantBranch)
+					}
+					if gotBB.Push.Changes[0].New.Target.Hash != tt.wantRevision {
+						t.Fatalf("parseBitbucket() got revision %s, want %s", gotBB.Push.Changes[0].New.Target.Hash, tt.wantRevision)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestParseBitbucketServer(t *testing.T) {
+	utilruntime.Must(corev1.AddToScheme(scheme.Scheme))
+
+	tests := map[string]struct {
+		secretData   map[string][]byte
+		body         []byte
+		headers      map[string]string
+		wantErr      bool
+		wantErrMsg   string
+		wantNilEvent bool
+		wantRepoURL  string
+		wantBranch   string
+		wantRevision string
+	}{
+		"valid-bitbucket-server-push-event-no-secret": {
+			secretData: nil,
+			body: []byte(`{
+				"eventKey": "repo:refs_changed",
+				"changes": [
+					{
+						"ref": {
+							"id": "refs/heads/main",
+							"type": "BRANCH"
+						},
+						"toHash": "af69d162de5a276abc86e0686b2b44033cd3f442"
+					}
+				],
+				"repository": {
+					"links": {
+						"clone": [
+							{
+								"href": "https://bitbucket.example.com/scm/example/repo.git",
+								"name": "http"
+							},
+							{
+								"href": "ssh://git@bitbucket.example.com:7999/example/repo.git",
+								"name": "ssh"
+							}
+						]
+					}
+				}
+			}`),
+			headers: map[string]string{
+				"X-Event-Key": "repo:refs_changed",
+			},
+			wantErr:      false,
+			wantNilEvent: false,
+			wantRepoURL:  "https://bitbucket.example.com/scm/example/repo.git",
+			wantBranch:   "main",
+			wantRevision: "af69d162de5a276abc86e0686b2b44033cd3f442",
+		},
+		"valid-bitbucket-server-push-event-with-secret": {
+			secretData: map[string][]byte{
+				bitbucketServerKey: []byte("secret"),
+			},
+			body: []byte(`{
+				"eventKey": "repo:refs_changed",
+				"changes": [
+					{
+						"ref": {
+							"id": "refs/heads/main",
+							"type": "BRANCH"
+						},
+						"toHash": "af69d162de5a276abc86e0686b2b44033cd3f442"
+					}
+				],
+				"repository": {
+					"links": {
+						"clone": [
+							{
+								"href": "https://bitbucket.example.com/scm/example/repo.git",
+								"name": "http"
+							},
+							{
+								"href": "ssh://git@bitbucket.example.com:7999/example/repo.git",
+								"name": "ssh"
+							}
+						]
+					}
+				}
+			}`),
+			headers: map[string]string{
+				"X-Event-Key":     "repo:refs_changed",
+				"X-Hub-Signature": "sha256=31233f258e5af3c0571515b460749da4babc891a1fc6088229d7c2904cad83d1",
+			},
+			wantErr:      false,
+			wantNilEvent: false,
+			wantRepoURL:  "https://bitbucket.example.com/scm/example/repo.git",
+			wantBranch:   "main",
+			wantRevision: "af69d162de5a276abc86e0686b2b44033cd3f442",
+		},
+		"invalid-bitbucket-server-push-event-with-secret": {
+			secretData: map[string][]byte{
+				bitbucketServerKey: []byte("secret"),
+			},
+			body: []byte(`{
+				"eventKey": "repo:refs_changed",
+				"changes": [
+					{
+						"ref": {
+							"id": "refs/heads/main",
+							"type": "BRANCH"
+						},
+						"toHash": "af69d162de5a276abc86e0686b2b44033cd3f442"
+					}
+				],
+				"repository": {
+					"links": {
+						"clone": [
+							{
+								"href": "https://bitbucket.example.com/scm/example/repo.git",
+								"name": "http"
+							},
+							{
+								"href": "ssh://git@bitbucket.example.com:7999/example/repo.git",
+								"name": "ssh"
+							}
+						]
+					}
+				}
+			}`),
+			headers: map[string]string{
+				"X-Event-Key":     "repo:refs_changed",
+				"X-Hub-Signature": "sha256=wrongsignature",
+			},
+			wantErr:      true,
+			wantErrMsg:   "HMAC verification failed",
+			wantNilEvent: true,
+		},
+		"missing-bitbucket-server-secret": {
+			secretData: map[string][]byte{
+				"wrongkey": []byte("secret"),
+			},
+			body: []byte(`{
+				"eventKey": "repo:refs_changed",
+				"changes": [
+					{
+						"ref": {
+							"id": "refs/heads/main",
+							"type": "BRANCH"
+						},
+						"toHash": "af69d162de5a276abc86e0686b2b44033cd3f442"
+					}
+				],
+				"repository": {
+					"links": {
+						"clone": [
+							{
+								"href": "https://bitbucket.example.com/scm/example/repo.git",
+								"name": "http"
+							},
+							{
+								"href": "ssh://git@bitbucket.example.com:7999/example/repo.git",
+								"name": "ssh"
+							}
+						]
+					}
+				}
+			}`),
+			headers: map[string]string{
+				"X-Event-Key":     "repo:refs_changed",
+				"X-Hub-Signature": "sha256=6043b765891b367c98604263173510004462847074747103258054242901590a",
+			},
+			wantErr:      true,
+			wantNilEvent: true,
+			wantErrMsg:   "secret key \"bitbucket-server\" not found in secret \"test-secret\"",
+		},
+		"no-bitbucket-server-event": {
+			secretData:   nil,
+			body:         []byte(`{}`),
+			headers:      map[string]string{},
+			wantErr:      true,
+			wantErrMsg:   "missing X-Event-Key Header",
+			wantNilEvent: true,
+		},
+		"empty-changes": {
+			secretData: nil,
+			body: []byte(`{
+				"eventKey": "repo:refs_changed",
+				"changes": [],
+				"repository": {
+					"links": {
+						"clone": [
+							{
+								"href": "https://bitbucket.example.com/scm/example/repo.git",
+								"name": "http"
+							},
+							{
+								"href": "ssh://git@bitbucket.example.com:7999/example/repo.git",
+								"name": "ssh"
+							}
+						]
+					}
+				}
+			}`),
+			headers: map[string]string{
+				"X-Event-Key": "repo:refs_changed",
+			},
+			wantErr:      false,
+			wantNilEvent: false,
+			wantRepoURL:  "https://bitbucket.example.com/scm/example/repo.git",
+			wantBranch:   "",
+			wantRevision: "",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			var secret *corev1.Secret
+			if tt.secretData != nil {
+				secret = &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-secret",
+						Namespace: "test-ns",
+					},
+					Data: tt.secretData,
+				}
+			}
+
+			req, err := http.NewRequest(http.MethodPost, "/", bytes.NewReader(tt.body))
+			if err != nil {
+				t.Fatalf("Failed to create HTTP request: %v", err)
+			}
+
+			for k, v := range tt.headers {
+				req.Header.Set(k, v)
+			}
+
+			got, err := parseBitbucketServer(req, secret)
+
+			if tt.wantErr {
+				assert.Error(t, err, tt.wantErrMsg)
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("parseBitbucketServer() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			if tt.wantNilEvent {
+				if got != nil {
+					t.Fatalf("parseBitbucketServer() got %v, want nil", got)
+				}
+			} else {
+				if got == nil {
+					t.Fatalf("parseBitbucketServer() got nil, want not nil")
+				}
+				gotBB, ok := got.(bitbucketserver.RepositoryReferenceChangedPayload)
+				if !ok {
+					t.Fatalf("parseBitbucketServer() got %T, want bitbucketserver.RepositoryReferenceChangedPayload", got)
+				}
+
+				_, okCloneLinks := gotBB.Repository.Links["clone"]
+				if okCloneLinks {
+					// if len(gotBB.Repository.Links["clone"]) > 0 {}
+					for _, l := range gotBB.Repository.Links["clone"].([]interface{}) {
+						link := l.(map[string]interface{})
+						if link["name"] == "http" {
+							if link["href"].(string) != tt.wantRepoURL {
+								t.Fatalf("parseBitbucketServer() got repo URL %s, want %s", link["href"].(string), tt.wantRepoURL)
+							}
+						}
+					}
+				}
+
+				if len(gotBB.Changes) > 0 {
+					if gotBB.Changes[0].Reference.ID != "refs/heads/"+tt.wantBranch && gotBB.Changes[0].Reference.ID != "refs/tags/"+tt.wantBranch {
+						t.Fatalf("parseBitbucketServer() got branch %s, want %s", gotBB.Changes[0].ReferenceId, tt.wantBranch)
+					}
+					if gotBB.Changes[0].ToHash != tt.wantRevision {
+						t.Fatalf("parseBitbucketServer() got revision %s, want %s", gotBB.Changes[0].ToHash, tt.wantRevision)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestParseAzureDevops(t *testing.T) {
+	utilruntime.Must(corev1.AddToScheme(scheme.Scheme))
+
+	tests := map[string]struct {
+		secretData   map[string][]byte
+		body         []byte
+		headers      map[string]string
+		wantErr      bool
+		wantErrMsg   string
+		wantNilEvent bool
+		wantRepoURL  string
+		wantBranch   string
+		wantRevision string
+	}{
+		"valid-azure-devops-push-event-no-secret": {
+			secretData: nil,
+			body: []byte(`{
+				"eventType": "git.push",
+				"resource": {
+					"refUpdates": [
+						{
+							"name": "refs/heads/main",
+							"newObjectId": "af69d162de5a276abc86e0686b2b44033cd3f442"
+						}
+					],
+					"repository": {
+						"remoteUrl": "https://dev.azure.com/example/repo/_git/repo"
+					}
+				}
+			}`),
+			headers: map[string]string{
+				"X-Vss-Activityid": "some-activity-id",
+			},
+			wantErr:      false,
+			wantNilEvent: false,
+			wantRepoURL:  "https://dev.azure.com/example/repo/_git/repo",
+			wantBranch:   "main",
+			wantRevision: "af69d162de5a276abc86e0686b2b44033cd3f442",
+		},
+		"valid-azure-devops-push-event-with-secret": {
+			secretData: map[string][]byte{
+				azureUsername: []byte("Aladdin"),
+				azurePassword: []byte("open sesame"),
+			},
+			body: []byte(`{
+				"eventType": "git.push",
+				"resource": {
+					"refUpdates": [
+						{
+							"name": "refs/heads/main",
+							"newObjectId": "af69d162de5a276abc86e0686b2b44033cd3f442"
+						}
+					],
+					"repository": {
+						"remoteUrl": "https://dev.azure.com/example/repo/_git/repo"
+					}
+				}
+			}`),
+			headers: map[string]string{
+				"X-Vss-Activityid": "some-activity-id",
+				"Authorization":    "Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ==",
+			},
+			wantErr:      false,
+			wantNilEvent: false,
+			wantRepoURL:  "https://dev.azure.com/example/repo/_git/repo",
+			wantBranch:   "main",
+			wantRevision: "af69d162de5a276abc86e0686b2b44033cd3f442",
+		},
+		"missing-azure-devops-username-secret": {
+			secretData: map[string][]byte{
+				"wrongkey":    []byte("testuser"),
+				azurePassword: []byte("testpassword"),
+			},
+			body: []byte(`{
+				"eventType": "git.push",
+				"resource": {
+					"refUpdates": [
+						{
+							"name": "refs/heads/main",
+							"newObjectId": "af69d162de5a276abc86e0686b2b44033cd3f442"
+						}
+					],
+					"repository": {
+						"remoteUrl": "https://dev.azure.com/example/repo/_git/repo"
+					}
+				}
+			}`),
+			headers: map[string]string{
+				"X-Vss-Activityid": "some-activity-id",
+			},
+			wantErr:      true,
+			wantNilEvent: true,
+			wantErrMsg:   "secret key \"azure-username\" not found in secret \"test-secret\"",
+		},
+		"missing-azure-devops-password-secret": {
+			secretData: map[string][]byte{
+				azureUsername: []byte("testuser"),
+				"wrongkey":    []byte("testpassword"),
+			},
+			body: []byte(`{
+				"eventType": "git.push",
+				"resource": {
+					"refUpdates": [
+						{
+							"name": "refs/heads/main",
+							"newObjectId": "af69d162de5a276abc86e0686b2b44033cd3f442"
+						}
+					],
+					"repository": {
+						"remoteUrl": "https://dev.azure.com/example/repo/_git/repo"
+					}
+				}
+			}`),
+			headers: map[string]string{
+				"X-Vss-Activityid": "some-activity-id",
+			},
+			wantErr:      true,
+			wantNilEvent: true,
+			wantErrMsg:   "secret key \"azure-password\" not found in secret \"test-secret\"",
+		},
+		"no-azure-devops-event": {
+			secretData:   nil,
+			body:         []byte(`{}`),
+			headers:      map[string]string{},
+			wantErr:      true,
+			wantErrMsg:   "unknown event ",
+			wantNilEvent: true,
+		},
+		"empty-refUpdates": {
+			secretData: nil,
+			body: []byte(`{
+				"eventType": "git.push",
+				"resource": {
+					"refUpdates": [],
+					"repository": {
+						"remoteUrl": "https://dev.azure.com/example/repo/_git/repo"
+					}
+				}
+			}`),
+			headers: map[string]string{
+				"X-Vss-Activityid": "some-activity-id",
+			},
+			wantErr:      false,
+			wantNilEvent: false,
+			wantRepoURL:  "https://dev.azure.com/example/repo/_git/repo",
+			wantBranch:   "",
+			wantRevision: "",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			var secret *corev1.Secret
+			if tt.secretData != nil {
+				secret = &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-secret",
+						Namespace: "test-ns",
+					},
+					Data: tt.secretData,
+				}
+			}
+
+			req, err := http.NewRequest(http.MethodPost, "/", bytes.NewReader(tt.body))
+			if err != nil {
+				t.Fatalf("Failed to create HTTP request: %v", err)
+			}
+
+			for k, v := range tt.headers {
+				req.Header.Set(k, v)
+			}
+
+			got, err := parseAzureDevops(req, secret)
+
+			if tt.wantErr {
+				assert.Error(t, err, tt.wantErrMsg)
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("parseAzureDevops() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			if tt.wantNilEvent {
+				if got != nil {
+					t.Fatalf("parseAzureDevops() got %v, want nil", got)
+				}
+			} else {
+				if got == nil {
+					t.Fatalf("parseAzureDevops() got nil, want not nil")
+				}
+				gotAzure, ok := got.(azuredevops.GitPushEvent)
+				if !ok {
+					t.Fatalf("parseAzureDevops() got %T, want azuredevops.GitPushEvent", got)
+				}
+
+				if gotAzure.Resource.Repository.RemoteURL != tt.wantRepoURL {
+					t.Fatalf("parseAzureDevops() got repo URL %s, want %s", gotAzure.Resource.Repository.RemoteURL, tt.wantRepoURL)
+				}
+				if len(gotAzure.Resource.RefUpdates) > 0 {
+					if gotAzure.Resource.RefUpdates[0].Name != "refs/heads/"+tt.wantBranch && gotAzure.Resource.RefUpdates[0].Name != "refs/tags/"+tt.wantBranch {
+						t.Fatalf("parseAzureDevops() got branch %s, want %s", gotAzure.Resource.RefUpdates[0].Name, tt.wantBranch)
+					}
+					if gotAzure.Resource.RefUpdates[0].NewObjectID != tt.wantRevision {
+						t.Fatalf("parseAzureDevops() got revision %s, want %s", gotAzure.Resource.RefUpdates[0].NewObjectID, tt.wantRevision)
+					}
+				}
+			}
+		})
+	}
+}

--- a/pkg/webhook/parser_test.go
+++ b/pkg/webhook/parser_test.go
@@ -104,7 +104,7 @@ func TestParseGogs(t *testing.T) {
 			}`),
 			headers: map[string]string{
 				"X-Gogs-Event":     "push",
-				"X-Gogs-Signature": "sha1=57968570459352679905f2372454008f9015101a",
+				"X-Gogs-Signature": "3453557968570459352679905f2372454008f9015101a",
 			},
 			wantErr:    true,
 			wantErrMsg: "secret key \"gogs\" not found in secret \"test-secret\"",
@@ -1038,7 +1038,6 @@ func TestParseBitbucketServer(t *testing.T) {
 
 				_, okCloneLinks := gotBB.Repository.Links["clone"]
 				if okCloneLinks {
-					// if len(gotBB.Repository.Links["clone"]) > 0 {}
 					for _, l := range gotBB.Repository.Links["clone"].([]interface{}) {
 						link := l.(map[string]interface{})
 						if link["name"] == "http" {

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -21,7 +21,6 @@ import (
 	"gopkg.in/go-playground/webhooks.v5/gitlab"
 	"gopkg.in/go-playground/webhooks.v5/gogs"
 
-	"github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
 	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
 
 	corev1 "k8s.io/api/core/v1"
@@ -77,7 +76,7 @@ func (w *Webhook) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 		return
 	default:
 		r.Body = io.NopCloser(bytes.NewBuffer(body))
-		payload, err = parseWebook(r, nil)
+		payload, err = parseWebhook(r, nil)
 		if payload == nil && err == nil {
 			w.log.V(1).Info("Ignoring unknown webhook event")
 			return
@@ -146,14 +145,14 @@ func (w *Webhook) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 					// The first parsing is used to get the gitrepo and, if a secret is
 					// defined in the gitrepo, it takes precedence over the global one.
 					r.Body = io.NopCloser(bytes.NewBuffer(body))
-					_, err = parseWebook(r, secret)
+					_, err = parseWebhook(r, secret)
 					if err != nil {
 						w.logAndReturn(rw, err)
 						return
 					}
 				}
 
-				var gitRepoFromCluster v1alpha1.GitRepo
+				var gitRepoFromCluster fleet.GitRepo
 				err = w.client.Get(
 					ctx,
 					types.NamespacedName{

--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -377,7 +377,7 @@ func TestGitHubSecretAndCommitUpdated(t *testing.T) {
 	expectedCommit := "af69d162de5a276abc86e0686b2b44033cd3f442"
 	gitrepoSecretName := "gitrepoSecret"
 	tests := map[string]struct {
-		secretValueInWebhook string
+		secretValueInRequest string
 		globalSecret         bool
 		gitrepoSecret        bool
 		globalSecretKey      string
@@ -389,7 +389,7 @@ func TestGitHubSecretAndCommitUpdated(t *testing.T) {
 		expectedCommitUpdate bool
 	}{
 		"global-secret-ok-no-gitrepo-secret": {
-			secretValueInWebhook: "supersecretvalue",
+			secretValueInRequest: "supersecretvalue",
 			globalSecret:         true,
 			gitrepoSecret:        false,
 			globalSecretKey:      "github",
@@ -401,7 +401,7 @@ func TestGitHubSecretAndCommitUpdated(t *testing.T) {
 			expectedCommitUpdate: true,
 		},
 		"global-secret-wrong-no-gitrepo-secret": {
-			secretValueInWebhook: "supersecretvalue",
+			secretValueInRequest: "supersecretvalue",
 			globalSecret:         true,
 			gitrepoSecret:        false,
 			globalSecretKey:      "github",
@@ -413,7 +413,7 @@ func TestGitHubSecretAndCommitUpdated(t *testing.T) {
 			expectedCommitUpdate: false,
 		},
 		"global-secret-ok-gitrepo-secret-ok": {
-			secretValueInWebhook: "supersecretvalue",
+			secretValueInRequest: "supersecretvalue",
 			globalSecret:         true,
 			gitrepoSecret:        true,
 			globalSecretKey:      "github",
@@ -427,7 +427,7 @@ func TestGitHubSecretAndCommitUpdated(t *testing.T) {
 		// does not matter that global secret is wrong because
 		// gitrepo secret takes preference
 		"global-secret-wrong-gitrepo-secret-ok": {
-			secretValueInWebhook: "supersecretvalue",
+			secretValueInRequest: "supersecretvalue",
 			globalSecret:         true,
 			gitrepoSecret:        true,
 			globalSecretKey:      "github",
@@ -441,7 +441,7 @@ func TestGitHubSecretAndCommitUpdated(t *testing.T) {
 		// does not matter that global secret is correct because
 		// gitrepo secret takes preference
 		"global-secret-ok-gitrepo-secret-wrong": {
-			secretValueInWebhook: "supersecretvalue",
+			secretValueInRequest: "supersecretvalue",
 			globalSecret:         true,
 			gitrepoSecret:        true,
 			globalSecretKey:      "github",
@@ -453,7 +453,7 @@ func TestGitHubSecretAndCommitUpdated(t *testing.T) {
 			expectedCommitUpdate: false,
 		},
 		"no-global-secret-gitrepo-secret-wrong": {
-			secretValueInWebhook: "supersecretvalue",
+			secretValueInRequest: "supersecretvalue",
 			globalSecret:         false,
 			gitrepoSecret:        true,
 			globalSecretKey:      "",
@@ -465,7 +465,7 @@ func TestGitHubSecretAndCommitUpdated(t *testing.T) {
 			expectedCommitUpdate: false,
 		},
 		"no-global-secret-gitrepo-secret-ok": {
-			secretValueInWebhook: "supersecretvalue",
+			secretValueInRequest: "supersecretvalue",
 			globalSecret:         false,
 			gitrepoSecret:        true,
 			globalSecretKey:      "",
@@ -477,7 +477,7 @@ func TestGitHubSecretAndCommitUpdated(t *testing.T) {
 			expectedCommitUpdate: true,
 		},
 		"global-secret-wrong-key-no-gitrepo-secret": {
-			secretValueInWebhook: "supersecretvalue",
+			secretValueInRequest: "supersecretvalue",
 			globalSecret:         true,
 			gitrepoSecret:        false,
 			globalSecretKey:      "github-bad-key",
@@ -491,7 +491,7 @@ func TestGitHubSecretAndCommitUpdated(t *testing.T) {
 		// does not matter that global secret is ok
 		// because gitrepo secret takes preference
 		"global-secret-ok-gitrepo-secret-wrong-key": {
-			secretValueInWebhook: "supersecretvalue",
+			secretValueInRequest: "supersecretvalue",
 			globalSecret:         true,
 			gitrepoSecret:        true,
 			globalSecretKey:      "github",
@@ -504,7 +504,7 @@ func TestGitHubSecretAndCommitUpdated(t *testing.T) {
 		},
 		// when no secret is defined we accept the payload
 		"no-global-secret-no-gitrepo-secret": {
-			secretValueInWebhook: "supersecretvalue",
+			secretValueInRequest: "supersecretvalue",
 			globalSecret:         false,
 			gitrepoSecret:        false,
 			globalSecretKey:      "",
@@ -516,9 +516,9 @@ func TestGitHubSecretAndCommitUpdated(t *testing.T) {
 			expectedCommitUpdate: true,
 		},
 
-		// when no secret is defined we accept the payload
+		// when a referenced secret does not exist, we throw an error
 		"no-global-secret-no-gitrepo-secret-secret-in-gitrepo": {
-			secretValueInWebhook: "supersecretvalue",
+			secretValueInRequest: "supersecretvalue",
 			globalSecret:         false,
 			gitrepoSecret:        false,
 			globalSecretKey:      "",
@@ -638,7 +638,7 @@ func TestGitHubSecretAndCommitUpdated(t *testing.T) {
 		}
 		req.Header.Set("X-Github-Event", "push")
 		// calculate the value to store in the X-Hub-Signature header
-		mac := hmac.New(sha1.New, []byte("supersecretvalue"))
+		mac := hmac.New(sha1.New, []byte(tt.secretValueInRequest))
 		_, _ = mac.Write(jsonBody)
 		expectedMAC := hex.EncodeToString(mac.Sum(nil))
 		req.Header.Set("X-Hub-Signature", fmt.Sprintf("sha1=%s", expectedMAC))

--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -10,7 +10,9 @@ import (
 	"time"
 
 	"go.uber.org/mock/gomock"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/kubectl/pkg/scheme"
 
@@ -22,7 +24,9 @@ import (
 	"gopkg.in/go-playground/webhooks.v5/github"
 	"gopkg.in/go-playground/webhooks.v5/gitlab"
 	"gopkg.in/go-playground/webhooks.v5/gogs"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	cfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -32,6 +36,12 @@ import (
 
 	"gotest.tools/assert"
 )
+
+type errReader int
+
+func (errReader) Read(p []byte) (n int, err error) {
+	return 0, fmt.Errorf("ERROR READING")
+}
 
 func TestGetBranchTagFromRef(t *testing.T) {
 	inputs := []string{
@@ -72,13 +82,11 @@ func TestAzureDevopsWebhook(t *testing.T) {
 		},
 	}
 	scheme := runtime.NewScheme()
-	err := v1alpha1.AddToScheme(scheme)
-	if err != nil {
-		t.Errorf("unexpected error %v", err)
-	}
+	utilruntime.Must(corev1.AddToScheme(scheme))
+	utilruntime.Must(v1alpha1.AddToScheme(scheme))
+
 	client := cfake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(gitRepo).WithStatusSubresource(gitRepo).Build()
 	w := &Webhook{client: client}
-	w.azureDevops, _ = azuredevops.New()
 	jsonBody := []byte(`{"subscriptionId":"xxx","notificationId":1,"id":"xxx","eventType":"git.push","publisherId":"tfs","message":{"text":"commit pushed","html":"commit pushed"},"detailedMessage":{"text":"pushed a commit to git-test"},"resource":{"commits":[{"commitId":"` + commit + `","author":{"name":"fleet","email":"fleet@suse.com","date":"2024-01-05T10:16:56Z"},"committer":{"name":"fleet","email":"fleet@suse.com","date":"2024-01-05T10:16:56Z"},"comment":"test commit","url":"https://dev.azure.com/fleet/_apis/git/repositories/xxx/commits/f00c3a181697bb3829a6462e931c7456bbed557b"}],"refUpdates":[{"name":"refs/heads/main","oldObjectId":"135f8a827edae980466f72eef385881bb4e158d8","newObjectId":"` + commit + `"}],"repository":{"id":"xxx","name":"git-test","url":"https://dev.azure.com/fleet/_apis/git/repositories/xxx","project":{"id":"xxx","name":"git-test","url":"https://dev.azure.com/fleet/_apis/projects/xxx","state":"wellFormed","visibility":"unchanged","lastUpdateTime":"0001-01-01T00:00:00"},"defaultBranch":"refs/heads/main","remoteUrl":"` + repoURL + `"},"pushedBy":{"displayName":"Fleet","url":"https://spsprodneu1.vssps.visualstudio.com/xxx/_apis/Identities/xxx","_links":{"avatar":{"href":"https://dev.azure.com/fleet/_apis/GraphProfile/MemberAvatars/msa.xxxx"}},"id":"xxx","uniqueName":"fleet@suse.com","imageUrl":"https://dev.azure.com/fleet/_api/_common/identityImage?id=xxx","descriptor":"xxxx"},"pushId":22,"date":"2024-01-05T10:17:18.735088Z","url":"https://dev.azure.com/fleet/_apis/git/repositories/xxx/pushes/22","_links":{"self":{"href":"https://dev.azure.com/fleet/_apis/git/repositories/xxx/pushes/22"},"repository":{"href":"https://dev.azure.com/fleet/xxx/_apis/git/repositories/xxx"},"commits":{"href":"https://dev.azure.com/fleet/_apis/git/repositories/xxx/pushes/22/commits"},"pusher":{"href":"https://spsprodneu1.vssps.visualstudio.com/xxx/_apis/Identities/xxx"},"refs":{"href":"https://dev.azure.com/fleet/xxx/_apis/git/repositories/xxx/refs/heads/main"}}},"resourceVersion":"1.0","resourceContainers":{"collection":{"id":"xxx","baseUrl":"https://dev.azure.com/fleet/"},"account":{"id":"ec365173-fce3-4dfc-8fc2-950f0b5728b1","baseUrl":"https://dev.azure.com/fleet/"},"project":{"id":"xxx","baseUrl":"https://dev.azure.com/fleet/"}},"createdDate":"2024-01-05T10:17:26.0098694Z"}`)
 	bodyReader := bytes.NewReader(jsonBody)
 	req, err := http.NewRequest(http.MethodPost, repoURL, bodyReader)
@@ -118,13 +126,11 @@ func TestAzureDevopsWebhookWithSSHURL(t *testing.T) {
 		},
 	}
 	scheme := runtime.NewScheme()
-	err := v1alpha1.AddToScheme(scheme)
-	if err != nil {
-		t.Errorf("unexpected error %v", err)
-	}
+	utilruntime.Must(corev1.AddToScheme(scheme))
+	utilruntime.Must(v1alpha1.AddToScheme(scheme))
+
 	client := cfake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(gitRepo).WithStatusSubresource(gitRepo).Build()
 	w := &Webhook{client: client}
-	w.azureDevops, _ = azuredevops.New()
 	jsonBody := []byte(`{"subscriptionId":"xxx","notificationId":1,"id":"xxx","eventType":"git.push","publisherId":"tfs","message":{"text":"commit pushed","html":"commit pushed"},"detailedMessage":{"text":"pushed a commit to git-test"},"resource":{"commits":[{"commitId":"` + commit + `","author":{"name":"fleet","email":"fleet@suse.com","date":"2024-01-05T10:16:56Z"},"committer":{"name":"fleet","email":"fleet@suse.com","date":"2024-01-05T10:16:56Z"},"comment":"test commit","url":"https://dev.azure.com/fleet/_apis/git/repositories/xxx/commits/f00c3a181697bb3829a6462e931c7456bbed557b"}],"refUpdates":[{"name":"refs/heads/main","oldObjectId":"135f8a827edae980466f72eef385881bb4e158d8","newObjectId":"` + commit + `"}],"repository":{"id":"xxx","name":"git-test","url":"https://dev.azure.com/fleet/_apis/git/repositories/xxx","project":{"id":"xxx","name":"git-test","url":"https://dev.azure.com/fleet/_apis/projects/xxx","state":"wellFormed","visibility":"unchanged","lastUpdateTime":"0001-01-01T00:00:00"},"defaultBranch":"refs/heads/main","remoteUrl":"` + responseRemoteURL + `"},"pushedBy":{"displayName":"Fleet","url":"https://spsprodneu1.vssps.visualstudio.com/xxx/_apis/Identities/xxx","_links":{"avatar":{"href":"https://dev.azure.com/fleet/_apis/GraphProfile/MemberAvatars/msa.xxxx"}},"id":"xxx","uniqueName":"fleet@suse.com","imageUrl":"https://dev.azure.com/fleet/_api/_common/identityImage?id=xxx","descriptor":"xxxx"},"pushId":22,"date":"2024-01-05T10:17:18.735088Z","url":"https://dev.azure.com/fleet/_apis/git/repositories/xxx/pushes/22","_links":{"self":{"href":"https://dev.azure.com/fleet/_apis/git/repositories/xxx/pushes/22"},"repository":{"href":"https://dev.azure.com/fleet/xxx/_apis/git/repositories/xxx"},"commits":{"href":"https://dev.azure.com/fleet/_apis/git/repositories/xxx/pushes/22/commits"},"pusher":{"href":"https://spsprodneu1.vssps.visualstudio.com/xxx/_apis/Identities/xxx"},"refs":{"href":"https://dev.azure.com/fleet/xxx/_apis/git/repositories/xxx/refs/heads/main"}}},"resourceVersion":"1.0","resourceContainers":{"collection":{"id":"xxx","baseUrl":"https://dev.azure.com/fleet/"},"account":{"id":"ec365173-fce3-4dfc-8fc2-950f0b5728b1","baseUrl":"https://dev.azure.com/fleet/"},"project":{"id":"xxx","baseUrl":"https://dev.azure.com/fleet/"}},"createdDate":"2024-01-05T10:17:26.0098694Z"}`)
 	bodyReader := bytes.NewReader(jsonBody)
 	req, err := http.NewRequest(http.MethodPost, responseRemoteURL, bodyReader)
@@ -175,10 +181,9 @@ func TestGitHubPingWebhook(t *testing.T) {
 
 	// Kubernetes scheme and client configuration
 	sch := scheme.Scheme
-	err := v1alpha1.AddToScheme(sch)
-	if err != nil {
-		t.Fatalf("unable to add to scheme: %v", err)
-	}
+	utilruntime.Must(corev1.AddToScheme(sch))
+	utilruntime.Must(v1alpha1.AddToScheme(sch))
+
 	client := cfake.NewClientBuilder().WithScheme(sch).WithRuntimeObjects(gitRepo).Build()
 
 	// Webhook initialisation
@@ -186,8 +191,6 @@ func TestGitHubPingWebhook(t *testing.T) {
 		client:    client,
 		namespace: "default",
 	}
-
-	w.github, _ = github.New(github.Options.Secret(""))
 
 	// JSON payload for the ping event
 	jsonBody := []byte(fmt.Sprintf(`{
@@ -315,13 +318,23 @@ func TestGitHubWrongSecret(t *testing.T) {
 		},
 	}
 
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      webhookSecretName,
+			Namespace: "default",
+		},
+		Data: map[string][]byte{
+			"github": []byte("badsecret"),
+		},
+	}
+
 	// Kubernetes scheme and client configuration
 	sch := scheme.Scheme
 	err := v1alpha1.AddToScheme(sch)
 	if err != nil {
 		t.Fatalf("unable to add to scheme: %v", err)
 	}
-	client := cfake.NewClientBuilder().WithScheme(sch).WithRuntimeObjects(gitRepo).Build()
+	client := cfake.NewClientBuilder().WithScheme(sch).WithRuntimeObjects(gitRepo, secret).Build()
 
 	// Webhook initialisation
 	w := &Webhook{
@@ -329,10 +342,14 @@ func TestGitHubWrongSecret(t *testing.T) {
 		namespace: "default",
 	}
 
-	w.github, _ = github.New(github.Options.Secret("badsecret"))
-
-	// The secret header check is not going to pass so we don't need any particular payload
-	jsonBody := []byte("{}")
+	jsonBody := []byte(`
+	{
+	  "ref":"refs/heads/main",
+	  "after":"af69d162de5a276abc86e0686b2b44033cd3f442",
+	  "repository":{
+		"html_url":"https://github.com/example/repo"
+      }
+    }`)
 
 	// Request creation
 	req, err := http.NewRequest(http.MethodPost, "/", bytes.NewReader(jsonBody))
@@ -356,83 +373,308 @@ func TestGitHubWrongSecret(t *testing.T) {
 	}
 }
 
-func TestGitHubRightSecretAndCommitUpdated(t *testing.T) {
+func TestGitHubSecretAndCommitUpdated(t *testing.T) {
 	expectedCommit := "af69d162de5a276abc86e0686b2b44033cd3f442"
-
-	ctlr := gomock.NewController(t)
-	mockClient := mocks.NewMockClient(ctlr)
-
-	gitRepo := &v1alpha1.GitRepo{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "test",
+	gitrepoSecretName := "gitrepoSecret"
+	tests := map[string]struct {
+		secretValueInWebhook string
+		globalSecret         bool
+		gitrepoSecret        bool
+		globalSecretKey      string
+		globalSecretValue    string
+		gitrepoSecretKey     string
+		gitrepoSecretValue   string
+		setSecretInGitrepo   bool
+		expectedResCode      int
+		expectedCommitUpdate bool
+	}{
+		"global-secret-ok-no-gitrepo-secret": {
+			secretValueInWebhook: "supersecretvalue",
+			globalSecret:         true,
+			gitrepoSecret:        false,
+			globalSecretKey:      "github",
+			globalSecretValue:    "supersecretvalue",
+			gitrepoSecretKey:     "",
+			gitrepoSecretValue:   "",
+			setSecretInGitrepo:   false,
+			expectedResCode:      http.StatusOK,
+			expectedCommitUpdate: true,
 		},
-		Spec: v1alpha1.GitRepoSpec{
-			Repo:   "https://github.com/example/repo",
-			Branch: "main",
+		"global-secret-wrong-no-gitrepo-secret": {
+			secretValueInWebhook: "supersecretvalue",
+			globalSecret:         true,
+			gitrepoSecret:        false,
+			globalSecretKey:      "github",
+			globalSecretValue:    "bad-secret",
+			gitrepoSecretKey:     "",
+			gitrepoSecretValue:   "",
+			setSecretInGitrepo:   false,
+			expectedResCode:      http.StatusUnauthorized,
+			expectedCommitUpdate: false,
+		},
+		"global-secret-ok-gitrepo-secret-ok": {
+			secretValueInWebhook: "supersecretvalue",
+			globalSecret:         true,
+			gitrepoSecret:        true,
+			globalSecretKey:      "github",
+			globalSecretValue:    "supersecretvalue",
+			gitrepoSecretKey:     "github",
+			gitrepoSecretValue:   "supersecretvalue",
+			setSecretInGitrepo:   true,
+			expectedResCode:      http.StatusOK,
+			expectedCommitUpdate: true,
+		},
+		// does not matter that global secret is wrong because
+		// gitrepo secret takes preference
+		"global-secret-wrong-gitrepo-secret-ok": {
+			secretValueInWebhook: "supersecretvalue",
+			globalSecret:         true,
+			gitrepoSecret:        true,
+			globalSecretKey:      "github",
+			globalSecretValue:    "bad-secret",
+			gitrepoSecretKey:     "github",
+			gitrepoSecretValue:   "supersecretvalue",
+			setSecretInGitrepo:   true,
+			expectedResCode:      http.StatusOK,
+			expectedCommitUpdate: true,
+		},
+		// does not matter that global secret is correct because
+		// gitrepo secret takes preference
+		"global-secret-ok-gitrepo-secret-wrong": {
+			secretValueInWebhook: "supersecretvalue",
+			globalSecret:         true,
+			gitrepoSecret:        true,
+			globalSecretKey:      "github",
+			globalSecretValue:    "supersecretvalue",
+			gitrepoSecretKey:     "github",
+			gitrepoSecretValue:   "bad-secret",
+			setSecretInGitrepo:   true,
+			expectedResCode:      http.StatusUnauthorized,
+			expectedCommitUpdate: false,
+		},
+		"no-global-secret-gitrepo-secret-wrong": {
+			secretValueInWebhook: "supersecretvalue",
+			globalSecret:         false,
+			gitrepoSecret:        true,
+			globalSecretKey:      "",
+			globalSecretValue:    "",
+			gitrepoSecretKey:     "github",
+			gitrepoSecretValue:   "bad-secret",
+			setSecretInGitrepo:   true,
+			expectedResCode:      http.StatusUnauthorized,
+			expectedCommitUpdate: false,
+		},
+		"no-global-secret-gitrepo-secret-ok": {
+			secretValueInWebhook: "supersecretvalue",
+			globalSecret:         false,
+			gitrepoSecret:        true,
+			globalSecretKey:      "",
+			globalSecretValue:    "",
+			gitrepoSecretKey:     "github",
+			gitrepoSecretValue:   "supersecretvalue",
+			setSecretInGitrepo:   true,
+			expectedResCode:      http.StatusOK,
+			expectedCommitUpdate: true,
+		},
+		"global-secret-wrong-key-no-gitrepo-secret": {
+			secretValueInWebhook: "supersecretvalue",
+			globalSecret:         true,
+			gitrepoSecret:        false,
+			globalSecretKey:      "github-bad-key",
+			globalSecretValue:    "supersecretvalue",
+			gitrepoSecretKey:     "",
+			gitrepoSecretValue:   "",
+			setSecretInGitrepo:   false,
+			expectedResCode:      http.StatusInternalServerError,
+			expectedCommitUpdate: false,
+		},
+		// does not matter that global secret is ok
+		// because gitrepo secret takes preference
+		"global-secret-ok-gitrepo-secret-wrong-key": {
+			secretValueInWebhook: "supersecretvalue",
+			globalSecret:         true,
+			gitrepoSecret:        true,
+			globalSecretKey:      "github",
+			globalSecretValue:    "supersecretvalue",
+			gitrepoSecretKey:     "github-bad-key",
+			gitrepoSecretValue:   "supersecretvalue",
+			setSecretInGitrepo:   true,
+			expectedResCode:      http.StatusInternalServerError,
+			expectedCommitUpdate: false,
+		},
+		// when no secret is defined we accept the payload
+		"no-global-secret-no-gitrepo-secret": {
+			secretValueInWebhook: "supersecretvalue",
+			globalSecret:         false,
+			gitrepoSecret:        false,
+			globalSecretKey:      "",
+			globalSecretValue:    "",
+			gitrepoSecretKey:     "",
+			gitrepoSecretValue:   "",
+			setSecretInGitrepo:   false,
+			expectedResCode:      http.StatusOK,
+			expectedCommitUpdate: true,
+		},
+
+		// when no secret is defined we accept the payload
+		"no-global-secret-no-gitrepo-secret-secret-in-gitrepo": {
+			secretValueInWebhook: "supersecretvalue",
+			globalSecret:         false,
+			gitrepoSecret:        false,
+			globalSecretKey:      "",
+			globalSecretValue:    "",
+			gitrepoSecretKey:     "",
+			gitrepoSecretValue:   "",
+			setSecretInGitrepo:   true,
+			expectedResCode:      http.StatusInternalServerError,
+			expectedCommitUpdate: false,
 		},
 	}
+	for _, tt := range tests {
+		ctlr := gomock.NewController(t)
+		mockClient := mocks.NewMockClient(ctlr)
 
-	// List GitRepos mock call
-	mockClient.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().DoAndReturn(
-		func(ctx context.Context, list *v1alpha1.GitRepoList, opts ...client.ListOption) error {
-			list.Items = append(list.Items, *gitRepo)
-			return nil
-		},
-	)
-	// Get GitRepo mock call
-	mockClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
-	statusClient := mocks.NewMockSubResourceWriter(ctlr)
+		gitRepo := &v1alpha1.GitRepo{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test",
+				Namespace: "gitrepoNamespace",
+			},
+			Spec: v1alpha1.GitRepoSpec{
+				Repo:   "https://github.com/example/repo",
+				Branch: "main",
+			},
+		}
 
-	// Status().Update() mock call
-	mockClient.EXPECT().Status().Return(statusClient).Times(1)
-	statusClient.EXPECT().Patch(gomock.Any(), gomock.Any(), gomock.Any()).Do(
-		func(ctx context.Context, repo *v1alpha1.GitRepo, _ client.Patch, opts ...interface{}) {
-			// check that the commit is the expected one
-			if repo.Status.WebhookCommit != expectedCommit {
-				t.Errorf("expecting gitrepo webhook commit %s, got %s", expectedCommit, repo.Status.WebhookCommit)
+		if tt.setSecretInGitrepo {
+			gitRepo.Spec.WebhookSecret = gitrepoSecretName
+		}
+
+		// List GitRepos mock call
+		mockClient.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().DoAndReturn(
+			func(ctx context.Context, list *v1alpha1.GitRepoList, opts ...client.ListOption) error {
+				list.Items = append(list.Items, *gitRepo)
+				return nil
+			},
+		)
+
+		// call for secret
+		mockClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+			func(ctx context.Context, name types.NamespacedName, secret *corev1.Secret, _ ...interface{}) error {
+				// check that we're calling Get with the expected name and Namespace
+				if tt.gitrepoSecret {
+					if name.Name != gitrepoSecretName {
+						t.Errorf("expecting calling secret Get with secret name %q, got %q", gitrepoSecretName, name.Name)
+					}
+					if name.Namespace != gitRepo.Namespace {
+						t.Errorf("expecting calling secret Get with secret namespace %q, got %q", gitRepo.Namespace, name.Namespace)
+					}
+				} else if tt.globalSecret {
+					// it expects the global secret name
+					if name.Name != webhookSecretName {
+						t.Errorf("expecting calling secret Get with secret name %q, got %q", webhookSecretName, name.Name)
+					}
+					// we're using "default" as the namespace for the webhook
+					if name.Namespace != "default" {
+						t.Errorf("expecting calling secret Get with secret namespace %q, got %q", "default", name.Namespace)
+					}
+				}
+				if tt.gitrepoSecret {
+					secret.Data = map[string][]byte{
+						tt.gitrepoSecretKey: []byte(tt.gitrepoSecretValue),
+					}
+					return nil
+				} else if tt.globalSecret {
+					secret.Data = map[string][]byte{
+						tt.globalSecretKey: []byte(tt.globalSecretValue),
+					}
+					return nil
+				}
+
+				// if no secret
+				return errors.NewNotFound(schema.GroupResource{}, "")
+			}).Times(1)
+
+		// Status().Update() mock call
+		if tt.expectedCommitUpdate {
+			mockClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+				func(ctx context.Context, name types.NamespacedName, gitrepo *v1alpha1.GitRepo, _ ...interface{}) error {
+					return nil
+				})
+			statusClient := mocks.NewMockSubResourceWriter(ctlr)
+
+			mockClient.EXPECT().Status().Return(statusClient).Times(1)
+			statusClient.EXPECT().Patch(gomock.Any(), gomock.Any(), gomock.Any()).Do(
+				func(ctx context.Context, repo *v1alpha1.GitRepo, _ client.Patch, opts ...interface{}) {
+					// check that the commit is the expected one
+					if repo.Status.WebhookCommit != expectedCommit {
+						t.Errorf("expecting gitrepo webhook commit %s, got %s", expectedCommit, repo.Status.WebhookCommit)
+					}
+					if repo.Spec.PollingInterval.Duration != time.Hour {
+						t.Errorf("expecting gitrepo polling interval 1h, got %s", repo.Spec.PollingInterval.Duration)
+					}
+				},
+			).Times(1)
+		}
+
+		w := &Webhook{
+			client:    mockClient,
+			namespace: "default",
+		}
+
+		// we set only the values that we're going to use in the push event to make things simple
+		jsonBody := []byte(fmt.Sprintf(`
+		{
+		  "ref":"refs/heads/main",
+		  "after":"%s",
+		  "repository":{
+			"html_url":"https://github.com/example/repo"
+		  }
+		}`, expectedCommit))
+
+		// Request creation
+		req, err := http.NewRequest(http.MethodPost, "/", bytes.NewReader(jsonBody))
+		if err != nil {
+			t.Fatalf("Failed to create HTTP request: %v", err)
+		}
+		req.Header.Set("X-Github-Event", "push")
+		// calculate the value to store in the X-Hub-Signature header
+		mac := hmac.New(sha1.New, []byte("supersecretvalue"))
+		_, _ = mac.Write(jsonBody)
+		expectedMAC := hex.EncodeToString(mac.Sum(nil))
+		req.Header.Set("X-Hub-Signature", fmt.Sprintf("sha1=%s", expectedMAC))
+
+		// request execution
+		rr := httptest.NewRecorder()
+		w.ServeHTTP(rr, req)
+
+		// Verify the response status code is correct
+		if status := rr.Code; status != tt.expectedResCode {
+			t.Errorf("handler returned wrong status code: got %v want %v", status, tt.expectedResCode)
+		}
+
+		// Verify the response message is correct
+		if tt.expectedResCode == http.StatusOK {
+			expectedResponse := "succeeded"
+			if rr.Body.String() != expectedResponse {
+				t.Errorf("handler returned unexpected body: got %v want %v", rr.Body, expectedResponse)
 			}
-			if repo.Spec.PollingInterval.Duration != time.Hour {
-				t.Errorf("expecting gitrepo polling interval 1h, got %s", repo.Spec.PollingInterval.Duration)
-			}
-		},
-	).Times(1)
+		}
+	}
+}
 
+func TestErrorReadingRequest(t *testing.T) {
+	ctlr := gomock.NewController(t)
+	mockClient := mocks.NewMockClient(ctlr)
 	w := &Webhook{
 		client:    mockClient,
 		namespace: "default",
 	}
-
-	w.github, _ = github.New(github.Options.Secret(""))
-
-	// we set only the values that we're going to use in the push event to make things simple
-	jsonBody := []byte(fmt.Sprintf(`
-	{
-	  "ref":"refs/heads/main",
-	  "after":"%s",
-	  "repository":{
-		"html_url":"https://github.com/example/repo"
-      }
-    }`, expectedCommit))
-
-	// Request creation
-	req, err := http.NewRequest(http.MethodPost, "/", bytes.NewReader(jsonBody))
-	if err != nil {
-		t.Fatalf("Failed to create HTTP request: %v", err)
-	}
-	req.Header.Set("X-Github-Event", "push")
-
-	// request execution
+	testRequest := httptest.NewRequest(http.MethodPost, "/something", errReader(0))
 	rr := httptest.NewRecorder()
-	w.ServeHTTP(rr, req)
+	w.ServeHTTP(rr, testRequest)
 
 	// Verify the response status code is correct
-	if status := rr.Code; status != http.StatusOK {
-		t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusOK)
-	}
-
-	// Verify the response message is correct
-	expectedResponse := "succeeded"
-	if rr.Body.String() != expectedResponse {
-		t.Errorf("handler returned unexpected body: got %v want %v", rr.Body, expectedResponse)
+	if status := rr.Code; status != http.StatusInternalServerError {
+		t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusInternalServerError)
 	}
 }


### PR DESCRIPTION
This PR changes the secret handling for webhooks in order to add the possibility to define a secret per `GitRepo`. The actual `main` code has a single global secret shared by all the possible `GitRepos` in the system, which forces the users to share the same secret for all their webhooks in the cluster.

The secret is also cached, which means that it listens to the informer cache for all secrets in the cluster and, if any secret is updated it checks if it's the global secret for webhooks. In that case it reinstantiates all the webhook parsers for all the supported providers with the new secret value (or none if the secret was deleted).

It also needs to instantiate the webhook parsers for all supported providers at the beginning.

Also... a bug was found in that secret caching. If all the `gitjob` pods are restarted, the secret will be completely ignored, accepting any webhook received (which might mean a security problem).

The new implementation does not cache any secret and does not create all the different providers in advance. It just checks for the secret right before updating the `WebhookCommit` and, depending on the payload, it will instantiate the needed parser for that provider.

The price we pay for this is that we need to double parse the webhook request. This is because when we receive the payload we don't know yet the name of the `GitRepo` it is trying to update and we cannot check if it has a secret defined for it.

The first round of parsing will be used to determine the name of the `GitRepo` and, if a secret is defined (global or per `GitRepo`) it will parse again setting that secret.

The library used to parse the webhook payload doesn't offer the possibility to check just the secret given a payload.

The new field added in the `GitRepo` CRD is called `webhookSecret` and references the name of the secret, which should be located at the same namespace as the `GitRepo`

If a `Gitrepo` secret is defined it will take preference over the global secret, that is still supported.

This is an example of a `GitRepo` with the new field.

```yaml
apiVersion: fleet.cattle.io/v1alpha1
kind: GitRepo
metadata:
  name: simple
  namespace: fleet-local
spec:
  repo: "https://github.com/rancher/fleet-examples"
  paths:
  - simple
  disablePolling: true
  webhookSecret: webhook-secret-name
```

Refers to: https://github.com/rancher/fleet/issues/2776

<!-- Specify the issue ID that this pull request is solving -->

<!-- Make sure that the referenced issue provides steps to reproduce it -->

<!-- Describe the changes introduced by this pull request -->

<!--
  Please provide a unit, integration (`./integrationtests/`) or e2e (`./e2e/`) test if possible.
-->

## Additional Information

### Checklist

- [ ] <!-- If applicable,--> I have updated the documentation via a pull request in the
[fleet-docs](https://github.com/rancher/fleet-docs) repository.
