### PR TITLE
Use correct platform for attestation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -156,7 +156,7 @@ jobs:
         run: |
           IMAGES=$(yq e '.dockers[].image_templates[0]' .goreleaser.yaml | grep STAGE_REGISTRY | sed "s/{{ .Env.STAGE_REGISTRY }}/${{ env.STAGE_REGISTRY }}/g" | sed "s/{{ .Tag }}/${{ github.ref_name }}/g")
 
-                    for IMG_NAME in $IMAGES; do
+          for IMG_NAME in $IMAGES; do
             # Extract Docker image reference plus digest from local image
             URL=$(docker inspect --format='{{index .RepoDigests 0}}' "${IMG_NAME}")
 
@@ -164,7 +164,13 @@ jobs:
             retry_delay=5
 
             for ((i=0; i<max_retries; i++)); do
-              if slsactl download provenance --format=slsav1 "${URL}" > provenance-slsav1.json; then
+              if [[ "${IMG_NAME}" =~ -linux-([^-]+)$ ]]; then
+                PLATFORM="linux/${BASH_REMATCH[1]}"
+              else
+                PLATFORM="linux/amd64"
+              fi
+
+              if slsactl download provenance --format=slsav1 --platform="${PLATFORM}" "${URL}" > provenance-slsav1.json; then
                 break
               fi
               if [ "${i}" -eq "$(( max_retries - 1 ))" ]; then


### PR DESCRIPTION
At the moment slsactl does not specify a platform and uses linux/amd64 by default. So instead of using the default we extract the platform from the docker image.

For now we do not attest provenance for manifest since they reference multiple architectures.
In  the future there might be an option to attach information for every architecture but until then we ignore it.