### PR TITLE
Revert the release action to use our own runners

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ env:
 
 jobs:
   build-fleet:
-    runs-on: ubuntu-latest
+    runs-on: runs-on,runner=8cpu-linux-x64,mem=16,run-id=${{ github.run_id }}
 
     env:
       IS_HOTFIX: ${{ contains(github.ref, '-hotfix-') }}


### PR DESCRIPTION
to keep it in sync with the other Rancher projects.