### PR TITLE
Monitor known_hosts entries through updatecli

### DIFF
--- a/.github/scripts/update_known_hosts_configmap.sh
+++ b/.github/scripts/update_known_hosts_configmap.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Write a new definition of the `known-hosts` config map in the fleet chart based on updated entries for each provider.
+# Entries are obtained through `ssh-keyscan` and sorted lexically to preserve ordering and hence prevent false
+# positives.
+providers=(
+    "bitbucket.org"
+    "github.com"
+    "gitlab.com"
+    "ssh.dev.azure.com"
+    "vs-ssh.visualstudio.com"
+)
+
+dst=charts/fleet/templates/configmap_known_hosts.yaml
+echo "apiVersion: v1" > "$dst"
+echo "kind: ConfigMap" >> "$dst"
+echo "metadata:" >> "$dst"
+echo "  name: known-hosts" >> "$dst"
+echo "data:" >> "$dst"
+echo "  known_hosts: |" >> "$dst"
+
+for prov in "${providers[@]}"; do
+    ssh-keyscan "$prov" | grep "^$prov" | sort -b | sed 's/^/    /' >> "$dst"
+done

--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -27,7 +27,7 @@ jobs:
         uses: updatecli/updatecli-action@v2
 
       - name: Apply
-        run: "updatecli apply --config ./updatecli/updatecli.d"
+        run: "updatecli apply --config ./updatecli/updatecli.d --values ./updatecli/values.d/scm.yaml"
         env:
           UPDATECLI_GITHUB_ACTOR: ${{ github.actor }}
           UPDATECLI_GITHUB_TOKEN: ${{ secrets.ADD_TO_PROJECT_PAT }}

--- a/updatecli/updatecli.d/installation.yaml
+++ b/updatecli/updatecli.d/installation.yaml
@@ -4,13 +4,13 @@ scms:
   fleet:
     kind: github
     spec:
-      user: fleet-bot
-      email: fleet@suse.de
-      owner: rancher
-      repository: fleet
+      user: '{{ .scm.default.user }}'
+      email: '{{ .scm.default.email }}'
+      owner: '{{ .scm.default.owner }}'
+      repository: '{{ .scm.default.repository }}'
       token: '{{ requiredEnv "UPDATECLI_GITHUB_TOKEN" }}'
       username: '{{ requiredEnv "UPDATECLI_GITHUB_ACTOR" }}'
-      branch: main
+      branch: '{{ .scm.default.branch }}'
 
 sources:
   fleet:

--- a/updatecli/updatecli.d/installation.yaml
+++ b/updatecli/updatecli.d/installation.yaml
@@ -1,4 +1,4 @@
-title: Bump Fleet version in installation documentation
+name: Bump Fleet version in installation documentation
 
 scms:
   fleet:
@@ -54,7 +54,7 @@ targets:
 
 actions:
   default:
-    title: '[updatecli] Bump Fleet version used within installation documentation to {{ source "fleet" }}'
+    name: '[updatecli] Bump Fleet version used within installation documentation to {{ source "fleet" }}'
     kind: github/pullrequest
     scmid: fleet
     spec:

