### PR TITLE
Fix Prometheus text parser instantiation in benchmarks

### DIFF
--- a/benchmarks/record/record.go
+++ b/benchmarks/record/record.go
@@ -235,7 +235,7 @@ func getMetrics(res map[string]float64, url string, controllers ...string) {
 	pod := addRandomSuffix("curl")
 	var (
 		mfs    map[string]*dto.MetricFamily
-		parser expfmt.TextParser = expfmt.NewTextParser(model.LegacyValidation)
+		parser = expfmt.NewTextParser(model.LegacyValidation)
 	)
 	Eventually(func() error {
 		GinkgoWriter.Print("Fetching metrics from " + url + "\n")


### PR DESCRIPTION
This follows up on a change made to end-to-end tests after a recent update of Prometheus libraries.

Follow-up to #4200.

Test runs:
* [before](https://github.com/rancher/fleet/actions/runs/18879257533/job/53877455908)
* [after](https://github.com/weyfonk/fleet/actions/runs/18879991639/job/53880099940)

## Additional Information

### Checklist

~- [ ] <!-- If applicable,--> I have updated the documentation via a pull request in the
[fleet-docs](https://github.com/rancher/fleet-docs) repository.~
