### PR TITLE
Ignore warnings about deprecated APIs

### DIFF
--- a/internal/cmd/agent/deployer/internal/diff/diff.go
+++ b/internal/cmd/agent/deployer/internal/diff/diff.go
@@ -486,6 +486,7 @@ func normalizeEndpoint(un *unstructured.Unstructured, o options) {
 	if gvk.Group != "" || gvk.Kind != "Endpoints" {
 		return
 	}
+	// nolint: staticcheck // Endpoint is deprecated; see fleet#3760.
 	var ep corev1.Endpoints
 	err := runtime.DefaultUnstructuredConverter.FromUnstructured(un.Object, &ep)
 	if err != nil {

--- a/internal/cmd/agent/deployer/internal/diff/kubernetes_vendor/pkg/api/v1/endpoints/util.go
+++ b/internal/cmd/agent/deployer/internal/diff/kubernetes_vendor/pkg/api/v1/endpoints/util.go
@@ -43,6 +43,7 @@ func LessEndpointAddress(a, b *v1.EndpointAddress) bool {
 
 // SortSubsets sorts an array of EndpointSubset objects in place.  For ease of
 // use it returns the input slice.
+// nolint: staticcheck // EndpointSubset is deprecated; see fleet#3760.
 func SortSubsets(subsets []v1.EndpointSubset) []v1.EndpointSubset {
 	for i := range subsets {
 		ss := &subsets[i]
@@ -59,6 +60,7 @@ func hashObject(hasher hash.Hash, obj interface{}) []byte {
 	return hasher.Sum(nil)
 }
 
+// nolint: staticcheck // EndpointSubset is deprecated; see fleet#3760.
 type subsetsByHash []v1.EndpointSubset
 
 func (sl subsetsByHash) Len() int      { return len(sl) }

--- a/internal/cmd/controller/gitops/reconciler/gitjob_controller.go
+++ b/internal/cmd/controller/gitops/reconciler/gitjob_controller.go
@@ -203,6 +203,7 @@ func (r *GitJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	// If so, we need to return a Result with EnqueueAfter set.
 
 	res, err := r.manageGitJob(ctx, logger, gitrepo, oldCommit, repoPolled)
+	// nolint: staticcheck // Requeue is deprecated; see fleet#3746.
 	if err != nil || res.Requeue {
 		return res, err
 	}

--- a/internal/cmd/controller/gitops/reconciler/gitjob_test.go
+++ b/internal/cmd/controller/gitops/reconciler/gitjob_test.go
@@ -141,6 +141,7 @@ func TestReconcile_ReturnsAndRequeuesAfterAddingFinalizer(t *testing.T) {
 	if err != nil {
 		t.Errorf("unexpected error %v", err)
 	}
+	// nolint: staticcheck // Requeue is deprecated; see fleet#3746.
 	if !res.Requeue {
 		t.Errorf("expecting Requeue set to true, it was false")
 	}

--- a/internal/cmd/controller/helmops/reconciler/helmop_controller.go
+++ b/internal/cmd/controller/helmops/reconciler/helmop_controller.go
@@ -117,6 +117,7 @@ func (r *HelmOpReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 			return ctrl.Result{}, err
 		}
 
+		// nolint: staticcheck // Requeue is deprecated; see fleet#3746.
 		return ctrl.Result{Requeue: true}, nil
 	}
 
@@ -141,6 +142,7 @@ func (r *HelmOpReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	if err != nil {
 		logger.Error(err, "Reconcile failed final update to HelmOp status", "status", helmop.Status)
 
+		// nolint: staticcheck // Requeue is deprecated; see fleet#3746.
 		return ctrl.Result{Requeue: true}, err
 	}
 


### PR DESCRIPTION
The following deprecation [warnings](https://github.com/rancher/fleet/actions/runs/15408910368/job/43356842842) will be addressed in future releases:
* `controller-runtime`'s `Result.Requeue` field, to be replaced with `Result.RequeueAfter`; see #3746
* Kubernetes' `v1.Endpoint` and `v1.EndpointSubset` resources; see #3760