### PR TITLE
Set HelmOp Accepted condition when no error happened

### DIFF
--- a/internal/cmd/controller/helmops/reconciler/helmop_controller.go
+++ b/internal/cmd/controller/helmops/reconciler/helmop_controller.go
@@ -451,9 +451,7 @@ func updateStatus(ctx context.Context, c client.Client, req types.NamespacedName
 		}
 		t.Status.Conditions = conds
 
-		if orgErr != nil {
-			setAcceptedConditionHelm(&t.Status, orgErr)
-		}
+		setAcceptedConditionHelm(&t.Status, orgErr)
 
 		statusPatch := client.MergeFrom(orig)
 		if patchData, err := statusPatch.Data(t); err == nil && string(patchData) == "{}" {

--- a/internal/cmd/controller/helmops/reconciler/polling_job.go
+++ b/internal/cmd/controller/helmops/reconciler/polling_job.go
@@ -163,6 +163,7 @@ func (j *helmPollingJob) pollHelm(ctx context.Context) error {
 		t.Status.LastPollingTime = metav1.Time{Time: pollingTimestamp}
 		t.Status.Version = version
 
+		condition.Cond(fleet.HelmOpAcceptedCondition).SetStatusBool(&t.Status, true)
 		condition.Cond(fleet.HelmOpPolledCondition).SetStatusBool(&t.Status, true)
 
 		statusPatch := client.MergeFrom(h)


### PR DESCRIPTION
The HelmOps reconciler would previously only update a HelmOp's `Accepted` condition in case of an error, meaning that that condition would stay false even after an update, for instance setting the chart version to a valid constraint resolving to one or more existing versions.

Such updates now reset the `Accepted` condition on a HelmOps, which reflects its actual state.

Refers to #3763
Follow-up to #3747.