### PR TITLE
Delete no longer targeted bundle deployments

### DIFF
--- a/internal/cmd/controller/reconciler/bundle_controller.go
+++ b/internal/cmd/controller/reconciler/bundle_controller.go
@@ -283,6 +283,17 @@ func (r *BundleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		}
 	}
 
+	// purge bundle deployments that exist in the bundle but are no longer targeted
+	notTargeted, err := findNotTargetedBundleDeployments(ctx, r.Client, req.NamespacedName, matchedTargets)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	if len(notTargeted) > 0 {
+		if err := finalize.PurgeBundleDeploymentList(ctx, r.Client, notTargeted); err != nil {
+			return ctrl.Result{}, err
+		}
+	}
+
 	updateDisplay(&bundle.Status)
 	err = r.updateStatus(ctx, bundleOrig, bundle)
 
@@ -486,4 +497,35 @@ func (r *BundleReconciler) updateStatus(ctx context.Context, orig *fleet.Bundle,
 	}
 	metrics.BundleCollector.Collect(ctx, bundle)
 	return nil
+}
+
+func findNotTargetedBundleDeployments(ctx context.Context, c client.Client, bundleId types.NamespacedName, targets []*target.Target) ([]types.NamespacedName, error) {
+	list := &fleet.BundleDeploymentList{}
+	err := c.List(
+		ctx,
+		list,
+		client.MatchingLabels{
+			fleet.BundleLabel:          bundleId.Name,
+			fleet.BundleNamespaceLabel: bundleId.Namespace,
+		},
+	)
+	if err != nil {
+		return []types.NamespacedName{}, err
+	}
+
+	var notTargeted []types.NamespacedName
+	for _, bd := range list.Items {
+		found := false
+		for _, t := range targets {
+			if t.Deployment.Name == bd.Name && t.Deployment.Namespace == bd.Namespace {
+				found = true
+				break
+			}
+		}
+		if !found {
+			notTargeted = append(notTargeted, types.NamespacedName{Namespace: bd.Namespace, Name: bd.Name})
+		}
+	}
+
+	return notTargeted, nil
 }


### PR DESCRIPTION
Delete Bundle deployments that exist in the Bundle, that are also deployed, but that are no longer targeted.

When changing either the target customisations or targets in the `GitRepo` definition, Fleet does not delete bundle deployments that are no longer targeted using the new target rules.

Refers to: https://github.com/rancher/fleet/issues/2995


