### PR TITLE
Don't add same field multiple times to logger

### DIFF
--- a/internal/cmd/controller/reconciler/bundle_controller.go
+++ b/internal/cmd/controller/reconciler/bundle_controller.go
@@ -347,7 +347,7 @@ func (r *BundleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		// and copy labels from Bundle as they might have changed.
 		// However, matchedTargets target.Deployment contains existing BundleDeployments.
 		bd := target.BundleDeployment()
-		logger = logger.WithValues("bundledeployment", bd.Name)
+		logger := logger.WithValues("bundledeployment", bd.Name)
 
 		// No need to check the deletion timestamp here before adding a finalizer, since the bundle has just
 		// been created.
@@ -475,13 +475,13 @@ func (r *BundleReconciler) ensureFinalizer(ctx context.Context, bundle *fleet.Bu
 
 func (r *BundleReconciler) createBundleDeployment(
 	ctx context.Context,
-	logger logr.Logger,
+	l logr.Logger,
 	bd *fleet.BundleDeployment,
 	contentsInOCI bool,
 	contentsInHelmChart bool,
 	manifestID string,
 ) (*fleet.BundleDeployment, error) {
-	logger = logger.WithValues("deploymentID", bd.Spec.DeploymentID)
+	logger := l.WithValues("deploymentID", bd.Spec.DeploymentID)
 
 	// When content resources are stored in etcd, we need to add finalizers.
 	if !contentsInOCI && !contentsInHelmChart {


### PR DESCRIPTION
When using a rollout strategy to maximize the partition size:
```
rolloutStrategy:
  maxUnavailable: 100%
  autoPartitionSize: 100%
```
 logger would log this for 50 bundles to 2000 clusters:


```
fleet-controller-5588b654fc-g2sxw fleet-controller {"level":"info","ts":"2025-09-22T16:10:58Z","logger":"bundle","msg":"Unchanged bundledeployment","controller":"bundle","controllerGroup":"fleet.cattle.io","controllerKind":"Bundle","Bundle":{"name":"scale-50-single-scale-50-bundles-fourty-thirty-five","namespace":"fleet-default"},"namespace":"fleet-default","name":"scale-50-single-scale-50-bundles-fourty-thirty-five","reconcileID":"100752e9-1f32-49ed-b371-07227a91e68b","gitrepo":"scale-50-single","commit":"c61c1ecb79473a24745fa84c4bf10cca56e9c8c2","manifestID":"s-21d4568ce16f9b2b635e976f918b33eca5e2a7387a2871997f8e1c938197f","bundledeployment":"scale-50-single-scale-50-bundles-fourty-thirty-five","bundledeployment":"scale-50-single-scale-50-bundles-fourty-thirty-five","bundledeployment":"scale-50-single-scale-50-bundles-fourty-thirty-five","bundledeployment":"scale-50-single-scale-50-bundles-fourty-thirty-five","bundledeployment":"scale-50-single-scale-50-bundles-fourty-thirty-five","bundledeployment":"scale-50-single-scale-50-bundles-fourty-thirty-five","bundledeployment":"scale-50-single-scale-50-bundles-fourty-thirty-five","bundledeployment":"scale-50-single-scale-50-bundles-fourty-thirty-five","bundledeployment":"scale-50-single-scale-50-bundles-fourty-thirty-five","bundledeployment":"scale-50-single-scale-50-bundles-fourty-thirty-five","bundledeployment":"scale-50-single-scale-50-bundles-fourty-thirty-five","bundledeployment":"scale-50-single-scale-50-bundles-fourty-thirty-five","bundledeployment":"scale-50-single-scale-50-bundles-fourty-thirty-five","bundledeployment":"scale-50-single-scale-50-bundles-fourty-thirty-five","bundledeployment":"scale-50-single-scale-50-bundles-fourty-thirty-five","bundledeployment":"scale-50-single-scale-50-bundles-fourty-thirty-five","bundledeployment":"scale-50-single-scale-50-bundles-fourty-thirty-five","bundledeployment":"scale-50-single-scale-50-bundles-fourty-thirty-five","bundledeployment":"scale-50-single-scale-50-bundles-fourty-thirty-five",
...
```

```
tail -1 logs | wc -c
146804
```
