### PR TITLE
[v0.13] - Trims the v prefix in versions before checking if it's a valid semver…

### DIFF
--- a/integrationtests/controller/bundle/bundle_helm_test.go
+++ b/integrationtests/controller/bundle/bundle_helm_test.go
@@ -102,6 +102,37 @@ var _ = Describe("Bundle with helm options", Ordered, func() {
 			By("not propagating helm values to BundleDeployments")
 			for _, bd := range bdList.Items {
 				Expect(bd.Spec.Options.Helm.Values).To(BeNil())
+				Expect(bd.Spec.Options.Helm.Version).To(Equal(version))
+			}
+		})
+	})
+
+	When("helm options is NOT nil, version has v prefix, and has no values", func() {
+		BeforeEach(func() {
+			helmOptions = &v1alpha1.BundleHelmOptions{}
+			bundleName = "helm-not-nil-vprefix-and-no-values"
+			bdLabels = map[string]string{
+				"fleet.cattle.io/bundle-name":      bundleName,
+				"fleet.cattle.io/bundle-namespace": namespace,
+			}
+			expectedNumberOfBundleDeployments = 3
+			// simulate targets. All targets are also added to targetRestrictions, which acts as a white list
+			targets = []v1alpha1.BundleTarget{
+				{
+					ClusterGroup: "all",
+				},
+			}
+			targetRestrictions = make([]v1alpha1.BundleTarget, len(targets))
+			copy(targetRestrictions, targets)
+			version = "v1.2.3"
+		})
+
+		It("creates three BundleDeployments with the expected helm options information", func() {
+			var bdList = verifyHelmBundlesDeploymentsAreCreated(expectedNumberOfBundleDeployments, bdLabels, bundleName, helmOptions)
+			By("not propagating helm values to BundleDeployments")
+			for _, bd := range bdList.Items {
+				Expect(bd.Spec.Options.Helm.Values).To(BeNil())
+				Expect(bd.Spec.Options.Helm.Version).To(Equal(version))
 			}
 		})
 	})

--- a/internal/cmd/controller/reconciler/bundle_controller.go
+++ b/internal/cmd/controller/reconciler/bundle_controller.go
@@ -9,6 +9,7 @@ import (
 	"maps"
 	"reflect"
 	"slices"
+	"strings"
 	"time"
 
 	"github.com/Masterminds/semver/v3"
@@ -231,7 +232,13 @@ func (r *BundleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	// version constraint. That constraint should be resolved into a strict version by the HelmOps reconciler before bundle
 	// deployments can be created.
 	if contentsInHelmChart && bundle.Spec.Helm != nil && len(bundle.Spec.Helm.Version) > 0 {
-		if _, err := semver.StrictNewVersion(bundle.Spec.Helm.Version); err != nil {
+		// #3953
+		// There are helm repositories that list chart versions with the "v" prefix.
+		// That's not recommended by Helm as the version with the prefix is not semver compliant,
+		// but those repositories are still valid.
+		// Delete the "v" prefix (if found) before checking for a valid semver.
+		versionToCheck := strings.TrimPrefix(bundle.Spec.Helm.Version, "v")
+		if _, err := semver.StrictNewVersion(versionToCheck); err != nil {
 			setReadyCondition(
 				&bundle.Status,
 				fmt.Errorf("chart version cannot be deployed; check HelmOp status for more details: %v", err),


### PR DESCRIPTION
As decribed in the related issue, some helm repositories identify versions using the "v" prefix (like v1.5.6). Although that's not recommended by Helm, those repositories are still valid.

This PR trims the "v" prefix (if exists) before checking if the version stored in the Bundle spec is semver compliant.


Refers to: https://github.com/rancher/fleet/issues/3958
Backport of: https://github.com/rancher/fleet/pull/3955

### Checklist

~- [ ] <!-- If applicable,--> I have updated the documentation via a pull request in the
[fleet-docs](https://github.com/rancher/fleet-docs) repository.~
