### PR TITLE
Using patch instead of update to 

### DIFF
--- a/internal/cmd/controller/gitops/reconciler/status_controller.go
+++ b/internal/cmd/controller/gitops/reconciler/status_controller.go
@@ -71,14 +71,16 @@ func (r *StatusReconciler) SetupWithManager(mgr ctrl.Manager) error {
 // display information to the user.
 func (r *StatusReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := log.FromContext(ctx).WithName("gitops-status")
-	gitrepo := &fleet.GitRepo{}
 
+	gitrepo := &fleet.GitRepo{}
 	if err := r.Get(ctx, req.NamespacedName, gitrepo); err != nil && !errors.IsNotFound(err) {
 		return ctrl.Result{}, err
 	} else if errors.IsNotFound(err) {
 		logger.V(1).Info("Gitrepo deleted, cleaning up poll jobs")
 		return ctrl.Result{}, nil
 	}
+
+	orig := gitrepo.DeepCopy()
 
 	// Restrictions / Overrides, gitrepo reconciler is responsible for setting error in status
 	if err := AuthorizeAndAssignDefaults(ctx, r.Client, gitrepo); err != nil {
@@ -141,13 +143,21 @@ func (r *StatusReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		return ctrl.Result{}, err
 	}
 
-	err = r.Client.Status().Update(ctx, gitrepo)
-	if err != nil {
+	if err := r.updateStatus(ctx, orig, gitrepo); err != nil {
 		logger.Error(err, "Reconcile failed update to git repo status", "status", gitrepo.Status)
 		return ctrl.Result{RequeueAfter: durations.GitRepoStatusDelay}, nil
 	}
 
 	return ctrl.Result{}, nil
+}
+
+func (r *StatusReconciler) updateStatus(ctx context.Context, orig *fleet.GitRepo, obj *fleet.GitRepo) error {
+	statusPatch := client.MergeFrom(orig)
+	if patchData, err := statusPatch.Data(obj); err == nil && string(patchData) == "{}" {
+		// skip update if patch is empty
+		return nil
+	}
+	return r.Client.Status().Patch(ctx, obj, statusPatch)
 }
 
 func setStatus(list *fleet.BundleDeploymentList, gitrepo *fleet.GitRepo) error {


### PR DESCRIPTION
Similar to #3021

The status_controller reconcile is using update, even though at a times it might not have anything to update 
we can call patch for a case of a status change, or a status from bundle is set, we also check if there is data to patch 
