### PR TITLE
Set agent deployment strategy and history

### DIFF
--- a/charts/fleet-agent/templates/deployment.yaml
+++ b/charts/fleet-agent/templates/deployment.yaml
@@ -6,6 +6,10 @@ spec:
   selector:
     matchLabels:
       app: fleet-agent
+  replicas: 1
+  revisionHistoryLimit: 0
+  strategy:
+    type: Recreate
   template:
     metadata:
       labels:

--- a/internal/cmd/controller/agentmanagement/agent/manifest.go
+++ b/internal/cmd/controller/agentmanagement/agent/manifest.go
@@ -156,6 +156,9 @@ func agentApp(namespace string, agentScope string, opts ManifestOptions) *appsv1
 					"app": name,
 				},
 			},
+			Replicas:             &[]int32{1}[0],
+			RevisionHistoryLimit: &[]int32{0}[0],
+			Strategy:             appsv1.DeploymentStrategy{Type: appsv1.RecreateDeploymentStrategyType},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{


### PR DESCRIPTION
<!-- Specify the issue ID that this pull request is solving -->
Refers to #3483 and #3377

Even if this turns out to be a garbage collector issue, I would still update the deployment options. 
Not sure if we need to bring back the explicit deletion of pods: https://github.com/rancher/fleet/pull/1905/files#diff-be5264e16d1776adf438294ce1bcdb18d6c5df2c06d03e3469acaff79ba310a8