### PR TITLE
Helmops controller resets conditions after recovering from error

### DIFF
--- a/charts/fleet/templates/rbac_helmops.yaml
+++ b/charts/fleet/templates/rbac_helmops.yaml
@@ -44,6 +44,7 @@ rules:
       - 'events'
     verbs:
       - "create"
+      - "patch"
   - apiGroups:
       - ""
     resources:

--- a/internal/cmd/controller/helmops/reconciler/polling_job.go
+++ b/internal/cmd/controller/helmops/reconciler/polling_job.go
@@ -165,6 +165,8 @@ func (j *helmPollingJob) pollHelm(ctx context.Context) error {
 
 		condition.Cond(fleet.HelmOpAcceptedCondition).SetStatusBool(&t.Status, true)
 		condition.Cond(fleet.HelmOpPolledCondition).SetStatusBool(&t.Status, true)
+		condition.Cond(fleet.HelmOpPolledCondition).Message(&t.Status, "")
+		kstatus.SetActive(&t.Status)
 
 		statusPatch := client.MergeFrom(h)
 		if patchData, err := statusPatch.Data(t); err == nil && string(patchData) == "{}" {


### PR DESCRIPTION
It also enables patching events for the HelmOp controller as both issues were found in the same test.

Refers to: https://github.com/rancher/fleet/issues/3896
Refers to: https://github.com/rancher/fleet/issues/3898


## Additional Information

### Checklist

~- [ ] <!-- If applicable,--> I have updated the documentation via a pull request in the
[fleet-docs](https://github.com/rancher/fleet-docs) repository.~
