### PR TITLE
Use the defaultNs for valuesFrom contained in downstream resources

### DIFF
--- a/internal/helmdeployer/install.go
+++ b/internal/helmdeployer/install.go
@@ -520,20 +520,17 @@ func getDryRunConfig(chart *chartv2.Chart, dryRun bool) dryRunConfig {
 	return cfg
 }
 
-// isInDownstreamResources returns true and the matching DownstreamResource
-// when a resource with the provided name exists in the provided
-// BundleDeploymentOptions.DownstreamResources slice. If not found, returns
-// false and the zero value for fleet.DownstreamResource.
+// isInDownstreamResources returns true when a resource with the
+// provided name exists in the provided BundleDeploymentOptions.DownstreamResources slice.
+// If not found, returns false.
 func isInDownstreamResources(resourceName, kind string, options fleet.BundleDeploymentOptions) bool {
 	if !experimental.CopyResourcesDownstreamEnabled() {
 		return false
 	}
 
 	for _, dr := range options.DownstreamResources {
-		if dr.Name == resourceName {
-			if dr.Kind == kind {
-				return true
-			}
+		if dr.Name == resourceName && dr.Kind == kind {
+			return true
 		}
 	}
 	return false

--- a/internal/helmdeployer/install_test.go
+++ b/internal/helmdeployer/install_test.go
@@ -571,6 +571,10 @@ func TestValuesFromUsesProvidedNamespaceWhenNotCopiedDownstream(t *testing.T) {
 		DownstreamResources: []fleet.DownstreamResource{{Kind: "ConfigMap", Name: "some-other"}},
 	}
 
+	// enable experimental copy behavior for this test
+	os.Setenv(experimental.CopyResourcesDownstreamFlag, "true")
+	defer os.Unsetenv(experimental.CopyResourcesDownstreamFlag)
+
 	vals, err := h.getValues(context.TODO(), opts, defaultNS)
 	r.NoError(err)
 	a.Equal("cmProvided", vals["cmVal"])


### PR DESCRIPTION
This PR adds a change to avoid having a "Not Found" error when using valuesFrom coming from COnfigMaps or Secrets that are also contained in the _DownstreamResources_ of the _BundleDeploymentOptions_

Refers to: https://github.com/rancher/fleet/issues/4274
## Additional Information

### Checklist

~- [ ] <!-- If applicable,--> I have updated the documentation via a pull request in the
[fleet-docs](https://github.com/rancher/fleet-docs) repository.~
