### PR TITLE
Avoid disabling auth if one of the charts does not match

### DIFF
--- a/internal/bundlereader/resources.go
+++ b/internal/bundlereader/resources.go
@@ -212,6 +212,7 @@ func addRemoteCharts(directories []directory, base string, charts []*fleet.HelmO
 			if err != nil {
 				return nil, fmt.Errorf("failed to add auth to request for %s: %w", downloadChartError(*chart), err)
 			}
+			auth := auth // loop-scoped variable
 			if !shouldAddAuthToRequest {
 				auth = Auth{}
 			}


### PR DESCRIPTION
While working on something else, I noticed this variable was being replaced in a for loop, which will affect the result for successive executions (and I believe this is not on purpose). I don't have evidence of any issues caused by this, though.