### PR TITLE
Explicitly delete bundle secrets on bundle deletion

### DIFF
--- a/internal/cmd/cli/apply/apply.go
+++ b/internal/cmd/cli/apply/apply.go
@@ -449,6 +449,7 @@ func writeBundle(ctx context.Context, c client.Client, r record.EventRecorder, b
 		valuesSecret := newValuesSecret(bundle, data)
 		updated := valuesSecret.DeepCopy()
 		_, err = controllerutil.CreateOrUpdate(ctx, c, valuesSecret, func() error {
+			valuesSecret.OwnerReferences = updated.OwnerReferences
 			valuesSecret.Labels = updated.Labels
 			valuesSecret.Data = updated.Data
 			valuesSecret.Type = updated.Type


### PR DESCRIPTION
Refers to https://github.com/rancher/fleet/issues/4143

This is a quick fix, to remove the secrets faster and not rely entirely on garbage collection.