### PR TITLE
bundle controller shard filtering based on cluster changes

### DIFF
--- a/internal/cmd/controller/reconciler/bundle_controller.go
+++ b/internal/cmd/controller/reconciler/bundle_controller.go
@@ -100,10 +100,7 @@ func (r *BundleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			// Fan out from bundledeployment to bundle, this is useful to update the
 			// bundle's status fields.
 			&fleet.BundleDeployment{}, handler.EnqueueRequestsFromMapFunc(BundleDeploymentMapFunc(r)),
-			builder.WithPredicates(
-				bundleDeploymentStatusChangedPredicate(),
-				sharding.FilterByShardID(r.ShardID),
-			),
+			builder.WithPredicates(bundleDeploymentStatusChangedPredicate()),
 		).
 		Watches(
 			// Fan out from cluster to bundle, this is useful for targeting and templating.


### PR DESCRIPTION
Refers to #4484

This PR updates shard filtering behavior for cluster->bundle fan-out in internal/cmd/controller/reconciler/bundle_controller.go. When a fleet.Cluster changes (labels/annotations/spec/status), the controller now only enqueues reconcile requests for fleet.Bundle objects that should be processed by the current shard (ShardID), preventing cross-shard reconciles triggered by cluster updates.
