### PR TITLE
Exit with non-zero exit code if tests fail

### DIFF
--- a/benchmarks/cmd/run.go
+++ b/benchmarks/cmd/run.go
@@ -66,7 +66,7 @@ var runCmd = &cobra.Command{
 		if verbose {
 			os.Setenv("FLEET_BENCH_VERBOSE", "true")
 		}
-		testing.MainStart(
+		exitCode := testing.MainStart(
 			matchStringOnly(nil),
 			[]testing.InternalTest{
 				{"BenchmarkSuite", benchmarks.TestBenchmarkSuite},
@@ -86,6 +86,8 @@ var runCmd = &cobra.Command{
 
 		fmt.Println()
 		fmt.Printf("Move the report %q to the %q folder, if you want to compare future benchmark against it.\n", report, db)
+
+		os.Exit(exitCode)
 		return nil
 	},
 }


### PR DESCRIPTION
<!-- Specify the issue ID that this pull request is solving -->

<!-- Make sure that the referenced issue provides steps to reproduce it -->

<!-- Describe the changes introduced by this pull request -->

<!--
  Please provide a unit, integration (`./integrationtests/`) or e2e (`./e2e/`) test if possible.
-->

## Additional Information

Works as intended as tested in https://github.com/rancher/fleet/actions/runs/18900740481/job/53947199462 from https://github.com/rancher/fleet/tree/refs/heads/benchmark-fail-with-exit-code

### Checklist

- [ ] <!-- If applicable,--> I have updated the documentation via a pull request in the
[fleet-docs](https://github.com/rancher/fleet-docs) repository.
