### PR TITLE
Use charts branch `dev-v2.12` when testing Fleet in Rancher

### DIFF
--- a/.github/workflows/release-against-test-charts.yml
+++ b/.github/workflows/release-against-test-charts.yml
@@ -8,7 +8,7 @@ on:
       charts_base_branch:
         description: "Use the following rancher/charts branch as a base (e.g. dev-v2.7)"
         required: true
-        default: "dev-v2.11"
+        default: "dev-v2.12"
       charts_repo:
         description: "Push to the following Rancher charts repo (which must exist)"
         required: true
@@ -34,7 +34,7 @@ jobs:
         id: compute_env
         run: |
           tmp=${{github.event.inputs.charts_base_branch}}
-          charts_base_branch=${tmp:-'dev-v2.11'}
+          charts_base_branch=${tmp:-'dev-v2.12'}
 
           tmp=${{github.event.inputs.charts_repo}}
           charts_repo=${tmp:-fleetrepoci/charts}


### PR DESCRIPTION
Branch `dev-v2.11`, apart from being outdated, leads to errors with a webhook chart version not being found, which prevents the check on the `rancher-webhook` deployment from succeeding. This eventually led jobs to be cancelled after a few hours.

Local tests suggest that this does not happen with `dev-v2.12`.

This should fix CI failures such as [this one](https://github.com/rancher/fleet/actions/runs/15955548875/job/45001427259).

## Additional Information

### Checklist

~- [ ] <!-- If applicable,--> I have updated the documentation via a pull request in the
[fleet-docs](https://github.com/rancher/fleet-docs) repository.~
