### PR TITLE
GitRepos and HelmOps don't Requeue when adding finalizers

### DIFF
--- a/internal/cmd/controller/finalize/finalize.go
+++ b/internal/cmd/controller/finalize/finalize.go
@@ -23,6 +23,7 @@ const (
 	BundleFinalizer           = "fleet.cattle.io/bundle-finalizer"
 	BundleDeploymentFinalizer = "fleet.cattle.io/bundle-deployment-finalizer"
 	ClusterFinalizer          = "fleet.cattle.io/cluster-finalizer"
+	ScheduleFinalizer         = "fleet.cattle.io/schedule-finalizer"
 )
 
 // PurgeBundles deletes all bundles related to the given resource namespaced name
@@ -156,4 +157,14 @@ func PurgeNamespace(ctx context.Context, c client.Client, deleteNamespace bool, 
 	}
 
 	return nil
+}
+
+// EnsureFinalizer adds a finalizer to the given object if it doesn't exist.
+func EnsureFinalizer(ctx context.Context, c client.Client, obj client.Object, finalizer string) error {
+	if controllerutil.ContainsFinalizer(obj, finalizer) {
+		return nil
+	}
+
+	controllerutil.AddFinalizer(obj, finalizer)
+	return c.Update(ctx, obj)
 }

--- a/internal/cmd/controller/reconciler/bundle_controller.go
+++ b/internal/cmd/controller/reconciler/bundle_controller.go
@@ -181,9 +181,7 @@ func (r *BundleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 
 	bundleOrig := bundle.DeepCopy()
 
-	if err := r.ensureFinalizer(ctx, bundle); err != nil {
-		// Retry without updating the status, as this should be a transient error about which users can't do
-		// anything.
+	if err := finalize.EnsureFinalizer(ctx, r.Client, bundle, finalize.BundleFinalizer); err != nil {
 		return ctrl.Result{}, fmt.Errorf("%w, failed to add finalizer to bundle: %w", fleetutil.ErrRetryable, err)
 	}
 
@@ -452,16 +450,6 @@ func (r *BundleReconciler) handleDelete(ctx context.Context, logger logr.Logger,
 	}
 
 	return ctrl.Result{}, err
-}
-
-// ensureFinalizer adds a finalizer to a recently created bundle.
-func (r *BundleReconciler) ensureFinalizer(ctx context.Context, bundle *fleet.Bundle) error {
-	if controllerutil.ContainsFinalizer(bundle, finalize.BundleFinalizer) {
-		return nil
-	}
-
-	controllerutil.AddFinalizer(bundle, finalize.BundleFinalizer)
-	return r.Update(ctx, bundle)
 }
 
 // removeDisplayNameLabel removes the obsolete created-by-display-name label from the bundle if it exists.

--- a/internal/cmd/controller/reconciler/schedule_controller_test.go
+++ b/internal/cmd/controller/reconciler/schedule_controller_test.go
@@ -6,6 +6,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/rancher/fleet/internal/cmd/controller/finalize"
 	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
 	"github.com/rancher/wrangler/v3/pkg/condition"
 	"github.com/reugn/go-quartz/quartz"
@@ -113,7 +114,7 @@ var _ = Describe("ScheduleReconciler", func() {
 			updatedSchedule := &fleet.Schedule{}
 			err = k8sclient.Get(ctx, req.NamespacedName, updatedSchedule)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(updatedSchedule.Finalizers).To(ContainElement(scheduleFinalizer))
+			Expect(updatedSchedule.Finalizers).To(ContainElement(finalize.ScheduleFinalizer))
 
 			// Check job in scheduler
 			jobKey := scheduleKey(schedule)


### PR DESCRIPTION
This PR changes the _HelmOp_ and _GitRepo_ controllers to not requeue after adding a finalizer.
Both follow now the same mechanism as other resources (add the finalizer and call `Update`)

## Additional Information

### Checklist

- ~[ ] <!-- If applicable,--> I have updated the documentation via a pull request in the
[fleet-docs](https://github.com/rancher/fleet-docs) repository.~
