### PR TITLE
[v0.14] Harden values files exclusion from bundle resources

### DIFF
--- a/integrationtests/cli/apply/apply_test.go
+++ b/integrationtests/cli/apply/apply_test.go
@@ -236,6 +236,38 @@ var _ = Describe("Fleet apply", Ordered, func() {
 			})
 		})
 	})
+
+	When("a fleet.yaml located beside a local chart dir references a values file prefixed by its directory", func() {
+		BeforeEach(func() {
+			name = "helm-values-ignore"
+			dirs = []string{cli.AssetsPath + name}
+		})
+
+		It("creates a bundle without the values file", func() {
+			bundle, err := cli.GetBundleFromOutput(buf)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(bundle.Spec.Resources).To(HaveLen(2))
+
+			Expect(cli.AssetsPath + "helm-values-ignore/config-chart/templates/configmap.yaml").To(bePresentInBundleResources(bundle.Spec.Resources))
+			Expect(cli.AssetsPath + "helm-values-ignore/config-chart/Chart.yaml").To(bePresentInBundleResources(bundle.Spec.Resources))
+		})
+	})
+
+	When("a fleet.yaml located within a local chart dir references a values file prefixed by its directory", func() {
+		BeforeEach(func() {
+			name = "helm-in-chart-fleetyaml-values-ignore"
+			dirs = []string{cli.AssetsPath + name}
+		})
+
+		It("creates a bundle without the values file", func() {
+			bundle, err := cli.GetBundleFromOutput(buf)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(bundle.Spec.Resources).To(HaveLen(2))
+
+			Expect(cli.AssetsPath + "helm-in-chart-fleetyaml-values-ignore/config-chart/templates/configmap.yaml").To(bePresentInBundleResources(bundle.Spec.Resources))
+			Expect(cli.AssetsPath + "helm-in-chart-fleetyaml-values-ignore/config-chart/Chart.yaml").To(bePresentInBundleResources(bundle.Spec.Resources))
+		})
+	})
 })
 
 var _ = Describe("Fleet apply driven", Ordered, func() {

--- a/integrationtests/cli/assets/helm-in-chart-fleetyaml-values-ignore/config-chart/Chart.yaml
+++ b/integrationtests/cli/assets/helm-in-chart-fleetyaml-values-ignore/config-chart/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: config-chart
+description: A test chart that verifies its config
+type: application
+version: 0.1.0
+appVersion: "1.16.0"

--- a/integrationtests/cli/assets/helm-in-chart-fleetyaml-values-ignore/config-chart/fleet.yaml
+++ b/integrationtests/cli/assets/helm-in-chart-fleetyaml-values-ignore/config-chart/fleet.yaml
@@ -1,0 +1,3 @@
+helm:
+  valuesFiles:
+    - config-chart/values.yaml # resolves to `values.yaml` inside the same directory, but looks like an out-of-tree file

--- a/integrationtests/cli/assets/helm-in-chart-fleetyaml-values-ignore/config-chart/templates/configmap.yaml
+++ b/integrationtests/cli/assets/helm-in-chart-fleetyaml-values-ignore/config-chart/templates/configmap.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: app-config
+data:
+  test: "value"
+  name: {{ .Values.name }}

--- a/integrationtests/cli/assets/helm-in-chart-fleetyaml-values-ignore/config-chart/values.yaml
+++ b/integrationtests/cli/assets/helm-in-chart-fleetyaml-values-ignore/config-chart/values.yaml
@@ -1,0 +1,1 @@
+name: global.fleet.clusterLabels.management.cattle.io/cluster-display-name

--- a/integrationtests/cli/assets/helm-values-ignore/config-chart/Chart.yaml
+++ b/integrationtests/cli/assets/helm-values-ignore/config-chart/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: config-chart
+description: A test chart that verifies its config
+type: application
+version: 0.1.0
+appVersion: "1.16.0"

--- a/integrationtests/cli/assets/helm-values-ignore/config-chart/templates/configmap.yaml
+++ b/integrationtests/cli/assets/helm-values-ignore/config-chart/templates/configmap.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: app-config
+data:
+  test: "value"
+  name: {{ .Values.name }}

--- a/integrationtests/cli/assets/helm-values-ignore/config-chart/values.yaml
+++ b/integrationtests/cli/assets/helm-values-ignore/config-chart/values.yaml
@@ -1,0 +1,1 @@
+name: global.fleet.clusterLabels.management.cattle.io/cluster-display-name

--- a/integrationtests/cli/assets/helm-values-ignore/fleet.yaml
+++ b/integrationtests/cli/assets/helm-values-ignore/fleet.yaml
@@ -1,0 +1,4 @@
+helm:
+  chart: config-chart
+  valuesFiles:
+    - config-chart/values.yaml

--- a/internal/bundlereader/resources.go
+++ b/internal/bundlereader/resources.go
@@ -98,15 +98,29 @@ type loadOpts struct {
 // * spec.Targets[].Helm.ValuesFiles
 func ignoreApplyConfigs(spec *fleet.HelmOptions, targets ...fleet.BundleTarget) []string {
 	ignore := []string{"fleet.yaml"}
+
+	// Values files may be referenced from `fleet.yaml` files either with their file name
+	// alone, or with a directory prefix, for instance for a chart directory.
+	// Values files must be ignored in both cases, and determining which of the filename or full path will be needed
+	// depends on where the `fleet.yaml` file lives relatively to the values file(s) which it references.
 	if spec != nil {
 		ignore = append(ignore, spec.ValuesFiles...)
+
+		for _, vf := range spec.ValuesFiles {
+			ignore = append(ignore, filepath.Base(vf))
+		}
 	}
 
 	for _, target := range targets {
 		if target.Helm == nil {
 			continue
 		}
+
 		ignore = append(ignore, target.Helm.ValuesFiles...)
+
+		for _, vf := range target.Helm.ValuesFiles {
+			ignore = append(ignore, filepath.Base(vf))
+		}
 	}
 
 	return ignore


### PR DESCRIPTION
Values files may be referenced by file name alone, or with a directory prefix. Both variants now lead to values files being excluded from bundles resources, regardless of where a `fleet.yaml` file referencing them lives (inside or outside of a chart directory).

Refers to #3957.
Forward-port of #3956 to `main`.

## Additional Information

### Checklist

~- [ ] <!-- If applicable,--> I have updated the documentation via a pull request in the
[fleet-docs](https://github.com/rancher/fleet-docs) repository.~
