### PR TITLE
Switch agent clusterstatus reporting to the upstream client

### DIFF
--- a/dev/setup-fleet
+++ b/dev/setup-fleet
@@ -41,6 +41,9 @@ helm -n cattle-fleet-system upgrade --install --create-namespace --wait --reset-
   --set apiServerURL="$server" \
   $shards_settings \
   --set bootstrap.agentNamespace=cattle-fleet-local-system \
+  --set agent.leaderElection.leaseDuration=10s \
+  --set agent.leaderElection.retryPeriod=1s \
+  --set agent.leaderElection.renewDeadline=5s \
   --set-string extraEnv[0].name=EXPERIMENTAL_OCI_STORAGE \
   --set-string extraEnv[0].value=true \
   --set-string extraEnv[1].name=EXPERIMENTAL_HELM_OPS \

--- a/dev/update-agent-k3d
+++ b/dev/update-agent-k3d
@@ -18,3 +18,15 @@ docker build -f package/Dockerfile.agent -t rancher/fleet-agent:dev --build-arg=
 fleet_ctx=$(kubectl config current-context)
 k3d image import rancher/fleet-agent:dev -m direct -c "${fleet_ctx#k3d-}"
 kubectl delete pod -l app=fleet-agent -n cattle-fleet-local-system
+
+upstream_ctx="${FLEET_E2E_CLUSTER-k3d-upstream}"
+downstream_ctx="${FLEET_E2E_CLUSTER_DOWNSTREAM-k3d-downstream1}"
+downstream_keyword="${downstream_ctx#k3d-}"
+downstream_keyword="${downstream_keyword%[0-9]*}"
+if [ "$upstream_ctx" != "$downstream_ctx" ]; then
+  for cluster in $(k3d cluster list -o json | \
+      jq -r ".[].name | select(. | contains(\"${downstream_keyword}\"))"); do
+    k3d image import rancher/fleet-agent:dev -m direct -c "${cluster}"
+    kubectl --context "k3d-$cluster" delete pod -l app=fleet-agent -n cattle-fleet-system
+  done
+fi

