### PR TITLE
Refactor container identity signing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,7 +144,7 @@ jobs:
             cosign sign \
               --oidc-provider=github-actions \
               --yes \
-              --sign-container-identity="${{ env.PRIME_REGISTRY }}/rancher/${IMAGE}:${{ github.ref_name }}" \
+              --sign-container-identity="${{ env.PRIME_REGISTRY }}/rancher/${IMAGE}" \
               "${URL}"
           done
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -370,7 +370,7 @@ docker_signs:
       - "sign"
       - "--oidc-provider=github-actions"
       - "--yes" # needed on cosign 2.0.0+
-      - "--sign-container-identity={{ .Env.PRIME_REGISTRY }}/rancher/fleet{{ if contains \"agent\" \"${artifact}\" }}-agent{{ end }}:{{ .Tag }}{{ if contains \"linux\" \"${artifact}\" }}-linux-{{ if contains \"amd64\" \"${artifact}\" }}amd64{{ else }}arm64{{ end }}{{ end }}"
+      - "--sign-container-identity={{ .Env.PRIME_REGISTRY }}/rancher/fleet{{ if contains \"agent\" \"${artifact}\" }}-agent{{ end }}"
       - "${artifact}@${digest}"
 
     # Which artifacts to sign.


### PR DESCRIPTION
The default identity only references the registry and the image, not the tag or architecture.