### PR TITLE
fleet cli json output

### DIFF
--- a/cmd/fleetcli/main.go
+++ b/cmd/fleetcli/main.go
@@ -6,18 +6,17 @@ import (
 	"strings"
 
 	// Ensure GVKs are registered
-
 	_ "github.com/rancher/fleet/pkg/generated/controllers/fleet.cattle.io"
 	_ "github.com/rancher/wrangler/v3/pkg/generated/controllers/apiextensions.k8s.io"
 	_ "github.com/rancher/wrangler/v3/pkg/generated/controllers/apps"
 	_ "github.com/rancher/wrangler/v3/pkg/generated/controllers/core"
 	_ "github.com/rancher/wrangler/v3/pkg/generated/controllers/rbac"
-	"github.com/sirupsen/logrus"
 
 	// Add non-default auth providers
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
 	"github.com/rancher/wrangler/v3/pkg/signals"
+	"github.com/sirupsen/logrus"
 
 	cmds "github.com/rancher/fleet/internal/cmd/cli"
 )

--- a/cmd/fleetcli/main.go
+++ b/cmd/fleetcli/main.go
@@ -2,18 +2,22 @@
 package main
 
 import (
+	"os"
+	"strings"
+
 	// Ensure GVKs are registered
+
 	_ "github.com/rancher/fleet/pkg/generated/controllers/fleet.cattle.io"
 	_ "github.com/rancher/wrangler/v3/pkg/generated/controllers/apiextensions.k8s.io"
 	_ "github.com/rancher/wrangler/v3/pkg/generated/controllers/apps"
 	_ "github.com/rancher/wrangler/v3/pkg/generated/controllers/core"
 	_ "github.com/rancher/wrangler/v3/pkg/generated/controllers/rbac"
+	"github.com/sirupsen/logrus"
 
 	// Add non-default auth providers
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
 	"github.com/rancher/wrangler/v3/pkg/signals"
-	"github.com/sirupsen/logrus"
 
 	cmds "github.com/rancher/fleet/internal/cmd/cli"
 )
@@ -22,7 +26,16 @@ func main() {
 	ctx := signals.SetupSignalContext()
 	cmd := cmds.App()
 	if err := cmd.ExecuteContext(ctx); err != nil {
-		logrus.Fatal(err)
+		if strings.ToLower(os.Getenv(cmds.JSONOutputEnvVar)) == "true" {
+			log := logrus.New()
+			log.SetFormatter(&logrus.JSONFormatter{})
+			// use a fleet specific field name so we are sure logs from other libraries
+			// are not considered.
+			log.WithFields(logrus.Fields{
+				"fleetErrorMessage": err.Error(),
+			}).Fatal("Fleet cli failed")
+		} else {
+			logrus.Fatal(err)
+		}
 	}
-
 }

--- a/internal/cmd/cli/root.go
+++ b/internal/cmd/cli/root.go
@@ -19,6 +19,8 @@ var (
 	Client Getter
 )
 
