### PR TITLE
Skip polling for OCI and tarball charts

### DIFF
--- a/internal/cmd/controller/helmops/reconciler/helmop_controller.go
+++ b/internal/cmd/controller/helmops/reconciler/helmop_controller.go
@@ -409,10 +409,6 @@ func usesPolling(helmop fleet.HelmOp) bool {
 
 	// Polling does not apply to OCI and tarball charts, where no index.yaml file is available to check for new
 	// chart versions.
-	if helmop.Spec.Helm.Repo == "" {
-		return false
-	}
-
 	if strings.HasSuffix(strings.ToLower(helmop.Spec.Helm.Chart), ".tgz") {
 		return false
 	}

--- a/internal/cmd/controller/helmops/reconciler/helmop_controller.go
+++ b/internal/cmd/controller/helmops/reconciler/helmop_controller.go
@@ -407,6 +407,20 @@ func usesPolling(helmop fleet.HelmOp) bool {
 		return false
 	}
 
+	// Polling does not apply to OCI and tarball charts, where no index.yaml file is available to check for new
+	// chart versions.
+	if helmop.Spec.Helm.Repo == "" {
+		return false
+	}
+
+	if strings.HasSuffix(strings.ToLower(helmop.Spec.Helm.Chart), ".tgz") {
+		return false
+	}
+
+	if strings.HasPrefix(strings.ToLower(helmop.Spec.Helm.Repo), "oci://") {
+		return false
+	}
+
 	// we only need to poll if the version is set to a constraint on versions, which may resolve to
 	// different available versions as the contents of the Helm repository evolves over time.
 	_, err := semver.StrictNewVersion(helmop.Spec.Helm.Version)


### PR DESCRIPTION
OCI and direct referencing through tarballs does not involve an `index.yaml` file which Helm can search for new versions over time. Therefore, Fleet now skips Helm polling in such cases.

Refers to #3764
Follow-up to #3784.

## Additional Information

### Checklist

- [x] <!-- If applicable,--> I have updated the documentation via a pull request in the
[fleet-docs](https://github.com/rancher/fleet-docs) repository: see https://github.com/rancher/fleet-docs/pull/272
