### PR TITLE
Fix Helm URL resolution

### DIFF
--- a/internal/bundlereader/charturl.go
+++ b/internal/bundlereader/charturl.go
@@ -95,9 +95,9 @@ func getOCIRepoClient(repoURI string, a Auth) (*remote.Repository, error) {
 	return r, nil
 }
 
-// chartURL returns the URL to the helm chart from a helm repo server, by
+// ChartURL returns the URL to the helm chart from a helm repo server, by
 // inspecting the repo's index.yaml
-func chartURL(ctx context.Context, location fleet.HelmOptions, auth Auth, isHelmOps bool) (string, error) {
+func ChartURL(ctx context.Context, location fleet.HelmOptions, auth Auth, isHelmOps bool) (string, error) {
 	if uri, ok := isOCIChart(location, isHelmOps); ok {
 		return uri, nil
 	}
@@ -270,10 +270,5 @@ func toAbsoluteURLIfNeeded(baseURL, chartURL string) (string, error) {
 		return chartURL, err
 	}
 
-	u, err := url.Parse(baseURL)
-	if err != nil {
-		return "", err
-	}
-
-	return u.ResolveReference(chartU).String(), nil
+	return url.JoinPath(baseURL, chartURL)
 }

--- a/internal/bundlereader/charturl_test.go
+++ b/internal/bundlereader/charturl_test.go
@@ -14,6 +14,8 @@ import (
 	"go.uber.org/mock/gomock"
 
 	"oras.land/oras-go/v2/registry/remote"
+
+	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
 )
 
 func Test_getOCITag(t *testing.T) {
@@ -114,6 +116,46 @@ func Test_getOCITag(t *testing.T) {
 
 			if tag != c.expectedTag {
 				t.Errorf("expected tag %q, got %q", c.expectedTag, tag)
+			}
+		})
+	}
+}
+
+func Test_ChartURL(t *testing.T) {
+	cases := []struct {
+		name     string
+		options  fleet.HelmOptions
+		expected string
+	}{
+		{
+			name: "repo URL with trailing slash",
+			options: fleet.HelmOptions{
+				Chart:   "rancher",
+				Repo:    "https://releases.rancher.com/server-charts/latest/",
+				Version: "2.13.0",
+			},
+			expected: "https://releases.rancher.com/server-charts/latest/rancher-2.13.0.tgz",
+		},
+		{
+			name: "repo URL without trailing slash",
+			options: fleet.HelmOptions{
+				Chart:   "rancher",
+				Repo:    "https://releases.rancher.com/server-charts/latest",
+				Version: "2.13.0",
+			},
+			expected: "https://releases.rancher.com/server-charts/latest/rancher-2.13.0.tgz",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			url, err := bundlereader.ChartURL(context.Background(), c.options, bundlereader.Auth{}, false)
+			if err != nil {
+				t.Errorf("expected no error, got %v", err)
+			}
+
+			if url != c.expected {
+				t.Errorf("expected %q, got %q", c.expected, url)
 			}
 		})
 	}

--- a/internal/bundlereader/helm.go
+++ b/internal/bundlereader/helm.go
@@ -32,7 +32,7 @@ func GetManifestFromHelmChart(ctx context.Context, c client.Reader, bd *fleet.Bu
 	}
 	auth.InsecureSkipVerify = bd.Spec.HelmChartOptions.InsecureSkipTLSverify
 
-	chartURL, err := chartURL(ctx, *helm, auth, true)
+	chartURL, err := ChartURL(ctx, *helm, auth, true)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/bundlereader/resources.go
+++ b/internal/bundlereader/resources.go
@@ -217,7 +217,7 @@ func addRemoteCharts(ctx context.Context, directories []directory, base string, 
 				auth = Auth{}
 			}
 
-			chartURL, err := chartURL(ctx, *chart, auth, false)
+			chartURL, err := ChartURL(ctx, *chart, auth, false)
 			if err != nil {
 				return nil, fmt.Errorf("failed to resolve URL of %s: %w", downloadChartError(*chart), err)
 			}


### PR DESCRIPTION
Recent refactoring around chart URL computations introduced a bug with `repo` fields not containing a trailing slash, where a chunk of the path would be skipped.

Follow-up to #4285.

## Additional Information

### Checklist

~- [ ] <!-- If applicable,--> I have updated the documentation via a pull request in the
[fleet-docs](https://github.com/rancher/fleet-docs) repository.~
