### PR TITLE
[v0.14] Fix: Set Recreate deployment strategy when hostNetwork is enabled

### DIFF
--- a/internal/cmd/controller/agentmanagement/agent/manifest.go
+++ b/internal/cmd/controller/agentmanagement/agent/manifest.go
@@ -279,6 +279,11 @@ func agentApp(namespace string, agentScope string, opts ManifestOptions) *appsv1
 
 	// Set hostNetwork
 	app.Spec.Template.Spec.HostNetwork = opts.HostNetwork
+	if opts.HostNetwork {
+		app.Spec.Strategy = appsv1.DeploymentStrategy{
+			Type: appsv1.RecreateDeploymentStrategyType,
+		}
+	}
 
 	// overwrite affinity if present on cluster
 	if opts.AgentAffinity != nil {

--- a/internal/cmd/controller/agentmanagement/agent/manifest_test.go
+++ b/internal/cmd/controller/agentmanagement/agent/manifest_test.go
@@ -133,16 +133,18 @@ func TestManifestAgentHostNetwork(t *testing.T) {
 	}
 
 	for _, testCase := range []struct {
-		name            string
-		getOpts         func() agent.ManifestOptions
-		expectedNetwork bool
+		name             string
+		getOpts          func() agent.ManifestOptions
+		expectedNetwork  bool
+		expectedStrategy appsv1.DeploymentStrategyType
 	}{
 		{
 			name: "DefaultSetting",
 			getOpts: func() agent.ManifestOptions {
 				return baseOpts
 			},
-			expectedNetwork: false,
+			expectedNetwork:  false,
+			expectedStrategy: appsv1.DeploymentStrategyType(""),
 		},
 		{
 			name: "With hostNetwork",
@@ -151,7 +153,8 @@ func TestManifestAgentHostNetwork(t *testing.T) {
 				withHostNetwork.HostNetwork = true
 				return withHostNetwork
 			},
-			expectedNetwork: true,
+			expectedNetwork:  true,
+			expectedStrategy: appsv1.RecreateDeploymentStrategyType,
 		},
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
@@ -162,6 +165,10 @@ func TestManifestAgentHostNetwork(t *testing.T) {
 
 			if !cmp.Equal(agent.Spec.Template.Spec.HostNetwork, testCase.expectedNetwork) {
 				t.Fatalf("hostNetwork is not as expected: %v", agent.Spec.Template.Spec.HostNetwork)
+			}
+
+			if !cmp.Equal(agent.Spec.Strategy.Type, testCase.expectedStrategy) {
+				t.Fatalf("strategy is not as expected: %v", agent.Spec.Strategy.Type)
 			}
 		})
 	}


### PR DESCRIPTION
<!-- Specify the issue ID that this pull request is solving -->
Refers to #4504
<!-- Make sure that the referenced issue provides steps to reproduce it -->

Backport of #4467.
<!-- Describe the changes introduced by this pull request -->

<!--
  Please provide a unit, integration (`./integrationtests/`) or e2e (`./e2e/`) test if possible.
-->

## Additional Information

### Checklist

- [ ] <!-- If applicable,--> I have updated the documentation via a pull request in the
[fleet-docs](https://github.com/rancher/fleet-docs) repository.
