### PR TITLE
Revert "Remove rate limiting removal (#3848)"

### DIFF
--- a/internal/cmd/agent/operator.go
+++ b/internal/cmd/agent/operator.go
@@ -322,6 +322,9 @@ func newCluster(ctx context.Context, config *rest.Config, options manager.Option
 
 func getAgentConfig(ctx context.Context, namespace string, cfg *rest.Config) (agentConfig *config.Config, err error) {
 	cfg = rest.CopyConfig(cfg)
+	// disable the rate limiter
+	cfg.QPS = -1
+	cfg.RateLimiter = nil
 
 	client, err := client.New(cfg, client.Options{})
 	if err != nil {

--- a/internal/cmd/agent/register/register.go
+++ b/internal/cmd/agent/register/register.go
@@ -69,6 +69,9 @@ func Register(ctx context.Context, namespace string, config *rest.Config) (*Agen
 // populated and the contained kubeconfig is working
 func tryRegister(ctx context.Context, namespace string, cfg *rest.Config) (*AgentInfo, error) {
 	cfg = rest.CopyConfig(cfg)
+	// disable the rate limiter
+	cfg.QPS = -1
+	cfg.RateLimiter = nil
 
 	k8s, err := core.NewFactoryFromConfig(cfg)
 	if err != nil {

--- a/internal/cmd/controller/agentmanagement/controllers/controllers.go
+++ b/internal/cmd/controller/agentmanagement/controllers/controllers.go
@@ -154,6 +154,8 @@ func NewAppContext(cfg clientcmd.ClientConfig) (*AppContext, error) {
 	if err != nil {
 		return nil, err
 	}
+	client.QPS = -1
+	client.RateLimiter = nil
 
 	scf, err := controllerFactory(client)
 	if err != nil {

--- a/internal/cmd/controller/agentmanagement/start.go
+++ b/internal/cmd/controller/agentmanagement/start.go
@@ -25,6 +25,8 @@ func start(ctx context.Context, kubeConfig, namespace string, disableBootstrap b
 
 	// try to claim leadership lease without rate limiting
 	localConfig := rest.CopyConfig(kc)
+	localConfig.QPS = -1
+	localConfig.RateLimiter = nil
 	k8s, err := kubernetes.NewForConfig(localConfig)
 	if err != nil {
 		return err

--- a/internal/cmd/controller/cleanup/controllers/controllers.go
+++ b/internal/cmd/controller/cleanup/controllers/controllers.go
@@ -81,6 +81,8 @@ func NewAppContext(cfg clientcmd.ClientConfig) (*AppContext, error) {
 	if err != nil {
 		return nil, err
 	}
+	client.QPS = -1
+	client.RateLimiter = nil
 
 	scf, err := controllerFactory(client)
 	if err != nil {

--- a/internal/cmd/controller/cleanup/start.go
+++ b/internal/cmd/controller/cleanup/start.go
@@ -21,6 +21,8 @@ func start(ctx context.Context, kubeConfig, namespace string) error {
 
 	// try to claim leadership lease without rate limiting
 	localConfig := rest.CopyConfig(kc)
+	localConfig.QPS = -1
+	localConfig.RateLimiter = nil
 	k8s, err := kubernetes.NewForConfig(localConfig)
 	if err != nil {
 		return err

--- a/internal/helmdeployer/impersonate.go
+++ b/internal/helmdeployer/impersonate.go
@@ -57,6 +57,8 @@ func newImpersonatingGetter(namespace, name string, getter genericclioptions.RES
 	if err != nil {
 		return nil, err
 	}
+	restConfig.QPS = -1
+	restConfig.RateLimiter = nil
 
 	return &impersonatingGetter{
 		RESTClientGetter: getter,


### PR DESCRIPTION
This reverts commit 2ffb043948706fb9b2e00c7e99b6be0f0e42799b.

<!-- Specify the issue ID that this pull request is solving -->
<!-- Make sure that the referenced issue provides steps to reproduce it -->

<!-- Describe the changes introduced by this pull request -->

Reverting because the default rate limiter might be too slow and since we have not added a configuration option for users to configure the rate limiter, we feel it is safer to wait with rate limiting until it is configurable.

<!--
  Please provide a unit, integration (`./integrationtests/`) or e2e (`./e2e/`) test if possible.
-->

## Additional Information

### Checklist

- [ ] <!-- If applicable,--> I have updated the documentation via a pull request in the
[fleet-docs](https://github.com/rancher/fleet-docs) repository.
