### PR TITLE
dev-scripts: Fix patching downstream clusters

### DIFF
--- a/dev/setup-fleet-multi-cluster
+++ b/dev/setup-fleet-multi-cluster
@@ -22,7 +22,9 @@ ns=${FLEET_E2E_NS_DOWNSTREAM-fleet-default}
 # Wait for clusters to become "ready" by waiting for bundles to become ready.
 num_clusters=$(k3d cluster list -o json | jq -r '.[].name | select( . | contains("downstream") )' | wc -l)
 while [[ $(kubectl get clusters.fleet.cattle.io -n "$ns" | grep '1/1' -c) -ne $num_clusters ]]; do
-    sleep 1
+  sleep 1
 done
 
-kubectl patch clusters.fleet.cattle.io -n "$ns" --all --type=json -p '[{"op": "add", "path": "/metadata/labels/env", "value": "test" }]'
+for cluster in $(kubectl get clusters.fleet.cattle.io -n "$ns" -o jsonpath='{.items[*].metadata.name}'); do
+  kubectl patch clusters.fleet.cattle.io "$cluster" -n "$ns" --type=json -p '[{"op": "add", "path": "/metadata/labels/env", "value": "test" }]'
+done


### PR DESCRIPTION
<!-- Specify the issue ID that this pull request is solving -->
Prevents

```
+ kubectl patch clusters.fleet.cattle.io -n fleet-default --all --type=json -p '[{"op": "add", "path": "/metadata/labels/env", "value": "test" }]'                         
error: unknown flag: --all                                                                                                                                                 
See 'kubectl patch --help' for usage.      
```

when running `dev/setup-fleet-multi-cluster`.
<!-- Make sure that the referenced issue provides steps to reproduce it -->

<!-- Describe the changes introduced by this pull request -->

<!--
  Please provide a unit, integration (`./integrationtests/`) or e2e (`./e2e/`) test if possible.
-->

## Additional Information

### Checklist

- [ ] <!-- If applicable,--> I have updated the documentation via a pull request in the
[fleet-docs](https://github.com/rancher/fleet-docs) repository.
