### PR TITLE
[v0.12] - Avoid using a global registry client when downloading OCI helm charts…

### DIFF
--- a/internal/bundlereader/loaddirectory.go
+++ b/internal/bundlereader/loaddirectory.go
@@ -26,23 +26,6 @@ import (
 	"helm.sh/helm/v3/pkg/registry"
 )
 
-var (
-	registryClient *registry.Client
-
-	fleetOciProvider = helmgetter.Provider{
-		Schemes: []string{registry.OCIScheme},
-		New:     NewFleetOCIProvider,
-	}
-)
-
-func NewFleetOCIProvider(options ...helmgetter.Option) (helmgetter.Getter, error) {
-	if registryClient == nil {
-		return nil, fmt.Errorf("oci registry client is nil")
-	}
-
-	return helmgetter.NewOCIGetter(helmgetter.WithRegistryClient(registryClient))
-}
-
 // ignoreTree represents a tree of ignored paths (read from .fleetignore files), each node being a directory.
 // It provides a means for ignored paths to be propagated down the tree, but not between subdirectories of a same
 // directory.
@@ -365,7 +348,7 @@ func downloadOCIChart(name, version, path string, auth Auth) (string, error) {
 	if auth.BasicHTTP {
 		clientOptions = append(clientOptions, registry.ClientOptPlainHTTP())
 	}
-	registryClient, err = registry.NewClient(clientOptions...)
+	registryClient, err := registry.NewClient(clientOptions...)
 	if err != nil {
 		return "", err
 	}
@@ -396,8 +379,15 @@ func downloadOCIChart(name, version, path string, auth Auth) (string, error) {
 	getterOptions = append(getterOptions, helmgetter.WithInsecureSkipVerifyTLS(auth.InsecureSkipVerify))
 
 	c := downloader.ChartDownloader{
-		Verify:         downloader.VerifyNever,
-		Getters:        helmgetter.Providers{fleetOciProvider},
+		Verify: downloader.VerifyNever,
+		Getters: helmgetter.Providers{
+			helmgetter.Provider{
+				Schemes: []string{registry.OCIScheme},
+				New: func(options ...helmgetter.Option) (helmgetter.Getter, error) {
+					return helmgetter.NewOCIGetter(helmgetter.WithRegistryClient(registryClient))
+				},
+			},
+		},
 		RegistryClient: registryClient,
 		Options:        getterOptions,
 	}


### PR DESCRIPTION
This changes how we instantiate the `registryClient` used when downloading helm charts stored in OCI registries. It fixes race conditions that could lead to `Not Logged In` or even authentication problems.

Refers to: https://github.com/rancher/fleet/issues/3940
Backport of: https://github.com/rancher/fleet/pull/3938

## Additional Information

### Checklist

~- [ ] <!-- If applicable,--> I have updated the documentation via a pull request in the
[fleet-docs](https://github.com/rancher/fleet-docs) repository.~
