### PR TITLE
Fix typo preventing successful build

### DIFF
--- a/internal/cmd/controller/reconciler/bundle_controller.go
+++ b/internal/cmd/controller/reconciler/bundle_controller.go
@@ -225,7 +225,7 @@ func (r *BundleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		if err := loadBundleValues(ctx, r.Client, bundle); err != nil {
 			if errors.Is(err, fleetutil.ErrRetryable) {
 				logger.Info(err.Error())
-				return ctrl.Result{RequeueAfter: durations.DefaultRequeueueAfter}, nil
+				return ctrl.Result{RequeueAfter: durations.DefaultRequeueAfter}, nil
 			}
 			return ctrl.Result{}, err
 		}


### PR DESCRIPTION
A leftover typo on `DefaultRequeueAfter` prevented Fleet from building.
Follow-up to #4077.