### PR TITLE
Simplify GitRepo end-to-end tests

### DIFF
--- a/e2e/single-cluster/gitrepo_test.go
+++ b/e2e/single-cluster/gitrepo_test.go
@@ -32,7 +32,7 @@ const (
 	repoName  = "repo"
 )
 
-var _ = FDescribe("Monitoring Git repos via HTTP for change", Label("infra-setup"), func() {
+var _ = Describe("Monitoring Git repos via HTTP for change", Label("infra-setup"), func() {
 	var (
 		tmpDir           string
 		clonedir         string
@@ -87,21 +87,7 @@ var _ = FDescribe("Monitoring Git repos via HTTP for change", Label("infra-setup
 			g.Expect(out).To(ContainSubstring("No resources found"))
 		}).Should(Succeed())
 
-		out, err := k.Namespace("cattle-fleet-system").Logs(
-			"-l",
-			"app=fleet-controller",
-			"-c",
-			"fleet-controller",
-		)
-		Expect(err).ToNot(HaveOccurred())
-
-		// Errors about resources other than bundles or bundle deployments not being found at deletion time
-		// should be ignored, as they may result from other test suites.
-		Expect(out).ToNot(MatchRegexp(
-			`ERROR.*Reconciler error.*Bundle(Deployment)?.fleet.cattle.io \\".*\\" not found`,
-		))
-
-		_, err = k.Delete("ns", targetNamespace, "--wait=false")
+		_, err := k.Delete("ns", targetNamespace, "--wait=false")
 		Expect(err).ToNot(HaveOccurred())
 	})
 

--- a/e2e/single-cluster/suite_test.go
+++ b/e2e/single-cluster/suite_test.go
@@ -16,6 +16,10 @@ func TestE2E(t *testing.T) {
 	RunSpecs(t, "E2E Suite for Single-Cluster")
 }
 
+const (
+	repoName = "repo"
+)
+
 var (
 	env *testenv.Env
 )


### PR DESCRIPTION
This reduces the risk of flakiness in single-cluster end-to-end tests for `GitRepo`, by:
* refactoring test cases to use separate `When` blocks from Ginkgo, instead of a loop with `Skip` statements, to ease tracking of which test cases run and which do not
* removing the check on logs from `AfterEach`, which could cause failures. That check was added back when our reconcilers were not as mature as they are now. Such a check would anyway not belong there, but rather in integration tests covering bundle deployment cleanup.