### PR TITLE
Allow to add any label to local cluster

### DIFF
--- a/charts/fleet/templates/configmap.yaml
+++ b/charts/fleet/templates/configmap.yaml
@@ -24,6 +24,7 @@ data:
         "paths": "{{.Values.bootstrap.paths}}",
         "repo": "{{.Values.bootstrap.repo}}",
         "secret": "{{.Values.bootstrap.secret}}",
+        "clusterLabels": "{{.Values.boostrap.clusterLabels}}",
         "branch":  "{{.Values.bootstrap.branch}}",
         "namespace": "{{.Values.bootstrap.namespace}}",
         "agentNamespace": "{{.Values.bootstrap.agentNamespace}}"

--- a/charts/fleet/values.yaml
+++ b/charts/fleet/values.yaml
@@ -53,6 +53,8 @@ bootstrap:
   # The namespace where the fleet agent for the local cluster will be ran, if empty
   # this will default to cattle-fleet-system
   agentNamespace: ""
+  # Apply extra clusterLables to the local cluster bootstrapped by fleet-controller
+  clusterLabels: {}
   # A repo to add at install time that will deploy to the local cluster. This allows
   # one to fully bootstrap fleet, its configuration and all its downstream clusters
   # in one shot.

--- a/internal/cmd/controller/agentmanagement/controllers/bootstrap/bootstrap.go
+++ b/internal/cmd/controller/agentmanagement/controllers/bootstrap/bootstrap.go
@@ -2,6 +2,7 @@ package bootstrap
 
 import (
 	"context"
+	"maps"
 	"os"
 	"regexp"
 
@@ -70,6 +71,11 @@ func (h *handler) OnConfig(config *fleetconfig.Config) error {
 	logrus.Debugf("Bootstrap config set, building namespace '%s', secret, local cluster, cluster group, ...", config.Bootstrap.Namespace)
 
 	var objs []runtime.Object
+	localClusterLabels := map[string]string{"name": "local"}
+
+	if config.Bootstrap.ClusterLabels != nil {
+		maps.Copy(localClusterLabels, config.Bootstrap.ClusterLabels)
+	}
 
 	if config.Bootstrap.Namespace == "" || config.Bootstrap.Namespace == "-" {
 		return nil
@@ -83,6 +89,7 @@ func (h *handler) OnConfig(config *fleetconfig.Config) error {
 	if err != nil {
 		return err
 	}
+
 	objs = append(objs, &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: config.Bootstrap.Namespace,
@@ -91,9 +98,7 @@ func (h *handler) OnConfig(config *fleetconfig.Config) error {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "local",
 			Namespace: config.Bootstrap.Namespace,
-			Labels: map[string]string{
-				"name": "local",
-			},
+			Labels:    localClusterLabels,
 		},
 		Spec: fleet.ClusterSpec{
 			KubeConfigSecret: secret.Name,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -136,8 +136,9 @@ type AgentWorkers struct {
 }
 
 type Bootstrap struct {
-	Namespace      string `json:"namespace,omitempty"`
-	AgentNamespace string `json:"agentNamespace,omitempty"`
+	Namespace      string            `json:"namespace,omitempty"`
+	AgentNamespace string            `json:"agentNamespace,omitempty"`
+	ClusterLabels  map[string]string `json:"clusterLabels,omitempty"`
 	// Repo to add at install time that will deploy to the local cluster. This allows
 	// one to fully bootstrap fleet, its configuration and all its downstream clusters
 	// in one shot.


### PR DESCRIPTION
Most real use-case for that is to set a "real" cluster name via ClusterName label. So multiple Rancher/Fleet controller instances have unique name/label.

<!-- Specify the issue ID that this pull request is solving -->
Refers to #XXX
<!-- Make sure that the referenced issue provides steps to reproduce it -->

<!-- Describe the changes introduced by this pull request -->

<!--
  Please provide a unit, integration (`./integrationtests/`) or e2e (`./e2e/`) test if possible.
-->

## Additional Information

### Checklist

- [ ] <!-- If applicable,--> I have updated the documentation via a pull request in the
[fleet-docs](https://github.com/rancher/fleet-docs) repository.
