### PR TITLE
[v0.11] Add known-hosts update script

### DIFF
--- a/.github/scripts/update_known_hosts_configmap.sh
+++ b/.github/scripts/update_known_hosts_configmap.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Write a new definition of the `known-hosts` config map in the fleet chart based on updated entries for each provider.
+# Entries are obtained through `ssh-keyscan` and sorted lexically to preserve ordering and hence prevent false
+# positives.
+providers=(
+    "bitbucket.org"
+    "github.com"
+    "gitlab.com"
+    "ssh.dev.azure.com"
+    "vs-ssh.visualstudio.com"
+)
+
+dst=charts/fleet/templates/configmap_known_hosts.yaml
+echo "apiVersion: v1" > "$dst"
+echo "kind: ConfigMap" >> "$dst"
+echo "metadata:" >> "$dst"
+echo "  name: known-hosts" >> "$dst"
+echo "data:" >> "$dst"
+echo "  known_hosts: |" >> "$dst"
+
+for prov in "${providers[@]}"; do
+    ssh-keyscan "$prov" | grep "^$prov" | sort -b | sed 's/^/    /' >> "$dst"
+done


### PR DESCRIPTION
The script is required to enable updatecli to compute the latest entries for the `known-hosts` config map after checking out this branch.

Backport of the script from #3680.