### PR TITLE
Improve benchmark report output

### DIFF
--- a/benchmarks/cmd/db.go
+++ b/benchmarks/cmd/db.go
@@ -60,7 +60,7 @@ func loadSampleFile(file string) (*parser.Sample, error) {
 	reports := []types.Report{}
 	err = json.Unmarshal(data, &reports)
 	if err != nil {
-		fmt.Printf("error: %s\n", data)
+		fmt.Printf("failed to unmarshal report: %q\n", data)
 		return nil, err
 	}
 	if len(reports) < 1 {

--- a/benchmarks/cmd/parser/parser.go
+++ b/benchmarks/cmd/parser/parser.go
@@ -59,7 +59,7 @@ func NewSetup(specReports types.SpecReports, result map[string]Measurement) (str
 			data := entry.Value.AsJSON
 			err := json.Unmarshal([]byte(data), &xp)
 			if err != nil {
-				fmt.Printf("error: %s\n", data)
+				fmt.Printf("failed to unmarshal setup: %s\n", data)
 				return "", err
 			}
 			// in report:
@@ -130,7 +130,7 @@ func NewExperiments(specReports types.SpecReports, result map[string]Experiment)
 			data := entry.Value.AsJSON
 			err := json.Unmarshal([]byte(data), &xp)
 			if err != nil {
-				fmt.Printf("error: %s\n", data)
+				fmt.Printf("failed to unmarshal experiment: %s\n", data)
 				return total, err
 			}
 			// raw := entry.GetRawValue()

--- a/benchmarks/cmd/root.go
+++ b/benchmarks/cmd/root.go
@@ -24,6 +24,7 @@ var (
 	input   string
 	db      string
 	verbose bool
+	debug   bool
 )
 
 func main() {
@@ -42,6 +43,7 @@ func init() {
 	rootCmd.AddCommand(reportCmd)
 	rootCmd.AddCommand(csvCmd)
 	rootCmd.PersistentFlags().StringVarP(&input, "input", "i", "report.json", "input file")
+	rootCmd.PersistentFlags().BoolVarP(&debug, "debug", "", false, "debug output")
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "verbose output")
 
 	reportCmd.PersistentFlags().StringVarP(&db, "db", "d", "db/", "path to json file database dir")
@@ -180,7 +182,7 @@ var reportCmd = &cobra.Command{
 
 		calculate(sample, dsPop, scores)
 
-		if verbose {
+		if debug {
 			fmt.Println("# Population from DB")
 			fmt.Println("```")
 			fmt.Println(prettyPrint(dsPop))
@@ -196,40 +198,54 @@ var reportCmd = &cobra.Command{
 		if sample.Description != "" {
 			fmt.Println("# Description of Setup")
 			fmt.Println()
+			fmt.Println("> This section contains information about the setup used for the current sample. Like the k8s version, the node resources and the images available to the node.")
 			fmt.Println(sample.Description)
-			fmt.Println()
-			fmt.Printf("Population size: %d\n", len(population.Samples))
+
+			fmt.Println("Population Size")
+			fmt.Println("===============")
+			fmt.Printf("Reports in %q: %d\n", db, len(population.Samples))
 			fmt.Println()
 		}
 
-		t1 := report.NewTable(sample.Setup)
-		t1.TableStyle.EnableTextStyling = false
-		fmt.Println(t1.Render())
-
-		fmt.Println("# Individual Measurements")
+		fmt.Println("# Results for Current Sample")
+		fmt.Println()
+		fmt.Println("> These measurements were taken before and after the experiments.")
 		fmt.Println()
 
-		mRows := map[string]map[string]MeasurementRow{}
-		for experiment, xp := range sample.Experiments {
-			mRows[experiment] = map[string]MeasurementRow{}
-			for measurement, m := range xp.Measurements {
-				row := MeasurementRow{
-					Experiment:  experiment,
-					Measurement: measurement,
-					Value:       m.String(),
-					Mean:        dsPop[experiment][measurement].Mean,
-					StdDev:      dsPop[experiment][measurement].StdDev,
-					ZScore:      dsPop[experiment][measurement].ZScore,
+		t := report.NewTable(sample.Setup)
+		t.TableStyle.EnableTextStyling = false
+		fmt.Println(t.Render())
+
+		if verbose {
+			fmt.Println("# Compare Individual Measurements to Population")
+			fmt.Println()
+			fmt.Println("> For each experiment, the measurements for the current sample are compared to the population's data.")
+			fmt.Println()
+
+			rows := map[string]map[string]MeasurementRow{}
+			for experiment, xp := range sample.Experiments {
+				rows[experiment] = map[string]MeasurementRow{}
+				for measurement, m := range xp.Measurements {
+					row := MeasurementRow{
+						Experiment:  experiment,
+						Measurement: measurement,
+						Value:       m.String(),
+						Mean:        dsPop[experiment][measurement].Mean,
+						StdDev:      dsPop[experiment][measurement].StdDev,
+						ZScore:      dsPop[experiment][measurement].ZScore,
+					}
+					rows[experiment][measurement] = row
 				}
-				mRows[experiment][measurement] = row
 			}
+
+			t := newMeasurementTable(rows)
+			fmt.Println(t.Render())
 		}
 
-		mTable := newMeasurementTable(mRows)
-		fmt.Println(mTable.Render())
-
 		// table for experiments
-		fmt.Println("# Experiment Summary")
+		fmt.Println("# Summary for each Experiment")
+		fmt.Println()
+		fmt.Println("> The duration of each experiment is compared to the population's data.")
 		fmt.Println()
 
 		rows := map[string]Row{}
@@ -244,12 +260,12 @@ var reportCmd = &cobra.Command{
 			rows[experiment] = row
 		}
 
-		xpTable := newTable(rows)
-		fmt.Println(xpTable.Render())
+		t = newTable(rows)
+		fmt.Println(t.Render())
 
-		// Final score
-		fmt.Println("# Total Score")
-		fmt.Printf("%s, %.02f\n", input, scores.AvgZScores())
+		fmt.Println("# Final Score")
+		fmt.Println()
+		fmt.Printf("%s: %.02f\n", input, scores.AvgZScores())
 
 		return nil
 	},
@@ -288,7 +304,6 @@ func newTable(rows map[string]Row) *table.Table {
 		table.C("ZScore"),
 		table.C(""),
 		table.Divider("="),
-		//"{{bold}}",
 	))
 
 	keys := slices.Sorted(maps.Keys(rows))
@@ -326,7 +341,6 @@ func newMeasurementTable(rows map[string]map[string]MeasurementRow) *table.Table
 		table.C("Population StdDev"),
 		table.C("ZScore"),
 		table.Divider("="),
-		//"{{bold}}",
 	))
 
 	keys := slices.Sorted(maps.Keys(rows))

--- a/benchmarks/record/record.go
+++ b/benchmarks/record/record.go
@@ -197,7 +197,7 @@ func Nodes(ctx context.Context, experiment *gm.Experiment) {
 }
 
 func Header(s string) string {
-	h := fmt.Sprintf("{{bold}}%s{{/}}\n", s)
+	h := fmt.Sprintf("%s\n", s)
 	h += strings.Repeat("=", len(s)) + "\n"
 	return h
 }


### PR DESCRIPTION
Improve the output by adding descriptions. 
Hide the detailed view behind the `--verbose` flag, move dump output to `--debug`.

Example Output: 

```
# Description of Setup

> This section contains information about the setup used for the current sample. Like the k8s version, the node resources and the images available to the node.

Node Resources
==============
CPU, Memory, Pods
2, 5033432Ki, 110

Images
======
docker.io/rancher/fleet-agent:dev, docker.io/rancher/fleet:dev, docker.io/rancher/klipper-helm:v0.9.3-build20241008, docker.io/rancher/klipper-lb:v0.4.9, docker.io/rancher/local-path-provisioner:v0.0.30, docker.io/rancher/mirrored-coredns-coredns:1.12.0, docker.io/rancher/mirrored-library-traefik:2.11.18, docker.io/rancher/mirrored-metrics-server:v0.7.2, docker.io/rancher/mirrored-pause:3.6

Kubernetes Version
==================
Client Version: v1.32.2
Kustomize Version: v5.5.0
Server Version: v1.31.5+k3s1


Population Size
===============
Reports in "benchmarks/db": 3

# Results for Current Sample

> These measurements were taken before and after the experiments.

Measurement            | Value     | Unit
===============================================
CPU                    | 132.5     | seconds
-----------------------------------------------
CRDCount               | 35        | CRDs
-----------------------------------------------
ClusterCount           | 1         | clusters
-----------------------------------------------
GCDuration             | 0.6       | seconds
-----------------------------------------------
Mem                    | -3        | MB
-----------------------------------------------
NetworkRX              | 239743271 | bytes
-----------------------------------------------
NetworkTX              | 100644938 | bytes
-----------------------------------------------
NodeCount              | 1         | nodes
-----------------------------------------------
RESTClientDELETE200    | 117       | requests
-----------------------------------------------
RESTClientDELETE404    | 2         | requests
-----------------------------------------------
RESTClientGET200       | 245       | requests
-----------------------------------------------
RESTClientGET404       | 1         | requests
-----------------------------------------------
RESTClientGET429       | 1         | requests
-----------------------------------------------
RESTClientPATCH200     | 3338      | requests
-----------------------------------------------
RESTClientPOST201      | 84        | requests
-----------------------------------------------
RESTClientPOST409      | 36        | requests
-----------------------------------------------
RESTClientPUT200       | 10872     | requests
-----------------------------------------------
RESTClientPUT409       | 18        | requests
-----------------------------------------------
ReconcileErrors        | 2048      | reconciles
-----------------------------------------------
ReconcileRequeue       | 11549     | reconciles
-----------------------------------------------
ReconcileSuccess       | 11018     | reconciles
-----------------------------------------------
ReconcileTime          | 14907.8   | seconds
-----------------------------------------------
ResourceCount          | -175      | resources
-----------------------------------------------
SumCPU                 | 2         | cores
-----------------------------------------------
SumMem                 | 4915      | MB
-----------------------------------------------
SumPods                | 110       | pods
-----------------------------------------------
TotalDuration          | 200.007   |
-----------------------------------------------
WorkqueueAdds          | 24615     | items
-----------------------------------------------
WorkqueueQueueDuration | 11339.7   | seconds
-----------------------------------------------
WorkqueueRetries       | 13597     | items
-----------------------------------------------
WorkqueueWorkDuration  | 14908.5   | seconds

# Summary for each Experiment

> The duration of each experiment is compared to the population's data.


Experiment                               | Duration | Population Mean       | Population StdDev       | ZScore |
                                         |          | Duration              | Duration                |        |
=======================================================================================================================
create-1-bundle                          | 1.10s    | 1.09s                 | 0.01s                   | 1.06   | worse
-----------------------------------------------------------------------------------------------------------------------
create-1-bundledeployment-10-resources   | 14.60s   | 11.36s                | 7.39s                   | 0.44   | worse
-----------------------------------------------------------------------------------------------------------------------
create-1-gitrepo-1-big-bundle            | 5.13s    | 5.12s                 | 0.01s                   | 0.50   | worse
-----------------------------------------------------------------------------------------------------------------------
create-1-gitrepo-1-bundle                | 4.12s    | 4.44s                 | 0.58s                   | -0.56  | better
-----------------------------------------------------------------------------------------------------------------------
create-1-gitrepo-50-bundle               | 7.30s    | 6.90s                 | 0.58s                   | 0.68   | worse
-----------------------------------------------------------------------------------------------------------------------
create-50-bundle                         | 6.12s    | 6.25s                 | 0.24s                   | -0.53  | better
-----------------------------------------------------------------------------------------------------------------------
create-50-bundledeployment-500-resources | 128.03s  | 89.62s                | 17.00s                  | 2.26   | worse
-----------------------------------------------------------------------------------------------------------------------
create-50-gitrepo-50-bundle              | 33.62s   | 34.16s                | 2.27s                   | -0.24  | better

# Final Score

b-2025-04-11_14:25:18.json: -0.62
```