### PR TITLE
Add v0.13 release branch to targets for known-hosts updates

### DIFF
--- a/updatecli/values.d/scm.yaml
+++ b/updatecli/values.d/scm.yaml
@@ -6,6 +6,9 @@ scms:
     owner: rancher
     repository: fleet
     branch: main
+  v13:
+    <<: *main
+    branch: 'release/v0.13'
   v12:
     <<: *main
     branch: 'release/v0.12'


### PR DESCRIPTION
The `known-hosts` config map must be automatically updated on all supported release branches, which includes v0.13.

Follow-up to #3926

## Additional Information

### Checklist

~- [ ] <!-- If applicable,--> I have updated the documentation via a pull request in the
[fleet-docs](https://github.com/rancher/fleet-docs) repository.~
