### PR TITLE
Support globbing in HelmSecretForPaths

### DIFF
--- a/integrationtests/cli/apply/helm_test.go
+++ b/integrationtests/cli/apply/helm_test.go
@@ -204,17 +204,22 @@ func testHelmRepo(path, port string) {
 		BeforeEach(func() {
 			authEnabled = true
 		})
-		It("uses credentials from HelmSecretNameForPaths", func() {
+		It("uses the first set of credentials matching the bundle path with patterns sorted in lexical order", func() {
 			Eventually(func() error {
 				return fleetApply(
 					"helm",
 					[]string{cli.AssetsPath + path},
 					apply.Options{
 						AuthByPath: map[string]bundlereader.Auth{
+							cli.AssetsPath + "*_url": { // these credentials also match the path, but should not be used.
+								Username: "wrong-" + username,
+								Password: "wrong-" + password,
+							},
 							cli.AssetsPath + "*": {
 								Username: username,
 								Password: password,
 							},
+							cli.AssetsPath + "no-match": {},
 						},
 					},
 				)

--- a/integrationtests/cli/apply/helm_test.go
+++ b/integrationtests/cli/apply/helm_test.go
@@ -200,13 +200,86 @@ func testHelmRepo(path, port string) {
 		})
 	})
 
+	When("Auth is required, and it is provided with globbing in HelmSecretNameForPaths", func() {
+		BeforeEach(func() {
+			authEnabled = true
+		})
+		It("uses credentials from HelmSecretNameForPaths", func() {
+			Eventually(func() error {
+				return fleetApply(
+					"helm",
+					[]string{cli.AssetsPath + path},
+					apply.Options{
+						AuthByPath: map[string]bundlereader.Auth{
+							cli.AssetsPath + "*": {
+								Username: username,
+								Password: password,
+							},
+						},
+					},
+				)
+			}).Should(Not(HaveOccurred()))
+			By("creating a Bundle with all the resources inside of the helm release", func() {
+				Eventually(verifyResourcesArePresent).Should(BeTrue())
+			})
+		})
+		It("errors if the pattern is invalid", func() {
+			Eventually(func(g Gomega) {
+				err := fleetApply(
+					"helm",
+					[]string{cli.AssetsPath + path},
+					apply.Options{
+						AuthByPath: map[string]bundlereader.Auth{
+							cli.AssetsPath + "\\": { // invalid pattern
+								Username: username,
+								Password: password,
+							},
+						},
+					},
+				)
+
+				Expect(err.Error()).To(ContainSubstring("failed to check for matches"))
+				Expect(err).To(MatchError(filepath.ErrBadPattern))
+			}).Should(Succeed())
+		})
+		It("fails with 401 unauthorized if no glob matches the path", func() {
+			Eventually(func(g Gomega) {
+				err := fleetApply(
+					"helm",
+					[]string{cli.AssetsPath + path},
+					apply.Options{
+						AuthByPath: map[string]bundlereader.Auth{
+							cli.AssetsPath + "/something-else": {
+								Username: username,
+								Password: password,
+							},
+						},
+					},
+				)
+
+				Expect(err.Error()).To(ContainSubstring("401"))
+			}).Should(Succeed())
+		})
+	})
+
 	When("Auth is required, and it is provided in HelmSecretNameForPaths", func() {
 		BeforeEach(func() {
 			authEnabled = true
 		})
 		It("fleet apply uses credentials from HelmSecretNameForPaths", func() {
 			Eventually(func() error {
-				return fleetApply("helm", []string{cli.AssetsPath + path}, apply.Options{AuthByPath: map[string]bundlereader.Auth{cli.AssetsPath + path: {Username: username, Password: password}}})
+				return fleetApply(
+					"helm",
+					[]string{cli.AssetsPath + path},
+					apply.Options{
+						AuthByPath: map[string]bundlereader.Auth{
+							cli.AssetsPath + path: {
+								Username: username,
+								Password: password,
+							},
+						},
+					},
+				)
 			}).Should(Not(HaveOccurred()))
 			By("verify Bundle is created with all the resources inside of the helm release", func() {
 				Eventually(verifyResourcesArePresent).Should(BeTrue())
@@ -220,7 +293,14 @@ func testHelmRepo(path, port string) {
 		})
 		It("fleet apply uses credentials from HelmSecretNameForPaths", func() {
 			Eventually(func() error {
-				return fleetApply("helm", []string{cli.AssetsPath + path}, apply.Options{Auth: bundlereader.Auth{Username: "wrong", Password: "wrong"}, AuthByPath: map[string]bundlereader.Auth{cli.AssetsPath + path: {Username: username, Password: password}}})
+				return fleetApply(
+					"helm",
+					[]string{cli.AssetsPath + path},
+					apply.Options{
+						Auth:       bundlereader.Auth{Username: "wrong", Password: "wrong"},
+						AuthByPath: map[string]bundlereader.Auth{cli.AssetsPath + path: {Username: username, Password: password}},
+					},
+				)
 			}).Should(Not(HaveOccurred()))
 			By("verify Bundle is created with all the resources inside of the helm release", func() {
 				Eventually(verifyResourcesArePresent).Should(BeTrue())

--- a/internal/cmd/cli/apply/apply.go
+++ b/internal/cmd/cli/apply/apply.go
@@ -149,6 +149,18 @@ func CreateBundles(pctx context.Context, client client.Client, r record.EventRec
 					eg.Go(func() error {
 						if auth, ok := opts.AuthByPath[path]; ok {
 							opts.Auth = auth
+						} else {
+							// No direct match; check for globs instead.
+							for pathKey, auth := range opts.AuthByPath {
+								isMatch, err := filepath.Match(pathKey, path)
+								if err != nil {
+									return fmt.Errorf("failed to check for matches in auth paths: %w", err)
+								}
+
+								if isMatch {
+									opts.Auth = auth
+								}
+							}
 						}
 
 						bundle, scans, err := bundleFromDir(ctx, repoName, path, opts)

--- a/internal/cmd/cli/apply/apply.go
+++ b/internal/cmd/cli/apply/apply.go
@@ -10,6 +10,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -149,16 +150,24 @@ func CreateBundles(pctx context.Context, client client.Client, r record.EventRec
 					eg.Go(func() error {
 						if auth, ok := opts.AuthByPath[path]; ok {
 							opts.Auth = auth
-						} else {
-							// No direct match; check for globs instead.
-							for pathKey, auth := range opts.AuthByPath {
-								isMatch, err := filepath.Match(pathKey, path)
+						} else { // No direct match; check for globs instead.
+							var patternKeys []string
+							for k := range opts.AuthByPath {
+								patternKeys = append(patternKeys, k)
+							}
+							// Sort patterns in lexical order to work around
+							// non-deterministic iteration order for Go maps.
+							slices.Sort(patternKeys)
+
+							for _, pattern := range patternKeys {
+								isMatch, err := filepath.Match(pattern, path)
 								if err != nil {
 									return fmt.Errorf("failed to check for matches in auth paths: %w", err)
 								}
 
 								if isMatch {
-									opts.Auth = auth
+									opts.Auth = opts.AuthByPath[pattern]
+									break
 								}
 							}
 						}


### PR DESCRIPTION
Secrets referenced by a GitRepo's `spec.helmSecretNameForPaths` field now support globbing.
Invalid patterns will lead to `fleet apply` returning an error.

If more than one pattern matches a given bundle path, then the first pattern, in lexical order, will be used.

Refers to #3398

## Additional Information

### Checklist

- [ ] <!-- If applicable,--> I have updated the documentation via a pull request in the
[fleet-docs](https://github.com/rancher/fleet-docs) repository.
