### PR TITLE
Fix crust-gather cache in CI workflows

### DIFF
--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -73,7 +73,9 @@ jobs:
             mkdir -p ~/.local/bin
             if curl -sSfL https://github.com/crust-gather/crust-gather/raw/main/install.sh | sh -s -- --yes; then
               # Cache the binary for future runs
-              which crust-gather && cp $(which crust-gather) ~/.local/bin/
+              if [ ! -f ~/.local/bin/crust-gather ]; then
+                which crust-gather && cp $(which crust-gather) ~/.local/bin/
+              fi
             else
               echo "Failed to download crust-gather"
               exit 1

--- a/.github/workflows/e2e-fleet-upgrade-ci.yml
+++ b/.github/workflows/e2e-fleet-upgrade-ci.yml
@@ -62,7 +62,9 @@ jobs:
             mkdir -p ~/.local/bin
             if curl -sSfL https://github.com/crust-gather/crust-gather/raw/main/install.sh | sh -s -- --yes; then
               # Cache the binary for future runs
-              which crust-gather && cp $(which crust-gather) ~/.local/bin/
+              if [ ! -f ~/.local/bin/crust-gather ]; then
+                which crust-gather && cp $(which crust-gather) ~/.local/bin/
+              fi
             else
               echo "Failed to download crust-gather"
               exit 1

--- a/.github/workflows/e2e-multicluster-ci.yml
+++ b/.github/workflows/e2e-multicluster-ci.yml
@@ -62,7 +62,9 @@ jobs:
             mkdir -p ~/.local/bin
             if curl -sSfL https://github.com/crust-gather/crust-gather/raw/main/install.sh | sh -s -- --yes; then
               # Cache the binary for future runs
-              which crust-gather && cp $(which crust-gather) ~/.local/bin/
+              if [ ! -f ~/.local/bin/crust-gather ]; then
+                which crust-gather && cp $(which crust-gather) ~/.local/bin/
+              fi
             else
               echo "Failed to download crust-gather"
               exit 1

--- a/.github/workflows/e2e-nightly-ci.yml
+++ b/.github/workflows/e2e-nightly-ci.yml
@@ -66,7 +66,9 @@ jobs:
             mkdir -p ~/.local/bin
             if curl -sSfL https://github.com/crust-gather/crust-gather/raw/main/install.sh | sh -s -- --yes; then
               # Cache the binary for future runs
-              which crust-gather && cp $(which crust-gather) ~/.local/bin/
+              if [ ! -f ~/.local/bin/crust-gather ]; then
+                which crust-gather && cp $(which crust-gather) ~/.local/bin/
+              fi
             else
               echo "Failed to download crust-gather"
               exit 1

--- a/.github/workflows/e2e-rancher-upgrade-fleet-to-head-ci.yml
+++ b/.github/workflows/e2e-rancher-upgrade-fleet-to-head-ci.yml
@@ -67,7 +67,9 @@ jobs:
             mkdir -p ~/.local/bin
             if curl -sSfL https://github.com/crust-gather/crust-gather/raw/main/install.sh | sh -s -- --yes; then
               # Cache the binary for future runs
-              which crust-gather && cp $(which crust-gather) ~/.local/bin/
+              if [ ! -f ~/.local/bin/crust-gather ]; then
+                which crust-gather && cp $(which crust-gather) ~/.local/bin/
+              fi
             else
               echo "Failed to download crust-gather"
               exit 1

--- a/.github/workflows/e2e-rancher-upgrade-fleet.yml
+++ b/.github/workflows/e2e-rancher-upgrade-fleet.yml
@@ -85,7 +85,9 @@ jobs:
             mkdir -p ~/.local/bin
             if curl -sSfL https://github.com/crust-gather/crust-gather/raw/main/install.sh | sh -s -- --yes; then
               # Cache the binary for future runs
-              which crust-gather && cp $(which crust-gather) ~/.local/bin/
+              if [ ! -f ~/.local/bin/crust-gather ]; then
+                which crust-gather && cp $(which crust-gather) ~/.local/bin/
+              fi
             else
               echo "Failed to download crust-gather"
               exit 1

--- a/.github/workflows/e2e-test-fleet-in-rancher.yml
+++ b/.github/workflows/e2e-test-fleet-in-rancher.yml
@@ -93,7 +93,9 @@ jobs:
             mkdir -p ~/.local/bin
             if curl -sSfL https://github.com/crust-gather/crust-gather/raw/main/install.sh | sh -s -- --yes; then
               # Cache the binary for future runs
-              which crust-gather && cp $(which crust-gather) ~/.local/bin/
+              if [ ! -f ~/.local/bin/crust-gather ]; then
+                which crust-gather && cp $(which crust-gather) ~/.local/bin/
+              fi
             else
               echo "Failed to download crust-gather"
               exit 1


### PR DESCRIPTION
because the location of the crust-gather installation has changed so no copying needed.
