### PR TITLE
Add HelmOps to cluster status and metrics

### DIFF
--- a/charts/fleet-crd/templates/crds.yaml
+++ b/charts/fleet-crd/templates/crds.yaml
@@ -5823,6 +5823,12 @@ spec:
 
                     are desired to be ready.'
                   type: integer
+                desiredReadyHelmOps:
+                  description: 'DesiredReadyHelmOps is the number of helmop resources
+                    for this cluster that
+
+                    are desired to be ready.'
+                  type: integer
                 display:
                   description: Display contains the number of ready bundles, nodes
                     and a summary state.
@@ -5857,6 +5863,10 @@ spec:
                 readyGitRepos:
                   description: ReadyGitRepos is the number of gitrepos for this cluster
                     that are ready.
+                  type: integer
+                readyHelmOps:
+                  description: ReadyHelmOps is the number of helmop resources for
+                    this cluster that are ready.
                   type: integer
                 resourceCounts:
                   description: ResourceCounts is an aggregate over the ResourceCounts.

--- a/e2e/metrics/cluster_test.go
+++ b/e2e/metrics/cluster_test.go
@@ -18,6 +18,8 @@ var (
 	expectedMetrics = MetricsSelector{
 		"fleet_cluster_desired_ready_git_repos":      {},
 		"fleet_cluster_ready_git_repos":              {},
+		"fleet_cluster_desired_ready_helm_ops":       {},
+		"fleet_cluster_ready_helm_ops":               {},
 		"fleet_cluster_resources_count_desiredready": {},
 		"fleet_cluster_resources_count_missing":      {},
 		"fleet_cluster_resources_count_modified":     {},

--- a/e2e/metrics/suite_test.go
+++ b/e2e/metrics/suite_test.go
@@ -91,14 +91,16 @@ func setupLoadBalancer(shard string, app string) (metricsURL string) {
 	if ip := os.Getenv("external_ip"); ip != "" {
 		metricsURL = fmt.Sprintf("http://%s:%d/metrics", ip, port)
 	} else {
-		Eventually(func() (string, error) {
+		Eventually(func(g Gomega) {
 			ip, err := ks.Get(
 				"service", loadBalancerName,
 				"-o", "jsonpath={.status.loadBalancer.ingress[0].ip}",
 			)
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(ip).ToNot(BeEmpty())
+
 			metricsURL = fmt.Sprintf("http://%s:%d/metrics", ip, port)
-			return ip, err
-		}).ShouldNot(BeEmpty())
+		}).Should(Succeed())
 	}
 
 	DeferCleanup(func() {

--- a/integrationtests/controller/cluster/status_test.go
+++ b/integrationtests/controller/cluster/status_test.go
@@ -1,6 +1,8 @@
 package cluster
 
 import (
+	"fmt"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -27,7 +29,7 @@ var _ = Describe("Cluster Status Fields", func() {
 		})
 	})
 
-	When("Bundledeployment is added", func() {
+	When("Bundledeployments are added", func() {
 		BeforeEach(func() {
 			cluster, err := utils.CreateCluster(ctx, k8sClient, "cluster", namespace, nil, namespace)
 			Expect(err).NotTo(HaveOccurred())
@@ -39,10 +41,28 @@ var _ = Describe("Cluster Status Fields", func() {
 					Namespace: namespace,
 				},
 				Spec: v1alpha1.GitRepoSpec{
-					Repo: "https://github.com/rancher/fleet-test-data/not-found",
+					Repo: "https://github.com/rancher/fleet-test-data/does-not-matter",
 				},
 			}
 			err = k8sClient.Create(ctx, gitrepo)
+			Expect(err).NotTo(HaveOccurred())
+
+			helmop := &v1alpha1.HelmOp{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-helmop",
+					Namespace: namespace,
+				},
+				Spec: v1alpha1.HelmOpSpec{
+					BundleSpec: v1alpha1.BundleSpec{
+						BundleDeploymentOptions: v1alpha1.BundleDeploymentOptions{
+							Helm: &v1alpha1.HelmOptions{
+								Chart: "https://github.com/rancher/fleet-test-data/does-not-matter.tgz",
+							},
+						},
+					},
+				},
+			}
+			err = k8sClient.Create(ctx, helmop)
 			Expect(err).NotTo(HaveOccurred())
 
 			targets := []v1alpha1.BundleTarget{
@@ -54,9 +74,13 @@ var _ = Describe("Cluster Status Fields", func() {
 					ClusterName: "cluster",
 				},
 			}
-			bundle, err := utils.CreateBundle(ctx, k8sClient, "name", namespace, targets, targets)
+			gitBundle, err := utils.CreateBundle(ctx, k8sClient, "gitrepo-bundle", namespace, targets, targets)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(bundle).To(Not(BeNil()))
+			Expect(gitBundle).To(Not(BeNil()))
+
+			helmBundle, err := utils.CreateBundle(ctx, k8sClient, "helmop-bundle", namespace, targets, targets)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(helmBundle).To(Not(BeNil()))
 		})
 
 		It("updates the status fields", func() {
@@ -69,24 +93,38 @@ var _ = Describe("Cluster Status Fields", func() {
 			}).Should(BeTrue())
 			Expect(cluster.Status.Summary.Ready).To(Equal(0))
 
-			bundle := &v1alpha1.Bundle{}
-			err := k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "name"}, bundle)
+			gBundle := &v1alpha1.Bundle{}
+			err := k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "gitrepo-bundle"}, gBundle)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(bundle).To(Not(BeNil()))
-			Expect(bundle.Status.Display.State).To(Equal(""))
+			Expect(gBundle).To(Not(BeNil()))
+			Expect(gBundle.Status.Display.State).To(Equal(""))
 
-			By("Add the gitrepo name to bundle")
+			hBundle := &v1alpha1.Bundle{}
+			err = k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "helmop-bundle"}, hBundle)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(hBundle).To(Not(BeNil()))
+			Expect(hBundle.Status.Display.State).To(Equal(""))
+
+			By("Adding the gitrepo name to the git bundle")
 			Eventually(func() error {
-				err := k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "name"}, bundle)
+				err := k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "gitrepo-bundle"}, gBundle)
 				Expect(err).ToNot(HaveOccurred())
-				bundle.Labels["fleet.cattle.io/repo-name"] = "test-gitrepo"
-				return k8sClient.Update(ctx, bundle)
+				gBundle.Labels["fleet.cattle.io/repo-name"] = "test-gitrepo"
+				return k8sClient.Update(ctx, gBundle)
 			}).ShouldNot(HaveOccurred())
 
