### PR TITLE
Fix end-to-end test for HelmOp install with strict TLS mode

### DIFF
--- a/e2e/multi-cluster/installation/agent_test.go
+++ b/e2e/multi-cluster/installation/agent_test.go
@@ -159,7 +159,7 @@ var _ = Describe("HelmOps installation with strict TLS mode", func() {
 				ns,
 				"",
 				"https://github.com/rancher/fleet/raw/refs/heads/main/integrationtests/cli/assets/helmrepository/config-chart-0.1.0.tgz",
-				"0.1.0",
+				"",
 				0,
 				"",
 				false,


### PR DESCRIPTION
Merging that test case should have been preceded by a rebase, to take validation logic into account, which uncovered a test failure. This patch fixes that failure, caused by the version field not being empty when installing a tarball chart.

Refers to #3589
Follow-up to #3806

## Additional Information

### Checklist

~- [ ] <!-- If applicable,--> I have updated the documentation via a pull request in the
[fleet-docs](https://github.com/rancher/fleet-docs) repository.~
