### PR TITLE
Incomplete Agent Registration Stops BundleDeployment Creation

### DIFF
--- a/integrationtests/utils/helpers.go
+++ b/integrationtests/utils/helpers.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -47,6 +48,16 @@ func CreateCluster(ctx context.Context, k8sClient client.Client, name, controlle
 	if err != nil {
 		return nil, err
 	}
+
+	err = k8sClient.Create(ctx, &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: clusterNs,
+		},
+	})
+	if client.IgnoreAlreadyExists(err) != nil {
+		return nil, err
+	}
+
 	cluster.Status.Namespace = clusterNs
 	err = k8sClient.Status().Update(ctx, cluster)
 	return cluster, err

--- a/internal/cmd/controller/reconciler/bundle_controller.go
+++ b/internal/cmd/controller/reconciler/bundle_controller.go
@@ -324,6 +324,15 @@ func (r *BundleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 
 		helmvalues.ClearOptions(bd)
 
+		// bd namespace does not exist yet, we should continue. The bd
+		// will re-trigger because the cluster's agent namespace will
+		// be updated when the namespace exists and cluster changes
+		// trigger this reconciler.
+		if err := r.Get(ctx, types.NamespacedName{Name: bd.Name}, &corev1.Namespace{}); err != nil {
+			logger.Info("Bundledeployment namespace does not exist yet, skipping bundle deployment creation", "bdName", bd.Name, "bdNamespace", bd.Namespace)
+			continue
+		}
+
 		bd, err = r.createBundleDeployment(
 			ctx,
 			logger,

--- a/internal/cmd/controller/target/builder.go
+++ b/internal/cmd/controller/target/builder.go
@@ -64,6 +64,7 @@ func (m *Manager) Targets(ctx context.Context, bundle *fleet.Bundle, manifestID 
 		}
 		for _, cluster := range clusters.Items {
 			cluster := cluster
+			// it is possible that agentmanagement did not create the cluster namespace yet
 			logger.V(4).Info("Cluster has namespace?", "cluster", cluster.Name, "namespace", cluster.Status.Namespace)
 			clusterGroups, err := m.clusterGroupsForCluster(ctx, &cluster)
 			if err != nil {


### PR DESCRIPTION
Refers to https://github.com/rancher/fleet/issues/3830

Try to continue if a namespace for a bundledeployment is missing.