### PR TITLE
Take respective timestamps into account when comparing snapshots

### DIFF
--- a/internal/cmd/cli/analyze.go
+++ b/internal/cmd/cli/analyze.go
@@ -689,6 +689,12 @@ func (a *Analyze) compareFiles(cmd *cobra.Command, file1, file2 string) error {
 	before := snapshots1[len(snapshots1)-1]
 	after := snapshots2[len(snapshots2)-1]
 
+	if before.Timestamp > after.Timestamp {
+		// Swap files for timestamp consistency
+		file1, file2 = file2, file1
+		before, after = after, before
+	}
+
 	printHeader(w, "COMPARING SNAPSHOTS")
 	fmt.Fprintf(w, "Before: %s (%s)\n", file1, before.Timestamp)
 	fmt.Fprintf(w, "After:  %s (%s)\n", file2, after.Timestamp)


### PR DESCRIPTION
Using `fleet analyze --compare file1.json file2.json` compares the last snapshot found in each referenced file.
The `analyze` command now takes those snapshots' respective timestamps into account to list the right one as having been created before the other one, preventing confusing output such as:
```
=== COMPARING SNAPSHOTS ===

Before: after.json (2026-01-19T12:25:27Z)
After:  before.json (2026-01-19T12:24:57Z)
```

This prevents users from obtaining different results depending on the order in which they provide snapshot files to `fleet analyze --compare`.

## Additional Information

### Checklist

- [ ] <!-- If applicable,--> I have updated the documentation via a pull request in the
[fleet-docs](https://github.com/rancher/fleet-docs) repository.
