### PR TITLE
Use specific secret types for access secrets cloned to downstream clusters

### DIFF
--- a/integrationtests/controller/bundle/bundle_helm_test.go
+++ b/integrationtests/controller/bundle/bundle_helm_test.go
@@ -265,6 +265,9 @@ func checkBundleDeploymentSecret(c client.Client, helmOptions *v1alpha1.BundleHe
 	// both secrets have the same data
 	Expect(bdSecret.Data).To(Equal(bundleSecret.Data))
 
+	// the bundle deployment secret should have the right type
+	Expect(string(bdSecret.Type)).To(Equal("fleet.cattle.io/bundle-helmops-access/v1alpha1"))
+
 	// check that the controller reference is set in the bundle deployment secret
 	controller := metav1.GetControllerOf(bdSecret)
 	Expect(controller).ToNot(BeNil())

--- a/integrationtests/helmops/controller/suite_test.go
+++ b/integrationtests/helmops/controller/suite_test.go
@@ -41,7 +41,7 @@ var (
 
 func TestGitJobController(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Helm AppOps Controller Suite")
+	RunSpecs(t, "Helm Ops Controller Suite")
 }
 
 var _ = BeforeSuite(func() {

--- a/internal/cmd/controller/helmops/reconciler/helmop_controller.go
+++ b/internal/cmd/controller/helmops/reconciler/helmop_controller.go
@@ -139,7 +139,7 @@ func (r *HelmOpReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 
 	err = updateStatus(ctx, r.Client, req.NamespacedName, helmop.Status)
 	if err != nil {
-		logger.Error(err, "Reconcile failed final update to helm app status", "status", helmop.Status)
+		logger.Error(err, "Reconcile failed final update to HelmOp status", "status", helmop.Status)
 
 		return ctrl.Result{Requeue: true}, err
 	}

--- a/internal/cmd/controller/helmops/reconciler/helmop_status.go
+++ b/internal/cmd/controller/helmops/reconciler/helmop_status.go
@@ -105,7 +105,7 @@ func (r *HelmOpStatusReconciler) Reconcile(ctx context.Context, req ctrl.Request
 
 	err = r.Client.Status().Update(ctx, helmop)
 	if err != nil {
-		logger.Error(err, "Reconcile failed update to helm app status", "status", helmop.Status)
+		logger.Error(err, "Reconcile failed update to HelmOp status", "status", helmop.Status)
 		return ctrl.Result{RequeueAfter: durations.HelmOpStatusDelay}, nil
 	}
 

--- a/pkg/apis/fleet.cattle.io/v1alpha1/bundle_types.go
+++ b/pkg/apis/fleet.cattle.io/v1alpha1/bundle_types.go
@@ -35,6 +35,10 @@ const (
 
 	// SecretTypeBundleValues is the secret type used to store the helm values
 	SecretTypeBundleValues = "fleet.cattle.io/bundle-values/v1alpha1"
+
+	// SecretTypeOCIStorage is the secret type used internally to store bundle resources in an OCI registry instead
+	// of etcd.
+	SecretTypeOCIStorage = "fleet.cattle.io/bundle-oci-storage/v1alpha1"
 )
 
 var (

--- a/pkg/apis/fleet.cattle.io/v1alpha1/helmop_types.go
+++ b/pkg/apis/fleet.cattle.io/v1alpha1/helmop_types.go
@@ -14,6 +14,9 @@ var (
 
 const (
 	HelmOpAcceptedCondition = "Accepted"
+
+	// SecretTypeHelmOpsAccess is the secret type used to access Helm registries for HelmOps bundles.
+	SecretTypeHelmOpsAccess = "fleet.cattle.io/bundle-helmops-access/v1alpha1"
 )
 
 // +genclient


### PR DESCRIPTION
When creating HelmOps resources, users will create and reference access secrets in the upstream cluster.
While we may not want to enforce typing of such secrets, cloning them to downstream clusters provides an opportunity to type them, thereby helping users identify secrets created by Fleet in downstream clusters, along with uses of those secrets.

This introduces 2 new secret types, applying them to previously `Opaque` secrets:
* `fleet.cattle.io/bundle-helmops-access/v1alpha1` for Helm access for deploying HelmOps bundles
* `fleet.cattle.io/bundle-oci-storage/v1alpha1` for OCI storage access when storing bundles in OCI instead of etcd.

Refers to #3435