### PR TITLE
Remove duplicated Helm unit tests step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,11 +42,6 @@ jobs:
         name: unit-test
         run: go test -shuffle=on $(go list ./... | grep -v -e /e2e -e /integrationtests -e /benchmarks)
       -
-        name: helm-unittest
-        run: |
-          helm plugin install https://github.com/helm-unittest/helm-unittest.git
-          helm unittest charts/fleet
-      -
         name: Install Ginkgo CLI
         run: go install github.com/onsi/ginkgo/v2/ginkgo
       -


### PR DESCRIPTION
Apart from being unnecessary, it would [fail](https://github.com/rancher/fleet/actions/runs/14443816068/job/40499715676?pr=3551) when trying to install an already installed Helm plugin.