### PR TITLE
[v0.13] Remove HTML response body from HelmOps errors (#4129)

### DIFF
--- a/integrationtests/helmops/controller/controller_test.go
+++ b/integrationtests/helmops/controller/controller_test.go
@@ -1043,7 +1043,7 @@ var _ = Describe("HelmOps controller", func() {
 						fleet.HelmOpAcceptedCondition,
 						v1.ConditionFalse,
 						"Error",
-						"error code: 401, response body: Unauthorized",
+						"error code: 401",
 					)
 
 				}).Should(Succeed())
@@ -1109,7 +1109,7 @@ var _ = Describe("HelmOps controller", func() {
 						fleet.HelmOpAcceptedCondition,
 						v1.ConditionFalse,
 						"Error",
-						"error code: 401, response body: Unauthorized",
+						"error code: 401",
 					)
 
 				}).Should(Succeed())

--- a/internal/bundlereader/charturl.go
+++ b/internal/bundlereader/charturl.go
@@ -159,7 +159,7 @@ func getHelmChartVersion(location fleet.HelmOptions, auth Auth) (*repo.ChartVers
 	}
 
 	if resp.StatusCode != 200 {
-		return nil, fmt.Errorf("failed to read helm repo from %s, error code: %v, response body: %s", location.Repo+"index.yaml", resp.StatusCode, bytes)
+		return nil, fmt.Errorf("failed to read helm repo from %s, error code: %v", location.Repo+"index.yaml", resp.StatusCode)
 	}
 
 	repo := &repo.IndexFile{}

--- a/internal/bundlereader/helm_test.go
+++ b/internal/bundlereader/helm_test.go
@@ -322,7 +322,7 @@ func TestGetManifestFromHelmChart(t *testing.T) {
 			expectedNilManifest: true,
 			expectedResources:   []fleet.BundleResource{},
 			expectedErrNotNil:   true,
-			expectedError:       "failed to read helm repo from ##URL##/index.yaml, error code: 401, response body: Unauthorized\n",
+			expectedError:       "failed to read helm repo from ##URL##/index.yaml, error code: 401",
 		},
 		{
 			name: "tls error",


### PR DESCRIPTION
When a chart version cannot be retrieved from a Helm repository, including the response body in the error message brings little context and can lead to excessively long error status messages. Therefore, Fleet now skips the response body in such cases, relying solely on the status code.

Refers to #3924
Backport of #4129 to `release/v0.13`

## Additional Information

### Checklist

~- [ ] <!-- If applicable,--> I have updated the documentation via a pull request in the
[fleet-docs](https://github.com/rancher/fleet-docs) repository.~
