### PR TITLE
Fix setting of CI certs dir in dev env files

### DIFF
--- a/dev/env.multi-cluster-defaults
+++ b/dev/env.multi-cluster-defaults
@@ -13,4 +13,4 @@ export CI_OCI_READER_USERNAME=fleet-ci-reader
 export CI_OCI_READER_PASSWORD=foo-reader
 export CI_OCI_NO_DELETER_USERNAME=fleet-ci-no-deleter
 export CI_OCI_NO_DELETER_PASSWORD=foo-no-deleter
-export CI_OCI_CERTS_DIR=FleetCI-RootCA/
+export CI_OCI_CERTS_DIR="$(git rev-parse --show-toplevel)"/FleetCI-RootCA/

--- a/dev/env.single-cluster-defaults
+++ b/dev/env.single-cluster-defaults
@@ -12,4 +12,4 @@ export CI_OCI_READER_USERNAME=fleet-ci-reader
 export CI_OCI_READER_PASSWORD=foo-reader
 export CI_OCI_NO_DELETER_USERNAME=fleet-ci-no-deleter
 export CI_OCI_NO_DELETER_PASSWORD=foo-no-deleter
-export CI_OCI_CERTS_DIR=FleetCI-RootCA/
+export CI_OCI_CERTS_DIR="$(git rev-parse --show-toplevel)"/FleetCI-RootCA/


### PR DESCRIPTION
Setting the location environment variable for locally-generated certs prevents errors at test infra setup time, where `helm.crt` would not be found.
That variable is already set in CI workflows.

## Additional Information

### Checklist

~- [ ] <!-- If applicable,--> I have updated the documentation via a pull request in the
[fleet-docs](https://github.com/rancher/fleet-docs) repository.~
