### PR TITLE
[0.13] Explicitly delete bundle secrets on bundle deletion

### DIFF
--- a/internal/cmd/cli/apply/apply.go
+++ b/internal/cmd/cli/apply/apply.go
@@ -420,6 +420,7 @@ func writeBundle(ctx context.Context, c client.Client, r record.EventRecorder, b
 		valuesSecret := newValuesSecret(bundle, data)
 		updated := valuesSecret.DeepCopy()
 		_, err = controllerutil.CreateOrUpdate(ctx, c, valuesSecret, func() error {
+			valuesSecret.OwnerReferences = updated.OwnerReferences
 			valuesSecret.Labels = updated.Labels
 			valuesSecret.Data = updated.Data
 			valuesSecret.Type = updated.Type


### PR DESCRIPTION
* Explicitly delete bundle secrets on bundle deletion
* Update owner reference when updating values/options secret

Backport of #4146 to 0.13

## Additional Information

### Checklist

~- [ ] <!-- If applicable,--> I have updated the documentation via a pull request in the
[fleet-docs](https://github.com/rancher/fleet-docs) repository.~
