### PR TITLE
[v0.13] - Adds basicHTTP to HelmOps (#3990)

### DIFF
--- a/internal/bundlereader/auth.go
+++ b/internal/bundlereader/auth.go
@@ -3,6 +3,7 @@ package bundlereader
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -50,6 +51,28 @@ func ReadHelmAuthFromSecret(ctx context.Context, c client.Reader, req types.Name
 	if ok {
 		auth.CABundle = caBundle
 	}
+
+	// Get the values for skipping TLS and basic HTTP connections.
+	// In case of error reading the values they will be considered
+	// as set to false as those values are security related.
+	insecureSkipVerify := false
+	if value, ok := secret.Data["insecureSkipVerify"]; ok {
+		boolValue, err := strconv.ParseBool(string(value))
+		if err == nil {
+			insecureSkipVerify = boolValue
+		}
+	}
+
+	basicHTTP := false
+	if value, ok := secret.Data["basicHTTP"]; ok {
+		boolValue, err := strconv.ParseBool(string(value))
+		if err == nil {
+			basicHTTP = boolValue
+		}
+	}
+
+	auth.InsecureSkipVerify = insecureSkipVerify
+	auth.BasicHTTP = basicHTTP
 
 	return auth, nil
 }

--- a/internal/bundlereader/auth_test.go
+++ b/internal/bundlereader/auth_test.go
@@ -128,6 +128,54 @@ func TestReadHelmAuthFromSecret(t *testing.T) {
 			expectedErrNotNil: true,
 			expectedError:     "error getting secret",
 		},
+		{
+			name: "insecureSkipVerify is set to true",
+			secretData: map[string][]byte{
+				"insecureSkipVerify": []byte("true"),
+			},
+			getError: "",
+			expectedAuth: bundlereader.Auth{
+				InsecureSkipVerify: true,
+			},
+			expectedErrNotNil: false,
+			expectedError:     "",
+		},
+		{
+			name: "insecureSkipVerify is set to an invalid value",
+			secretData: map[string][]byte{
+				"insecureSkipVerify": []byte("THIS_IS_NOT_A_VALID_VALUE"),
+			},
+			getError: "",
+			expectedAuth: bundlereader.Auth{
+				InsecureSkipVerify: false,
+			},
+			expectedErrNotNil: false,
+			expectedError:     "",
+		},
+		{
+			name: "basicHTTP is set to true",
+			secretData: map[string][]byte{
+				"basicHTTP": []byte("true"),
+			},
+			getError: "",
+			expectedAuth: bundlereader.Auth{
+				BasicHTTP: true,
+			},
+			expectedErrNotNil: false,
+			expectedError:     "",
+		},
+		{
+			name: "basicHTTP is set to an invalid value",
+			secretData: map[string][]byte{
+				"basicHTTP": []byte("THIS_IS_NOT_A_VALID_VALUE"),
+			},
+			getError: "",
+			expectedAuth: bundlereader.Auth{
+				BasicHTTP: false,
+			},
+			expectedErrNotNil: false,
+			expectedError:     "",
+		},
 	}
 
 	mockCtrl := gomock.NewController(t)

--- a/internal/bundlereader/charturl.go
+++ b/internal/bundlereader/charturl.go
@@ -49,6 +49,10 @@ func ChartVersion(location fleet.HelmOptions, a Auth) (string, error) {
 
 		r.Client = authCli
 
+		if a.BasicHTTP {
+			r.PlainHTTP = true
+		}
+
 		tag, err := GetOCITag(r, location.Version)
 
 		if len(tag) == 0 || err != nil {


### PR DESCRIPTION
BasicHTTP should be also supported when downloading OCI stored helm charts for `HelmOps`

follow-up to: https://github.com/rancher/fleet/pull/3872
Refers to: https://github.com/rancher/fleet/issues/3855
Backport of: https://github.com/rancher/fleet/pull/3990
### Checklist

~- [ ] <!-- If applicable,--> I have updated the documentation via a pull request in the
[fleet-docs](https://github.com/rancher/fleet-docs) repository.~
