### PR TITLE
[v0.13] Exclude Fleet config files regardless of their naming

### DIFF
--- a/integrationtests/cli/apply/apply_test.go
+++ b/integrationtests/cli/apply/apply_test.go
@@ -338,13 +338,26 @@ var _ = Describe("Fleet apply driven", Ordered, func() {
 				cli.AssetsPath + "driven/kustomize/overlays/dev/secret.yaml",
 				cli.AssetsPath + "driven/kustomize/overlays/prod/kustomization.yaml",
 				cli.AssetsPath + "driven/kustomize/overlays/prod/secret.yaml",
-				cli.AssetsPath + "driven/kustomize/dev.yaml",
-				cli.AssetsPath + "driven/kustomize/prod.yaml",
 			}
-			Expect(kDevBundle.Spec.Resources).To(HaveLen(8))
-			Expect(kProdBundle.Spec.Resources).To(HaveLen(8))
-			for _, r := range kResources {
+
+			// Note: the presence of a .fleetignore file, at the same level as both `dev.yaml` and
+			// `prod.yaml`, excluding only `dev.yaml`, enables us to ensure that that file does not end up in
+			// any bundle, being excluded from the dev bundle, but _also_ from the prod bundle.
+			// We deliberately don't exclude both `dev.yaml` and `prod.yaml` from `.fleetignore`, simply to
+			// validate that `prod.yaml` is excluded from the prod bundle without needing to be excluded from
+			// `.fleetignore`.
+
+			kDevResources := append(slices.Clone(kResources), cli.AssetsPath+"driven/kustomize/prod.yaml")
+			kProdResources := slices.Clone(kResources)
+
+			Expect(kDevBundle.Spec.Resources).To(HaveLen(7))
+			Expect(kProdBundle.Spec.Resources).To(HaveLen(6))
+
+			for _, r := range kDevResources {
 				Expect(r).To(bePresentInBundleResources(kDevBundle.Spec.Resources))
+			}
+
+			for _, r := range kProdResources {
 				Expect(r).To(bePresentInBundleResources(kProdBundle.Spec.Resources))
 			}
 
@@ -386,13 +399,26 @@ var _ = Describe("Fleet apply driven", Ordered, func() {
 				cli.AssetsPath + "driven2/kustomize/overlays/dev/secret.yaml",
 				cli.AssetsPath + "driven2/kustomize/overlays/prod/kustomization.yaml",
 				cli.AssetsPath + "driven2/kustomize/overlays/prod/secret.yaml",
-				cli.AssetsPath + "driven2/kustomize/fleetDev.yaml",
-				cli.AssetsPath + "driven2/kustomize/fleetProd.yaml",
 			}
-			Expect(kDevBundle.Spec.Resources).To(HaveLen(8))
-			Expect(kProdBundle.Spec.Resources).To(HaveLen(8))
-			for _, r := range kResources {
+
+			// Note: the presence of a .fleetignore file, at the same level as both `fleetDev.yaml` and
+			// `fleetProd.yaml`, excluding only `fleetProd.yaml`, enables us to ensure that that file does
+			// not end up in any bundle, being excluded from the prod bundle, but _also_ from the dev bundle.
+			// We deliberately don't exclude both `fleetDev.yaml` and `fleetProd.yaml` from `.fleetignore`,
+			// simply to validate that `fleetDev.yaml` is excluded from the dev bundle without needing to be
+			// excluded from `.fleetignore`.
+
+			kDevResources := slices.Clone(kResources)
+			kProdResources := append(slices.Clone(kResources), cli.AssetsPath+"driven2/kustomize/fleetDev.yaml")
+
+			Expect(kDevBundle.Spec.Resources).To(HaveLen(6))
+			Expect(kProdBundle.Spec.Resources).To(HaveLen(7))
+
+			for _, r := range kDevResources {
 				Expect(r).To(bePresentInBundleResources(kDevBundle.Spec.Resources))
+			}
+
+			for _, r := range kProdResources {
 				Expect(r).To(bePresentInBundleResources(kProdBundle.Spec.Resources))
 			}
 
@@ -457,7 +483,7 @@ var _ = Describe("Fleet apply driven", Ordered, func() {
 			// helm bundle
 			helmBundle := bundles[0]
 			Expect(helmBundle.Name).To(Equal("assets-driven-fleet-yaml-subfolder-helm-test-fl-b676f"))
-			Expect(helmBundle.Spec.Resources).To(HaveLen(4))
+			Expect(helmBundle.Spec.Resources).To(HaveLen(3))
 			// as files were unpacked from the downloaded chart we can't just
 			// list the files in the original folder and compare.
 			// Files are only located in the bundle resources
@@ -465,7 +491,7 @@ var _ = Describe("Fleet apply driven", Ordered, func() {
 			Expect("values.yaml").To(bePresentOnlyInBundleResources(helmBundle.Spec.Resources))
 			Expect("templates/configmap.yaml").To(bePresentOnlyInBundleResources(helmBundle.Spec.Resources))
 			resPath := cli.AssetsPath + "driven_fleet_yaml_subfolder/helm/test/fleet.yaml"
-			Expect(resPath).To(bePresentInBundleResources(helmBundle.Spec.Resources))
+			Expect(resPath).NotTo(bePresentInBundleResources(helmBundle.Spec.Resources))
 			// check for helm options defined in the fleet.yaml file
 			Expect(helmBundle.Spec.Helm).ToNot(BeNil())
 			Expect(helmBundle.Spec.Helm.ReleaseName).To(Equal("config-chart"))

--- a/integrationtests/cli/assets/driven/kustomize/.fleetignore
+++ b/integrationtests/cli/assets/driven/kustomize/.fleetignore
@@ -1,0 +1,1 @@
+dev.yaml

--- a/integrationtests/cli/assets/driven2/kustomize/.fleetignore
+++ b/integrationtests/cli/assets/driven2/kustomize/.fleetignore
@@ -1,0 +1,1 @@
+fleetProd.yaml

--- a/internal/bundlereader/read.go
+++ b/internal/bundlereader/read.go
@@ -24,6 +24,7 @@ import (
 
 // Options include the GitRepo overrides, which are passed via command line args
 type Options struct {
+	BundleFile       string
 	Compress         bool
 	Labels           map[string]string
 	ServiceAccount   string
@@ -189,7 +190,7 @@ func bundleFromDir(ctx context.Context, name, baseDir string, bundleData []byte,
 
 	propagateHelmChartProperties(&fy.BundleSpec)
 
-	resources, err := readResources(ctx, &fy.BundleSpec, opts.Compress, baseDir, opts.Auth, opts.HelmRepoURLRegex)
+	resources, err := readResources(ctx, &fy.BundleSpec, opts.Compress, baseDir, opts.Auth, opts.HelmRepoURLRegex, opts.BundleFile)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed reading resources for %q: %w", baseDir, err)
 	}

--- a/internal/cmd/cli/apply/apply.go
+++ b/internal/cmd/cli/apply/apply.go
@@ -329,6 +329,7 @@ func newBundle(ctx context.Context, name, baseDir string, opts Options) (*fleet.
 	} else {
 		var err error
 		bundle, scans, err = bundlereader.NewBundle(ctx, name, baseDir, opts.BundleFile, &bundlereader.Options{
+			BundleFile:       opts.BundleFile,
 			Compress:         opts.Compress,
 			Labels:           opts.Labels,
 			ServiceAccount:   opts.ServiceAccount,


### PR DESCRIPTION
While Fleet config files are typically named `fleet.yaml`, the recent introduction of user-driven bundle scanning enables a config file to be named arbitrarily, in which case it must still be excluded from the corresponding bundle. Fleet now takes care of this without any action needed from the user.

Integration tests also demonstrate that `.fleetignore` files can be leveraged to exclude config files living in the same directory as the config file referenced explicitly through user-driven bundle scanning. Fleet would otherwise not exclude those files from the bundle.

Refers to https://github.com/rancher/fleet-docs/issues/307
Backport of #4207 to `release/v0.13`.

## Additional Information

### Checklist

- [x] <!-- If applicable,--> I have updated the documentation via a pull request in the
[fleet-docs](https://github.com/rancher/fleet-docs) repository: see https://github.com/rancher/fleet-docs/pull/354
