### PR TITLE
Ensure same bundle is selected for non-ready status

### DIFF
--- a/internal/cmd/controller/gitops/reconciler/status_controller.go
+++ b/internal/cmd/controller/gitops/reconciler/status_controller.go
@@ -271,6 +271,12 @@ func (r StatusReconciler) setReadyStatusFromBundle(ctx context.Context, gitrepo 
 		return err
 	}
 
+	// Make sure the bundles are always iterated in the same order
+	// The code below will pick the first element matching the condition, so successive executions should produce the same result.
+	sort.Slice(bList.Items, func(i, j int) bool {
+		return bList.Items[i].UID < bList.Items[j].UID
+	})
+
 	found := false
 	// Find a ready status condition in a bundle which is not ready.
 	var condition genericcondition.GenericCondition


### PR DESCRIPTION
Backport of https://github.com/rancher/fleet/pull/3485
Refers to:https://github.com/rancher/fleet/issues/3488