### PR TITLE
Remove nolint for dupl in agent

### DIFF
--- a/internal/cmd/agent/controller/bundledeployment_controller.go
+++ b/internal/cmd/agent/controller/bundledeployment_controller.go
@@ -283,8 +283,6 @@ func (r *BundleDeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Req
 // copyResourcesFromUpstream copies bd's DownstreamResources, from the downstream cluster's namespace on the management
 // cluster to the destination namespace on the downstream cluster, creating that namespace if needed.
 // If bd does not have any DownstreamResources, this method does not issue any API server calls.
-//
-//nolint:dupl // Same pattern between secrets and config map, but different logic.
 func (r *BundleDeploymentReconciler) copyResourcesFromUpstream(
 	ctx context.Context,
 	bd *fleetv1.BundleDeployment,


### PR DESCRIPTION
That comment no longer applies. Removing it makes the linters happy.

## Additional Information

### Checklist

~- [ ] <!-- If applicable,--> I have updated the documentation via a pull request in the
[fleet-docs](https://github.com/rancher/fleet-docs) repository.~
