### PR TITLE
Allow setting integer flags from env variables

### DIFF
--- a/internal/cmd/builder.go
+++ b/internal/cmd/builder.go
@@ -137,11 +137,22 @@ func Command(obj Runnable, cmd cobra.Command) *cobra.Command {
 		for _, env := range env {
 			envs = append(envs, func() {
 				v := os.Getenv(env)
-				if v != "" {
+				if v == "" {
+					return
+				}
+				switch fieldType.Type.Kind() {
+				case reflect.String:
 					fv, err := flags.GetString(name)
 					if err == nil && (fv == "" || fv == defValue) {
 						_ = flags.Set(name, v)
 					}
+				case reflect.Int:
+					fv, err := flags.GetInt(name)
+					if err == nil && fv == defInt {
+						_ = flags.Set(name, v)
+					}
+				default:
+					// unsupported
 				}
 			})
 		}


### PR DESCRIPTION
<!-- Specify the issue ID that this pull request is solving -->
Refers to #4233
Follow up of #4292

The previous code used `flag.GetString`, which only works for flags of type string. When used for:
```
BundleCreationMaxConcurrency int               `usage:"Maximum number of concurrent bundle creation routines" name:"bundle-creation-max-concurrency" default:"4" env:"FLEET_BUNDLE_CREATION_MAX_CONCURRENCY"`
```
`GetString` will produce an error and the flag won't be set.