### PR TITLE
Stuck helm release in pending-install are replaced (SURE-10627)

### DIFF
--- a/integrationtests/cli/deploy/deploy_test.go
+++ b/integrationtests/cli/deploy/deploy_test.go
@@ -1,6 +1,11 @@
 package deploy_test
 
 import (
+	"bytes"
+	"compress/gzip"
+	"encoding/base64"
+	"encoding/json"
+
 	"github.com/onsi/gomega/gbytes"
 
 	clihelper "github.com/rancher/fleet/integrationtests/cli"
@@ -149,6 +154,27 @@ var _ = Describe("Fleet CLI Deploy", func() {
 
 	When("deploying on top of a release in `pending-install` status", func() {
 		BeforeEach(func() {
+			release := map[string]interface{}{
+				"name": "testbundle-simple-chart",
+				"info": map[string]string{
+					"status": "pending-install",
+				},
+				// Other release fields (e.g. chart, manifests) omitted for simplicity, not needed to
+				// check for a `pending-install` release.
+			}
+			releaseJSON, err := json.Marshal(release)
+			Expect(err).ToNot(HaveOccurred())
+
+			var gzBuf bytes.Buffer
+			gzWriter := gzip.NewWriter(&gzBuf)
+			_, err = gzWriter.Write(releaseJSON)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(gzWriter.Close()).ToNot(HaveOccurred())
+
+			rel := make([]byte, base64.StdEncoding.EncodedLen(gzBuf.Len()))
+			base64.StdEncoding.Encode(rel, gzBuf.Bytes())
+
 			releaseSecret := corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "sh.helm.release.v1.testbundle-simple-chart.v1",
@@ -161,14 +187,15 @@ var _ = Describe("Fleet CLI Deploy", func() {
 					},
 				},
 				Type: "helm.sh/release.v1",
-				Data: map[string][]byte{
-					"release": []byte("H4sIAAAAAAAAA51V23LiOBD9FZdfF4htAgFXzUNgA8vkMpUbBG9SKVlu2wqypLJkByeVfx/JhpBkZpLafTJq+pzuPupWP9sMZWD7tgKpwoJFFNqSZEJ/cIpyZbdswmJu+892THKp7iMQlFcQaYjneL22M2h7vSu35ztDf/+g47ruwO0O+4O/HM93HA2n6P+gIqCgav/6IHFOhCKcacOMSYUotTA3aSrQDtqgCqn/E8AiwpI2aXzsl5bdlKHzz0ChCClkfm+KxpzFJHmttIRcNjGcjttxfol8aBmVrNrdUilSlkaQmIC0iJJWw6ZRSJD5K1Xp1Raxs7gdt1+zI8a4zlxbZS0wBVAdjJSi0CF8DyXAVNukKgXC0Gjx0WlzZyT69A4/olYAop2D5EWOwQgXIyrhN44S8pJgaCOMecGUyUFrqiph0tFVUYLrAoyVcryyfVZQqj1Ax0fKcP/7vOuxjXGvkSpDolOhjBqh64uxlzcjMc/mFfZoGT7wJHo4OkYeLYK/eXLuDYsgo+xqMXkcZy6NppPV8uYi/ZHwZDbtpeHiuj/754Li7rnSeIWna3qyOOPLm++O/pZhFojgUewwjW9/Nv7uLRdrN7g6qk6r2fFsPCqWC5f+IKMDqA6LeTaR0WL+dJLVMZL4xjnW5f6mqo1YG63+Q2nX3ryKMvoQXE8elt7QDdn5cbiYO8vFRRpNj/pjcpgsF70i7JqzxrPT2qZT5cFirU7YGT/x0jL0pJZgVAWXrgjZmcav5cl49IizaxXdjBjOJqvg3Mi1TpfZXOInrsvVPNOgDJ94sswmleENs4kKrniCvaHSXCWezistW4mTb9/slzs9KYgWIN9MUgQxKmjTraYXJE4hQ9tuiAk13uZgJrKZkx0Y1qju1prVoDPESKybue6x7Sz5VuneMqOmf8ssy2B96x3UmM0MaE9zdL3uLVsRFvnWuA55isQt2z4DNcmbCazPlsXDB8BK6iHICX8zCESzbIv8w5wZAopCoF9xpUimvtXFqDtEUdRznGEY9feH+14Y457rDcIDFEM4QIOugz20K9bEfRex3Uh5y3SbpZyv3k2b5Bm0uYAcKZ5rB6OENl82TXq4GeiWLZBKP7yFe1/19CcX1Aj+PsqXqqdAs45M90wRviVy2L7grfpQiCRHEfwicMy5b4Uo30n0sWgo9RtqZLHfkJqid6z23WZJ5QUzTaldcr167pH6w7bq9p39QW/gdV+31XYVfQoa9txufzB8BQndBuaeLguMASK97F62e+9ecP2wkvr1tEOIuc7WSNPGOTTP7V09hduV4rbst2ti06f2y09Y3Y4W3gcAAA=="),
-				},
+				Data: map[string][]byte{"release": rel},
 			}
+			// Fleet creates release secrets into the default namespace, therefore a cleanup is needed here
+			// to prevent conflicts with other test cases.
+			_ = k8sClient.Delete(ctx, &releaseSecret)
 			Expect(k8sClient.Create(ctx, &releaseSecret)).ToNot(HaveOccurred())
 			args = []string{
 				"--input-file", clihelper.AssetsPath + "bundledeployment/bd.yaml",
-				"--namespace", "default",
+				"--namespace", namespace,
 			}
 			DeferCleanup(func() {
 				Expect(k8sClient.Delete(ctx, &releaseSecret)).ToNot(HaveOccurred())

--- a/internal/helmdeployer/install.go
+++ b/internal/helmdeployer/install.go
@@ -128,6 +128,7 @@ func (h *Helm) install(ctx context.Context, bundleID string, manifest *manifest.
 		u.TakeOwnership = options.Helm.TakeOwnership
 		u.EnableDNS = !options.Helm.DisableDNS
 		u.Replace = true
+		u.Atomic = options.Helm.Atomic
 		u.ReleaseName = releaseName
 		u.CreateNamespace = true
 		u.Namespace = defaultNamespace
@@ -191,7 +192,7 @@ func (h *Helm) mustUninstall(cfg *action.Configuration, releaseName string) (boo
 	if err != nil {
 		return false, nil
 	}
-	return r.Info.Status == release.StatusUninstalling, err
+	return r.Info.Status == release.StatusUninstalling || r.Info.Status == release.StatusPendingInstall, err
 }
 
 func (h *Helm) mustInstall(cfg *action.Configuration, releaseName string) (bool, error) {


### PR DESCRIPTION
Also allows atomic flag for install, not just update.


### Notes

Get a chart into pending install:

```
fleet apply -o timeout-frab-bundle.yaml test ../../frab/helm/frab
fleet target -b timeout-frab-bundle.yaml > timeout-frab-bundledeployment.yaml
fleet deploy -i timeout-frab-bundledeployment.yaml
# hit ctrl-c while the helm hooks run
```

If the timing is right, this results in a helm chart that is in `pending-install`:
```
apiVersion: v1
data:
  release: [...blob...]
kind: Secret
metadata:
  labels:
    name: frab-helm-frab-02710957
    owner: helm
    status: pending-install
    version: "1"
  name: sh.helm.release.v1.frab-helm-frab-02710957.v1
  namespace: default
type: helm.sh/release.v1
```

Another deploy results in:

```
% fleet deploy  -i timeout-frab-bundledeployment.yaml                                                                                                                                                                    
2025-08-22T14:34:59+02:00	INFO	helm-deployer.install	Installing helm release	{"commit": "", "dryRun": false}
FATA[0000] cannot re-use a name that is still in use
```


Now we can try this PR:

```
% go run ./cmd/fleetcli/main.go  deploy  -i timeout-frab-bundledeployment.yaml                                                                                                                                           
2025-08-22T14:36:00+02:00	INFO	helm-deployer.install	Uninstalling helm release first	{"commit": "", "dryRun": true}
2025-08-22T14:36:00+02:00	INFO	helm-deployer.install	Uninstalling helm release first	{"commit": "", "dryRun": false}
2025-08-22T14:36:00+02:00	INFO	helm-deployer.delete	Helm: Uninstalling	{"dryRun": false}
2025-08-22T14:36:00+02:00	DEBUG	helmSDK	uninstall: Deleting frab-helm-frab-02710957
2025-08-22T14:36:00+02:00	DEBUG	helmSDK	uninstall: given cascade value: , defaulting to delete propagation background
2025-08-22T14:36:00+02:00	DEBUG	helmSDK	purge requested for frab-helm-frab-02710957
2025-08-22T14:36:01+02:00	INFO	helm-deployer.install	Installing helm release	{"commit": "", "dryRun": false}
2025-08-22T14:36:01+02:00	DEBUG	helmSDK	API Version list given outside of client only mode, this list will be ignored
FATA[0000] failed pre-install: context deadline exceeded
exit status 1
go run ./cmd/fleetcli/main.go deploy -i   115,26s user 24,96s system 528% cpu 26,542 total
```

Still fails, because the chart is missing arm64 images, but we can see the uninstall.