### PR TITLE
Use fully qualified image name + digest for attestation of provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -194,8 +194,9 @@ jobs:
           IMAGES=$(yq e '.dockers[].image_templates[0]' .goreleaser.yaml | grep STAGE_REGISTRY | sed "s/{{ .Env.STAGE_REGISTRY }}/${{ env.STAGE_REGISTRY }}/g" | sed "s/{{ .Tag }}/${{ github.ref_name }}/g")
 
           for IMG_NAME in $IMAGES; do
-            # Extract Docker image reference plus digest from local image
-            URL=$(docker inspect --format='{{index .RepoDigests 0}}' "${IMG_NAME}")
+            DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' "${IMG_NAME}" | cut -d'@' -f2)
+            # Construct fully qualified image name with both tag and digest
+            URL="${IMG_NAME}@${DIGEST}"
 
             max_retries=3
             retry_delay=5


### PR DESCRIPTION
to implement the following [ecm-distro-tool changes](https://github.com/rancher/ecm-distro-tools/commit/8b2e71203cc4d01d44e3c8c053d5fa8c466a2d93).
This should fix the issues during release.