-			By("Prepare bundledeployment so the bundle gets to 'Ready' state")
+			By("Adding the helmop name to the Helm bundle")
+			Eventually(func() error {
+				err := k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "helmop-bundle"}, hBundle)
+				Expect(err).ToNot(HaveOccurred())
+				hBundle.Labels["fleet.cattle.io/fleet-helm-name"] = "test-helmop"
+				return k8sClient.Update(ctx, hBundle)
+			}).ShouldNot(HaveOccurred())
+
+			By("Preparing the bundledeployments so the bundles get to 'Ready' state")
 			bd := &v1alpha1.BundleDeployment{}
 			Eventually(func() error {
-				err = k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "name"}, bd)
+				err = k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "gitrepo-bundle"}, bd)
 				if err != nil {
 					return err
 				}
@@ -98,7 +136,7 @@ var _ = Describe("Cluster Status Fields", func() {
 			}).ShouldNot(HaveOccurred())
 
 			Eventually(func() error {
-				err = k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "name"}, bd)
+				err = k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "gitrepo-bundle"}, bd)
 				if err != nil {
 					return err
 				}
@@ -106,15 +144,53 @@ var _ = Describe("Cluster Status Fields", func() {
 				return k8sClient.Update(ctx, bd)
 			}).ShouldNot(HaveOccurred())
 
-			cluster = &v1alpha1.Cluster{}
-			Eventually(func() bool {
-				err := k8sClient.Get(ctx, types.NamespacedName{Name: "cluster", Namespace: namespace}, cluster)
-				Expect(err).NotTo(HaveOccurred())
+			bd = &v1alpha1.BundleDeployment{}
+			Eventually(func() error {
+				err = k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "helmop-bundle"}, bd)
+				if err != nil {
+					return err
+				}
+				bd.Status.Display.State = "Ready"
+				bd.Status.AppliedDeploymentID = bd.Spec.DeploymentID
+				bd.Status.Ready = true
+				bd.Status.NonModified = true
+				return k8sClient.Status().Update(ctx, bd)
+			}).ShouldNot(HaveOccurred())
 
