### PR TITLE
Fix race when creating secrets and Kubernetes jobs

### DIFF
--- a/internal/cmd/controller/gitops/reconciler/gitjob.go
+++ b/internal/cmd/controller/gitops/reconciler/gitjob.go
@@ -152,7 +152,7 @@ func (r *GitJobReconciler) createCABundleSecret(ctx context.Context, gitrepo *v1
 			return err
 		}
 		if !strings.EqualFold(updatedSecret.Annotations["revision"], secret.Annotations["revision"]) {
-			return fmt.Errorf("revision did not match")
+			return fmt.Errorf("CA bundle secret %s/%s has not been synced in time before git job creation", gitrepo.Namespace, name)
 		}
 		return nil
 	})


### PR DESCRIPTION
When creating secrets and a Kubernetes Job that uses those secrets in volumes, it is possible that the job is created before the secret has been synchronized. If the job required the content of the secret to be mounted, the file would be missing.

Also fixes usage of `controllerutil.CreateOrUpdate`.

Possibly related to https://github.com/kubernetes-sigs/secrets-store-csi-driver/issues/1051.

<!-- Specify the issue ID that this pull request is solving -->
<!-- Make sure that the referenced issue provides steps to reproduce it -->

<!-- Describe the changes introduced by this pull request -->

<!--
  Please provide a unit, integration (`./integrationtests/`) or e2e (`./e2e/`) test if possible.
-->

## Additional Information

The implementation of the annotations I didn't test. It only would be used in case of updates, which in turn would only happen if the reconciler was unable to complete the creation of the job after the secret was created, so that it would have to re-reconcile. That case should be fairly rare, but since it can happen, I have included this mechanism that would take care of that. In my tests I never hit the point where the secret could be retrieved but wasn't equal to the one that was created and/or updated.

On the other hand, hitting a case where the secret could not be fetched right after it's creation, I have encountered about every 10th attempt.

The tests that seem to be most affected by this change are the infra setup tests for git, helm and OCI. I noticed that because they all failed when I still used `retry.RetryOnConflict` which is not suitable for this case, it requires an error of type `Conflict` to trigger the back-off. Other errors end the attempts of retrying. Which I have replaced that functionality with `retry.OnError`.

### Checklist

- [ ] <!-- If applicable,--> I have updated the documentation via a pull request in the
[fleet-docs](https://github.com/rancher/fleet-docs) repository.
