### PR TITLE
Exclude Fleet config files regardless of their naming

### DIFF
--- a/integrationtests/cli/assets/driven/kustomize/.fleetignore
+++ b/integrationtests/cli/assets/driven/kustomize/.fleetignore
@@ -1,0 +1,1 @@
+dev.yaml

--- a/integrationtests/cli/assets/driven2/kustomize/.fleetignore
+++ b/integrationtests/cli/assets/driven2/kustomize/.fleetignore
@@ -1,0 +1,1 @@
+fleetProd.yaml

--- a/internal/bundlereader/read.go
+++ b/internal/bundlereader/read.go
@@ -24,6 +24,7 @@ import (
 
 // Options include the GitRepo overrides, which are passed via command line args
 type Options struct {
+	BundleFile       string
 	Compress         bool
 	Labels           map[string]string
 	ServiceAccount   string
@@ -189,7 +190,7 @@ func bundleFromDir(ctx context.Context, name, baseDir string, bundleData []byte,
 
 	propagateHelmChartProperties(&fy.BundleSpec)
 
-	resources, err := readResources(ctx, &fy.BundleSpec, opts.Compress, baseDir, opts.Auth, opts.HelmRepoURLRegex)
+	resources, err := readResources(ctx, &fy.BundleSpec, opts.Compress, baseDir, opts.Auth, opts.HelmRepoURLRegex, opts.BundleFile)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed reading resources for %q: %w", baseDir, err)
 	}

--- a/internal/cmd/cli/apply/apply.go
+++ b/internal/cmd/cli/apply/apply.go
@@ -332,6 +332,7 @@ func newBundle(ctx context.Context, name, baseDir string, opts Options) (*fleet.
 	} else {
 		var err error
 		bundle, scans, err = bundlereader.NewBundle(ctx, name, baseDir, opts.BundleFile, &bundlereader.Options{
+			BundleFile:       opts.BundleFile,
 			Compress:         opts.Compress,
 			Labels:           opts.Labels,
 			ServiceAccount:   opts.ServiceAccount,


### PR DESCRIPTION
While Fleet config files are typically named `fleet.yaml`, the recent introduction of user-driven bundle scanning enables a config file to be named arbitrarily, in which case it must still be excluded from the corresponding bundle. Fleet now takes care of this without any action needed from the user.

Integration tests also demonstrate that `.fleetignore` files can be leveraged to exclude config files living in the same directory as the config file referenced explicitly through user-driven bundle scanning. Fleet would otherwise not exclude those files from the bundle.

Refers to https://github.com/rancher/fleet-docs/issues/307

## Additional Information

### Checklist

- [x] <!-- If applicable,--> I have updated the documentation via a pull request in the
[fleet-docs](https://github.com/rancher/fleet-docs) repository: see https://github.com/rancher/fleet-docs/pull/354
