### PR TITLE
Reduce flakiness of signal handling tests

### DIFF
--- a/e2e/single-cluster/signals_test.go
+++ b/e2e/single-cluster/signals_test.go
@@ -28,8 +28,10 @@ var _ = Describe("Shuts down gracefully", func() {
 		})
 
 		JustBeforeEach(func() {
-			out, err := k.Run("exec", "deploy/fleet-agent", "--", "kill", "1")
-			Expect(err).ToNot(HaveOccurred(), out)
+			Eventually(func(g Gomega) {
+				out, err := k.Run("exec", "deploy/fleet-agent", "--", "kill", "1")
+				g.Expect(err).ToNot(HaveOccurred(), out)
+			}).Should(Succeed())
 		})
 
 		It("exits gracefully", func() {
@@ -59,11 +61,13 @@ var _ = Describe("Shuts down gracefully", func() {
 		})
 
 		JustBeforeEach(func() {
-			pod, err := k.Get("pod", "-l", labels, "-o", "jsonpath={.items[0].metadata.name}")
-			Expect(err).ToNot(HaveOccurred(), pod)
+			Eventually(func(g Gomega) {
+				pod, err := k.Get("pod", "-l", labels, "-o", "jsonpath={.items[0].metadata.name}")
+				g.Expect(err).ToNot(HaveOccurred(), pod)
 
-			out, err := k.Run("exec", pod, "--", "kill", "1")
-			Expect(err).ToNot(HaveOccurred(), out)
+				out, err := k.Run("exec", pod, "--", "kill", "1")
+				g.Expect(err).ToNot(HaveOccurred(), out)
+			}).Should(Succeed())
 		})
 
 		It("exits gracefully", func() {
@@ -93,11 +97,13 @@ var _ = Describe("Shuts down gracefully", func() {
 		})
 
 		JustBeforeEach(func() {
-			pod, err := k.Get("pod", "-l", labels, "-o", "jsonpath={.items[0].metadata.name}")
-			Expect(err).ToNot(HaveOccurred(), pod)
+			Eventually(func(g Gomega) {
+				pod, err := k.Get("pod", "-l", labels, "-o", "jsonpath={.items[0].metadata.name}")
+				g.Expect(err).ToNot(HaveOccurred(), pod)
 
-			out, err := k.Run("exec", pod, "--", "kill", "1")
-			Expect(err).ToNot(HaveOccurred(), out)
+				out, err := k.Run("exec", pod, "--", "kill", "1")
+				g.Expect(err).ToNot(HaveOccurred(), out)
+			}).Should(Succeed())
 		})
 
 		It("exits gracefully", func() {
@@ -127,11 +133,13 @@ var _ = Describe("Shuts down gracefully", func() {
 		})
 
 		JustBeforeEach(func() {
-			pod, err := k.Get("pod", "-l", labels, "-o", "jsonpath={.items[0].metadata.name}")
-			Expect(err).ToNot(HaveOccurred(), pod)
+			Eventually(func(g Gomega) {
+				pod, err := k.Get("pod", "-l", labels, "-o", "jsonpath={.items[0].metadata.name}")
+				g.Expect(err).ToNot(HaveOccurred(), pod)
 
-			out, err := k.Run("exec", pod, "--", "kill", "1")
-			Expect(err).ToNot(HaveOccurred(), out)
+				out, err := k.Run("exec", pod, "--", "kill", "1")
+				g.Expect(err).ToNot(HaveOccurred(), out)
+			}).Should(Succeed())
 		})
 
 		It("exits gracefully", func() {


### PR DESCRIPTION
End-to-end tests for signal handling depend on availability of deployments, which may be affected by other running test suites, as is the case of the Fleet agent with pod disruption budgets and priority classes.
Therefore, signal handling tests now retry killing a deployment if that deployment or its targeted container is not available.

<!-- Specify the issue ID that this pull request is solving -->
Refers to #4246.
<!-- Make sure that the referenced issue provides steps to reproduce it -->

<!-- Describe the changes introduced by this pull request -->

<!--
  Please provide a unit, integration (`./integrationtests/`) or e2e (`./e2e/`) test if possible.
-->

## Additional Information

### Checklist

~- [ ] <!-- If applicable,--> I have updated the documentation via a pull request in the
[fleet-docs](https://github.com/rancher/fleet-docs) repository.~
