### PR TITLE
[0.13] Prevent bundle reconciles triggered by bundle status updates

### DIFF
--- a/integrationtests/controller/bundle/status_test.go
+++ b/integrationtests/controller/bundle/status_test.go
@@ -162,6 +162,8 @@ var _ = Describe("Bundle Status Fields", func() {
 			Expect(bd.Status.Display.State).To(Equal("Ready"))
 			Expect(bd.Status.AppliedDeploymentID).To(Equal(bd.Spec.DeploymentID))
 
+			deplIDBefore := bd.Spec.DeploymentID
+
 			Eventually(func() bool {
 				err = k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "name"}, bundle)
 				Expect(err).NotTo(HaveOccurred())
@@ -185,15 +187,18 @@ var _ = Describe("Bundle Status Fields", func() {
 				return k8sClient.Update(ctx, cluster)
 			}).ShouldNot(HaveOccurred())
 
-			// Change in cluster state reflects a change in bundle state
-			Eventually(func() bool {
+			// Change in cluster state results in a bundle deployment update
+			Eventually(func(g Gomega) {
+				err = k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "name"}, bd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(bd.Spec.DeploymentID).ToNot(Equal(deplIDBefore))
+
 				err = k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "name"}, bundle)
-				Expect(err).NotTo(HaveOccurred())
-				return bundle.Status.Summary.Ready == 0
-			}).Should(BeTrue())
-			Expect(bundle.Status.Summary.WaitApplied).To(Equal(1))
-			Expect(bundle.Status.Display.ReadyClusters).To(Equal("0/1"))
-			Expect(bundle.Status.Display.State).To(Equal("WaitApplied"))
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(bundle.Status.Summary.WaitApplied).To(Equal(0))
+				g.Expect(bundle.Status.Display.ReadyClusters).To(Equal("1/1"))
+				g.Expect(bundle.Status.Display.State).To(BeEmpty()) // all resources ready
+			}).Should(Succeed())
 		})
 	})
 })

