### PR TITLE
[0.12] Don't requeue for missing resources

### DIFF
--- a/internal/cmd/controller/finalize/finalize.go
+++ b/internal/cmd/controller/finalize/finalize.go
@@ -78,7 +78,7 @@ func PurgeContent(ctx context.Context, c client.Client, name, deplID string) err
 	if controllerutil.ContainsFinalizer(content, name) {
 		err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 			if err := c.Get(ctx, nn, content); err != nil {
-				return err
+				return client.IgnoreNotFound(err)
 			}
 
 			controllerutil.RemoveFinalizer(content, name)

--- a/internal/cmd/controller/reconciler/bundledeployment_controller.go
+++ b/internal/cmd/controller/reconciler/bundledeployment_controller.go
@@ -73,7 +73,7 @@ func (r *BundleDeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Req
 			err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
 				err := r.Get(ctx, req.NamespacedName, bd)
 				if err != nil {
-					return err
+					return client.IgnoreNotFound(err)
 				}
 
 				controllerutil.RemoveFinalizer(bd, finalize.BundleDeploymentFinalizer)


### PR DESCRIPTION
This happens occasionally as the bundledeployment controller is triggered a lot.

Backport of #4172 to v0.12.

## Additional Information

### Checklist

~- [ ] <!-- If applicable,--> I have updated the documentation via a pull request in the
[fleet-docs](https://github.com/rancher/fleet-docs) repository.~
