### PR TITLE
Fix panic due to mismatching key-value pair expected from logger

### DIFF
--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -84,7 +84,7 @@ func (c *CollectorCollection) Collect(ctx context.Context, obj metav1.ObjectMeta
 			if !ok {
 				msg = "unexpected error"
 			}
-			logger.Error(errors.New("error collecting metrics"), msg, r)
+			logger.Error(errors.New("error collecting metrics"), msg)
 		}
 	}()
 	c.Delete(obj.GetObjectMeta().GetName(), obj.GetObjectMeta().GetNamespace())


### PR DESCRIPTION
I found multiple panics in the logs of a failed CI run (successful runs omit verbose logs so it was not being printed):
https://github.com/rancher/fleet/actions/runs/19454838598/job/55666698529#step:5:84:
```
"Observed a panic" panic="odd number of arguments passed as key-value pairs for logging"
```
