### PR TITLE
Use the upstream connection to read helm secrets in the agent

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -131,6 +131,7 @@ require (
 	github.com/gobuffalo/flect v1.0.3 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
+	github.com/golang/mock v1.6.0 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/btree v1.1.3 // indirect
 	github.com/google/gnostic-models v0.6.9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -868,6 +868,7 @@ github.com/golang/mock v1.4.1/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt
 github.com/golang/mock v1.4.3/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt3cw=
 github.com/golang/mock v1.4.4/go.mod h1:l3mdAwkq5BuhzHwde/uurv3sEJeZMXNpwsxVWU71h+4=
 github.com/golang/mock v1.5.0/go.mod h1:CWnOUgYIOo4TcNZ0wHX3YZCqsaM1I1Jvs6v3mP3KVu8=
+github.com/golang/mock v1.6.0 h1:ErTB+efbowRARo13NNdxyJji2egdxLGQhRaY+DUumQc=
 github.com/golang/mock v1.6.0/go.mod h1:p6yTPP+5HYm5mzsMV8JkE6ZKdX+/wYM6Hr+LicevLPs=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=

--- a/internal/bundlereader/auth.go
+++ b/internal/bundlereader/auth.go
@@ -18,7 +18,7 @@ type Auth struct {
 	BasicHTTP          bool   `json:"basicHTTP,omitempty"`
 }
 
-func ReadHelmAuthFromSecret(ctx context.Context, c client.Client, req types.NamespacedName) (Auth, error) {
+func ReadHelmAuthFromSecret(ctx context.Context, c client.Reader, req types.NamespacedName) (Auth, error) {
 	if req.Name == "" {
 		return Auth{}, nil
 	}

--- a/internal/bundlereader/helm.go
+++ b/internal/bundlereader/helm.go
@@ -13,7 +13,7 @@ import (
 
 // GetManifestFromHelmChart downloads the given helm chart and creates a
 // manifest with its contents. This is used by the agent to deploy HelmOps.
-func GetManifestFromHelmChart(ctx context.Context, c client.Client, bd *fleet.BundleDeployment) (*manifest.Manifest, error) {
+func GetManifestFromHelmChart(ctx context.Context, c client.Reader, bd *fleet.BundleDeployment) (*manifest.Manifest, error) {
 	helm := bd.Spec.Options.Helm
 
 	if helm == nil {

--- a/internal/cmd/agent/deployer/deployer.go
+++ b/internal/cmd/agent/deployer/deployer.go
@@ -134,7 +134,7 @@ func (d *Deployer) helmdeploy(ctx context.Context, logger logr.Logger, bd *fleet
 			return "", fmt.Errorf("invalid or corrupt manifest. Expecting id: %q, got %q", manifestID, actualID)
 		}
 	} else if bd.Spec.HelmChartOptions != nil {
-		m, err = bundlereader.GetManifestFromHelmChart(ctx, d.client, bd)
+		m, err = bundlereader.GetManifestFromHelmChart(ctx, d.upstreamClient, bd)
 		if err != nil {
 			return "", err
 		}


### PR DESCRIPTION
When installing HelmOps in downstream agents (different from the local one) we had an issue because the agent was trying to read the secret from the downstream client.

The secret is cloned to the cluster's namespace in the upstream cluster so, same as we do when reading the BundleDeployment, we should read the secret from upstream.

Also the functions affected now use a `client.Reader` which is safer than `client.Client` because Readers only implement the `Get` and `List` functions.

Refers to: https://github.com/rancher/fleet/issues/3658

### Checklist

~- [ ] <!-- If applicable,--> I have updated the documentation via a pull request in the
[fleet-docs](https://github.com/rancher/fleet-docs) repository.~
