### PR TITLE
[backport v2.12.1] Treat updating status as notReady for perClusterState

### DIFF
--- a/internal/resourcestatus/resourcekey.go
+++ b/internal/resourcestatus/resourcekey.go
@@ -200,7 +200,11 @@ func appendToPerClusterState(states *fleet.PerClusterState, state, clusterID str
 		states.Pending = append(states.Pending, clusterID)
 	case "Modified":
 		states.Modified = append(states.Modified, clusterID)
-	case "NotReady":
+	case "NotReady", "updating":
+		// `updating` comes from checkTransitioning summarizer in the
+		// fleet-agent. When the `Available` condition is set to false, the
+		// state is set to `updating`, but we treat it as nonReady for per
+		// cluster states.
 		states.NotReady = append(states.NotReady, clusterID)
 	case "Orphaned":
 		states.Orphaned = append(states.Orphaned, clusterID)


### PR DESCRIPTION
<!-- Specify the issue ID that this pull request is solving -->
Refers to #3951
<!-- Make sure that the referenced issue provides steps to reproduce it -->

<!-- Describe the changes introduced by this pull request -->

<!--
  Please provide a unit, integration (`./integrationtests/`) or e2e (`./e2e/`) test if possible.
-->

## Additional Information

### Checklist

- [ ] <!-- If applicable,--> I have updated the documentation via a pull request in the
[fleet-docs](https://github.com/rancher/fleet-docs) repository.
(cherry picked from commit 0d2ef58)