### PR TITLE
Simplify cache rotation to monthly (year-month)

### DIFF
--- a/.github/scripts/determine-cache-key.sh
+++ b/.github/scripts/determine-cache-key.sh
@@ -1,18 +1,8 @@
 #!/usr/bin/env bash
-# Determine cache key that changes every 28 days
+# Determine cache key that rotates monthly (year-month format)
 # Outputs to GITHUB_OUTPUT in GitHub Actions context
-#
-# Usage: determine-cache-key.sh
 
 set -e
 
-# Get the day of year (1-366)
-DAY_OF_YEAR=$(date +%-j)
-
-# Use modulo to create a key that changes every 28 days
-if [ $((DAY_OF_YEAR % 28)) -eq 0 ]; then
-  # On the 28th, 56th, 84th... day of the year, use a date-based key
-  echo "value=$(date +%Y-%m-%d)" >> "$GITHUB_OUTPUT"
-else
-  echo "value=latest" >> "$GITHUB_OUTPUT"
-fi
+# Use year-month as cache key, rotating monthly
+echo "value=$(date +%Y-%m)" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Replace the complex 28-day modulo logic with a year-month approach that rotates the cache 12 times per year.