### PR TITLE
Allow ignore options to be omitted when empty

### DIFF
--- a/charts/fleet-crd/templates/crds.yaml
+++ b/charts/fleet-crd/templates/crds.yaml
@@ -452,6 +452,7 @@ spec:
                     ignore:
                       description: IgnoreOptions can be used to ignore fields when
                         monitoring the bundle.
+                      nullable: true
                       properties:
                         conditions:
                           description: Conditions is a list of conditions to be ignored
@@ -821,6 +822,7 @@ spec:
                     ignore:
                       description: IgnoreOptions can be used to ignore fields when
                         monitoring the bundle.
+                      nullable: true
                       properties:
                         conditions:
                           description: Conditions is a list of conditions to be ignored
@@ -1741,6 +1743,7 @@ spec:
                 ignore:
                   description: IgnoreOptions can be used to ignore fields when monitoring
                     the bundle.
+                  nullable: true
                   properties:
                     conditions:
                       description: Conditions is a list of conditions to be ignored
@@ -2611,6 +2614,7 @@ spec:
                       ignore:
                         description: IgnoreOptions can be used to ignore fields when
                           monitoring the bundle.
+                        nullable: true
                         properties:
                           conditions:
                             description: Conditions is a list of conditions to be
@@ -7535,6 +7539,7 @@ spec:
                 ignore:
                   description: IgnoreOptions can be used to ignore fields when monitoring
                     the bundle.
+                  nullable: true
                   properties:
                     conditions:
                       description: Conditions is a list of conditions to be ignored
@@ -8422,6 +8427,7 @@ spec:
                       ignore:
                         description: IgnoreOptions can be used to ignore fields when
                           monitoring the bundle.
+                        nullable: true
                         properties:
                           conditions:
                             description: Conditions is a list of conditions to be

