### PR TITLE
Make charts release script more flexible

### DIFF
--- a/.github/scripts/release-against-charts.sh
+++ b/.github/scripts/release-against-charts.sh
@@ -19,7 +19,7 @@ if [ ! -e ~/.gitconfig ]; then
     git config --global user.email fleet@suse.de
 fi
 
-if [[ "$(git rev-parse --abbrev-ref HEAD)" =~ dev-v2\.1[0-9]+ ]]; then
+if [ -f packages/fleet/package.yaml ];  then
     # Use new auto bump scripting until the Github action CI works as expected
     # no parameters besides the target branch are needed in theory, but the pr
     # creation still needs the new Chart and Fleet version


### PR DESCRIPTION
by checking for the new package.yaml instead of a branch.

Successful run: https://github.com/rancher/fleet/actions/runs/14397526523/job/40375890228

Additional pr to roll back the auto-bump changes for dev-v2.10: https://github.com/rancher/charts/pull/5488