### PR TITLE
Prevent GitRepo creation with empty repo URL

### DIFF
--- a/charts/fleet-crd/templates/crds.yaml
+++ b/charts/fleet-crd/templates/crds.yaml
@@ -6498,7 +6498,7 @@ spec:
                   type: string
                 repo:
                   description: Repo is a URL to a git repo to clone and index.
-                  nullable: true
+                  minLength: 1
                   type: string
                 revision:
                   description: Revision A specific commit or tag to operate on.
@@ -6660,6 +6660,8 @@ spec:
                   description: WebhookSecret contains the name of the secret to use
                     for webhook parsing
                   type: string
+              required:
+                - repo
               type: object
             status:
               properties:

--- a/pkg/apis/fleet.cattle.io/v1alpha1/gitrepo_types.go
+++ b/pkg/apis/fleet.cattle.io/v1alpha1/gitrepo_types.go
@@ -51,7 +51,8 @@ type GitRepoList struct {
 
 type GitRepoSpec struct {
 	// Repo is a URL to a git repo to clone and index.
-	// +nullable
+	// +required
+	// +kubebuilder:validation:MinLength=1
 	Repo string `json:"repo,omitempty"`
 
 	// Branch The git branch to follow.


### PR DESCRIPTION
This adds validation on the `repo` field of `GitRepo` resources to check that:
* that field is provided
* its length is at least 1 character. Even if a one-char URL is provided, it will be validated by the gitOps controller which will then output an error, made visible on the `GitRepo` status, if applicable.

Refers to #3392

Written in collaboration with @khushalchandak17.

## Additional Information

### Checklist

- [ ] <!-- If applicable,--> I have updated the documentation via a pull request in the
[fleet-docs](https://github.com/rancher/fleet-docs) repository.