--- a/updatecli/updatecli.d/known-hosts.yaml
+++ b/updatecli/updatecli.d/known-hosts.yaml
@@ -1,0 +1,61 @@
+name: Update known_hosts config map
+
+scms:
+  fleet:
+    kind: github
+    spec:
+      user: '{{ .scm.default.user }}'
+      email: '{{ .scm.default.email }}'
+      owner: '{{ .scm.default.owner }}'
+      repository: '{{ .scm.default.repository }}'
+      token: '{{ requiredEnv "UPDATECLI_GITHUB_TOKEN" }}'
+      username: '{{ requiredEnv "UPDATECLI_GITHUB_ACTOR" }}'
+      branch: '{{ .scm.default.branch }}'
+
+      # XXX: could we get this to work with minimal duplication and maintenance effort for _all_ maintained branches
+      # containing the file?
+      # e.g. currently `main`, `release/v0.12`, `release/v0.11`, `release/v0.10`
+
+targets:
+  configMapWithUpdatedEntries:
+    name: 'chore: synchronise config map from new entries'
+    kind: 'shell'
+    scmid: 'fleet'
+    disablesourceinput: true
+    spec:
+      changedif:
+        kind: 'file/checksum'
+        spec:
+          files:
+            - charts/fleet/templates/configmap_known_hosts.yaml
+      command: |
+        providers=(
+            'bitbucket.org'
+            'github.com'
+            'gitlab.com'
+            'ssh.dev.azure.com'
+            'vs-ssh.visualstudio.com'
+        )
+
+        dst=charts/fleet/templates/configmap_known_hosts.yaml
+        echo "apiVersion: v1" > "$dst"
+        echo "kind: ConfigMap" >> "$dst"
+        echo "metadata:" >> "$dst"
+        echo "  name: known-hosts" >> "$dst"
+        echo "data:" >> "$dst"
+        echo "  known_hosts: |" >> "$dst"
+
+        for prov in "${providers[@]}"; do
+            ssh-keyscan "$prov" | grep "^$prov" | sort -b | sed 's/^/    /' >> "$dst"
+        done
+
+actions:
+  default:
+    name: '[updatecli] Update known-hosts config map with new entries'
+    kind: github/pullrequest
+    scmid: fleet
+    spec:
+      automerge: false
+      mergemethod: squash
+      labels:
+        - kind/known-hosts # /!\ label must exist in the repo!

--- a/updatecli/updatecli.d/known-hosts.yaml
+++ b/updatecli/updatecli.d/known-hosts.yaml
@@ -18,7 +18,7 @@ scms:
 
 targets:
   configMapWithUpdatedEntries:
-    name: 'chore: synchronise config map from new entries'
+    name: 'synchronise config map from new entries'
     kind: 'shell'
     scmid: 'fleet'
     disablesourceinput: true
@@ -28,26 +28,7 @@ targets:
         spec:
           files:
             - charts/fleet/templates/configmap_known_hosts.yaml
-      command: |
-        providers=(
-            'bitbucket.org'
-            'github.com'
-            'gitlab.com'
-            'ssh.dev.azure.com'
-            'vs-ssh.visualstudio.com'
-        )
-
-        dst=charts/fleet/templates/configmap_known_hosts.yaml
-        echo "apiVersion: v1" > "$dst"
-        echo "kind: ConfigMap" >> "$dst"
-        echo "metadata:" >> "$dst"
-        echo "  name: known-hosts" >> "$dst"
-        echo "data:" >> "$dst"
-        echo "  known_hosts: |" >> "$dst"
-
-        for prov in "${providers[@]}"; do
-            ssh-keyscan "$prov" | grep "^$prov" | sort -b | sed 's/^/    /' >> "$dst"
-        done
+      command: bash .github/scripts/update_known_hosts_configmap.sh
 
 actions:
   default:

--- a/updatecli/values.d/scm.yaml
+++ b/updatecli/values.d/scm.yaml
@@ -1,0 +1,8 @@
+scm:
+  enabled: true
+  default:
+    user: 'fleet-bot'
+    email: 'fleet@suse.de'
+    owner: rancher
+    repository: fleet
+    branch: main


### PR DESCRIPTION
This provides a new updatecli pipeline to:
1. Compute up-to-date `known_hosts` entries for providers featured in the Fleet chart's `known-hosts` config map
2. Update that config map if entries have changed
3. Submit a pull request with the changes.

Example test run: [here](https://github.com/weyfonk/fleet/actions/runs/14994905550/job/42126707571), leading to [this PR](https://github.com/weyfonk/fleet/pull/5) which basically reorders entries alphabetically to ensure that future pipeline runs will not generate false positives. Once this new pipeline is merged, we should expect a similar PR against `rancher/fleet`.

Open points:
* do we need a separate pipeline for each release branch under maintenance?