### PR TITLE
Adds extra labels and annotations in charts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,7 @@ on:
 env:
   GOARCH: amd64
   CGO_ENABLED: 0
-  HELM_VERSION: 3.17.2
-  HELM_UNITTEST_VERSION: 0.8.1
+
 jobs:
   unit-test:
     runs-on: runs-on,runner=16cpu-linux-x64,mem=16,run-id=${{ github.run_id }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,8 @@ on:
 env:
   GOARCH: amd64
   CGO_ENABLED: 0
-
+  HELM_VERSION: 3.17.2
+  HELM_UNITTEST_VERSION: 0.8.1
 jobs:
   unit-test:
     runs-on: runs-on,runner=16cpu-linux-x64,mem=16,run-id=${{ github.run_id }}
@@ -28,6 +29,13 @@ jobs:
       -
         name: Run chart-testing (lint)
         run: ct lint --all --validate-maintainers=false charts/
+      - 
+        name: Run helm charts unittests
+        run: |
+          curl https://get.helm.sh/helm-v${{ env.HELM_VERSION }}-linux-amd64.tar.gz | tar xvzf - --strip-components=1 -C /tmp/
+          chmod +x /tmp/helm
+          /tmp/helm plugin install https://github.com/helm-unittest/helm-unittest.git --version ${{ env.HELM_UNITTEST_VERSION }}; \
+          /tmp/helm unittest ./charts/fleet
       -
         uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,13 +29,11 @@ jobs:
       -
         name: Run chart-testing (lint)
         run: ct lint --all --validate-maintainers=false charts/
-      - 
-        name: Run helm charts unittests
+      -
+        name: helm-unittest
         run: |
-          curl https://get.helm.sh/helm-v${{ env.HELM_VERSION }}-linux-amd64.tar.gz | tar xvzf - --strip-components=1 -C /tmp/
-          chmod +x /tmp/helm
-          /tmp/helm plugin install https://github.com/helm-unittest/helm-unittest.git --version ${{ env.HELM_UNITTEST_VERSION }}; \
-          /tmp/helm unittest ./charts/fleet
+          helm plugin install https://github.com/helm-unittest/helm-unittest.git
+          helm unittest ./charts/fleet
       -
         uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5
         with:

--- a/charts/fleet/templates/deployment.yaml
+++ b/charts/fleet/templates/deployment.yaml
@@ -26,6 +26,13 @@ spec:
         {{- if empty $shard.id }}
         fleet.cattle.io/shard-default: "true"
         {{- end }}
+{{- if $.Values.extraLabels }}
+{{ toYaml $.Values.extraLabels | indent 8 }}
+{{- end }}
+{{- if $.Values.extraAnnotations }}
+      annotations:
+{{ toYaml $.Values.extraAnnotations | indent 8 }}
+{{- end }}
     spec:
       containers:
       - env:

--- a/charts/fleet/templates/deployment_gitjob.yaml
+++ b/charts/fleet/templates/deployment_gitjob.yaml
@@ -27,6 +27,13 @@ spec:
         {{- if empty $shard.id }}
         fleet.cattle.io/shard-default: "true"
         {{- end }}
+{{- if $.Values.extraLabels }}
+{{ toYaml $.Values.extraLabels | indent 8 }}
+{{- end }}
+{{- if $.Values.extraAnnotations }}
+      annotations:
+{{ toYaml $.Values.extraAnnotations | indent 8 }}
+{{- end }}
     spec:
       serviceAccountName: gitjob
       containers:

--- a/charts/fleet/templates/deployment_helmops.yaml
+++ b/charts/fleet/templates/deployment_helmops.yaml
@@ -27,6 +27,13 @@ spec:
         {{- if empty $shard.id }}
         fleet.cattle.io/shard-default: "true"
         {{- end }}
+{{- if $.Values.extraLabels }}
+{{ toYaml $.Values.extraLabels | indent 8 }}
+{{- end }}
+{{- if $.Values.extraAnnotations }}
+      annotations:
+{{ toYaml $.Values.extraAnnotations | indent 8 }}
+{{- end }}
     spec:
       serviceAccountName: helmops
       containers:

--- a/charts/fleet/tests/extraAnnotations_test.yaml
+++ b/charts/fleet/tests/extraAnnotations_test.yaml
@@ -1,0 +1,75 @@
+suite: extraAnnotations tests
+templates:
+  - deployment.yaml
+  - deployment_gitjob.yaml
+  - deployment_helmops.yaml
+tests:
+  - it: should set extraAnnotations variables in fleet-controller deployment
+    set:
+      extraAnnotations:
+        test-annotation-1: testvalue1
+        test-annotation-2: testvalue2
+    template: deployment.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Deployment
+      - equal:
+          path: spec.template.metadata.annotations.test-annotation-1
+          value: testvalue1
+      - equal:
+          path: spec.template.metadata.annotations.test-annotation-2
+          value: testvalue2
+  - it: should set extraAnnotations variables in gitjob deployment
+    set:
+      extraAnnotations:
+        test-annotation-1: testvalue1
+        test-annotation-2: testvalue2
+      gitops:
+        enabled: true
+    template: deployment_gitjob.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Deployment
+      - equal:
+          path: spec.template.metadata.annotations.test-annotation-1
+          value: testvalue1
+      - equal:
+          path: spec.template.metadata.annotations.test-annotation-2
+          value: testvalue2
+  - it: should set extraAnnotations variables in helmops deployment
+    set:
+      extraAnnotations:
+        test-annotation-1: testvalue1
+        test-annotation-2: testvalue2
+      extraEnv:
+        - name: EXPERIMENTAL_HELM_OPS
+          value: "true"
+    template: deployment_helmops.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Deployment
+      - equal:
+          path: spec.template.metadata.annotations.test-annotation-1
+          value: testvalue1
+      - equal:
+          path: spec.template.metadata.annotations.test-annotation-2
+          value: testvalue2
+  - it: should not set extraAnnotations variables when empty
+    set:
+      extraAnnotations: {}
+      extraEnv:
+        - name: EXPERIMENTAL_HELM_OPS
+          value: "true"
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind: 
+          of: Deployment
+      - notExists:
+          path: spec.template.metadata.annotations

--- a/charts/fleet/tests/extraLabels_test.yaml
+++ b/charts/fleet/tests/extraLabels_test.yaml
@@ -1,0 +1,120 @@
+suite: extraLabels tests
+tests:
+  - it: should set extraLabels variables in fleet-controller deployment
+    set:
+      extraLabels:
+        test-label-1: testvalue1
+        test-label-2: testvalue2
+    template: deployment.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Deployment
+      - equal:
+          path: spec.template.metadata.labels
+          value: 
+            app: fleet-controller
+            fleet.cattle.io/shard-default: "true" 
+            fleet.cattle.io/shard-id: ""
+            test-label-1: testvalue1
+            test-label-2: testvalue2
+  - it: should set extraLabels variables in gitjob deployment
+    set:
+      extraLabels:
+        test-label-1: testvalue1
+        test-label-2: testvalue2
+      gitops:
+        enabled: true
+    template: deployment_gitjob.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Deployment
+      - equal:
+          path: spec.template.metadata.labels
+          value: 
+            app: gitjob
+            fleet.cattle.io/shard-default: "true" 
+            fleet.cattle.io/shard-id: ""
+            test-label-1: testvalue1
+            test-label-2: testvalue2
+  - it: should set extraLabels variables in helmops deployment
+    set:
+      extraLabels:
+        test-label-1: testvalue1
+        test-label-2: testvalue2
+      extraEnv:
+        - name: EXPERIMENTAL_HELM_OPS
+          value: "true"
+    template: deployment_helmops.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Deployment
+      - equal:
+          path: spec.template.metadata.labels
+          value: 
+            app: helmops
+            fleet.cattle.io/shard-default: "true" 
+            fleet.cattle.io/shard-id: ""
+            test-label-1: testvalue1
+            test-label-2: testvalue2
+  - it: should not set more labels in fleet-controller deployment when extraLabels is empty
+    set:
+      extraLabels: {}
+      extraEnv:
+        - name: EXPERIMENTAL_HELM_OPS
+          value: "true"
+    template: deployment.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind: 
+          of: Deployment
+      - equal:
+          path: spec.template.metadata.labels
+          value: 
+            app: fleet-controller
+            fleet.cattle.io/shard-default: "true" 
+            fleet.cattle.io/shard-id: ""
+
+  - it: should not set more labels in gitjob deployment when extraLabels is empty
+    set:
+      extraLabels: {}
+      extraEnv:
+        - name: EXPERIMENTAL_HELM_OPS
+          value: "true"
+    template: deployment_gitjob.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind: 
+          of: Deployment
+      - equal:
+          path: spec.template.metadata.labels
+          value: 
+            app: gitjob
+            fleet.cattle.io/shard-default: "true" 
+            fleet.cattle.io/shard-id: ""
+
+  - it: should not set more labels in helmops deployment when extraLabels is empty
+    set:
+      extraLabels: {}
+      extraEnv:
+        - name: EXPERIMENTAL_HELM_OPS
+          value: "true"
+    template: deployment_helmops.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind: 
+          of: Deployment
+      - equal:
+          path: spec.template.metadata.labels
+          value: 
+            app: helmops
+            fleet.cattle.io/shard-default: "true" 
+            fleet.cattle.io/shard-id: ""

--- a/charts/fleet/values.yaml
+++ b/charts/fleet/values.yaml
@@ -136,3 +136,13 @@ agent:
 #   - id: shard2
 #     nodeSelector:
 #       kubernetes.io/hostname: k3d-upstream-server-2
+
+# Extra labels passed to the fleet pods.
+# extraLabels:
+#   new-label: "new-label-value"
+#   new-label-2: "new-label-value-2"
+
+# Extra annotations passed to the fleet pods.
+# extraAnnotations:
+#   new-annotation: "new-annotation-value"
+#   new-annotation-2: "new-annotation-value-2"


### PR DESCRIPTION
Adds the `extraLabels` and `extraAnnotations` values to the helm charts. Those values are propagated to the `fleet-controller`, `gitjob` and `helmops` deployments.

It also introduces helm charts unittests testing those 2 new values.


Refers to https://github.com/rancher/fleet/issues/3295

### Checklist

- [ ] <!-- If applicable,--> I have updated the documentation via a pull request in the
[fleet-docs](https://github.com/rancher/fleet-docs) repository.
