### PR TITLE
[v0.11] Prevent panic when fetching latest commit

### DIFF
--- a/pkg/git/fetch.go
+++ b/pkg/git/fetch.go
@@ -58,7 +58,7 @@ func (f *Fetch) LatestCommit(ctx context.Context, gitrepo *v1alpha1.GitRepo, cli
 		knownHosts = kh
 	}
 
-	if f.KnownHosts != nil && !f.KnownHosts.IsStrict() {
+	if secret.Data != nil && f.KnownHosts != nil && !f.KnownHosts.IsStrict() {
 		// This prevents errors about keys being mismatch or not found when host key checks are disabled.
 		secret.Data["known_hosts"] = nil
 	}

--- a/pkg/git/fetch_test.go
+++ b/pkg/git/fetch_test.go
@@ -147,6 +147,32 @@ var _ = Describe("git fetch's LatestCommit tests", func() {
 		Expect(commit).To(Equal("2ada7cca738877df8459b3a34839a15e5683edaa"))
 	})
 
+	It("returns the commit for the expected branch with no secret", func() {
+		gr := &fleetv1.GitRepo{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-gitrepo",
+				Namespace: "test-ns",
+			},
+			Spec: fleetv1.GitRepoSpec{
+				ClientSecretName: "test-secret",
+				Repo:             fakeGithub.URL,
+				Branch:           "master",
+			},
+			Status: fleetv1.GitRepoStatus{
+				Commit: "",
+			},
+		}
+		c := newTestClient()
+		f := git.Fetch{
+			KnownHosts: mockKnownHostsGetter{
+				data: "foo",
+			},
+		}
+		commit, err := f.LatestCommit(context.Background(), gr, c)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(commit).To(Equal("2ada7cca738877df8459b3a34839a15e5683edaa"))
+	})
+
 	It("returns an error when secret's type is not expected", func() {
 		secret := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
This fixes a panic happening when the following conditions are met:
* strict host key checks are disabled
* `known_hosts` entries are found
* no secret exists, neither referenced through a `GitRepo`'s nor a `gitcredential` secret

In that case, emptying a secret's `data` field does not make sense, and would indeed lead to a panic. This commit ensures that said field is only emptied if doing so is needed and safe.

Backport of #3539 to v0.11.
Follow-up to #3525.