### PR TITLE
[v2.11] Fix panic found in OCI test

### DIFF
--- a/internal/bundlereader/loaddirectory.go
+++ b/internal/bundlereader/loaddirectory.go
@@ -424,26 +424,25 @@ func newHttpGetter(auth Auth) *getter.HttpGetter {
 		header.Add("Authorization", "Basic "+basicAuth(auth.Username, auth.Password))
 		httpGetter.Header = header
 	}
+
+	transport := http.DefaultTransport.(*http.Transport).Clone()
 	if auth.CABundle != nil {
 		pool, err := x509.SystemCertPool()
 		if err != nil {
 			pool = x509.NewCertPool()
 		}
 		pool.AppendCertsFromPEM(auth.CABundle)
-		transport := http.DefaultTransport.(*http.Transport).Clone()
 		transport.TLSClientConfig = &tls.Config{
 			RootCAs:            pool,
 			MinVersion:         tls.VersionTLS12,
 			InsecureSkipVerify: auth.InsecureSkipVerify, // nolint:gosec
 		}
-		httpGetter.Client.Transport = transport
 	} else if auth.InsecureSkipVerify {
-		transport := http.DefaultTransport.(*http.Transport).Clone()
 		transport.TLSClientConfig = &tls.Config{
 			InsecureSkipVerify: auth.InsecureSkipVerify, // nolint:gosec
 		}
-		httpGetter.Client.Transport = transport
 	}
+	httpGetter.Client.Transport = transport
 
 	return httpGetter
 }

--- a/internal/bundlereader/loaddirectory_test.go
+++ b/internal/bundlereader/loaddirectory_test.go
@@ -29,7 +29,29 @@ func TestGetContent(t *testing.T) {
 		name               string
 		directoryStructure fsNode
 		expectedFiles      map[string][]byte
+		source             string
+		auth               bundlereader.Auth
+		expectedErr        string
 	}{
+		{
+			name: "ensure panic doesn't occur when InsecureSkipVerify is set to false (#3782)",
+			directoryStructure: fsNode{
+				name: "fleet.yaml",
+				contents: `namespace: fleet-helm-oci-with-auth-example
+		 helm:
+		   chart: "oci://ghcr.io/fleetqa/fleet-qa-examples/fleet-test-configmap-chart"
+		   version: "0.1.0"
+		   values:
+		     replicas: 2`,
+			},
+			source: "oci://ghcr.io/fleetqa/fleet-qa-examples/fleet-test-configmap-chart",
+			auth: bundlereader.Auth{
+				Username: "foo",
+				Password: "bar",
+				//InsecureSkipVerify: true, // When commented out, the panic disappears
+			},
+			expectedErr: "denied: denied",
+		},
 		{
 			name: "no .fleetignore",
 			directoryStructure: fsNode{
@@ -554,8 +576,15 @@ func TestGetContent(t *testing.T) {
 
 			root := createDirStruct(t, base, c.directoryStructure)
 
-			files, err := bundlereader.GetContent(context.Background(), root, root, "", bundlereader.Auth{}, false, ignoreApplyConfigs)
-			assert.NoError(t, err)
+			if c.source == "" {
+				c.source = root
+			}
+			files, err := bundlereader.GetContent(context.Background(), root, c.source, "", c.auth, false, ignoreApplyConfigs)
+			if c.expectedErr == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.ErrorContains(t, err, c.expectedErr, c.name)
+			}
 
 			assert.Equal(t, len(c.expectedFiles), len(files))
 			for k, v := range c.expectedFiles {


### PR DESCRIPTION
Refers to #3782

(cherry picked from commit 074a1890e023974de70405d74e2e67ae4fcfa468)

Adapted expectedErr to 'denied: denied'

<!-- Specify the issue ID that this pull request is solving -->

<!-- Make sure that the referenced issue provides steps to reproduce it -->

<!-- Describe the changes introduced by this pull request -->

<!--
  Please provide a unit, integration (`./integrationtests/`) or e2e (`./e2e/`) test if possible.
-->

## Additional Information

### Checklist

- [ ] <!-- If applicable,--> I have updated the documentation via a pull request in the
[fleet-docs](https://github.com/rancher/fleet-docs) repository.
