### PR TITLE
Revert "Remove rate limiting removal"

### DIFF
--- a/internal/cmd/agent/operator.go
+++ b/internal/cmd/agent/operator.go
@@ -22,6 +22,7 @@ import (
 	"helm.sh/helm/v3/pkg/cli"
 
 	"github.com/rancher/wrangler/v3/pkg/generated/controllers/core"
+	"github.com/rancher/wrangler/v3/pkg/ratelimit"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -307,7 +308,8 @@ func newCluster(ctx context.Context, config *rest.Config, options manager.Option
 
 func getAgentConfig(ctx context.Context, namespace string, cfg *rest.Config) (agentConfig *config.Config, err error) {
 	cfg = rest.CopyConfig(cfg)
-
+	// disable the rate limiter
+	cfg.RateLimiter = ratelimit.None
 	k8s, err := core.NewFactoryFromConfig(cfg)
 	if err != nil {
 		return nil, err

--- a/internal/cmd/agent/register/register.go
+++ b/internal/cmd/agent/register/register.go
@@ -18,6 +18,7 @@ import (
 	"github.com/rancher/wrangler/v3/pkg/generated/controllers/core"
 	corecontrollers "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
 	"github.com/rancher/wrangler/v3/pkg/randomtoken"
+	"github.com/rancher/wrangler/v3/pkg/ratelimit"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -69,7 +70,8 @@ func Register(ctx context.Context, namespace string, config *rest.Config) (*Agen
 // populated and the contained kubeconfig is working
 func tryRegister(ctx context.Context, namespace string, cfg *rest.Config) (*AgentInfo, error) {
 	cfg = rest.CopyConfig(cfg)
-
+	// disable the rate limiter
+	cfg.RateLimiter = ratelimit.None
 	k8s, err := core.NewFactoryFromConfig(cfg)
 	if err != nil {
 		return nil, err

--- a/internal/cmd/controller/agentmanagement/controllers/controllers.go
+++ b/internal/cmd/controller/agentmanagement/controllers/controllers.go
@@ -26,6 +26,7 @@ import (
 	corecontrollers "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
 	"github.com/rancher/wrangler/v3/pkg/generated/controllers/rbac"
 	rbaccontrollers "github.com/rancher/wrangler/v3/pkg/generated/controllers/rbac/v1"
+	"github.com/rancher/wrangler/v3/pkg/ratelimit"
 	"github.com/rancher/wrangler/v3/pkg/start"
 
 	"github.com/sirupsen/logrus"
@@ -154,6 +155,7 @@ func NewAppContext(cfg clientcmd.ClientConfig) (*AppContext, error) {
 	if err != nil {
 		return nil, err
 	}
+	client.RateLimiter = ratelimit.None
 
 	scf, err := controllerFactory(client)
 	if err != nil {

--- a/internal/cmd/controller/agentmanagement/start.go
+++ b/internal/cmd/controller/agentmanagement/start.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/rancher/wrangler/v3/pkg/kubeconfig"
 	"github.com/rancher/wrangler/v3/pkg/leader"
+	"github.com/rancher/wrangler/v3/pkg/ratelimit"
 	"github.com/rancher/wrangler/v3/pkg/schemes"
 
 	"github.com/sirupsen/logrus"
@@ -25,6 +26,7 @@ func start(ctx context.Context, kubeConfig, namespace string, disableBootstrap b
 
 	// try to claim leadership lease without rate limiting
 	localConfig := rest.CopyConfig(kc)
+	localConfig.RateLimiter = ratelimit.None
 	k8s, err := kubernetes.NewForConfig(localConfig)
 	if err != nil {
 		return err

--- a/internal/cmd/controller/cleanup/controllers/controllers.go
+++ b/internal/cmd/controller/cleanup/controllers/controllers.go
@@ -17,6 +17,7 @@ import (
 	corecontrollers "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
 	"github.com/rancher/wrangler/v3/pkg/generated/controllers/rbac"
 	rbaccontrollers "github.com/rancher/wrangler/v3/pkg/generated/controllers/rbac/v1"
+	"github.com/rancher/wrangler/v3/pkg/ratelimit"
 	"github.com/rancher/wrangler/v3/pkg/start"
 
 	"github.com/sirupsen/logrus"
@@ -81,6 +82,7 @@ func NewAppContext(cfg clientcmd.ClientConfig) (*AppContext, error) {
 	if err != nil {
 		return nil, err
 	}
+	client.RateLimiter = ratelimit.None
 
 	scf, err := controllerFactory(client)
 	if err != nil {

--- a/internal/cmd/controller/cleanup/start.go
+++ b/internal/cmd/controller/cleanup/start.go
@@ -6,6 +6,7 @@ import (
 	"github.com/rancher/fleet/internal/cmd/controller/cleanup/controllers"
 	"github.com/rancher/wrangler/v3/pkg/kubeconfig"
 	"github.com/rancher/wrangler/v3/pkg/leader"
+	"github.com/rancher/wrangler/v3/pkg/ratelimit"
 	"github.com/sirupsen/logrus"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -20,6 +21,7 @@ func start(ctx context.Context, kubeConfig, namespace string) error {
 
 	// try to claim leadership lease without rate limiting
 	localConfig := rest.CopyConfig(kc)
+	localConfig.RateLimiter = ratelimit.None
 	k8s, err := kubernetes.NewForConfig(localConfig)
 	if err != nil {
 		return err

--- a/internal/helmdeployer/impersonate.go
+++ b/internal/helmdeployer/impersonate.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/rancher/wrangler/v3/pkg/ratelimit"
+
 	corev1 "k8s.io/api/core/v1"
 	apierror "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
@@ -56,6 +58,7 @@ func newImpersonatingGetter(namespace, name string, getter genericclioptions.RES
 	if err != nil {
 		return nil, err
 	}
+	restConfig.RateLimiter = ratelimit.None
 
 	return &impersonatingGetter{
 		RESTClientGetter: getter,


### PR DESCRIPTION
This partially reverts commit a7af4609a8236108e5bdafecff5d8c186f147419

It completely disables rate limiting (again).

<!-- Specify the issue ID that this pull request is solving -->
<!-- Make sure that the referenced issue provides steps to reproduce it -->

<!-- Describe the changes introduced by this pull request -->

<!--
  Please provide a unit, integration (`./integrationtests/`) or e2e (`./e2e/`) test if possible.
-->

## Additional Information

### Checklist

- [ ] <!-- If applicable,--> I have updated the documentation via a pull request in the
[fleet-docs](https://github.com/rancher/fleet-docs) repository.