--- a/internal/cmd/controller/gitops/reconciler/gitjob_controller.go
+++ b/internal/cmd/controller/gitops/reconciler/gitjob_controller.go
@@ -15,6 +15,7 @@ import (
 	fleetutil "github.com/rancher/fleet/internal/cmd/controller/errorutil"
 	"github.com/rancher/fleet/internal/cmd/controller/finalize"
 	"github.com/rancher/fleet/internal/cmd/controller/imagescan"
+	"github.com/rancher/fleet/internal/cmd/controller/reconciler"
 	"github.com/rancher/fleet/internal/metrics"
 	v1alpha1 "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
 	"github.com/rancher/fleet/pkg/durations"
@@ -136,7 +137,7 @@ func (r *GitJobReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			builder.WithPredicates(
 				// do not trigger for GitRepo status changes (except for commit changes and cache sync)
 				predicate.Or(
-					TypedResourceVersionUnchangedPredicate[client.Object]{},
+					reconciler.TypedResourceVersionUnchangedPredicate[client.Object]{},
 					predicate.GenerationChangedPredicate{},
 					predicate.AnnotationChangedPredicate{},
 					predicate.LabelChangedPredicate{},

--- a/internal/cmd/controller/gitops/reconciler/predicate.go
+++ b/internal/cmd/controller/gitops/reconciler/predicate.go
@@ -5,52 +5,9 @@ import (
 
 	v1alpha1 "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
 	batchv1 "k8s.io/api/batch/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
-
-// TypedResourceVersionUnchangedPredicate implements a update predicate to
-// allow syncPeriod to trigger the reconciler
-type TypedResourceVersionUnchangedPredicate[T metav1.Object] struct {
-	predicate.TypedFuncs[T]
-}
-
-func isNil(arg any) bool {
-	if v := reflect.ValueOf(arg); !v.IsValid() || ((v.Kind() == reflect.Ptr ||
-		v.Kind() == reflect.Interface ||
-		v.Kind() == reflect.Slice ||
-		v.Kind() == reflect.Map ||
-		v.Kind() == reflect.Chan ||
-		v.Kind() == reflect.Func) && v.IsNil()) {
-		return true
-	}
-	return false
-}
-
-func (TypedResourceVersionUnchangedPredicate[T]) Create(e event.CreateEvent) bool {
-	return false
-}
-
-func (TypedResourceVersionUnchangedPredicate[T]) Delete(e event.DeleteEvent) bool {
-	return false
-}
-
-// Update implements default UpdateEvent filter for validating resource version change.
-func (TypedResourceVersionUnchangedPredicate[T]) Update(e event.TypedUpdateEvent[T]) bool {
-	if isNil(e.ObjectOld) {
-		return false
-	}
-	if isNil(e.ObjectNew) {
-		return false
-	}
-
-	return e.ObjectNew.GetResourceVersion() == e.ObjectOld.GetResourceVersion()
-}
-
-func (TypedResourceVersionUnchangedPredicate[T]) Generic(e event.GenericEvent) bool {
-	return false
-}
 
 func jobUpdatedPredicate() predicate.Funcs {
 	return predicate.Funcs{

--- a/internal/cmd/controller/reconciler/bundle_controller.go
+++ b/internal/cmd/controller/reconciler/bundle_controller.go
@@ -83,7 +83,17 @@ type BundleReconciler struct {
 // SetupWithManager sets up the controller with the Manager.
 func (r *BundleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&fleet.Bundle{}).
+		For(&fleet.Bundle{},
+			builder.WithPredicates(
+				// do not trigger for bundle status changes (except for cache sync)
+				predicate.Or(
+					TypedResourceVersionUnchangedPredicate[client.Object]{},
+					predicate.GenerationChangedPredicate{},
+					predicate.AnnotationChangedPredicate{},
+					predicate.LabelChangedPredicate{},
+				),
+			),
+		).
 		// Note: Maybe improve with WatchesMetadata, does it have access to labels?
 		Watches(
 			// Fan out from bundledeployment to bundle, this is useful to update the

--- a/internal/cmd/controller/reconciler/predicate.go
+++ b/internal/cmd/controller/reconciler/predicate.go
@@ -1,0 +1,51 @@
+package reconciler
+
+import (
+	"reflect"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+// TypedResourceVersionUnchangedPredicate implements a update predicate to
+// allow syncPeriod to trigger the reconciler
+type TypedResourceVersionUnchangedPredicate[T metav1.Object] struct {
+	predicate.TypedFuncs[T]
+}
+
+func isNil(arg any) bool {
+	if v := reflect.ValueOf(arg); !v.IsValid() || ((v.Kind() == reflect.Ptr ||
+		v.Kind() == reflect.Interface ||
+		v.Kind() == reflect.Slice ||
+		v.Kind() == reflect.Map ||
+		v.Kind() == reflect.Chan ||
+		v.Kind() == reflect.Func) && v.IsNil()) {
+		return true
+	}
+	return false
+}
+
+func (TypedResourceVersionUnchangedPredicate[T]) Create(e event.CreateEvent) bool {
+	return false
+}
+
+func (TypedResourceVersionUnchangedPredicate[T]) Delete(e event.DeleteEvent) bool {
+	return false
+}
+
+// Update implements default UpdateEvent filter for validating resource version change.
+func (TypedResourceVersionUnchangedPredicate[T]) Update(e event.TypedUpdateEvent[T]) bool {
+	if isNil(e.ObjectOld) {
+		return false
+	}
+	if isNil(e.ObjectNew) {
+		return false
+	}
+
+	return e.ObjectNew.GetResourceVersion() == e.ObjectOld.GetResourceVersion()
+}
+
+func (TypedResourceVersionUnchangedPredicate[T]) Generic(e event.GenericEvent) bool {
+	return false
+}


### PR DESCRIPTION
A bundle must only be reconciled upon changes impacting its spec, or a related cluster or bundle deployment. Changes to the bundle's status must not lead to new reconciles, which may cause endless loops.

Backport of #4171 to v0.13.

## Additional Information

### Checklist

~- [ ] <!-- If applicable,--> I have updated the documentation via a pull request in the
[fleet-docs](https://github.com/rancher/fleet-docs) repository.~
