### PR TITLE
[v0.12] chore: update Go toolchain to version 1.24.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/rancher/fleet
 
 go 1.24.0
 
-toolchain go1.24.4
+toolchain go1.24.6
 
 replace (
 	github.com/imdario/mergo => github.com/imdario/mergo v0.3.16


### PR DESCRIPTION
a manual update is needed because we have bumped the Helm libraries which required a new Go version and renovate only bumps go versions fitting the according Rancher version (1.23.x).