### PR TITLE
Reduce flakiness in release cleanup end-to-end tests

### DIFF
--- a/e2e/single-cluster/release_cleanup_test.go
+++ b/e2e/single-cluster/release_cleanup_test.go
@@ -46,11 +46,9 @@ var _ = Describe("Monitoring Helm releases along bundle namespace updates", Orde
 		out, err := k.Delete("bundle", bundleName)
 		Expect(err).ToNot(HaveOccurred(), out)
 
-		out, err = k.Delete("ns", oldNamespace, "--wait=false")
-		Expect(err).ToNot(HaveOccurred(), out)
+		_, _ = k.Delete("ns", oldNamespace, "--wait=false")
 
-		out, err = k.Delete("ns", newNamespace, "--wait=false")
-		Expect(err).ToNot(HaveOccurred(), out)
+		_, _ = k.Delete("ns", newNamespace, "--wait=false")
 	})
 
 	When("updating a bundle's namespace", func() {


### PR DESCRIPTION
An old namespace may already have been deleted, meaning that its explicit deletion as part of the cleanup process of the test suite may fail. This should not count as a test failure ([example](https://github.com/rancher/fleet/actions/runs/17950462036/job/51048078679?pr=4158)).

## Additional Information

### Checklist

~- [ ] <!-- If applicable,--> I have updated the documentation via a pull request in the
[fleet-docs](https://github.com/rancher/fleet-docs) repository.~