-				return cluster.Status.Summary.DesiredReady == 1 && cluster.Status.ReadyGitRepos == 1
-			}).Should(BeTrue())
-			Expect(cluster.Status.Display.ReadyBundles).To(Equal("1/1"))
-			Expect(cluster.Status.Summary.Ready).To(Equal(1))
+			Eventually(func() error {
+				err = k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "helmop-bundle"}, bd)
+				if err != nil {
+					return err
+				}
+				bd.Labels["fleet.cattle.io/fleet-helm-name"] = "test-helmop"
+				return k8sClient.Update(ctx, bd)
+			}).ShouldNot(HaveOccurred())
+
+			cluster = &v1alpha1.Cluster{}
+			Eventually(func(g Gomega) {
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: "cluster", Namespace: namespace}, cluster)
+				g.Expect(err).NotTo(HaveOccurred())
+
+				g.Expect(cluster.Status.Summary.DesiredReady).To(Equal(2))
+				g.Expect(cluster.Status.DesiredReadyGitRepos).To(
+					Equal(1),
+					fmt.Sprintf("got %d desired ready GitRepos, expected 1", cluster.Status.DesiredReadyGitRepos),
+				)
+				g.Expect(cluster.Status.ReadyGitRepos).To(
+					Equal(1),
+					fmt.Sprintf("got %d ready GitRepos, expected 1", cluster.Status.ReadyGitRepos),
+				)
+				g.Expect(cluster.Status.DesiredReadyHelmOps).To(
+					Equal(1),
+					fmt.Sprintf("got %d desired ready HelmOps, expected 1", cluster.Status.DesiredReadyHelmOps),
+				)
+				g.Expect(cluster.Status.ReadyHelmOps).To(
+					Equal(1),
+					fmt.Sprintf("got %d ready HelmOps, expected 1", cluster.Status.ReadyHelmOps),
+				)
+			}).Should(Succeed())
+			Expect(cluster.Status.Display.ReadyBundles).To(Equal("2/2"))
+			Expect(cluster.Status.Summary.Ready).To(Equal(2))
 		})
 	})
 })

--- a/internal/metrics/cluster_metrics.go
+++ b/internal/metrics/cluster_metrics.go
@@ -56,6 +56,24 @@ var (
 			},
 			clusterLabels,
 		),
+		"desired_ready_helm_ops": promauto.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: metricPrefix,
+				Subsystem: clusterSubsystem,
+				Name:      "desired_ready_helm_ops",
+				Help:      "The desired number of HelmOps to be in a ready state.",
+			},
+			clusterLabels,
+		),
+		"ready_helm_ops": promauto.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: metricPrefix,
+				Subsystem: clusterSubsystem,
+				Name:      "ready_helm_ops",
+				Help:      "The number of HelmOps in a ready state.",
+			},
+			clusterLabels,
+		),
 		"resources_count_desiredready": promauto.NewGaugeVec(
 			prometheus.GaugeOpts{
 				Namespace: metricPrefix,
@@ -159,6 +177,10 @@ func collectClusterMetrics(obj any, metrics map[string]prometheus.Collector) {
 		With(labels).Set(float64(cluster.Status.DesiredReadyGitRepos))
 	metrics["ready_git_repos"].(*prometheus.GaugeVec).
 		With(labels).Set(float64(cluster.Status.ReadyGitRepos))
+	metrics["desired_ready_helm_ops"].(*prometheus.GaugeVec).
+		With(labels).Set(float64(cluster.Status.DesiredReadyHelmOps))
+	metrics["ready_helm_ops"].(*prometheus.GaugeVec).
+		With(labels).Set(float64(cluster.Status.ReadyHelmOps))
 	metrics["resources_count_desiredready"].(*prometheus.GaugeVec).
 		With(labels).Set(float64(cluster.Status.ResourceCounts.DesiredReady))
 	metrics["resources_count_missing"].(*prometheus.GaugeVec).

--- a/pkg/apis/fleet.cattle.io/v1alpha1/cluster_types.go
+++ b/pkg/apis/fleet.cattle.io/v1alpha1/cluster_types.go
@@ -148,13 +148,24 @@ type ClusterStatus struct {
 	Summary BundleSummary `json:"summary,omitempty"`
 	// ResourceCounts is an aggregate over the ResourceCounts.
 	ResourceCounts ResourceCounts `json:"resourceCounts,omitempty"`
+
 	// ReadyGitRepos is the number of gitrepos for this cluster that are ready.
 	// +optional
 	ReadyGitRepos int `json:"readyGitRepos"`
+
 	// DesiredReadyGitRepos is the number of gitrepos for this cluster that
 	// are desired to be ready.
 	// +optional
 	DesiredReadyGitRepos int `json:"desiredReadyGitRepos"`
+
+	// ReadyHelmOps is the number of helmop resources for this cluster that are ready.
+	// +optional
+	ReadyHelmOps int `json:"readyHelmOps"`
+
+	// DesiredReadyHelmOps is the number of helmop resources for this cluster that
+	// are desired to be ready.
+	// +optional
+	DesiredReadyHelmOps int `json:"desiredReadyHelmOps"`
 
 	// AgentEnvVarsHash is a hash of the agent's env vars, used to detect changes.
 	// +nullable


### PR DESCRIPTION
HelmOp resources were previously missing from cluster statuses and metrics.
They are now reflected there next to GitRepos, with 2 new status fields:
* `DesiredReadyHelmOps`
* `ReadyHelmOps`

Refers to #3435
Related to https://github.com/rancher/dashboard/issues/14713

## Additional Information

### Checklist

- [ ] <!-- If applicable,--> I have updated the documentation via a pull request in the
[fleet-docs](https://github.com/rancher/fleet-docs) repository.
