### PR TITLE
Fix e2e commits when running in Mac

### DIFF
--- a/dev/setup-k3d
+++ b/dev/setup-k3d
@@ -54,6 +54,7 @@ k3d cluster create "$name" \
   -p "$(( 8080 + offs )):8080@server:0" \
   -p "$(( 8081 + offs )):8081@server:0" \
   -p "$(( 8082 + offs )):8082@server:0" \
+  -p "$(( 4343 + offs )):4343@server:0" \
   -p "$unique_tls_port:443@server:0" \
   --k3s-arg '--tls-san=k3d-upstream-server-0@server:0' \
   $args

--- a/e2e/testenv/githelper/git.go
+++ b/e2e/testenv/githelper/git.go
@@ -307,7 +307,7 @@ func BuildGitHostname() string {
 // and repo name.
 func GetExternalRepoAddr(env *testenv.Env, port int, repoName string) (string, error) {
 	if v := os.Getenv("external_ip"); v != "" {
-		return fmt.Sprintf("http://%s:8080/%s", v, repoName), nil
+		return fmt.Sprintf("http://%s:%d/%s", v, port, repoName), nil
 	}
 
 	systemk := env.Kubectl.Namespace(cmd.InfraNamespace)


### PR DESCRIPTION
Fixes the e2e tests when running in Mac.

The infra tests were broken when implementing the http/https change in the git repository deployed in the test cluster
