### PR TITLE
Wait for webhook deployment before testing Fleet in Rancher

### DIFF
--- a/.github/workflows/e2e-test-fleet-in-rancher.yml
+++ b/.github/workflows/e2e-test-fleet-in-rancher.yml
@@ -182,6 +182,9 @@ jobs:
 
           until kubectl get bundles -n fleet-local | grep -q "fleet-agent-local.*1/1"; do sleep 3; done
 
+          # wait for deployment of webhook, needed by tests
+          kubectl -n cattle-system rollout status deploy/rancher-webhook
+
           helm list -A
 
       -


### PR DESCRIPTION
This prevents CI failures such as [this one](https://github.com/rancher/fleet/actions/runs/14310039929/job/40102823796).