### PR TITLE
Calls semaphore Acquire inside go routine

### DIFF
--- a/internal/bundlereader/resources.go
+++ b/internal/bundlereader/resources.go
@@ -258,12 +258,22 @@ func loadDirectories(ctx context.Context, opts loadOpts, directories ...director
 
 	eg, ctx := errgroup.WithContext(ctx)
 
+	alreadyLoaded := make(map[string]directory)
 	for _, dir := range directories {
-		if err := sem.Acquire(ctx, 1); err != nil {
-			return nil, err
+		// Avoid loading the same directory more than once
+		// We don't take auth into account because having the same source
+		// with different authentication means having the same resources anyway.
+		// Using a comma separator to avoid false equivalents due to combinations with empty strings.
+		dirId := fmt.Sprintf("%s,%s,%s,%s", dir.prefix, dir.base, dir.source, dir.version)
+		if _, ok := alreadyLoaded[dirId]; ok {
+			continue
 		}
+		alreadyLoaded[dirId] = dir
 		dir := dir
 		eg.Go(func() error {
+			if err := sem.Acquire(ctx, 1); err != nil {
+				return fmt.Errorf("waiting to load directory %s, %s: %w", dir.prefix, dir.base, err)
+			}
 			defer sem.Release(1)
 			resources, err := loadDirectory(ctx, opts, dir)
 			if err != nil {

--- a/internal/bundlereader/resources.go
+++ b/internal/bundlereader/resources.go
@@ -258,7 +258,7 @@ func loadDirectories(ctx context.Context, opts loadOpts, directories ...director
 
 	eg, ctx := errgroup.WithContext(ctx)
 
-	alreadyLoaded := make(map[string]directory)
+	alreadyLoaded := make(map[string]struct{})
 	for _, dir := range directories {
 		// Avoid loading the same directory more than once
 		// We don't take auth into account because having the same source
@@ -268,7 +268,7 @@ func loadDirectories(ctx context.Context, opts loadOpts, directories ...director
 		if _, ok := alreadyLoaded[dirId]; ok {
 			continue
 		}
-		alreadyLoaded[dirId] = dir
+		alreadyLoaded[dirId] = struct{}{}
 		dir := dir
 		eg.Go(func() error {
 			if err := sem.Acquire(ctx, 1); err != nil {

--- a/internal/bundlereader/resources.go
+++ b/internal/bundlereader/resources.go
@@ -264,7 +264,7 @@ func loadDirectories(ctx context.Context, opts loadOpts, directories ...director
 		// We don't take auth into account because having the same source
 		// with different authentication means having the same resources anyway.
 		// Using a comma separator to avoid false equivalents due to combinations with empty strings.
-		dirId := fmt.Sprintf("%s,%s,%s,%s", dir.prefix, dir.base, dir.source, dir.version)
+		dirId := fmt.Sprintf("%q,%q,%q,%q", dir.prefix, dir.base, dir.source, dir.version)
 		if _, ok := alreadyLoaded[dirId]; ok {
 			continue
 		}


### PR DESCRIPTION
Calls semaphone Acquire inside the go route instead to before the go routine.

Placing the Acquire call before the creation of the goroutine means that if any previously launched goroutine fails, it will cancel the shared context used by Acquire.

As a result, since Acquire is called outside the goroutine, it may return an error due to the canceled context—causing us to propagate a generic "context canceled" error instead of the original error that caused the goroutine to fail.

For example, suppose we're trying to download 10 charts, using a semaphore with a limit of 4. If the first call to `downloadDirectory` fails, the errgroup will cancel the context. Then, when the next goroutine attempts to call Acquire, it will receive an error due to the canceled context. This causes the function to return a "context canceled" error, rather than the more informative error from errgroup.Wait(), which would be more helpful to the user.

Additionally, this pull request ensures that we avoid downloading duplicate directories.

Example of error returned by `fleet apply` before the change:
```bash
./bin/fleet-cli apply -n fleet-local test ./testcontext
FATA[0000] failed to process bundle: context canceled
```

Error returned after the change:
```bash
./bin/fleet-cli apply -n fleet-local test ./testcontext
FATA[0000] failed to process bundle: loading directory .chart/2ace3fcaa23682ab77cf7bdcd5a6df94dbc1d2e2a3a25bd63a1d4b82a0fde0d1, testcontext/test: helm chart download: failed to do request: Head "https://registry01.suse/v2/helm/rancher-monitoring/manifests/106.0.1_up66.7.1-rancher.10": dial tcp: lookup registry01.suse: no such host 
```

Refers to: https://github.com/rancher/fleet/issues/3234
