### PR TITLE
Fix crust gatherer caching

### DIFF
--- a/.github/scripts/determine-cache-key.sh
+++ b/.github/scripts/determine-cache-key.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Determine cache key that changes every 28 days
+# Outputs to GITHUB_OUTPUT in GitHub Actions context
+#
+# Usage: determine-cache-key.sh
+
+set -e
+
+# Get the day of year (1-366)
+DAY_OF_YEAR=$(date +%-j)
+
+# Use modulo to create a key that changes every 28 days
+if [ $((DAY_OF_YEAR % 28)) -eq 0 ]; then
+  # On the 28th, 56th, 84th... day of the year, use a date-based key
+  echo "value=$(date +%Y-%m-%d)" >> "$GITHUB_OUTPUT"
+else
+  echo "value=latest" >> "$GITHUB_OUTPUT"
+fi

--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -54,13 +54,7 @@ jobs:
       -
         name: Determine cache key
         id: cache-key
-        run: |
-          DAY_OF_YEAR=$(date +%-j)
-          if [ $((DAY_OF_YEAR % 28)) -eq 0 ]; then
-            echo "value=$(date +%Y-%m-%d)" >> $GITHUB_OUTPUT
-          else
-            echo "value=latest" >> $GITHUB_OUTPUT
-          fi
+        run: ./.github/scripts/determine-cache-key.sh
       -
         name: Cache crust-gather CLI
         id: cache-crust

--- a/.github/workflows/e2e-fleet-upgrade-ci.yml
+++ b/.github/workflows/e2e-fleet-upgrade-ci.yml
@@ -38,13 +38,7 @@ jobs:
       -
         name: Determine cache key
         id: cache-key
-        run: |
-          DAY_OF_YEAR=$(date +%-j)
-          if [ $((DAY_OF_YEAR % 28)) -eq 0 ]; then
-            echo "value=$(date +%Y-%m-%d)" >> $GITHUB_OUTPUT
-          else
-            echo "value=latest" >> $GITHUB_OUTPUT
-          fi
+        run: ./.github/scripts/determine-cache-key.sh
       -
         name: Cache crust-gather CLI
         id: cache-crust

--- a/.github/workflows/e2e-multicluster-ci.yml
+++ b/.github/workflows/e2e-multicluster-ci.yml
@@ -34,17 +34,7 @@ jobs:
       -
         name: Determine cache key
         id: cache-key
-        run: |
-          # Get the day of year (1-366)
-          DAY_OF_YEAR=$(date +%-j)
-          
-          # Use modulo to create a key that changes every 28 days
-          if [ $((DAY_OF_YEAR % 28)) -eq 0 ]; then
-            # On the 28th, 56th, 84th... day of the year, use a date-based key
-            echo "value=$(date +%Y-%m-%d)" >> $GITHUB_OUTPUT
-          else
-            echo "value=latest" >> $GITHUB_OUTPUT
-          fi
+        run: ./.github/scripts/determine-cache-key.sh
       -
         name: Cache crust-gather CLI
         id: cache-crust

--- a/.github/workflows/e2e-nightly-ci.yml
+++ b/.github/workflows/e2e-nightly-ci.yml
@@ -60,13 +60,7 @@ jobs:
       -
         name: Determine cache key
         id: cache-key
-        run: |
-          DAY_OF_YEAR=$(date +%-j)
-          if [ $((DAY_OF_YEAR % 28)) -eq 0 ]; then
-            echo "value=$(date +%Y-%m-%d)" >> $GITHUB_OUTPUT
-          else
-            echo "value=latest" >> $GITHUB_OUTPUT
-          fi
+        run: ./.github/scripts/determine-cache-key.sh
       -
         name: Cache crust-gather CLI
         id: cache-crust

--- a/.github/workflows/e2e-rancher-upgrade-fleet-to-head-ci.yml
+++ b/.github/workflows/e2e-rancher-upgrade-fleet-to-head-ci.yml
@@ -43,13 +43,7 @@ jobs:
       -
         name: Determine cache key
         id: cache-key
-        run: |
-          DAY_OF_YEAR=$(date +%-j)
-          if [ $((DAY_OF_YEAR % 28)) -eq 0 ]; then
-            echo "value=$(date +%Y-%m-%d)" >> $GITHUB_OUTPUT
-          else
-            echo "value=latest" >> $GITHUB_OUTPUT
-          fi
+        run: ./.github/scripts/determine-cache-key.sh
       -
         name: Cache crust-gather CLI
         id: cache-crust

--- a/.github/workflows/e2e-rancher-upgrade-fleet.yml
+++ b/.github/workflows/e2e-rancher-upgrade-fleet.yml
@@ -61,13 +61,7 @@ jobs:
       -
         name: Determine cache key
         id: cache-key
-        run: |
-          DAY_OF_YEAR=$(date +%-j)
-          if [ $((DAY_OF_YEAR % 28)) -eq 0 ]; then
-            echo "value=$(date +%Y-%m-%d)" >> $GITHUB_OUTPUT
-          else
-            echo "value=latest" >> $GITHUB_OUTPUT
-          fi
+        run: ./.github/scripts/determine-cache-key.sh
       -
         name: Cache crust-gather CLI
         id: cache-crust

--- a/.github/workflows/e2e-test-fleet-in-rancher.yml
+++ b/.github/workflows/e2e-test-fleet-in-rancher.yml
@@ -67,13 +67,7 @@ jobs:
       -
         name: Determine cache key
         id: cache-key
-        run: |
-          DAY_OF_YEAR=$(date +%-j)
-          if [ $((DAY_OF_YEAR % 28)) -eq 0 ]; then
-            echo "value=$(date +%Y-%m-%d)" >> $GITHUB_OUTPUT
-          else
-            echo "value=latest" >> $GITHUB_OUTPUT
-          fi
+        run: ./.github/scripts/determine-cache-key.sh
       -
         name: Cache crust-gather CLI
         id: cache-crust


### PR DESCRIPTION
The `date +%j` format returns values with leading zeros (e.g., `008` for January 8th). Bash interprets numbers with leading zeros as octal in arithmetic expressions, causing an error since octal only supports digits `0-7`.

Use `date +%-j` instead to get the day of year without leading zeros, avoiding the octal interpretation issue.