### PR TITLE
Revert dev-scripts: Spawn arbitrary amount of downstream clusters

### DIFF
--- a/.github/scripts/label-downstream-cluster.sh
+++ b/.github/scripts/label-downstream-cluster.sh
@@ -4,12 +4,6 @@ set -euxo pipefail
 
 ns=${FLEET_E2E_NS_DOWNSTREAM-fleet-default}
 
-# Wait for clusters to become "ready" by waiting for bundles to become ready.
-num_clusters=$(k3d cluster list -o json | jq -r '.[].name | select( . | contains("downstream") )' | wc -l)
-while [[ $(kubectl get clusters.fleet.cattle.io -n "$ns" | grep '1/1' -c) -ne $num_clusters ]]; do
-    sleep 1
-done
-
-for cluster in $(kubectl get clusters.fleet.cattle.io -n "$ns" -o=jsonpath='{.items[*].metadata.name}'); do
-  kubectl patch clusters.fleet.cattle.io -n "$ns" "$cluster" --type=json -p '[{"op": "add", "path": "/metadata/labels/env", "value": "test" }]'
-done
+{ grep -q -m 1 -e "1/1"; kill $!; } < <(kubectl get clusters.fleet.cattle.io -n "$ns" -w)
+name=$(kubectl get clusters.fleet.cattle.io -o=jsonpath='{.items[0].metadata.name}' -n "$ns")
+kubectl patch clusters.fleet.cattle.io -n "$ns" "$name" --type=json -p '[{"op": "add", "path": "/metadata/labels/env", "value": "test" }]'

--- a/dev/setup-fleet-multi-cluster
+++ b/dev/setup-fleet-multi-cluster
@@ -17,4 +17,12 @@ dev/setup-fleet-managed-downstream
 
 kubectl config use-context "$upstream_ctx"
 
-.github/scripts/label-downstream-cluster.sh
+ns=${FLEET_E2E_NS_DOWNSTREAM-fleet-default}
+
+# Wait for clusters to become "ready" by waiting for bundles to become ready.
+num_clusters=$(k3d cluster list -o json | jq -r '.[].name | select( . | contains("downstream") )' | wc -l)
+while [[ $(kubectl get clusters.fleet.cattle.io -n "$ns" | grep '1/1' -c) -ne $num_clusters ]]; do
+    sleep 1
+done
+
+kubectl patch clusters.fleet.cattle.io -n "$ns" --all --type=json -p '[{"op": "add", "path": "/metadata/labels/env", "value": "test" }]'

--- a/dev/setup-rancher-clusters
+++ b/dev/setup-rancher-clusters
@@ -53,4 +53,6 @@ kubectl -n cattle-fleet-system rollout status deploy/fleet-controller
 export cluster_downstream="$downstream_ctx"
 ./.github/scripts/register-downstream-clusters.sh "$public_hostname"
 
+# register-downstream-clusters.sh only supports fleet-default
+export FLEET_E2E_NS_DOWNSTREAM=fleet-default
 ./.github/scripts/label-downstream-cluster.sh


### PR DESCRIPTION
No need to change the CI scripts. The change was not aware of the cluster's namespace and incompatible with dev/setup-rancher-clusters.

Reverts CI script change from https://github.com/rancher/fleet/pull/3139