### PR TITLE
Fixes schedule update reset active

### DIFF
--- a/internal/cmd/controller/reconciler/schedule_controller.go
+++ b/internal/cmd/controller/reconciler/schedule_controller.go
@@ -273,7 +273,7 @@ func setClusterScheduled(ctx context.Context, c client.Client, name, namespace s
 	old := cluster.DeepCopy()
 	cluster.Status.Scheduled = scheduled
 
-	// when this function is called is either because we're updating a
+	// This function is called either because we're updating a
 	// Schedule or because we're creating it.
 	// In both cases ActiveSchedule should be false as a Schedule
 	// always begins in OffSchedule mode until the first start call is executed.
@@ -414,7 +414,6 @@ func setClustersScheduled(ctx context.Context, c client.Client, clusters []strin
 }
 
 func updateScheduledClusters(ctx context.Context, scheduler quartz.Scheduler, c client.Client, clustersNew []string, clustersOld []string, namespace string) error {
-	// first look for clusters that are not scheduled yet and flag them as scheduled
 	for _, cluster := range clustersNew {
 		if err := setClusterScheduled(ctx, c, cluster, namespace, true); err != nil {
 			return err


### PR DESCRIPTION
There was a bug in the recently merged **Scheduling** PR.

The bug consists of applying a label to the Schedule that initially matches **all clusters**, and then, while the Schedule is active, changing the target so that it matches **fewer clusters**.

The clusters that remained as targets would stay in the **ActiveSchedule** state, which is incorrect, since modifying the Schedule should reset it and set its status to **not active**.

Follow-up to #4184.
Related to #3726.

## Additional Information

### Checklist

- ~[ ] <!-- If applicable,--> I have updated the documentation via a pull request in the
[fleet-docs](https://github.com/rancher/fleet-docs) repository.~
