### PR TITLE
Support git auth with access token

### DIFF
--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -232,6 +232,7 @@ jobs:
           GIT_REPO_HOST: "github.com"
           GIT_REPO_USER: "git"
           GIT_REPO_BRANCH: ${{ matrix.k3s.version }}
+          GITHUB_PAT_TOKEN: ${{ secrets.CI_PRIVATE_REPO_PAT }}
           CI_OCI_USERNAME:  ${{ secrets.CI_OCI_USERNAME }}
           CI_OCI_PASSWORD:  ${{ secrets.CI_OCI_PASSWORD }}
           GITHUB_APP_ID:  ${{ secrets.CI_GITHUB_APP_ID }}

--- a/internal/cmd/cli/gitcloner/cloner.go
+++ b/internal/cmd/cli/gitcloner/cloner.go
@@ -181,10 +181,16 @@ func createAuthFromOpts(opts *GitCloner) (transport.AuthMethod, error) {
 		return auth, nil
 	}
 
-	if opts.Username != "" && opts.PasswordFile != "" {
+	if opts.PasswordFile != "" {
 		password, err := readFile(opts.PasswordFile)
 		if err != nil {
 			return nil, err
+		}
+
+		if len(opts.Username) == 0 {
+			return &httpgit.BasicAuth{
+				Username: string(password),
+			}, nil
 		}
 
 		return &httpgit.BasicAuth{

--- a/pkg/git/netutils.go
+++ b/pkg/git/netutils.go
@@ -33,8 +33,14 @@ func GetAuthFromSecret(url string, creds *corev1.Secret, knownHosts string) (tra
 	switch creds.Type {
 	case corev1.SecretTypeBasicAuth:
 		username, password := creds.Data[corev1.BasicAuthUsernameKey], creds.Data[corev1.BasicAuthPasswordKey]
-		if len(password) == 0 && len(username) == 0 {
-			return nil, nil
+		if len(username) == 0 {
+			if len(password) == 0 {
+				return nil, nil
+			}
+
+			return &httpgit.BasicAuth{
+				Username: string(password),
+			}, nil
 		}
 		return &httpgit.BasicAuth{
 			Username: string(username),


### PR DESCRIPTION
Fleet is now able to authenticate to git using an access token, beside HTTP basic auth and SSH.
This applies to fetching a repository's latest commit and to cloning.

While Github supports personal access tokens on their own, Bitbucket requires a username to be set as `x-token-auth` beside the token.

This patch includes an end-to-end test case for Github.

Refers to #4038

## Additional Information

### Checklist

- [x] <!-- If applicable,--> I have updated the documentation via a pull request in the
[fleet-docs](https://github.com/rancher/fleet-docs) repository: https://github.com/rancher/fleet-docs/pull/334
- [x] backport this to `release/v0.13`: #4190