--- a/internal/cmd/agent/clusterstatus.go
+++ b/internal/cmd/agent/clusterstatus.go
@@ -2,12 +2,9 @@ package agent
 
 import (
 	"context"
-	"fmt"
-	"os"
 	"time"
 
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -17,54 +14,41 @@ import (
 	"github.com/rancher/fleet/internal/cmd/agent/register"
 )
 
-type ClusterStatus struct {
-	UpstreamOptions
-	CheckinInterval string `usage:"How often to post cluster status" env:"CHECKIN_INTERVAL"`
-	AgentInfo       *register.AgentInfo
+type ClusterStatusRunnable struct {
+	config          *rest.Config
+	namespace       string
+	checkinInterval string
+	agentInfo       *register.AgentInfo
 }
 
-func (cs *ClusterStatus) Start(ctx context.Context) error {
+func (cs *ClusterStatusRunnable) Start(ctx context.Context) error {
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(zopts)))
 	ctx = log.IntoContext(ctx, ctrl.Log)
 
 	var err error
 	var checkinInterval time.Duration
-	if cs.CheckinInterval != "" {
-		checkinInterval, err = time.ParseDuration(cs.CheckinInterval)
+	if cs.checkinInterval != "" {
+		checkinInterval, err = time.ParseDuration(cs.checkinInterval)
 		if err != nil {
 			return err
 		}
 	}
 
-	localConfig, err := clientcmd.BuildConfigFromFlags("", cs.Kubeconfig)
+	setupLog.Info("Starting cluster status ticker", "checkin interval", checkinInterval.String(), "cluster namespace", cs.agentInfo.ClusterNamespace, "cluster name", cs.agentInfo.ClusterName)
+
+	// use a separate client for the cluster status ticker, that does not use a cache
+	client, err := client.New(cs.config, client.Options{Scheme: scheme})
 	if err != nil {
-		return fmt.Errorf("failed to load kubeconfig: %w", err)
+		return err
 	}
-
-	// without rate limiting
-	localConfig = rest.CopyConfig(localConfig)
-	localConfig.QPS = -1
-	localConfig.RateLimiter = nil
-
-	setupLog.Info("Fetching kubeconfig for upstream cluster from registration", "namespace", cs.Namespace)
-
-	clnt, err := client.New(localConfig, client.Options{
-		Scheme: scheme,
-	})
-	if err != nil {
-		fmt.Println("failed to create client")
-		os.Exit(1)
-	}
-
-	setupLog.Info("Starting cluster status ticker", "checkin interval", checkinInterval.String(), "cluster namespace", cs.AgentInfo.ClusterNamespace, "cluster name", cs.AgentInfo.ClusterName)
 
 	go func() {
 		clusterstatus.Ticker(
 			ctx,
-			clnt,
-			cs.Namespace,
-			cs.AgentInfo.ClusterNamespace,
-			cs.AgentInfo.ClusterName,
+			client,
+			cs.namespace,
+			cs.agentInfo.ClusterNamespace,
+			cs.agentInfo.ClusterName,
 			checkinInterval,
 		)
 

--- a/internal/cmd/agent/clusterstatus/ticker.go
+++ b/internal/cmd/agent/clusterstatus/ticker.go
@@ -5,8 +5,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/sirupsen/logrus"
-
 	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
 	"github.com/rancher/fleet/pkg/durations"
 
@@ -41,7 +39,7 @@ func Ticker(ctx context.Context, client client.Client, agentNamespace string, cl
 		time.Sleep(durations.ClusterRegisterDelay)
 		logger.V(1).Info("Reporting cluster status once")
 		if err := h.Update(ctx); err != nil {
-			logrus.Errorf("failed to report cluster status: %v", err)
+			logger.Error(err, "failed to report initial cluster status")
 		}
 	}()
 	go func() {
@@ -51,7 +49,7 @@ func Ticker(ctx context.Context, client client.Client, agentNamespace string, cl
 		for range ticker.Context(ctx, checkinInterval) {
 			logger.V(1).Info("Reporting cluster status")
 			if err := h.Update(ctx); err != nil {
-				logrus.Errorf("failed to report cluster status: %v", err)
+				logger.Error(err, "failed to report cluster status")
 			}
 		}
 	}()
@@ -68,21 +66,21 @@ func (h *handler) Update(ctx context.Context) error {
 		return nil
 	}
 
-	cluster := &fleet.Cluster{}
-	err := h.client.Get(context.Background(), types.NamespacedName{
-		Namespace: h.clusterNamespace,
-		Name:      h.clusterName,
-	}, cluster)
-	if err != nil {
-		return err
+	cluster := &fleet.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      h.clusterName,
+			Namespace: h.clusterNamespace,
+		},
 	}
 
-	// Create a patch with the updated status
-	patch := client.MergeFrom(cluster.DeepCopy())
-	cluster.Status.Agent = agentStatus
+	// Create a patch with the updated status, we avoid Get as that would
+	// need additonal RBAC
+	patch := `[{"op":"add","path":"/status/agent","value":{"lastSeen":"` +
+		agentStatus.LastSeen.Format(time.RFC3339) +
+		`","namespace":"` + agentStatus.Namespace +
+		`"}}]`
 
-	// Apply the patch
-	err = h.client.Status().Patch(ctx, cluster, patch)
+	err := h.client.Status().Patch(ctx, cluster, client.RawPatch(types.JSONPatchType, []byte(patch)))
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/agent/clusterstatus/ticker.go
+++ b/internal/cmd/agent/clusterstatus/ticker.go
@@ -74,7 +74,7 @@ func (h *handler) Update(ctx context.Context) error {
 	}
 
 	// Create a patch with the updated status, we avoid Get as that would
-	// need additonal RBAC
+	// need additional RBAC
 	patch := `[{"op":"add","path":"/status/agent","value":{"lastSeen":"` +
 		agentStatus.LastSeen.Format(time.RFC3339) +
 		`","namespace":"` + agentStatus.Namespace +

--- a/internal/cmd/agent/operator.go
+++ b/internal/cmd/agent/operator.go
@@ -59,10 +59,10 @@ func init() {
 func start(
 	ctx context.Context,
 	localConfig *rest.Config,
-	systemNamespace,
+	systemNamespace string,
 	agentScope string,
+	checkinInterval string,
 	workersOpts AgentReconcilerWorkers,
-	clusterStatus *ClusterStatus,
 	agentInfo *register.AgentInfo,
 ) error {
 	upstreamConfig, err := agentInfo.ClientConfig.ClientConfig()
@@ -91,7 +91,7 @@ func start(
 		Metrics:                metricsserver.Options{BindAddress: metricsAddr},
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         false,
-		// only watch resources in the fleet namespace
+		// only watch resources in the cluster namespace
 		Cache: cache.Options{
 			DefaultNamespaces: map[string]cache.Config{fleetNamespace: {}},
 		},
@@ -148,6 +148,12 @@ func start(
 		return err
 	}
 
+	clusterStatus := &ClusterStatusRunnable{
+		agentInfo:       agentInfo,
+		config:          upstreamConfig,
+		checkinInterval: checkinInterval,
+		namespace:       systemNamespace,
+	}
 	if err := mgr.Add(clusterStatus); err != nil {
 		setupLog.Error(err, "unable to add cluster status controller")
 		return err

--- a/internal/cmd/agent/root.go
+++ b/internal/cmd/agent/root.go
@@ -25,7 +25,7 @@ import (
 )
 
 type UpstreamOptions struct {
-	Kubeconfig string `usage:"kubeconfig file for agent's cluster"`
+	Kubeconfig string `usage:"kubeconfig file for upstream cluster"`
 	Namespace  string `usage:"system namespace is the namespace, the agent runs in, e.g. cattle-fleet-system" env:"NAMESPACE"`
 }
 
@@ -156,16 +156,7 @@ func (a *FleetAgent) Run(cmd *cobra.Command, args []string) error {
 					workersOpts.Drift = w
 				}
 
-				clusterStatus := &ClusterStatus{
-					UpstreamOptions: UpstreamOptions{
-						Kubeconfig: a.Kubeconfig,
-						Namespace:  a.Namespace,
-					},
-					CheckinInterval: a.CheckinInterval,
-					AgentInfo:       agentInfo,
-				}
-
-				if err := start(ctx, localConfig, a.Namespace, a.AgentScope, workersOpts, clusterStatus, agentInfo); err != nil {
+				if err := start(ctx, localConfig, a.Namespace, a.AgentScope, a.CheckinInterval, workersOpts, agentInfo); err != nil {
 					setupLog.Error(err, "failed to start agent")
 				}
 			},


### PR DESCRIPTION
Refers to https://github.com/rancher/fleet/issues/3466

Fixes a bug in main (https://github.com/rancher/fleet/pull/3436), where downstream agents could not report their status, because they used the wrong kubeconfig.

This also avoids a caching client, as we the agent is only allowed to patch cluster status in the cluster registration namespace.