### PR TITLE
[v0.14] Backport #4185 -- Use CABundle when fetching chart with helm.chart field of fleet.yaml file #4371

### DIFF
--- a/e2e/assets/gitrepo/gitrepo.yaml
+++ b/e2e/assets/gitrepo/gitrepo.yaml
@@ -10,4 +10,20 @@ spec:
   targetNamespace: {{.TargetNamespace}}
   {{- end }}
   paths:
+  {{- if .Path }}
+  - {{.Path}}
+  {{- else }}
   - examples
+  {{- end }}
+  {{- if .CABundle}}
+  caBundle: {{.CABundle}}
+  {{- end}}
+  {{- if .HelmSecretName }}
+  helmSecretName: {{.HelmSecretName}}
+  {{- end }}
+  {{- if .HelmSecretNameForPaths }}
+  helmSecretNameForPaths: {{.HelmSecretNameForPaths}}
+  {{- end }}
+  {{- if .InsecureSkipTLSVerify }}
+  insecureSkipTLSVerify: {{.InsecureSkipTLSVerify}}
+  {{- end }}

--- a/e2e/single-cluster/gitrepo_test.go
+++ b/e2e/single-cluster/gitrepo_test.go
@@ -31,6 +31,19 @@ const (
 	HTTPSPort = 4343
 )
 
