### PR TITLE
[v0.11] - Avoids returning nil map when options.Helm is used

### DIFF
--- a/internal/helmdeployer/install.go
+++ b/internal/helmdeployer/install.go
@@ -212,6 +212,10 @@ func (h *Helm) getValues(ctx context.Context, options fleet.BundleDeploymentOpti
 		values = options.Helm.Values.Data
 	}
 
+	// avoid the possibility of returning a nil map
+	if values == nil {
+		values = map[string]interface{}{}
+	}
 	// do not run this when using template
 	if !h.template {
 		for _, valuesFrom := range options.Helm.ValuesFrom {


### PR DESCRIPTION
Backport of: https://github.com/rancher/fleet/pull/3567
Refers to: https://github.com/rancher/fleet/issues/3569