+const JSONOutputEnvVar = "FLEET_JSON_OUTPUT"
+
 func App() *cobra.Command {
 	root := command.Command(&Fleet{}, cobra.Command{
 		Version:       version.FriendlyVersion(),

--- a/internal/cmd/controller/gitops/reconciler/gitjob.go
+++ b/internal/cmd/controller/gitops/reconciler/gitjob.go
@@ -552,7 +552,13 @@ func (r *GitJobReconciler) newGitCloner(
 		args = append(args, "--ca-bundle-file", "/gitjob/cabundle/"+bundleCAFile)
 	}
 
-	env := proxyEnvVars()
+	env := []corev1.EnvVar{
+		{
+			Name:  fleetcli.JSONOutputEnvVar,
+			Value: "true",
+		},
+	}
+	env = append(env, proxyEnvVars()...)
 
 	// If strict host key checks are enabled but no entries are available, another error will be shown by the known
 	// hosts getter, as that means that the Fleet deployment is incomplete.
@@ -638,6 +644,10 @@ func argsAndEnvs(
 		{
 			Name:  "HOME",
 			Value: fleetHomeDir,
+		},
+		{
+			Name:  fleetcli.JSONOutputEnvVar,
+			Value: "true",
 		},
 		{
 			Name:  fleetcli.FleetApplyConflictRetriesEnv,

--- a/internal/cmd/controller/gitops/reconciler/gitjob_test.go
+++ b/internal/cmd/controller/gitops/reconciler/gitjob_test.go
@@ -12,14 +12,14 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-	"go.uber.org/mock/gomock"
-
+	fleetcli "github.com/rancher/fleet/internal/cmd/cli"
 	"github.com/rancher/fleet/internal/cmd/controller/finalize"
 	"github.com/rancher/fleet/internal/config"
 	"github.com/rancher/fleet/internal/mocks"
 	"github.com/rancher/fleet/internal/ssh"
 	fleetv1 "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
 	"github.com/rancher/wrangler/v3/pkg/genericcondition"
+	"go.uber.org/mock/gomock"
 
 	fleetevent "github.com/rancher/fleet/pkg/event"
 	gitmocks "github.com/rancher/fleet/pkg/git/mocks"
@@ -741,6 +741,12 @@ func TestNewJob(t *testing.T) { // nolint:funlen
 						},
 					},
 					SecurityContext: securityContext,
+					Env: []corev1.EnvVar{
+						{
+							Name:  fleetcli.JSONOutputEnvVar,
+							Value: "true",
+						},
+					},
 				},
 			},
 			expectedVolumes: []corev1.Volume{
@@ -808,6 +814,12 @@ func TestNewJob(t *testing.T) { // nolint:funlen
 						},
 					},
 					SecurityContext: securityContext,
+					Env: []corev1.EnvVar{
+						{
+							Name:  fleetcli.JSONOutputEnvVar,
+							Value: "true",
+						},
+					},
 				},
 			},
 			expectedVolumes: []corev1.Volume{
@@ -875,6 +887,12 @@ func TestNewJob(t *testing.T) { // nolint:funlen
 						},
 					},
 					SecurityContext: securityContext,
+					Env: []corev1.EnvVar{
+						{
+							Name:  fleetcli.JSONOutputEnvVar,
+							Value: "true",
+						},
+					},
 				},
 			},
 			expectedVolumes: []corev1.Volume{
@@ -950,6 +968,12 @@ func TestNewJob(t *testing.T) { // nolint:funlen
 						},
 					},
 					SecurityContext: securityContext,
+					Env: []corev1.EnvVar{
+						{
+							Name:  fleetcli.JSONOutputEnvVar,
+							Value: "true",
+						},
+					},
 				},
 			},
 			expectedVolumes: []corev1.Volume{
@@ -1043,6 +1067,12 @@ func TestNewJob(t *testing.T) { // nolint:funlen
 						},
 					},
 					SecurityContext: securityContext,