+type gitRepoTestValues struct {
+	Name                   string
+	Repo                   string
+	Branch                 string
+	PollingInterval        string
+	TargetNamespace        string
+	Path                   string
+	CABundle               string
+	HelmSecretName         string
+	HelmSecretNameForPaths string
+	InsecureSkipTLSVerify  bool
+}
+
 var _ = Describe("Monitoring Git repos via HTTP for change", Label("infra-setup"), func() {
 	var (
 		tmpDir           string
@@ -100,18 +113,12 @@ var _ = Describe("Monitoring Git repos via HTTP for change", Label("infra-setup"
 		})
 
 		JustBeforeEach(func() {
-			err := testenv.ApplyTemplate(k, testenv.AssetPath("gitrepo/gitrepo.yaml"), struct {
-				Name            string
-				Repo            string
-				Branch          string
-				PollingInterval string
-				TargetNamespace string
-			}{
-				gitrepoName,
-				inClusterRepoURL,
-				gh.Branch,
-				"15s",           // default
-				targetNamespace, // to avoid conflicts with other tests
+			err := testenv.ApplyTemplate(k, testenv.AssetPath("gitrepo/gitrepo.yaml"), gitRepoTestValues{
+				Name:            gitrepoName,
+				Repo:            inClusterRepoURL,
+				Branch:          gh.Branch,
+				PollingInterval: "15s",           // default
+				TargetNamespace: targetNamespace, // to avoid conflicts with other tests
 			})
 			Expect(err).ToNot(HaveOccurred())
 
@@ -157,18 +164,12 @@ var _ = Describe("Monitoring Git repos via HTTP for change", Label("infra-setup"
 		})
 
 		JustBeforeEach(func() {
-			err := testenv.ApplyTemplate(k, testenv.AssetPath("gitrepo/gitrepo.yaml"), struct {
-				Name            string
-				Repo            string
-				Branch          string
-				PollingInterval string
-				TargetNamespace string
-			}{
-				gitrepoName,
-				inClusterRepoURL,
-				gh.Branch,
-				"15s",           // default
-				targetNamespace, // to avoid conflicts with other tests
+			err := testenv.ApplyTemplate(k, testenv.AssetPath("gitrepo/gitrepo.yaml"), gitRepoTestValues{
+				Name:            gitrepoName,
+				Repo:            inClusterRepoURL,
+				Branch:          gh.Branch,
+				PollingInterval: "15s",           // default
+				TargetNamespace: targetNamespace, // to avoid conflicts with other tests
 			})
 			Expect(err).ToNot(HaveOccurred())
 
@@ -270,18 +271,12 @@ var _ = Describe("Monitoring Git repos via HTTP for change", Label("infra-setup"
 			clone, err = gh.Create(clonedir, testenv.AssetPath("gitrepo/sleeper-chart"), "examples")
 			Expect(err).ToNot(HaveOccurred())
 
-			err = testenv.ApplyTemplate(k, testenv.AssetPath("gitrepo/gitrepo.yaml"), struct {
-				Name            string
-				Repo            string
-				Branch          string
-				PollingInterval string
-				TargetNamespace string
-			}{
-				gitrepoName,
-				inClusterRepoURL,
-				gh.Branch,
-				"24h",           // prevent polling
-				targetNamespace, // to avoid conflicts with other tests
+			err = testenv.ApplyTemplate(k, testenv.AssetPath("gitrepo/gitrepo.yaml"), gitRepoTestValues{
+				Name:            gitrepoName,
+				Repo:            inClusterRepoURL,
+				Branch:          gh.Branch,
+				PollingInterval: "24h",           // prevent polling
+				TargetNamespace: targetNamespace, // to avoid conflicts with other tests
 			})
 			Expect(err).ToNot(HaveOccurred())
 		})

--- a/e2e/single-cluster/go_getter_custom_ca_test.go
+++ b/e2e/single-cluster/go_getter_custom_ca_test.go
@@ -1,0 +1,309 @@
+package singlecluster_test
+
+// These test cases rely on a local git server, so that they can be run locally and against PRs.
+// For tests monitoring external git hosting providers, see `e2e/require-secrets`.
+
+import (
+	"encoding/base64"
+	"fmt"
+	"math/rand"
+	"os"
+	"path"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/rancher/fleet/e2e/testenv"
+	"github.com/rancher/fleet/e2e/testenv/githelper"
+	"github.com/rancher/fleet/e2e/testenv/kubectl"
+
+	"sigs.k8s.io/yaml"
+)
+
+// Those tests are specifically targeting one feature of go-getter, namely cloning of git
+// repositories using HTTPS. That is, because TLS certificates are only used in HTTPS URLs, not if
+// SSH keys are used to clone those repositories. Since go-getter shells out to the `git` CLI for
+// cloning git repositories, the configuration of TLS certificates or ignoring those needs to be
+// configured with `git` typical environment variables. Those are the tests for that implementation.
+// For go-getter to be used, the `helm.chart` field in `fleet.yaml` needs to point to a URL that
+// tells go-getter to use the git protocol over HTTPS. Such an URL is prefixed with `git::https://`.
+// The contents fetched from those repositories are expected to be helm charts.
+var _ = Describe("Testing go-getter CA bundles and insecureSkipVerify for cloning git repositories", Label("infra-setup"), func() {
+	const (
+		sleeper    = "sleeper"
+		entrypoint = "entrypoint"
+	)
+
+	var (
+		tmpDir          string
+		cloneDir        string
+		k               kubectl.Command
+		gh              *githelper.Git
+		gitrepoName     string
+		r               = rand.New(rand.NewSource(GinkgoRandomSeed()))
+		targetNamespace string
+		// Build git repo URL reachable _within_ the cluster, for the GitRepo
+		host = githelper.BuildGitHostname()
+	)
+
+	getExternalRepoURL := func(repoName string) string {
+		GinkgoHelper()
+		addr, err := githelper.GetExternalRepoAddr(env, HTTPSPort, repoName)
+		Expect(err).ToNot(HaveOccurred())
+		addr = strings.Replace(addr, "http://", "https://", 1)
+		return addr
+	}
+
+	mustReadFileAsBase64 := func(filePath string) string {
+		GinkgoHelper()
+		data, err := os.ReadFile(filePath)
+		Expect(err).ToNot(HaveOccurred(), "failed to read file: %s", filePath)
+		return base64.StdEncoding.EncodeToString(data)
+	}
+
+	// getCertificateFilePath returns the path to the CA certificate file used to set up the local
+	// git server.
+	getCertificateFilePath := func() string {
+		GinkgoHelper()
+		certsDir := os.Getenv("CI_OCI_CERTS_DIR")
+		Expect(certsDir).ToNot(BeEmpty())
+		return path.Join(certsDir, "helm.crt")
+	}
+
+	createInvalidCACertFile := func() *os.File {
+		tmpFile, err := os.CreateTemp("", "invalid-ca-*.crt")
+		Expect(err).ToNot(HaveOccurred(), "failed to create temp file for invalid CA bundle")
+		_, err = tmpFile.Write([]byte("invalid-ca-bundle"))
+		Expect(err).ToNot(HaveOccurred(), "failed to write invalid CA bundle to temp file")
+		err = tmpFile.Close()
+		Expect(err).ToNot(HaveOccurred(), "failed to close temp file for invalid CA bundle")
+		return tmpFile
+	}
+
+	expectGitRepoToNotBeReady := func(g Gomega) {
+		out, err := k.Get("gitrepo", gitrepoName, `-o=jsonpath={.status.display.readyBundleDeployments}`)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(out).To(ContainSubstring("0/0"))
+	}
+
+	expectGitRepoToBeReady := func(g Gomega) {
+		out, err := k.Get("gitrepo", gitrepoName, `-o=jsonpath={.status.display.readyBundleDeployments}`)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(out).To(ContainSubstring("1/1"))
+	}
+
+	type Auth struct {
+		Username           string `json:"username,omitempty"`
+		Password           string `json:"password,omitempty"`
+		CABundle           string `json:"caBundle,omitempty"`
+		SSHPrivateKey      string `json:"sshPrivateKey,omitempty"`
+		InsecureSkipVerify bool   `json:"insecureSkipVerify,omitempty"`
+		BasicHTTP          bool   `json:"basicHTTP,omitempty"`
+	}
+	type AuthConfigByPath map[string]Auth
+
+	createHelmSecretForPaths := func(secretName string, config AuthConfigByPath) {
+		GinkgoHelper()
+		data, err := yaml.Marshal(config)
+		Expect(err).ToNot(HaveOccurred())
+
+		file, err := os.CreateTemp("", "helm-auth-*.yaml")
+		Expect(err).ToNot(HaveOccurred(), "failed to create temp file for helm auth config")
+		defer os.Remove(file.Name())
+		_, err = file.Write(data)
+		Expect(err).ToNot(HaveOccurred(), "failed to write helm auth config to temp file")
+
+		_, err = k.Create("secret", "generic", secretName, "--from-file=secrets-path.yaml="+file.Name(), "-n", env.Namespace)
+		Expect(err).ToNot(HaveOccurred())
+	}
+
+	type gitRepoOptions struct {
+		CABundle               string
+		InsecureSkipTLSVerify  bool
+		HelmSecretName         string
+		HelmSecretNameForPaths string
+	}
+
+	createGitRepo := func(options gitRepoOptions) {
+		GinkgoHelper()
+		values := gitRepoTestValues{
+			// Defaults
+			Name:            gitrepoName,
+			Repo:            gh.GetInClusterURL(host, HTTPSPort, "repo"),
+			Branch:          gh.Branch,
+			PollingInterval: "15s",           // default
+			TargetNamespace: targetNamespace, // to avoid conflicts with other tests
+			Path:            entrypoint,
+			// Customizations
+			CABundle:               options.CABundle,
+			InsecureSkipTLSVerify:  options.InsecureSkipTLSVerify,
+			HelmSecretName:         options.HelmSecretName,
+			HelmSecretNameForPaths: options.HelmSecretNameForPaths,
+		}
+
+		err := testenv.ApplyTemplate(k, testenv.AssetPath("gitrepo/gitrepo.yaml"), values)
+		Expect(err).ToNot(HaveOccurred())
+	}
+
+	BeforeEach(func() {
+		k = env.Kubectl.Namespace(env.Namespace)
+	})
+
+	JustBeforeEach(func() {
+		// Create the first repository
+		addr := getExternalRepoURL("repo")
+		gh = githelper.NewHTTP(addr)
+		tmpDir, err := os.MkdirTemp("", "fleet-")
+		Expect(err).ToNot(HaveOccurred())
+		cloneDir = path.Join(tmpDir, "repo") // Fixed and built into the container image.
+		gitrepoName = testenv.RandomFilename("gitjob-test", r)
+		// Creates the content in the sleeper directory
+		_, err = gh.Create(cloneDir, testenv.AssetPath("gitrepo/sleeper-chart"), sleeper)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Create the second repository, referencing the Helm chart from the
+		// first repository through a fleet.yaml
+		tmpAssetDir := path.Join(tmpDir, "entryPoint")
+		err = os.Mkdir(tmpAssetDir, 0755)
+		Expect(err).ToNot(HaveOccurred())
+		url := "git::" + gh.GetInClusterURL(host, HTTPSPort, "repo?ref="+sleeper)
+		err = os.WriteFile(
+			path.Join(tmpAssetDir, "fleet.yaml"),
+			fmt.Appendf([]byte{}, "helm:\n  chart: %s\n", url),
+			0755,
+		)
+		Expect(err).NotTo(HaveOccurred())
+
+		_, err = gh.Add(cloneDir, tmpAssetDir, entrypoint)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		_ = os.RemoveAll(tmpDir)
+		_, _ = k.Delete("gitrepo", gitrepoName)
+		_, _ = k.Delete("ns", targetNamespace)
+	})
+
+	When("testing custom CA bundles for cloning git with HTTPS using go-getter (fleet.yaml)", func() {
+		It("should succeed when not configuring any CA", func() {
+			// Create and apply GitRepo, don't configure CABundle, InsecureSkipTLSVerify,
+			// helmSecretName, or helmSecretNameForPath in GitRepo.spec which makes it fall back to
+			// Rancher certificates that work.
+			createGitRepo(gitRepoOptions{})
+			Eventually(expectGitRepoToBeReady).Should(Succeed())
+		})
+
+		It("should succeed when using the correct CA bundle provided in GitRepo's CABundle field", func() {
+			encodedCert := mustReadFileAsBase64(getCertificateFilePath())
+			createGitRepo(gitRepoOptions{CABundle: encodedCert})
+			Eventually(expectGitRepoToBeReady).Should(Succeed())
+		})
+
+		It("should fail when using the incorrect CA bundle provided in GitRepo's CABundle field", func() {
+			// But it should fail in gitcloner already, not later in fleet apply.
+			encodedCert := base64.StdEncoding.EncodeToString([]byte("invalid-ca-bundle"))
+			createGitRepo(gitRepoOptions{CABundle: encodedCert})
+			Eventually(expectGitRepoToNotBeReady).Should(Succeed())
+			Consistently(expectGitRepoToNotBeReady).Should(Succeed())
+		})
+
+		It("should succeed when using the correct CA bundle provided in helmSecretName", func() {
+			helmCrtFile := getCertificateFilePath()
+
+			// Create secret with CA bundle
+			secretName := testenv.RandomFilename("helm-ca-bundle", r)
+			out, err := k.Create("secret", "generic", secretName, "--from-file=cacerts="+helmCrtFile, "-n", env.Namespace)
+			Expect(err).ToNot(HaveOccurred(), out)
+
+			createGitRepo(gitRepoOptions{HelmSecretName: secretName})
+			Eventually(expectGitRepoToBeReady).Should(Succeed())
+		})
+
+		// That's the one that produces an error in the gitjob, but we provoked it by setting a
+		// certificate that it can't use. That's basically what the resulting error says.
+		It("should fail when using an incorrect CA bundle provided in helmSecretName", func() {
+			invalidCACertsFile := createInvalidCACertFile()
+			defer os.Remove(invalidCACertsFile.Name())
+
+			// Create secret with CA bundle
+			secretName := testenv.RandomFilename("helm-ca-bundle", r)
+			out, err := k.Create("secret", "generic", secretName, "--from-file=cacerts="+invalidCACertsFile.Name(), "-n", env.Namespace)
+			Expect(err).ToNot(HaveOccurred(), out)
+
+			createGitRepo(gitRepoOptions{HelmSecretName: secretName})
+			Eventually(expectGitRepoToNotBeReady).Should(Succeed())
+			Consistently(expectGitRepoToNotBeReady).Should(Succeed())
+		})
+
+		It("should succeed when using the correct CA bundle provided in helmSecretNameForPath", func() {
+			secretName := "helm-ca-bundle-by-path-" + gitrepoName
+			createHelmSecretForPaths(
+				secretName,
+				AuthConfigByPath{
+					entrypoint: {
+						CABundle: mustReadFileAsBase64(getCertificateFilePath()),
+					},
+				},
+			)
+
+			createGitRepo(gitRepoOptions{HelmSecretNameForPaths: secretName})
+			Eventually(expectGitRepoToBeReady).Should(Succeed())
+		})
+
+		It("should not succeed when using an incorrect CA bundle provided in helmSecretNameForPath", func() {
+			secretName := "helm-ca-bundle-by-path-" + gitrepoName
+			createHelmSecretForPaths(
+				secretName,
+				AuthConfigByPath{
+					entrypoint: {
+						CABundle: "asdf", // invalid
+					},
+				},
+			)
+
+			createGitRepo(gitRepoOptions{HelmSecretNameForPaths: secretName})
+			Consistently(expectGitRepoToNotBeReady).Should(Succeed())
+		})
+	})
+
+	When("testing ignoring insecure certificates for cloning git repositories with HTTPS using go-getter (fleet.yaml)", func() {
+		It("should succeed when using the incorrect CA bundle provided in GitRepo's CABundle field but setting InsecureSkipTLSVerify to true", func() {
+			// But it should fail in gitcloner already, not later in fleet apply.
+			encodedCert := base64.StdEncoding.EncodeToString([]byte("invalid-ca-bundle"))
+			createGitRepo(gitRepoOptions{CABundle: encodedCert, InsecureSkipTLSVerify: true})
+			Eventually(expectGitRepoToBeReady).Should(Succeed())
+		})
+
+		It("should succeed when using the incorrect CA bundle provided in helmSecretName but setting InsecureSkipVerify to true", func() {
+			invalidCertFile := createInvalidCACertFile()
+			defer os.Remove(invalidCertFile.Name())
+
+			secretName := testenv.RandomFilename("helm-ca-bundle", r)
+			out, err := k.Create("secret", "generic", secretName,
+				"--from-file=cacerts="+invalidCertFile.Name(),
+				"--from-literal=insecureSkipVerify=true",
+				"-n", env.Namespace)
+			Expect(err).ToNot(HaveOccurred(), out)
+
+			createGitRepo(gitRepoOptions{HelmSecretName: secretName})
+			Eventually(expectGitRepoToBeReady).Should(Succeed())
+		})
+
+		It("should succeed when using the incorrect CA bundle provided in helmSecretNameForPath but setting InsecureSkipVerify to true", func() {
+			secretName := "helm-ca-bundle-by-path-" + gitrepoName
+			createHelmSecretForPaths(
+				secretName,
+				AuthConfigByPath{
+					entrypoint: {
+						CABundle:           "asdf", // invalid
+						InsecureSkipVerify: true,
+					},
+				},
+			)
+
+			createGitRepo(gitRepoOptions{HelmSecretNameForPaths: secretName})
+			Eventually(expectGitRepoToBeReady).Should(Succeed())
+		})
+	})
+})

--- a/e2e/single-cluster/sharding_test.go
+++ b/e2e/single-cluster/sharding_test.go
@@ -7,6 +7,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
 	"github.com/rancher/fleet/e2e/testenv"
 	"github.com/rancher/fleet/e2e/testenv/kubectl"
 )

--- a/e2e/single-cluster/suite_test.go
+++ b/e2e/single-cluster/suite_test.go
@@ -9,6 +9,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -38,6 +39,8 @@ var (
 var _ = BeforeSuite(func() {
 	SetDefaultEventuallyTimeout(testenv.Timeout)
 	SetDefaultEventuallyPollingInterval(time.Second)
+	SetDefaultConsistentlyDuration(time.Minute)
+	SetDefaultConsistentlyPollingInterval(1 * time.Second)
 	testenv.SetRoot("../..")
 
 	env = testenv.New()

--- a/e2e/testenv/githelper/git.go
+++ b/e2e/testenv/githelper/git.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"slices"
 	"strings"
 	"time"
 
@@ -19,6 +20,8 @@ import (
 	"github.com/go-git/go-git/v5/plumbing/transport/http"
 	"github.com/go-git/go-git/v5/plumbing/transport/ssh"
 	"github.com/go-git/go-git/v5/storage/filesystem"
+
+	"github.com/otiai10/copy"
 
 	"github.com/rancher/fleet/e2e/testenv"
 	"github.com/rancher/fleet/e2e/testenv/infra/cmd"
@@ -171,7 +174,9 @@ func (g *Git) GetInClusterURL(host string, port int, repoName string) string {
 // g's URL.
 func (g *Git) Create(repodir string, from string, subdir string) (*git.Repository, error) {
 	s := osfs.New(path.Join(repodir, ".git"))
-	repo, err := git.Init(filesystem.NewStorage(s, cache.NewObjectLRUDefault()), osfs.New(repodir))
+	storer := filesystem.NewStorage(s, cache.NewObjectLRUDefault())
+	fs := osfs.New(repodir)
+	repo, err := git.Init(storer, fs)
 	if err != nil {
 		return nil, err
 	}
@@ -184,52 +189,44 @@ func (g *Git) Create(repodir string, from string, subdir string) (*git.Repositor
 		return nil, err
 	}
 
-	cmd := exec.Command("cp", "-a", from, path.Join(repodir, subdir)) //nolint:gosec // test code should never receive user input
-	err = cmd.Run()
+	err = copy.Copy(from, path.Join(repodir, subdir))
 	if err != nil {
 		return nil, err
 	}
 
-	w, err := repo.Worktree()
-	if err != nil {
-		return nil, err
-	}
-
-	if _, err := w.Add("."); err != nil {
-		return nil, err
-	}
-
-	_, err = w.Commit("add chart", &git.CommitOptions{
-		Author: author(),
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	po := git.PushOptions{
-		Progress: os.Stdout,
-		// Force push, so our initial state is deterministic
-		RefSpecs: []config.RefSpec{config.RefSpec("+refs/heads/master:refs/heads/" + g.Branch)},
-		// This prevents IP SANs from being needed on the git server cert; the TLS verification we are most
-		// interested in is the one happening in Fleet's controllers and jobs.
-		InsecureSkipTLS: true,
-	}
-	k, err := g.Auth.getKeys()
-	if err != nil {
-		return nil, fmt.Errorf("failed to getKeys: %w", err)
-	}
-
-	if k != nil {
-		po.Auth = k
-	}
-
-	err = repo.Push(&po)
+	_, err = g.Update(repo, UpdateForce)
 
 	return repo, err
 }
 
+// Add adds files to a repo, commits them and pushes the changes.
+func (g *Git) Add(repodir, from, destSubdir string) (string, error) {
+	s := osfs.New(path.Join(repodir, ".git"))
+	storer := filesystem.NewStorage(s, cache.NewObjectLRUDefault())
+	fs := osfs.New(repodir)
+	repo, err := git.Open(storer, fs)
+	if err != nil {
+		return "", err
+	}
+
+	err = copy.Copy(from, path.Join(repodir, destSubdir))
+	if err != nil {
+		return "", err
+	}
+
+	hash, err := g.Update(repo)
+
+	return hash, err
+}
+
+type UpdateOption int
+
+const (
+	UpdateForce UpdateOption = iota
+)
+
 // Update commits and pushes the current state of the worktree to the remote.
-func (g *Git) Update(repo *git.Repository) (string, error) {
+func (g *Git) Update(repo *git.Repository, updateOptions ...UpdateOption) (string, error) {
 	w, err := repo.Worktree()
 	if err != nil {
 		return "", err
@@ -252,6 +249,7 @@ func (g *Git) Update(repo *git.Repository) (string, error) {
 		// This prevents IP SANs from being needed on the git server cert; the TLS verification we are most
 		// interested in is the one happening in Fleet's controllers and jobs.
 		InsecureSkipTLS: true,
+		Force:           slices.Contains(updateOptions, UpdateForce),
 	}
 	k, err := g.Auth.getKeys()
 	if err != nil {
@@ -265,7 +263,7 @@ func (g *Git) Update(repo *git.Repository) (string, error) {
 	return h.String(), repo.Push(&po)
 }
 
-// Checkouts the specified remote branch from the given repository
+// CheckoutRemote checks the specified remote branch from the given repository out
 func (g *Git) CheckoutRemote(repo *git.Repository, branch string) error {
 	w, err := repo.Worktree()
 	if err != nil {

--- a/e2e/testenv/template.go
+++ b/e2e/testenv/template.go
@@ -152,7 +152,7 @@ func Template(output string, tmplPath string, data any) error {
 	return nil
 }
 
-// RandomName returns a slightly random name, so temporary assets don't conflict
+// RandomFilename returns a slightly random name, so temporary assets don't conflict
 func RandomFilename(filename string, r *rand.Rand) string {
 	ext := path.Ext(filename)
 	filename = path.Base(filename)


### PR DESCRIPTION
* Address review comments
* InsecureSkipVerify for cloning git repos with fleet.yaml's helm.chart field
* Refactor code duplication
* Address review comments

(cherry picked from commit 3ec37b2c6886328d8c25f9d4ac000b6757abed75)

Conflicts resolved:
-	e2e/testenv/githelper/git.go
-	internal/bundlereader/loaddirectory.go

<!-- Specify the issue ID that this pull request is solving -->
Refers to #4370 
Backport of #4185

<!-- Make sure that the referenced issue provides steps to reproduce it -->

<!-- Describe the changes introduced by this pull request -->

<!--
  Please provide a unit, integration (`./integrationtests/`) or e2e (`./e2e/`) test if possible.
-->

## Additional Information

### Checklist

- [ ] <!-- If applicable,--> I have updated the documentation via a pull request in the
[fleet-docs](https://github.com/rancher/fleet-docs) repository.
