### PR TITLE
Lightly refactor bundle creation

### DIFF
--- a/internal/bundlereader/read.go
+++ b/internal/bundlereader/read.go
@@ -38,16 +38,16 @@ type Options struct {
 	CorrectDrift     *fleet.CorrectDrift
 }
 
-// New reads the fleet.yaml, from stdin, or basedir, or a file in basedir.
+// NewBundle reads the fleet.yaml, from stdin, or basedir, or a file in basedir.
 // Then it reads/downloads all referenced resources. It returns the populated
 // bundle and any existing imagescans.
-func New(ctx context.Context, name, baseDir, file string, opts *Options) (*fleet.Bundle, []*fleet.ImageScan, error) {
+func NewBundle(ctx context.Context, name, baseDir, file string, opts *Options) (*fleet.Bundle, []*fleet.ImageScan, error) {
 	if baseDir == "" {
 		baseDir = "."
 	}
 
 	if file == "-" {
-		b, s, err := mayCompress(ctx, name, baseDir, os.Stdin, opts)
+		b, s, err := loadBundle(ctx, name, baseDir, os.Stdin, opts)
 		if err != nil {
 			return b, s, fmt.Errorf("failed to process bundle from STDIN: %w", err)
 		}
@@ -76,7 +76,7 @@ func New(ctx context.Context, name, baseDir, file string, opts *Options) (*fleet
 		in = f
 	}
 
-	b, s, err := mayCompress(ctx, name, baseDir, in, opts)
+	b, s, err := loadBundle(ctx, name, baseDir, in, opts)
 	if err != nil {
 		return b, s, fmt.Errorf("failed to process bundle: %w", err)
 	}
@@ -105,7 +105,9 @@ func setupIOReader(baseDir string) (*os.File, error) {
 	return nil, nil
 }
 
-func mayCompress(ctx context.Context, name, baseDir string, bundleSpecReader io.Reader, opts *Options) (*fleet.Bundle, []*fleet.ImageScan, error) {
+// loadBundle creates a bundle and imagescan from a base directory name and a reader (which may represent data from a
+// directory structure or from standard input).
+func loadBundle(ctx context.Context, name, baseDir string, bundleSpecReader io.Reader, opts *Options) (*fleet.Bundle, []*fleet.ImageScan, error) {
 	if opts == nil {
 		opts = &Options{}
 	}
@@ -115,7 +117,7 @@ func mayCompress(ctx context.Context, name, baseDir string, bundleSpecReader io.
 		return nil, nil, err
 	}
 
-	bundle, scans, err := read(ctx, name, baseDir, bytes.NewBuffer(data), opts)
+	bundle, scans, err := bundleFromDir(ctx, name, baseDir, bytes.NewBuffer(data), opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -128,7 +130,7 @@ func mayCompress(ctx context.Context, name, baseDir string, bundleSpecReader io.
 
 	newOpts := *opts
 	newOpts.Compress = true
-	return read(ctx, name, baseDir, bytes.NewBuffer(data), &newOpts)
+	return bundleFromDir(ctx, name, baseDir, bytes.NewBuffer(data), &newOpts)
 }
 
 func size(bundle *fleet.Bundle) (int, error) {
@@ -139,8 +141,8 @@ func size(bundle *fleet.Bundle) (int, error) {
 	return len(marshalled), nil
 }
 
-// read reads the fleet.yaml from the bundleSpecReader and loads all resources
-func read(ctx context.Context, name, baseDir string, bundleSpecReader io.Reader, opts *Options) (*fleet.Bundle, []*fleet.ImageScan, error) {
+// bundleFromDir reads the fleet.yaml from the bundleSpecReader and loads all resources
+func bundleFromDir(ctx context.Context, name, baseDir string, bundleSpecReader io.Reader, opts *Options) (*fleet.Bundle, []*fleet.ImageScan, error) {
 	if opts == nil {
 		opts = &Options{}
 	}

--- a/internal/cmd/cli/apply/apply.go
+++ b/internal/cmd/cli/apply/apply.go
@@ -261,7 +261,7 @@ func newBundle(ctx context.Context, name, baseDir string, opts *Options) (*fleet
 		return bundle, nil, nil
 	}
 
-	return bundlereader.New(ctx, name, baseDir, opts.BundleFile, &bundlereader.Options{
+	return bundlereader.NewBundle(ctx, name, baseDir, opts.BundleFile, &bundlereader.Options{
 		Compress:         opts.Compress,
 		Labels:           opts.Labels,
 		ServiceAccount:   opts.ServiceAccount,

--- a/internal/cmd/cli/match/match.go
+++ b/internal/cmd/cli/match/match.go
@@ -45,7 +45,7 @@ func Match(ctx context.Context, opts *Options) error {
 	)
 
 	if opts.BundleFile == "" {
-		bundle, _, err = bundlereader.New(ctx, "test", opts.BaseDir, opts.BundleSpec, nil)
+		bundle, _, err = bundlereader.NewBundle(ctx, "test", opts.BaseDir, opts.BundleSpec, nil)
 		if err != nil {
 			return err
 		}

--- a/internal/cmd/controller/imagescan/update/filereader.go
+++ b/internal/cmd/controller/imagescan/update/filereader.go
@@ -19,6 +19,7 @@ package update
 import (
 	"bytes"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 
@@ -61,13 +62,13 @@ func (r *ScreeningLocalReader) Read() ([]*yaml.RNode, error) {
 
 	// For the filename annotation, I want a directory for filenames
 	// to be relative to; but I don't know whether path is a directory
-	// or file yet so this must wait until the body of the filepath.Walk.
+	// or file yet so this must wait until the body of the filepath.WalkDir.
 	var relativePath string
 
 	tokenbytes := []byte(r.Token)
 
 	var result []*yaml.RNode
-	err = filepath.Walk(root, func(p string, info os.FileInfo, err error) error {
+	err = filepath.WalkDir(root, func(p string, info fs.DirEntry, err error) error {
 		if err != nil {
 			return fmt.Errorf("walking path for files: %w", err)
 		}


### PR DESCRIPTION
This brings a few small improvements to the way Fleet builds bundles from directories:
* renaming some functions in the hope of making call chains easier to follow
* skipping a duplicate read of data from directories
* using `filepath.WalkDir` to iterate through a directory structure, which is more efficient than `filepath.Walk`.

Related to #210.