### PR TITLE
Detect bundle naming collision

### DIFF
--- a/internal/cmd/cli/apply/apply.go
+++ b/internal/cmd/cli/apply/apply.go
@@ -305,6 +305,7 @@ func Dir(ctx context.Context, client client.Client, name, baseDir string, opts *
 	if len(bundle.Spec.Resources) == 0 {
 		return ErrNoResources
 	}
+
 	gitRepoBundlesMap[bundle.Name] = true
 
 	objects := []runtime.Object{bundle}
@@ -394,6 +395,10 @@ func pushOCIManifest(ctx context.Context, bundle *fleet.Bundle, opts *Options) (
 func save(ctx context.Context, c client.Client, bundle *fleet.Bundle) (*fleet.Bundle, error) {
 	updated := bundle.DeepCopy()
 	result, err := controllerutil.CreateOrUpdate(ctx, c, bundle, func() error {
+		if (updated.Spec.HelmOpOptions == nil) != (bundle.Spec.HelmOpOptions == nil) {
+			return fmt.Errorf("a helmOps bundle with name %q already exists", bundle.Name)
+		}
+
 		bundle.Spec = updated.Spec
 		bundle.Annotations = updated.Annotations
 		bundle.Labels = updated.Labels
@@ -435,6 +440,10 @@ func saveOCIBundle(ctx context.Context, c client.Client, bundle *fleet.Bundle, o
 
 	updated := bundle.DeepCopy()
 	_, err = controllerutil.CreateOrUpdate(ctx, c, bundle, func() error {
+		if (updated.Spec.HelmOpOptions == nil) != (bundle.Spec.HelmOpOptions == nil) {
+			return fmt.Errorf("a helmOps bundle with name %q already exists", bundle.Name)
+		}
+
 		bundle.Spec = updated.Spec
 		bundle.Annotations = updated.Annotations
 		bundle.Labels = updated.Labels

--- a/internal/cmd/cli/apply/apply.go
+++ b/internal/cmd/cli/apply/apply.go
@@ -395,7 +395,7 @@ func pushOCIManifest(ctx context.Context, bundle *fleet.Bundle, opts *Options) (
 func save(ctx context.Context, c client.Client, bundle *fleet.Bundle) (*fleet.Bundle, error) {
 	updated := bundle.DeepCopy()
 	result, err := controllerutil.CreateOrUpdate(ctx, c, bundle, func() error {
-		if (updated.Spec.HelmOpOptions == nil) != (bundle.Spec.HelmOpOptions == nil) {
+		if bundle != nil && bundle.Spec.HelmOpOptions != nil {
 			return fmt.Errorf("a helmOps bundle with name %q already exists", bundle.Name)
 		}
 
@@ -440,7 +440,7 @@ func saveOCIBundle(ctx context.Context, c client.Client, bundle *fleet.Bundle, o
 
 	updated := bundle.DeepCopy()
 	_, err = controllerutil.CreateOrUpdate(ctx, c, bundle, func() error {
-		if (updated.Spec.HelmOpOptions == nil) != (bundle.Spec.HelmOpOptions == nil) {
+		if bundle != nil && bundle.Spec.HelmOpOptions != nil {
 			return fmt.Errorf("a helmOps bundle with name %q already exists", bundle.Name)
 		}
 

--- a/internal/cmd/controller/helmops/reconciler/helmop_controller.go
+++ b/internal/cmd/controller/helmops/reconciler/helmop_controller.go
@@ -159,6 +159,11 @@ func (r *HelmOpReconciler) createUpdateBundle(ctx context.Context, helmop *fleet
 		return nil, err
 	}
 
+	if err == nil && b.Spec.HelmOpOptions == nil {
+		// A gitOps bundle with the same name exists; abort.
+		return nil, fmt.Errorf("a non-helmops bundle already exists with name %s; aborting", helmop.Name)
+	}
+
 	// calculate the new representation of the helmop resource
 	bundle := r.calculateBundle(helmop)
 


### PR DESCRIPTION
When creating a bundle, Fleet checks if a different bundle already exists with the same name, and errors if so.
By "different", we mean:
* detecting existence of a non-HelmOps bundle when creating a bundle from the HelmOps reconciler
* detecting existence of a HelmOps bundle when creating a bundle from `fleet apply`.

Refers to #3435.