+					Env: []corev1.EnvVar{
+						{
+							Name:  fleetcli.JSONOutputEnvVar,
+							Value: "true",
+						},
+					},
 				},
 			},
 			expectedVolumes: []corev1.Volume{
@@ -1105,6 +1135,10 @@ func TestNewJob(t *testing.T) { // nolint:funlen
 						"/gitjob/ssh/" + corev1.SSHAuthPrivateKey,
 					},
 					Env: []corev1.EnvVar{
+						{
+							Name:  fleetcli.JSONOutputEnvVar,
+							Value: "true",
+						},
 						{
 							Name:  "FLEET_KNOWN_HOSTS",
 							Value: "some known hosts",
@@ -1193,6 +1227,10 @@ func TestNewJob(t *testing.T) { // nolint:funlen
 						"/gitjob/ssh/" + corev1.SSHAuthPrivateKey,
 					},
 					Env: []corev1.EnvVar{
+						{
+							Name:  fleetcli.JSONOutputEnvVar,
+							Value: "true",
+						},
 						{
 							Name:  "FLEET_KNOWN_HOSTS",
 							Value: "foo",
@@ -1287,6 +1325,10 @@ func TestNewJob(t *testing.T) { // nolint:funlen
 					},
 					Env: []corev1.EnvVar{
 						{
+							Name:  fleetcli.JSONOutputEnvVar,
+							Value: "true",
+						},
+						{
 							Name:  "FLEET_KNOWN_HOSTS",
 							Value: "foo",
 						},
@@ -1375,6 +1417,12 @@ func TestNewJob(t *testing.T) { // nolint:funlen
 						},
 					},
 					SecurityContext: securityContext,
+					Env: []corev1.EnvVar{
+						{
+							Name:  fleetcli.JSONOutputEnvVar,
+							Value: "true",
+						},
+					},
 				},
 			},
 			expectedVolumes: []corev1.Volume{
@@ -1465,6 +1513,12 @@ func TestNewJob(t *testing.T) { // nolint:funlen
 						},
 					},
 					SecurityContext: securityContext,
+					Env: []corev1.EnvVar{
+						{
+							Name:  fleetcli.JSONOutputEnvVar,
+							Value: "true",
+						},
+					},
 				},
 			},
 			expectedVolumes: []corev1.Volume{
@@ -1588,6 +1642,12 @@ func TestNewJob(t *testing.T) { // nolint:funlen
 						},
 					},
 					SecurityContext: securityContext,
+					Env: []corev1.EnvVar{
+						{
+							Name:  fleetcli.JSONOutputEnvVar,
+							Value: "true",
+						},
+					},
 				},
 			},
 			expectedVolumes: []corev1.Volume{
@@ -1652,6 +1712,12 @@ func TestNewJob(t *testing.T) { // nolint:funlen
 						},
 					},
 					SecurityContext: securityContext,
+					Env: []corev1.EnvVar{
+						{
+							Name:  fleetcli.JSONOutputEnvVar,
+							Value: "true",
+						},
+					},
 				},
 			},
 			expectedVolumes: []corev1.Volume{
@@ -1836,6 +1902,10 @@ func TestGenerateJob_EnvVars(t *testing.T) {
 					Value: "/fleet-home",
 				},
 				{
+					Name:  fleetcli.JSONOutputEnvVar,
+					Value: "true",
+				},
+				{
 					Name:  "FLEET_APPLY_CONFLICT_RETRIES",
 					Value: "1",
 				},
@@ -1860,6 +1930,12 @@ func TestGenerateJob_EnvVars(t *testing.T) {
 					Value: "commit",
 				},
 			},
