### PR TITLE
Prevent dangling HelmOps polling jobs

### DIFF
--- a/internal/cmd/controller/helmops/reconciler/helmop_controller_test.go
+++ b/internal/cmd/controller/helmops/reconciler/helmop_controller_test.go
@@ -332,9 +332,18 @@ func TestReconcile_Validate(t *testing.T) {
 			client.EXPECT().Status().Return(statusClient)
 			statusClient.EXPECT().Patch(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
 
+			scheduler := mocks.NewMockScheduler(mockCtrl)
+
+			if len(c.err) > 0 {
+				job := mocks.NewMockScheduledJob(mockCtrl)
+				scheduler.EXPECT().GetScheduledJob(gomock.Any()).Return(job, nil)
+				scheduler.EXPECT().DeleteJob(gomock.Any()).Return(nil)
+			}
+
 			r := HelmOpReconciler{
-				Client: client,
-				Scheme: scheme,
+				Client:    client,
+				Scheme:    scheme,
+				Scheduler: scheduler,
 			}
 
 			ctx := context.TODO()


### PR DESCRIPTION
When validation fails upon an update on a HelmOp, any polling job for that HelmOp must be deleted, as it relies on an outdated definition of the resource and any updates made by such a job would lead to potentially corrupt HelmOp and bundle states.

Refers to #3435.
Follow-up to #3795.

## Additional Information

### Checklist

~- [ ] <!-- If applicable,--> I have updated the documentation via a pull request in the
[fleet-docs](https://github.com/rancher/fleet-docs) repository.~
