### PR TITLE
Request known hosts update validation

### DIFF
--- a/.github/scripts/check-for-known-hosts-changes.sh
+++ b/.github/scripts/check-for-known-hosts-changes.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+set -u
+
+if [ $# -eq 0 ]; then
+    echo "Usage: $0 <base_branch>"
+    exit 1
+fi
+
+base=$1
+
+git diff --quiet $base HEAD -- charts/fleet/templates/configmap_known_hosts.yaml
+if [ $? -eq 1 ]; then # The PR contains changes to the config map
+    .github/scripts/update_known_hosts_configmap.sh
+
+    git diff --quiet charts/fleet/templates/configmap_known_hosts.yaml
+    if [ $? -eq 1 ]; then
+        echo "Locally-computed changes for the known-hosts config map do not match initial changes."
+        exit 1
+    fi
+fi

--- a/.github/scripts/check-for-known-hosts-changes.sh
+++ b/.github/scripts/check-for-known-hosts-changes.sh
@@ -8,7 +8,8 @@ fi
 
 base=$1
 
-git diff --quiet $base HEAD -- charts/fleet/templates/configmap_known_hosts.yaml
+git fetch origin $base
+git diff --quiet origin/$base HEAD -- charts/fleet/templates/configmap_known_hosts.yaml
 if [ $? -eq 1 ]; then # The PR contains changes to the config map
     .github/scripts/update_known_hosts_configmap.sh
 

--- a/.github/workflows/check-changes.yml
+++ b/.github/workflows/check-changes.yml
@@ -31,3 +31,6 @@ jobs:
       -
         name: generate.go
         run: ./.github/scripts/check-for-auto-generated-changes.sh
+      -
+        name: known-hosts
+        run: ./.github/scripts/check-for-known-hosts-changes.sh $GITHUB_BASE_REF

--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   updatecli:
-    runs-on: ubuntu-latest
+    runs-on: runs-on,runner=8cpu-linux-x64,mem=16,run-id=${{ github.run_id }}
 
     if: github.ref == 'refs/heads/main'
     steps:

--- a/updatecli/updatecli.d/known-hosts.yaml
+++ b/updatecli/updatecli.d/known-hosts.yaml
@@ -40,5 +40,15 @@ actions:
       mergemethod: squash
       labels:
         - kind/known-hosts # /!\ label must exist in the repo!
+      description: |
+        Before approving this PR, please do one of the following:
+          - [ ] Check new fingerprints against the following URLs:
+            - Bitbucket: [here](https://support.atlassian.com/bitbucket-cloud/docs/configure-ssh-and-two-step-verification/) or using `curl https://bitbucket.org/site/ssh`
+            - Github: [here](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/githubs-ssh-key-fingerprints)
+            - Gitlab: [here](https://docs.gitlab.com/ee/user/gitlab_com/index.html#ssh-known_hosts-entries)
+            - Azure DevOps: [here](https://learn.microsoft.com/en-us/azure/devops/repos/git/use-ssh-keys-to-authenticate?view=azure-devops)
+          - [ ] Check out the PR's branch locally (for instance running `gh pr checkout <url>`) and:
+            1. Run the [update script](https://github.com/rancher/fleet/blob/main/.github/scripts/update_known_hosts_configmap.sh) again
+            2. Check that `charts/fleet/templates/configmap_known_hosts.yaml` is left unchanged as a result.
 
 {{ end }}

--- a/updatecli/updatecli.d/known-hosts.yaml
+++ b/updatecli/updatecli.d/known-hosts.yaml
@@ -28,7 +28,10 @@ targets:
         spec:
           files:
             - charts/fleet/templates/configmap_known_hosts.yaml
-      command: bash <(git show main:.github/scripts/update_known_hosts_configmap.sh)
+      command: |
+        git show main:.github/scripts/update_known_hosts_configmap.sh > /tmp/script
+        chmod +x /tmp/script
+        bash /tmp/script
 
 actions:
   default:


### PR DESCRIPTION
This makes auto-generated changes to the `known-hosts` config map a bit more robust, by:
* Running the update script against each PR updating that config map, to detect any discrepancies ([example run](https://github.com/weyfonk/fleet/pull/14))
* Advising reviewers of any PR generated by updatecli and updating that config map to manually check that the generated updates to the config map are sound ([example PR description](https://github.com/weyfonk/fleet/pull/17))

It also fixes logic to call the update script itself, to fix runtime errors such as [this one](https://github.com/rancher/fleet/actions/runs/16584258322/job/46906435770#step:4:328).

Follow-up to #3709.

## Additional Information

### Checklist

~- [ ] <!-- If applicable,--> I have updated the documentation via a pull request in the
[fleet-docs](https://github.com/rancher/fleet-docs) repository.~
