### PR TITLE
Avoid panic if leader election opts are not set for the client

### DIFF
--- a/internal/cmd/options.go
+++ b/internal/cmd/options.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 	"time"
+
+	"k8s.io/utils/ptr"
 )
 
 type LeaderElectionOptions struct {
@@ -32,6 +34,10 @@ func NewLeaderElectionOptions() (LeaderElectionOptions, error) {
 		}
 		leaderOpts.LeaseDuration = &v
 	}
+	if leaderOpts.LeaseDuration == nil {
+		leaderOpts.LeaseDuration = ptr.To(time.Duration(0))
+	}
+
 	if d := os.Getenv("CATTLE_ELECTION_RENEW_DEADLINE"); d != "" {
 		v, err := time.ParseDuration(d)
 		if err != nil {


### PR DESCRIPTION
client-go uses non-pointer time.Duration values, so it will only apply its own defaults when 0 is provided, not nil.

Refers to: https://github.com/rancher/fleet/issues/3501

See also: https://github.com/rancher/fleet/pull/3463#discussion_r2028648698