### PR TITLE
Add step to pull Docker manifest for local inspection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,6 +146,9 @@ jobs:
               --yes \
               --sign-container-identity="${{ env.PRIME_REGISTRY }}/rancher/${IMAGE}" \
               "${URL}"
+
+            # Pull the manifest locally to make it available for inspection
+            docker pull "${URL}"
           done
 
       - name: Attest provenance


### PR DESCRIPTION
because `docker inspect` does only work locally.

[Successful test run](https://github.com/rancher/fleet/actions/runs/16004043675/job/45146140256)