### PR TITLE
Replace gopkg.in/yaml with sigs.k8s.io/yaml

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -51,7 +51,6 @@ require (
 	golang.org/x/sync v0.13.0
 	gonum.org/v1/gonum v0.16.0
 	gopkg.in/go-playground/webhooks.v5 v5.17.0
-	gopkg.in/yaml.v2 v2.4.0
 	gotest.tools v2.2.0+incompatible
 	helm.sh/helm/v3 v3.17.2
 	k8s.io/api v0.32.2
@@ -243,6 +242,7 @@ require (
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiserver v0.32.2 // indirect
 	k8s.io/code-generator v0.32.2 // indirect

--- a/integrationtests/controller/bundle/bundle_targets_test.go
+++ b/integrationtests/controller/bundle/bundle_targets_test.go
@@ -5,7 +5,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"gopkg.in/yaml.v2"
+	"sigs.k8s.io/yaml"
 
 	"github.com/rancher/fleet/integrationtests/utils"
 	"github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"

--- a/internal/cmd/agent/deployer/internal/resource/ignore.go
+++ b/internal/cmd/agent/deployer/internal/resource/ignore.go
@@ -4,7 +4,7 @@ package resource
 import (
 	"encoding/json"
 
-	"gopkg.in/yaml.v2"
+	"sigs.k8s.io/yaml"
 )
 
 // ResourceIgnoreDifferences contains resource filter and list of json paths which should be ignored during comparison with live state.


### PR DESCRIPTION
[gopkg.in](http://gopkg.in/) is a URL rewriter. 
`gopkg.in/yaml` is actually [`go-yaml/yaml`](https://github.com/go-yaml/yaml). Both are archived by the author and no longer maintained.

```
% curl -SsLfi 'gopkg.in/yaml.v3?go-get=1' | grep go-
<meta name="go-import" content="gopkg.in/yaml.v3 git https://gopkg.in/yaml.v3">
<meta name="go-source" content="gopkg.in/yaml.v3 _ https://github.com/go-yaml/yaml/tree/v3.0.1{/dir} https://github.com/go-yaml/yaml/blob/v3.0.1{/dir}/{file}#L{line}">
```

We switch to `sigs.k8s.io/yaml`, which we use in other places already:

> kubernetes-sigs/yaml is a permanent fork of [ghodss/yaml](https://github.com/ghodss/yaml).


