### PR TITLE
Support multiple repositories in e2e/nginx-git-setup

### DIFF
--- a/e2e/assets/gitrepo/Dockerfile.gitserver
+++ b/e2e/assets/gitrepo/Dockerfile.gitserver
@@ -20,11 +20,9 @@ COPY <<-"EOT" /root/.gitconfig
         denyNonFastforwards = false
 EOT
 
-# Configure git remote
-RUN mkdir -p /srv/git/repo
-WORKDIR /srv/git/repo
-RUN git init . --bare
-RUN git update-server-info
+# Configure dynamic backend; creates repos on first access.
+COPY git-http-backend-dynamic /usr/local/bin/git-http-backend-dynamic
+RUN chmod +x /usr/local/bin/git-http-backend-dynamic
 
 # Configure nginx
 COPY nginx_git.conf /etc/nginx/nginx.conf

--- a/e2e/assets/gitrepo/git-http-backend-dynamic
+++ b/e2e/assets/gitrepo/git-http-backend-dynamic
@@ -1,0 +1,65 @@
+#!/bin/sh
+# git-http-backend-dynamic (stores repos without .git suffix)
+set -eu
+
+# --- Debug ---------------------------------------------------------------
+echo "=== Git HTTP Backend Dynamic ===" >&2
+echo "PATH_INFO: ${PATH_INFO:-}" >&2
+echo "REQUEST_URI: ${REQUEST_URI:-}" >&2
+echo "QUERY_STRING: ${QUERY_STRING:-}" >&2
+
+orig_pi="${PATH_INFO:-/}"
+trim="${orig_pi#/}" # strip leading /
+repo_part=""
+rest=""
+
+# Prefer URLs that include .git (common case)
+if printf '%s' "$trim" | grep -qE '\.git(/|$)'; then
+  repo_part="${trim%%.git*}"      # everything before ".git"
+  rest="${trim#${repo_part}.git}" # remainder (may be empty or start with /...)
+else
+  # Try to split before known service/endpoints (no .git in URL)
+  for marker in "/info/refs" "/git-upload-pack" "/git-receive-pack" "/HEAD" "/objects/"; do
+    case "$trim" in
+      *"$marker"*)
+        repo_part="${trim%%$marker*}"
+        rest="${trim#${repo_part}}"
+        break
+        ;;
+    esac
+  done
+  # Fallback: first path segment only
+  if [ -z "$repo_part" ]; then
+    repo_part="${trim%%/*}"
+    rest="${trim#${repo_part}}"
+  fi
+fi
+
+# Sanitize repo path (defend against ../ etc.; allow nested paths like team/project)
+safe_repo="$(printf '%s' "$repo_part" |
+  sed -E 's/\.\.//g; s#^/+##; s#//+#/#g; s#[^A-Za-z0-9._/\-]##g')"
+
+REPO_DIR="/srv/git/$safe_repo"
+echo "Repo (sanitized): $safe_repo" >&2
+echo "Full repo dir:    $REPO_DIR" >&2
+
+# Create repository if missing (bare, no .git suffix on disk)
+if [ ! -d "$REPO_DIR/objects" ]; then
+  echo "Creating new repository: $safe_repo" >&2
+  mkdir -p "$REPO_DIR"
+  git init --bare "$REPO_DIR" >&2
+  git -C "$REPO_DIR" config http.receivepack true
+  git -C "$REPO_DIR" config receive.denyNonFastforwards false
+  git -C "$REPO_DIR" update-server-info
+  echo "Repository created successfully: $safe_repo" >&2
+else
+  echo "Repository exists: $safe_repo" >&2
+fi
+
+# Normalize PATH_INFO so git-http-backend looks in /srv/git/<repo> (no .git)
+export PATH_INFO="/$safe_repo$rest"
+export GIT_PROJECT_ROOT="/srv/git"
+export GIT_HTTP_EXPORT_ALL=""
+
+echo "Calling real git-http-backend with PATH_INFO=$PATH_INFO ..." >&2
+exec /usr/libexec/git-core/git-http-backend

--- a/e2e/assets/gitrepo/nginx_git.conf
+++ b/e2e/assets/gitrepo/nginx_git.conf
@@ -1,4 +1,5 @@
 events {}
+
 http {
     server {
         error_log stderr info;
@@ -8,20 +9,19 @@ http {
         ssl_certificate /etc/ssl/certs/helm.crt;
         ssl_certificate_key /etc/ssl/certs/helm.key;
 
-        # This is where the repositories live on the server
-        root /srv/git;
-
         auth_basic "git requires auth";
         auth_basic_user_file /srv/.htpasswd;
 
-        location ~ (/.*) {
+        # Handle ALL requests
+        location / {
             include /etc/nginx/fastcgi_params;
             fastcgi_pass  unix:/var/run/fcgiwrap.socket;
-            fastcgi_param SCRIPT_FILENAME   /usr/libexec/git-core/git-http-backend;
-            fastcgi_param PATH_INFO         $uri;
-            fastcgi_param REMOTE_USER $remote_user;
+            fastcgi_param SCRIPT_FILENAME /usr/local/bin/git-http-backend-dynamic;
+            fastcgi_param PATH_INFO $uri;
             fastcgi_param GIT_HTTP_EXPORT_ALL "";
-            fastcgi_param GIT_PROJECT_ROOT  /srv/git;
+            fastcgi_param GIT_PROJECT_ROOT /srv/git;
+            
+            add_header X-Debug-Matched "all-requests" always;
         }
     }
 }


### PR DESCRIPTION
Which adds support for using several git repositories, for instance when
testing fleet.yaml's helm.chart field with a HTTPS URL.<!-- Specify the issue ID that this pull request is solving -->

Refers to #3646 
<!-- Make sure that the referenced issue provides steps to reproduce it -->

<!-- Describe the changes introduced by this pull request -->

<!--
  Please provide a unit, integration (`./integrationtests/`) or e2e (`./e2e/`) test if possible.
-->

## Additional Information

### Checklist

- [ ] <!-- If applicable,--> I have updated the documentation via a pull request in the
[fleet-docs](https://github.com/rancher/fleet-docs) repository.
