### PR TITLE
chore: update Go version to 1.25.0 and toolchain to 1.25.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/rancher/fleet
 
-go 1.24.0
+go 1.25.0
 
-toolchain go1.24.10
+toolchain go1.25.5
 
 replace (
 	github.com/imdario/mergo => github.com/imdario/mergo v1.0.2

--- a/pkg/apis/go.mod
+++ b/pkg/apis/go.mod
@@ -1,8 +1,8 @@
 module github.com/rancher/fleet/pkg/apis
 
-go 1.24.0
+go 1.25.0
 
-toolchain go1.24.10
+toolchain go1.25.5
 
 require (
 	github.com/rancher/wrangler/v3 v3.3.1


### PR DESCRIPTION
Rancher has recently upgraded `main` to Go 1.25.