--- a/internal/cmd/agent/deployer/monitor/conditions_test.go
+++ b/internal/cmd/agent/deployer/monitor/conditions_test.go
@@ -27,37 +27,43 @@ func TestExcludeIgnoredConditions(t *testing.T) {
 	}
 	tests := map[string]struct {
 		obj           *unstructured.Unstructured
-		ignoreOptions fleet.IgnoreOptions
+		ignoreOptions *fleet.IgnoreOptions
 		expectedObj   *unstructured.Unstructured
 		expectedErr   error
 	}{
-		"nothing is changed without IgnoreOptions": {
+		"nothing is changed with empty IgnoreOptions": {
 			obj:           &unstructured.Unstructured{Object: uPodInitializedAndNotReady},
-			ignoreOptions: fleet.IgnoreOptions{},
+			ignoreOptions: &fleet.IgnoreOptions{},
+			expectedObj:   &unstructured.Unstructured{Object: uPodInitializedAndNotReady},
+			expectedErr:   nil,
+		},
+		"nothing is changed with nil IgnoreOptions": {
+			obj:           &unstructured.Unstructured{Object: uPodInitializedAndNotReady},
+			ignoreOptions: nil,
 			expectedObj:   &unstructured.Unstructured{Object: uPodInitializedAndNotReady},
 			expectedErr:   nil,
 		},
 		"nothing is changed when IgnoreOptions don't match any condition": {
 			obj:           &unstructured.Unstructured{Object: uPodInitializedAndNotReady},
-			ignoreOptions: fleet.IgnoreOptions{Conditions: []map[string]string{{"Not": "Found"}}},
+			ignoreOptions: &fleet.IgnoreOptions{Conditions: []map[string]string{{"Not": "Found"}}},
 			expectedObj:   &unstructured.Unstructured{Object: uPodInitializedAndNotReady},
 			expectedErr:   nil,
 		},
 		"'Type: Ready' condition is excluded when IgnoreOptions contains 'Type: Ready' condition": {
 			obj:           &unstructured.Unstructured{Object: uPodInitializedAndNotReady},
-			ignoreOptions: fleet.IgnoreOptions{Conditions: []map[string]string{{"type": "Ready"}}},
+			ignoreOptions: &fleet.IgnoreOptions{Conditions: []map[string]string{{"type": "Ready"}}},
 			expectedObj:   &unstructured.Unstructured{Object: uPodInitialized},
 			expectedErr:   nil,
 		},
 		"'Type: Ready' condition is excluded when IgnoreOptions contains 'Type: Ready, status: False' condition": {
 			obj:           &unstructured.Unstructured{Object: uPodInitializedAndNotReady},
-			ignoreOptions: fleet.IgnoreOptions{Conditions: []map[string]string{{"type": "Ready", "status": "False"}}},
+			ignoreOptions: &fleet.IgnoreOptions{Conditions: []map[string]string{{"type": "Ready", "status": "False"}}},
 			expectedObj:   &unstructured.Unstructured{Object: uPodInitialized},
 			expectedErr:   nil,
 		},
 		"nothing is changed when IgnoreOptions contains 'type: Ready, status: True' condition": {
 			obj:           &unstructured.Unstructured{Object: uPodInitializedAndNotReady},
-			ignoreOptions: fleet.IgnoreOptions{Conditions: []map[string]string{{"type": "Ready", "status": "True"}}},
+			ignoreOptions: &fleet.IgnoreOptions{Conditions: []map[string]string{{"type": "Ready", "status": "True"}}},
 			expectedObj:   &unstructured.Unstructured{Object: uPodInitializedAndNotReady},
 			expectedErr:   nil,
 		},

--- a/internal/cmd/agent/deployer/monitor/updatestatus.go
+++ b/internal/cmd/agent/deployer/monitor/updatestatus.go
@@ -312,7 +312,7 @@ func calculateDesiredReady(liveResourceKeys map[fleet.ResourceKey]struct{}, modi
 	return desired
 }
 
-func nonReady(ctx context.Context, plan desiredset.Plan, ignoreOptions fleet.IgnoreOptions) (result []fleet.NonReadyStatus) {
+func nonReady(ctx context.Context, plan desiredset.Plan, ignoreOptions *fleet.IgnoreOptions) (result []fleet.NonReadyStatus) {
 	logger := log.FromContext(ctx)
 	defer func() {
 		sort.Slice(result, func(i, j int) bool {
@@ -322,7 +322,7 @@ func nonReady(ctx context.Context, plan desiredset.Plan, ignoreOptions fleet.Ign
 
 	for _, obj := range plan.Objects {
 		if u, ok := obj.(*unstructured.Unstructured); ok {
-			if ignoreOptions.Conditions != nil {
+			if ignoreOptions != nil && ignoreOptions.Conditions != nil {
 				if err := excludeIgnoredConditions(u, ignoreOptions); err != nil {
 					logger.Error(err, "failed to ignore conditions")
 				}
@@ -438,7 +438,11 @@ func isResourceInPreviousRelease(key objectset.ObjectKey, kind string, objsPrevi
 }
 
 // excludeIgnoredConditions removes the conditions that are included in ignoreOptions from the object passed as a parameter
-func excludeIgnoredConditions(obj *unstructured.Unstructured, ignoreOptions fleet.IgnoreOptions) error {
+func excludeIgnoredConditions(obj *unstructured.Unstructured, ignoreOptions *fleet.IgnoreOptions) error {
+	if ignoreOptions == nil {
+		return nil
+	}
+
 	conditions, _, err := unstructured.NestedSlice(obj.Object, "status", "conditions")
 	if err != nil {
 		return err

--- a/pkg/apis/fleet.cattle.io/v1alpha1/bundledeployment_types.go
+++ b/pkg/apis/fleet.cattle.io/v1alpha1/bundledeployment_types.go
@@ -97,8 +97,8 @@ type BundleDeploymentOptions struct {
 	DeleteNamespace bool `json:"deleteNamespace,omitempty"`
 
 	//IgnoreOptions can be used to ignore fields when monitoring the bundle.
-	// +optional
-	IgnoreOptions `json:"ignore,omitempty"`
+	// +nullable
+	IgnoreOptions *IgnoreOptions `json:"ignore,omitempty"`
 
 	// CorrectDrift specifies how drift correction should work.
 	CorrectDrift *CorrectDrift `json:"correctDrift,omitempty"`

--- a/pkg/apis/fleet.cattle.io/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/fleet.cattle.io/v1alpha1/zz_generated.deepcopy.go
@@ -174,7 +174,11 @@ func (in *BundleDeploymentOptions) DeepCopyInto(out *BundleDeploymentOptions) {
 		*out = new(DiffOptions)
 		(*in).DeepCopyInto(*out)
 	}
-	in.IgnoreOptions.DeepCopyInto(&out.IgnoreOptions)
+	if in.IgnoreOptions != nil {
+		in, out := &in.IgnoreOptions, &out.IgnoreOptions
+		*out = new(IgnoreOptions)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.CorrectDrift != nil {
 		in, out := &in.CorrectDrift, &out.CorrectDrift
 		*out = new(CorrectDrift)


### PR DESCRIPTION
Using a pointer field instead of embedding a value prevents empty ignore options from appearing in a HelmOp's specs.

Refers to #3834

## Additional Information

### Checklist

~- [ ] <!-- If applicable,--> I have updated the documentation via a pull request in the
[fleet-docs](https://github.com/rancher/fleet-docs) repository.~
