### PR TITLE
Check Helm for static version

### DIFF
--- a/internal/cmd/controller/helmops/reconciler/helmop_controller.go
+++ b/internal/cmd/controller/helmops/reconciler/helmop_controller.go
@@ -262,7 +262,7 @@ func (r *HelmOpReconciler) handleVersion(ctx context.Context, oldBundle *fleet.B
 
 	version, err := getChartVersion(ctx, r.Client, *helmop)
 	if err != nil {
-		return fmt.Errorf("could not get chart version: %w", err)
+		return err
 	}
 
 	if usesPolling(*helmop) {

--- a/internal/cmd/controller/helmops/reconciler/helmop_controller.go
+++ b/internal/cmd/controller/helmops/reconciler/helmop_controller.go
@@ -254,11 +254,6 @@ func (r *HelmOpReconciler) handleVersion(ctx context.Context, oldBundle *fleet.B
 		return fmt.Errorf("the provided HelmOp is nil; this should not happen")
 	}
 
-	if _, err := semver.StrictNewVersion(helmop.Spec.Helm.Version); err == nil {
-		bundle.Spec.Helm.Version = helmop.Spec.Helm.Version
-		return nil
-	}
-
 	if !helmChartSpecChanged(oldBundle.Spec.Helm, bundle.Spec.Helm, helmop.Status.Version) {
 		bundle.Spec.Helm.Version = helmop.Status.Version
 
@@ -524,7 +519,7 @@ func helmChartSpecChanged(o *fleet.HelmOptions, n *fleet.HelmOptions, statusVers
 	}
 	// check also against statusVersion in case that Reconcile is called
 	// before the status subresource has been fully updated in the cluster (and the cache)
-	if o.Version != n.Version && statusVersion != o.Version {
+	if o.Version != n.Version && statusVersion == o.Version {
 		return true
 	}
 	return false

--- a/internal/cmd/controller/helmops/reconciler/helmop_controller_test.go
+++ b/internal/cmd/controller/helmops/reconciler/helmop_controller_test.go
@@ -620,12 +620,13 @@ func TestReconcile_ManagePollingJobs(t *testing.T) {
 					Namespace: "default",
 				},
 				Spec: fleet.HelmOpSpec{
+					InsecureSkipTLSverify: true,
 					BundleSpec: fleet.BundleSpec{
 						BundleDeploymentOptions: fleet.BundleDeploymentOptions{
 							Helm: &fleet.HelmOptions{
 								Repo:    svr1.URL,
-								Chart:   "chart",
-								Version: "1.1.2", // static version
+								Chart:   "alpine",
+								Version: "0.1.0", // static version
 							},
 						},
 					},
@@ -645,12 +646,13 @@ func TestReconcile_ManagePollingJobs(t *testing.T) {
 					Namespace: "default",
 				},
 				Spec: fleet.HelmOpSpec{
+					InsecureSkipTLSverify: true,
 					BundleSpec: fleet.BundleSpec{
 						BundleDeploymentOptions: fleet.BundleDeploymentOptions{
 							Helm: &fleet.HelmOptions{
 								Repo:    svr1.URL,
-								Chart:   "chart",
-								Version: "1.1.2", // static version
+								Chart:   "alpine",
+								Version: "0.1.0", // static version
 							},
 						},
 					},

--- a/internal/cmd/controller/helmops/reconciler/polling_job.go
+++ b/internal/cmd/controller/helmops/reconciler/polling_job.go
@@ -138,7 +138,7 @@ func (j *helmPollingJob) pollHelm(ctx context.Context) error {
 	orig := b.DeepCopy()
 	b.Spec.Helm.Version = version
 
-	if version != b.Spec.Helm.Version {
+	if version != h.Status.Version {
 		j.recorder.Event(h, fleetevent.Normal, "GotNewChartVersion", version)
 	}
 


### PR DESCRIPTION
When a HelmOp resource references a static chart version, the HelmOps controller checks Helm for existence of that version.

This prevents errors about the version not existing in the Helm index from going undetected until a bundle deployment is created and an agent attempts to deploy it.
Consequently, this also ensures that errors about the version not existing are produced even if no target cluster is found for the HelmOp.

Refers to #3763
Follow-up to #3747.

## Additional Information

### Checklist

~- [ ] <!-- If applicable,--> I have updated the documentation via a pull request in the
[fleet-docs](https://github.com/rancher/fleet-docs) repository.~
