### PR TITLE
Fix slsactl installation action commit reference

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,7 +116,7 @@ jobs:
 
       - name: Install Cosign
         uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
-      - uses: rancherlabs/slsactl/actions/install-slsactl@2539cebd3fe5c291e5431f042e225c5b65850f50 # v0.1.2
+      - uses: rancherlabs/slsactl/actions/install-slsactl@45cc1a7e497bbe1f5c144ef9d9ee709924df5ce0 # v0.1.2
         with:
           version: v0.1.2
 


### PR DESCRIPTION
it was still pointing to the old version.