### PR TITLE
Run all tests during nightly e2e manual runs

### DIFF
--- a/.github/workflows/e2e-nightly-ci.yml
+++ b/.github/workflows/e2e-nightly-ci.yml
@@ -11,15 +11,6 @@ on:
         description: 'K3s version to test (e.g., v1.34.1-k3s1)'
         required: false
         default: 'v1.34.1-k3s1'
-      test_type:
-        description: 'Test type to run'
-        required: false
-        default: 'e2e-nosecrets'
-        type: choice
-        options:
-          - acceptance
-          - e2e-secrets
-          - e2e-nosecrets
 
 env:
   GOARCH: amd64
@@ -38,9 +29,9 @@ jobs:
           - ${{ github.event.inputs.k3s_version || 'v1.34.1-k3s1' }}
           - ${{ github.event_name == 'schedule' && 'v1.33.5-k3s1' || '' }}
         test_type:
-          - ${{ github.event.inputs.test_type || 'acceptance' }}
-          - ${{ github.event_name == 'schedule' && 'e2e-secrets' || '' }}
-          - ${{ github.event_name == 'schedule' && 'e2e-nosecrets' || '' }}
+          - acceptance
+          - e2e-secrets
+          - e2e-nosecrets
         exclude:
           - k3s_version: ''
           - test_type: ''


### PR DESCRIPTION
because they partly seem to be dependent on each other and it is better to run the whole set to have a similar comparison.