### PR TITLE
[v0.14] Use controlled Requeue for non-ready dependencies during deploy

### DIFF
--- a/internal/cmd/agent/deployer/deployer.go
+++ b/internal/cmd/agent/deployer/deployer.go
@@ -24,6 +24,14 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
+type NotReadyDependenciesError struct {
+	Pending []string
+}
+
+func (e *NotReadyDependenciesError) Error() string {
+	return fmt.Sprintf("dependent bundle(s) are not ready: %v", e.Pending)
+}
+
 type Deployer struct {
 	client         client.Client
 	upstreamClient client.Reader
@@ -350,7 +358,7 @@ func (d *Deployer) checkDependency(ctx context.Context, bd *fleet.BundleDeployme
 	}
 
 	if len(depBundleList) != 0 {
-		return fmt.Errorf("dependent bundle(s) are not ready: %v", depBundleList)
+		return &NotReadyDependenciesError{Pending: depBundleList}
 	}
 
 	return nil

--- a/pkg/durations/durations.go
+++ b/pkg/durations/durations.go
@@ -38,6 +38,8 @@ const (
 	// the helmop status first, before the status controller looks at
 	// bundledeployments.
 	HelmOpStatusDelay = time.Second * 5
+	// WaitForDependenciesReadyRequeueInterval is the wait time after the Fleet agent finds a BundleDeployment has non-ready dependencies
+	WaitForDependenciesReadyRequeueInterval = time.Second * 15
 )
 
 // Equal reports whether the duration t is equal to u.


### PR DESCRIPTION
<!-- Specify the issue ID that this pull request is solving -->
Refers to #4468

Forward port of #4459