+			expectedInitContainerEnvVars: []corev1.EnvVar{
+				{
+					Name:  fleetcli.JSONOutputEnvVar,
+					Value: "true",
+				},
+			},
 		},
 		"Helm secret name with strict host key checks": {
 			gitrepo: &fleetv1.GitRepo{
@@ -1873,6 +1949,10 @@ func TestGenerateJob_EnvVars(t *testing.T) {
 			strictSSHHostKeyChecks: true,
 			expectedInitContainerEnvVars: []corev1.EnvVar{
 				{
+					Name:  fleetcli.JSONOutputEnvVar,
+					Value: "true",
+				},
+				{
 					Name: "FLEET_KNOWN_HOSTS",
 				},
 			},
@@ -1880,6 +1960,10 @@ func TestGenerateJob_EnvVars(t *testing.T) {
 				{
 					Name:  "HOME",
 					Value: "/fleet-home",
+				},
+				{
+					Name:  fleetcli.JSONOutputEnvVar,
+					Value: "true",
 				},
 				{
 					Name:  "FLEET_APPLY_CONFLICT_RETRIES",
@@ -1922,6 +2006,10 @@ func TestGenerateJob_EnvVars(t *testing.T) {
 					Value: "/fleet-home",
 				},
 				{
+					Name:  fleetcli.JSONOutputEnvVar,
+					Value: "true",
+				},
+				{
 					Name:  "FLEET_APPLY_CONFLICT_RETRIES",
 					Value: "1",
 				},
@@ -1932,6 +2020,12 @@ func TestGenerateJob_EnvVars(t *testing.T) {
 				{
 					Name:  "COMMIT",
 					Value: "commit",
+				},
+			},
+			expectedInitContainerEnvVars: []corev1.EnvVar{
+				{
+					Name:  fleetcli.JSONOutputEnvVar,
+					Value: "true",
 				},
 			},
 		},
@@ -1947,6 +2041,10 @@ func TestGenerateJob_EnvVars(t *testing.T) {
 			strictSSHHostKeyChecks: true,
 			expectedInitContainerEnvVars: []corev1.EnvVar{
 				{
+					Name:  fleetcli.JSONOutputEnvVar,
+					Value: "true",
+				},
+				{
 					Name: "FLEET_KNOWN_HOSTS",
 				},
 			},
@@ -1954,6 +2052,10 @@ func TestGenerateJob_EnvVars(t *testing.T) {
 				{
 					Name:  "HOME",
 					Value: "/fleet-home",
+				},
+				{
+					Name:  fleetcli.JSONOutputEnvVar,
+					Value: "true",
 				},
 				{
 					Name:  "FLEET_APPLY_CONFLICT_RETRIES",
@@ -1982,6 +2084,10 @@ func TestGenerateJob_EnvVars(t *testing.T) {
 					Value: "/fleet-home",
 				},
 				{
+					Name:  fleetcli.JSONOutputEnvVar,
+					Value: "true",
+				},
+				{
 					Name:  "FLEET_APPLY_CONFLICT_RETRIES",
 					Value: "1",
 				},
@@ -1999,6 +2105,10 @@ func TestGenerateJob_EnvVars(t *testing.T) {
 				},
 			},
 			expectedInitContainerEnvVars: []corev1.EnvVar{
+				{
+					Name:  fleetcli.JSONOutputEnvVar,
+					Value: "true",
+				},
 				{
 					Name:  "HTTP_PROXY",
 					Value: "httpProxy",
@@ -2023,6 +2133,10 @@ func TestGenerateJob_EnvVars(t *testing.T) {
 					Value: "/fleet-home",
 				},
 				{
+					Name:  fleetcli.JSONOutputEnvVar,
+					Value: "true",
+				},
+				{
 					Name:  "FLEET_APPLY_CONFLICT_RETRIES",
 					Value: "3",
 				},
@@ -2032,6 +2146,12 @@ func TestGenerateJob_EnvVars(t *testing.T) {
 				},
 			},
 			osEnv: map[string]string{"FLEET_APPLY_CONFLICT_RETRIES": "3"},
+			expectedInitContainerEnvVars: []corev1.EnvVar{
+				{
+					Name:  fleetcli.JSONOutputEnvVar,
+					Value: "true",
+				},
+			},
 		},
 		"retries_not_valid": {
 			gitrepo: &fleetv1.GitRepo{
@@ -2046,6 +2166,10 @@ func TestGenerateJob_EnvVars(t *testing.T) {
 					Value: "/fleet-home",
 				},
 				{
+					Name:  fleetcli.JSONOutputEnvVar,
+					Value: "true",
+				},
+				{
 					Name:  "FLEET_APPLY_CONFLICT_RETRIES",
 					Value: "1",
 				},
@@ -2055,6 +2179,12 @@ func TestGenerateJob_EnvVars(t *testing.T) {
 				},
 			},
 			osEnv: map[string]string{"FLEET_APPLY_CONFLICT_RETRIES": "this_is_not_an_int"},
+			expectedInitContainerEnvVars: []corev1.EnvVar{
+				{
+					Name:  fleetcli.JSONOutputEnvVar,
+					Value: "true",
+				},
+			},
 		},
 	}
 
@@ -2439,6 +2569,86 @@ func TestDrivenScanSeparator(t *testing.T) {
 				if err.Error() != expectedErrorMessage {
 					t.Errorf("expecting error %q, got %q", expectedErrorMessage, err.Error())
 				}
+			}
+		})
+	}
+}
+
+func TestFilterFleetApplyJobOutput(t *testing.T) {
+	tests := map[string]struct {
+		input          string
+		expectedOutput string
+	}{
+		"Filter a few lines and return a couple from Fleet": {
+			input: `this line should be ignored
+		this line should be ignored, too
+		{"level":"fatal","msg":"This line is not from fleet cli","time":"2025-04-15T14:53:15+02:00"}
+		{"fleetErrorMessage":"fleet line 1","level":"fatal","msg":"Fleet cli failed","time":"2025-04-15T14:53:15+02:00"}
+		ignore this line as well
+		{"fleetErrorMessage":"fleet line 2","level":"fatal","msg":"Fleet cli failed","time":"2025-04-15T14:53:15+02:00"}`,
+			expectedOutput: "fleet line 1\nfleet line 2",
+		},
+		"There are no lines from fleet apply": {
+			input: `this line should be ignored
+		this line should be ignored, too
+		{"level":"fatal","msg":"This line is not from fleet cli","time":"2025-04-15T14:53:15+02:00"}
+		ignore this line as well`,
+			expectedOutput: "Unknown error",
+		},
+		"The output is from fleet apply, but it's not in json format": {
+			input:          "FATA[0000] no resource found at the following paths to deploy: [tt]",
+			expectedOutput: "Unknown error",
+		},
+		"Valid message with some extra text before and after": {
+			input: `this line should be ignored
+		this line should be ignored, too
+		This line is OK{"fleetErrorMessage":"fleet line error 1","level":"fatal","msg":"Fleet cli failed","time":"2025-04-15T14:53:15+02:00"}This part should be ignored
+		ignore this line as well`,
+			expectedOutput: "fleet line error 1",
+		},
+		"Valid message with some extra text before": {
+			input: `this line should be ignored
+		this line should be ignored, too
+		This line is OK{"fleetErrorMessage":"fleet line error 1","level":"fatal","msg":"Fleet cli failed","time":"2025-04-15T14:53:15+02:00"}
+		ignore this line as well`,
+			expectedOutput: "fleet line error 1",
+		},
+		"Valid message with some extra text after": {
+			input: `this line should be ignored
+		this line should be ignored, too
+		This line is OK{"fleetErrorMessage":"fleet line error 1","level":"fatal","msg":"Fleet cli failed","time":"2025-04-15T14:53:15+02:00"}
+		ignore this line as well`,
+			expectedOutput: "fleet line error 1",
+		},
+		"Not valid json message": {
+			input: `this line should be ignored
+		this line should be ignored, too
+		This lin}e is OK "{fleetErrorMessage":"fleet line error 1","level":"fatal","msg":"Fleet cli failed","time":"2025-04-15T14:53:15+02:00"}
+		ignore this line as well`,
+			expectedOutput: "Unknown error",
+		},
+		"More than one error in the same line": {
+			input: `this line should be ignored
+this line should be ignored, too
+T}his{ lin}e is OK "{"fleetErrorMessage":"fleet line error 1","level":"fatal","msg":"Fleet cli failed","time":"2025-04-15T14:53:15+02:00"}more garbage{"fleetErrorMessage":"fleet line error 2","level":"fatal","msg":"Fleet cli failed","time":"2025-04-15T14:53:15+02:00"}some more noise
+ignore this line as well`,
+			expectedOutput: "fleet line error 1\nfleet line error 2",
+		},
+		"Empty input": {
+			input:          "",
+			expectedOutput: "Unknown error",
+		},
+
+		"The fleetErrorMessage field is empty": {
+			input:          `{"fleetErrorMessage":"","level":"fatal","msg":"Fleet cli failed","time":"2025-04-15T14:53:15+02:00"}`,
+			expectedOutput: "Unknown error",
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			filteredMsg := filterFleetCLIJobOutput(test.input)
+			if filteredMsg != test.expectedOutput {
+				t.Errorf("expecting output %q, got %q", test.expectedOutput, filteredMsg)
 			}
 		})
 	}


### PR DESCRIPTION
Uses a JSONFormatter in fleet cli.
It also filters out the output received from fleet cli so the error set in the conditions is only the one sent by the fleet cli code and not from any used libraries.

In order to use the json formatter we need to set the `FLEET_JSON_OUTPUT` env var to `true`. This way the command line user won't get the json output unless it's explicitly specified.

Difference in the UI

Before the change:
![Screenshot 2025-04-15 at 16 10 54](https://github.com/user-attachments/assets/ae3512f2-8a30-4716-8772-0029b1390177)

After the change:
![Screenshot 2025-04-15 at 15 37 49](https://github.com/user-attachments/assets/9e1b9d17-72e3-4c87-9abc-c62ff30f9ec1)

 
Refers to: https://github.com/rancher/fleet/issues/3234
