### PR TITLE
Delete Gitjob metrics when the GitRepo is deleted

### DIFF
--- a/e2e/metrics/gitjob_test.go
+++ b/e2e/metrics/gitjob_test.go
@@ -18,6 +18,7 @@ var _ = Describe("GitOps Metrics", Label("gitops"), func() {
 		namespace string
 		name      = "metrics"
 		branch    = "master"
+		labels    map[string]string
 	)
 
 	BeforeEach(func() {
@@ -41,6 +42,11 @@ var _ = Describe("GitOps Metrics", Label("gitops"), func() {
 		)
 		Expect(err).ToNot(HaveOccurred())
 
+		labels = map[string]string{
+			"name":      name,
+			"namespace": namespace,
+		}
+
 		DeferCleanup(func() {
 			out, err = k.Delete("ns", namespace)
 			Expect(err).ToNot(HaveOccurred(), out)
@@ -50,26 +56,26 @@ var _ = Describe("GitOps Metrics", Label("gitops"), func() {
 	// This test is ordered because we can safely test for metrics that don't exist if we have
 	// waited for metrics that do exist to have appeared, in which case we don't need to use
 	// `Eventually` to wait for it to time out.
-	When("testing counter metrics", Ordered, func() {
-		It("should have exactly one metric of each type for the gitrepo", func() {
-			gitOpsMetricNamesExist := []string{
-				"fleet_gitjobs_created_success_total",
-				"fleet_gitrepo_fetch_latest_commit_success_total",
-				"fleet_gitjob_duration_seconds_gauge",
-				"fleet_gitjob_duration_seconds",
-				"fleet_gitrepo_fetch_latest_commit_duration_seconds",
-			}
+	When("testing counter metrics", func() {
+		gitOpsMetricNamesExist := []string{
+			"fleet_gitjobs_created_success_total",
+			"fleet_gitrepo_fetch_latest_commit_success_total",
+			"fleet_gitjob_duration_seconds_gauge",
+			"fleet_gitjob_duration_seconds",
+			"fleet_gitrepo_fetch_latest_commit_duration_seconds",
+		}
+		gitOpsMetricNamesMissing := []string{
+			"gitrepo_fetch_latest_commit_failure_total",
+			"gitjobs_created_failure_total",
+		}
 
+		It("should have exactly one metric of each type for the gitrepo", func() {
 			Eventually(func() error {
 				metrics, err := etGitjob.Get()
 				if err != nil {
 					return err
 				}
 
-				labels := map[string]string{
-					"name":      name,
-					"namespace": namespace,
-				}
 				for _, metricName := range gitOpsMetricNamesExist {
 					_, err := etGitjob.FindOneMetric(
 						metrics,
@@ -87,18 +93,9 @@ var _ = Describe("GitOps Metrics", Label("gitops"), func() {
 		It("should not find any metric that counts errors", func() {
 			// We want metrics to be missing when they count errors. If an error curred, the metric
 			// would be present.
-			gitOpsMetricNamesMissing := []string{
-				"gitrepo_fetch_latest_commit_failure_total",
-				"gitjobs_created_failure_total",
-			}
-
 			metrics, err := etGitjob.Get()
 			Expect(err).ToNot(HaveOccurred())
 
-			labels := map[string]string{
-				"name":      name,
-				"namespace": namespace,
-			}
 			for _, metricName := range gitOpsMetricNamesMissing {
 				_, err := etGitjob.FindOneMetric(
 					metrics,
@@ -111,6 +108,45 @@ var _ = Describe("GitOps Metrics", Label("gitops"), func() {
 					labels,
 				))
 			}
+		})
+
+		It("should not have any metrics when the GitRepo has been deleted", func() {
+			// Make sure the metrics exist before removing them by deleting the GitRepo.
+			Eventually(func() error {
+				metrics, err := etGitjob.Get()
+				if err != nil {
+					return err
+				}
+
+				for _, metricName := range gitOpsMetricNamesExist {
+					_, err := etGitjob.FindOneMetric(
+						metrics,
+						metricName,
+						labels,
+					)
+					if err != nil {
+						return err
+					}
+				}
+				return nil
+			}).ShouldNot(HaveOccurred())
+
+			// Delete the	GitRepo.
+			Eventually(func() error {
+				_, err := kw.Delete("gitrepo", name)
+				return err
+			}).ShouldNot(HaveOccurred())
+
+			// Maker sure the metrics are gone.
+			metrics := append(gitOpsMetricNamesExist, gitOpsMetricNamesMissing...)
+			Eventually(func(g Gomega) {
+				for _, metricName := range metrics {
+					allMetrics, err := etGitjob.Get()
+					g.Expect(err).ToNot(HaveOccurred())
+					_, err = etGitjob.FindOneMetric(allMetrics, metricName, labels)
+					g.Expect(err).To(HaveOccurred(), fmt.Sprintf("metric found but expected not to: %q", metricName))
+				}
+			})
 		})
 	})
 })

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -250,6 +250,10 @@ func (m *ObjCounterVec) Inc(obj metav1.Object) {
 	m.counterVec.WithLabelValues(obj.GetName(), obj.GetNamespace()).Inc()
 }
 
+func (m *ObjCounterVec) Delete(obj metav1.Object) bool {
+	return m.counterVec.DeleteLabelValues(obj.GetName(), obj.GetNamespace())
+}
+
 var BucketsLatency = []float64{.1, .2, .5, 1, 2, 5, 10, 30}
 
 func ObjHistogram(name, help string, buckets []float64) (h ObjHistogramVec) {
@@ -280,6 +284,10 @@ func (m *ObjHistogramVec) Observe(obj metav1.Object, value float64) {
 	m.histogram.WithLabelValues(obj.GetName(), obj.GetNamespace()).Observe(value)
 }
 
+func (m *ObjHistogramVec) Delete(obj metav1.Object) bool {
+	return m.histogram.DeleteLabelValues(obj.GetName(), obj.GetNamespace())
+}
+
 func ObjGauge(name, help string) (g ObjGaugeVec) {
 	gauge := promauto.NewGaugeVec(
 		prometheus.GaugeOpts{
@@ -305,4 +313,8 @@ type ObjGaugeVec struct {
 
 func (m *ObjGaugeVec) Set(obj metav1.Object, value float64) {
 	m.gauge.WithLabelValues(obj.GetName(), obj.GetNamespace()).Set(value)
+}
+
+func (m *ObjGaugeVec) Delete(obj metav1.Object) bool {
+	return m.gauge.DeleteLabelValues(obj.GetName(), obj.GetNamespace())
 }

--- a/pkg/git/fetch.go
+++ b/pkg/git/fetch.go
@@ -2,10 +2,8 @@ package git
 
 import (
 	"context"
-	"time"
 
 	"github.com/rancher/fleet/internal/config"
-	"github.com/rancher/fleet/internal/metrics"
 	"github.com/rancher/fleet/internal/ssh"
 	v1alpha1 "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
 	"github.com/rancher/fleet/pkg/cert"
@@ -15,22 +13,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
-)
-
-var (
-	fetchLatestCommitSuccess = metrics.ObjCounter(
-		"gitrepo_fetch_latest_commit_success_total",
-		"Total number of successful fetches of latest commit",
-	)
-	fetchLatestCommitFailure = metrics.ObjCounter(
-		"gitrepo_fetch_latest_commit_failure_total",
-		"Total number of failed attempts to retrieve the latest commit, for any reason",
-	)
-	timeToFetchLatestCommit = metrics.ObjHistogram(
-		"gitrepo_fetch_latest_commit_duration_seconds",
-		"Duration in seconds to fetch the latest commit",
-		metrics.BucketsLatency,
-	)
 )
 
 type KnownHostsGetter interface {
@@ -58,7 +40,6 @@ func (f *Fetch) LatestCommit(ctx context.Context, gitrepo *v1alpha1.GitRepo, cli
 	}, &secret)
 
 	if err != nil && !errors.IsNotFound(err) {
-		fetchLatestCommitFailure.Inc(gitrepo)
 		return "", err
 	}
 
@@ -72,7 +53,6 @@ func (f *Fetch) LatestCommit(ctx context.Context, gitrepo *v1alpha1.GitRepo, cli
 	if len(cabundle) == 0 {
 		cab, err := cert.GetRancherCABundle(ctx, client)
 		if err != nil {
-			fetchLatestCommitFailure.Inc(gitrepo)
 			return "", err
 		}
 
@@ -83,7 +63,6 @@ func (f *Fetch) LatestCommit(ctx context.Context, gitrepo *v1alpha1.GitRepo, cli
 	if f.KnownHosts != nil && f.KnownHosts.IsStrict() && ssh.Is(gitrepo.Spec.Repo) {
 		kh, err := f.KnownHosts.GetWithSecret(ctx, client, &secret)
 		if err != nil {
-			fetchLatestCommitFailure.Inc(gitrepo)
 			return "", err
 		}
 
@@ -105,24 +84,11 @@ func (f *Fetch) LatestCommit(ctx context.Context, gitrepo *v1alpha1.GitRepo, cli
 		log:               log.FromContext(ctx),
 	})
 	if err != nil {
-		fetchLatestCommitFailure.Inc(gitrepo)
 		return "", err
 	}
 
 	if gitrepo.Spec.Revision != "" {
-		result, err := r.RevisionCommit(gitrepo.Spec.Revision)
-		if err != nil {
-			fetchLatestCommitFailure.Inc(gitrepo)
-		}
-		return result, err
+		return r.RevisionCommit(gitrepo.Spec.Revision)
 	}
-	t := time.Now()
-	result, err := r.LatestBranchCommit(branch)
-	if err != nil {
-		fetchLatestCommitFailure.Inc(gitrepo)
-	}
-	timeToFetchLatestCommit.Observe(gitrepo, time.Since(t).Seconds())
-
-	fetchLatestCommitSuccess.Inc(gitrepo)
-	return result, err
+	return r.LatestBranchCommit(branch)
 }


### PR DESCRIPTION
Metrics for specific GitRepos should be deleted alongside the corresponding GitRepos.

<!-- Specify the issue ID that this pull request is solving -->
Refers to #3668
<!-- Make sure that the referenced issue provides steps to reproduce it -->

<!-- Describe the changes introduced by this pull request -->

<!--
  Please provide a unit, integration (`./integrationtests/`) or e2e (`./e2e/`) test if possible.
-->

## Additional Information

### Checklist

- [ ] <!-- If applicable,--> I have updated the documentation via a pull request in the
[fleet-docs](https://github.com/rancher/fleet-docs) repository.
