### PR TITLE
[v0.10] Bump Go toolchain version to 1.23.8

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/rancher/fleet
 
 go 1.23.0
 
-toolchain go1.23.6
+toolchain go1.23.8
 
 replace (
 	github.com/imdario/mergo => github.com/imdario/mergo v0.3.16

--- a/pkg/apis/go.mod
+++ b/pkg/apis/go.mod
@@ -2,7 +2,7 @@ module github.com/rancher/fleet/pkg/apis
 
 go 1.23.0
 
-toolchain go1.23.6
+toolchain go1.23.8
 
 require (
 	github.com/rancher/wrangler/v3 v3.0.0


### PR DESCRIPTION
https://artifacthub.io/packages/helm/fleet/fleet?modal=security-report