### PR TITLE
Calls semaphore Acquire inside go routine (#3593)

### DIFF
--- a/internal/bundlereader/resources.go
+++ b/internal/bundlereader/resources.go
@@ -258,12 +258,22 @@ func loadDirectories(ctx context.Context, opts loadOpts, directories ...director
 
 	eg, ctx := errgroup.WithContext(ctx)
 
+	alreadyLoaded := make(map[string]struct{})
 	for _, dir := range directories {
-		if err := sem.Acquire(ctx, 1); err != nil {
-			return nil, err
+		// Avoid loading the same directory more than once
+		// We don't take auth into account because having the same source
+		// with different authentication means having the same resources anyway.
+		// Using a comma separator to avoid false equivalents due to combinations with empty strings.
+		dirId := fmt.Sprintf("%q,%q,%q,%q", dir.prefix, dir.base, dir.source, dir.version)
+		if _, ok := alreadyLoaded[dirId]; ok {
+			continue
 		}
+		alreadyLoaded[dirId] = struct{}{}
 		dir := dir
 		eg.Go(func() error {
+			if err := sem.Acquire(ctx, 1); err != nil {
+				return fmt.Errorf("waiting to load directory %s, %s: %w", dir.prefix, dir.base, err)
+			}
 			defer sem.Release(1)
 			resources, err := loadDirectory(ctx, opts, dir)
 			if err != nil {


### PR DESCRIPTION
* Calls semaphore Acquire inside go routine

Calls semaphone Acquire inside the go route instead to before the go routine.

Placing the Acquire call before the creation of the goroutine means that if any previously launched goroutine fails, it will cancel the shared context used by Acquire.

As a result, since Acquire is called outside the goroutine, it may return an error due to the canceled context—causing us to propagate a generic "context canceled" error instead of the original error that caused the goroutine to fail.

For example, suppose we're trying to download 10 charts, using a semaphore with a limit of 4. If the first call to `downloadDirectory` fails, the errgroup will cancel the context. Then, when the next goroutine attempts to call Acquire, it will receive an error due to the canceled context. This causes the function to return a "context canceled" error, rather than the more informative error from errgroup.Wait(), which would be more helpful to the user.

Additionally, this pull request ensures that we avoid downloading duplicate directories.


---------

Refers to https://github.com/rancher/fleet/issues/3598
Backport of https://github.com/rancher/fleet/pull/3593

