### PR TITLE
Test bundle name override

### DIFF
--- a/integrationtests/cli/apply/apply_test.go
+++ b/integrationtests/cli/apply/apply_test.go
@@ -49,6 +49,23 @@ var _ = Describe("Fleet apply", Ordered, func() {
 		})
 	})
 
+	When("folder contains simple resources and a fleet.yaml specifying a bundle name", func() {
+		BeforeEach(func() {
+			name = "simple"
+			dirs = []string{cli.AssetsPath + "simple-fleet-yaml"}
+		})
+
+		It("creates a bundle with that name, containing all the resources, and keepResources is false", func() {
+			bundle, err := cli.GetBundleFromOutput(buf)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(bundle.Spec.Resources).To(HaveLen(2))
+			Expect(bundle.Name).To(Equal("my-great-bundle"))
+			Expect(dirs[0] + "/svc.yaml").To(bePresentInBundleResources(bundle.Spec.Resources))
+			Expect(dirs[0] + "/deployment.yaml").To(bePresentInBundleResources(bundle.Spec.Resources))
+			Expect(bundle.Spec.KeepResources).Should(BeFalse())
+		})
+	})
+
 	When("simple resources in a nested folder", func() {
 		BeforeEach(func() {
 			name = "nested_simple"

--- a/integrationtests/cli/assets/simple-fleet-yaml/deployment.yaml
+++ b/integrationtests/cli/assets/simple-fleet-yaml/deployment.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+  labels:
+    app: nginx
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.14.2
+        ports:
+        - containerPort: 80

--- a/integrationtests/cli/assets/simple-fleet-yaml/fleet.yaml
+++ b/integrationtests/cli/assets/simple-fleet-yaml/fleet.yaml
@@ -1,0 +1,1 @@
+name: 'my-great-bundle'

--- a/integrationtests/cli/assets/simple-fleet-yaml/svc.yaml
+++ b/integrationtests/cli/assets/simple-fleet-yaml/svc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx-service
+spec:
+  selector:
+    app: nginx
+  ports:
+  - name: name-of-service-port
+    protocol: TCP
+    port: 80
+    targetPort: http-web-svc


### PR DESCRIPTION
A bundle's name can be computed from a GitRepo's name and the path leading to the bundle. However, overriding that name is also possible, by populating the `name` field in a `fleet.yaml` file.

A new integration test case covers and demonstrates this.

## Additional Information

### Checklist

- [x] <!-- If applicable,--> I have updated the documentation via a pull request in the
[fleet-docs](https://github.com/rancher/fleet-docs) repository: see https://github.com/rancher/fleet-docs/pull/303
