### PR TITLE
Copy Github App secrets to nightly CI workflow

### DIFF
--- a/.github/workflows/e2e-nightly-ci.yml
+++ b/.github/workflows/e2e-nightly-ci.yml
@@ -172,6 +172,9 @@ jobs:
           GIT_REPO_URL: "git@github.com:fleetrepoci/test.git"
           GIT_REPO_HOST: "github.com"
           GIT_REPO_USER: "git"
+          GITHUB_APP_ID:  ${{ secrets.CI_GITHUB_APP_ID }}
+          GITHUB_APP_INSTALLATION_ID:  ${{ secrets.CI_GITHUB_APP_INSTALLATION_ID }}
+          GITHUB_APP_PRIVATE_KEY: ${{ secrets.CI_GITHUB_APP_PRIVATE_KEY }}
           GITHUB_PAT_TOKEN: ${{ secrets.CI_PRIVATE_REPO_PAT }}
           GIT_REPO_BRANCH: ${{ matrix.k3s_version }}
           CI_OCI_USERNAME:  ${{ secrets.CI_OCI_USERNAME }}


### PR DESCRIPTION
End-to-end tests requiring secrets, including Github Apps credentials,
are also run as part of our nightly end-to-end tests workflow.

## Additional Information

### Checklist

~- [ ] <!-- If applicable,--> I have updated the documentation via a pull request in the
[fleet-docs](https://github.com/rancher/fleet-docs) repository.~
