### PR TITLE
Wait for `rancher-webhook` deployment to exist

### DIFF
--- a/.github/workflows/e2e-test-fleet-in-rancher.yml
+++ b/.github/workflows/e2e-test-fleet-in-rancher.yml
@@ -183,6 +183,7 @@ jobs:
           until kubectl get bundles -n fleet-local | grep -q "fleet-agent-local.*1/1"; do sleep 3; done
 
           # wait for deployment of webhook, needed by tests
+          until kubectl get deployments -n cattle-system | grep -q "rancher-webhook"; do sleep 3; done
           kubectl -n cattle-system rollout status deploy/rancher-webhook
 
           helm list -A


### PR DESCRIPTION
This updates the CI workflow testing Fleet in Rancher, which would previously not check that the `rancher-webhook` deployment actually existed before checking its status. Adding that existence check prevents unwanted failures, such as [this one](https://github.com/rancher/fleet/actions/runs/14549416066/job/40818887299).
