### PR TITLE
Go back to slsactl action to v0.0.16

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,7 +116,9 @@ jobs:
 
       - name: Install Cosign
         uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
-      - uses: rancherlabs/slsactl/actions/install-slsactl@3cf520cf69c770a9be71e8efe33fafaf0d0a8550 # v0.0.21
+      - uses: rancherlabs/slsactl/actions/install-slsactl@883774aee17dd2d82f388f3e93a8df623c3437a6 # v0.0.16
+        with:
+          version: v0.0.16
 
       - name: "Read Vault Secrets"
         uses: rancher-eio/read-vault-secrets@main


### PR DESCRIPTION
and specify a fixed version to prevent pulling the latest cli version, which is broken.

After running into several [issues](https://github.com/rancher/fleet/actions/workflows/release.yml) with the new versions.