### PR TITLE
[v0.14] - Avoid using DeepCopy when copying Downstream Resources (#4560)

### DIFF
--- a/e2e/assets/single-cluster/helmop_downstream_resources.yaml
+++ b/e2e/assets/single-cluster/helmop_downstream_resources.yaml
@@ -1,0 +1,36 @@
+apiVersion: fleet.cattle.io/v1alpha1
+kind: HelmOp
+metadata:
+  name: {{.Name}}
+  namespace: {{.Namespace}}
+spec:
+  helm:
+    releaseName: testhelm-single-cluster
+    repo: {{.Repo}}
+    chart: {{.Chart}}
+    version: '{{.Version}}'
+    valuesFrom:
+    {{- range $vf := .ValuesFrom}}
+      {{- if $vf.ConfigMapKeyRef }}
+      - configMapKeyRef:
+          namespace: {{$vf.ConfigMapKeyRef.Namespace}}
+          name: {{$vf.ConfigMapKeyRef.Name}}
+          key: {{$vf.ConfigMapKeyRef.Key}}
+      {{- end }}
+      {{- if $vf.SecretKeyRef }}
+      - secretKeyRef:
+          namespace: {{$vf.SecretKeyRef.Namespace}}
+          name: {{$vf.SecretKeyRef.Name}}
+          key: {{$vf.SecretKeyRef.Key}}
+      {{- end }}
+    {{- end}}
+  downstreamResources:
+    {{- range $dr := .DownstreamResources}}
+    - kind: {{$dr.Kind}}
+      name: {{$dr.Name}}
+    {{- end}}
+  keepResources: {{.KeepResources}}
+  pollingInterval: {{.PollingInterval}}
+  namespace: {{.DeployNamespace}}
+  helmSecretName: {{.HelmSecretName}}
+  insecureSkipTLSVerify: {{.InsecureSkipTLSVerify}}

--- a/e2e/assets/single-cluster/values-cm.yaml
+++ b/e2e/assets/single-cluster/values-cm.yaml
@@ -1,0 +1,1 @@
+name: name-from-downstream-cluster-configmap

--- a/e2e/assets/single-cluster/values-secret.yaml
+++ b/e2e/assets/single-cluster/values-secret.yaml
@@ -1,0 +1,1 @@
+name: name-from-downstream-cluster-secret

--- a/e2e/single-cluster/downstream_clone_objects_test.go
+++ b/e2e/single-cluster/downstream_clone_objects_test.go
@@ -1,0 +1,239 @@
+package singlecluster_test
+
+import (
+	"fmt"
+	"path"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/rancher/fleet/e2e/testenv"
+	"github.com/rancher/fleet/e2e/testenv/kubectl"
+	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
+)
+
+// This test uses a single cluster to demonstrate cloning of configured resources within the same cluster.
+var _ = Describe("Downstream objects cloning", Ordered, func() {
+	var (
+		k kubectl.Command
+
+		asset               string
+		name                string
+		deployNamespace     string
+		keepResources       bool
+		valuesFrom          []fleet.ValuesFrom
+		downstreamResources []fleet.DownstreamResource
+		cmName              = "test-simple-chart-config"
+	)
+
+	BeforeEach(func() {
+		k = env.Kubectl.Namespace(env.Namespace)
+	})
+
+	JustBeforeEach(func() {
+		cmAsset := path.Join(testenv.AssetPath("single-cluster/values-cm.yaml"))
+		out, err := k.Create("configmap", "config-values", fmt.Sprintf("--from-file=values.yaml=%s", cmAsset))
+		Expect(err).ToNot(HaveOccurred(), out)
+
+		secretAsset := path.Join(testenv.AssetPath("single-cluster/values-secret.yaml"))
+		out, err = k.Create("secret", "generic", "secret-values", fmt.Sprintf("--from-file=values.yaml=%s", secretAsset))
+		Expect(err).ToNot(HaveOccurred(), out)
+
+		// Not actually used by the deployment, but validates secret type preservation over copy
+		out, err = k.Create(
+			"secret",
+			"docker-registry",
+			"secret-image-pull",
+			// credentials do not matter, we just need the combination of fields to obtain a valid secret
+			"--docker-username=test-user",
+			"--docker-password=test-pwd",
+		)
+		Expect(err).ToNot(HaveOccurred(), out)
+
+		// Use default downstream resources if not set
+		if downstreamResources == nil {
+			downstreamResources = []fleet.DownstreamResource{
+				{
+					Kind: "Secret",
+					Name: "secret-values",
+				},
+				{
+					Kind: "ConfigMap",
+					Name: "config-values",
+				},
+				{
+					Kind: "Secret",
+					Name: "secret-image-pull",
+				},
+			}
+		}
+
+		err = testenv.ApplyTemplate(k, testenv.AssetPath(asset), struct {
+			Name                  string
+			Namespace             string
+			DeployNamespace       string
+			Repo                  string
+			Chart                 string
+			Version               string
+			PollingInterval       time.Duration
+			HelmSecretName        string
+			InsecureSkipTLSVerify bool
+			DownstreamResources   []fleet.DownstreamResource
+			KeepResources         bool
+			ValuesFrom            []fleet.ValuesFrom
+		}{
+			name,
+			env.Namespace,
+			deployNamespace,
+			"",
+			"https://github.com/rancher/fleet/raw/refs/heads/main/integrationtests/cli/assets/helmrepository/config-chart-0.1.0.tgz",
+			"",
+			0,
+			"",
+			false,
+			downstreamResources,
+			keepResources,
+			valuesFrom,
+		})
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		_, _ = k.Delete("secret", "secret-values")
+		_, _ = k.Delete("secret", "secret-image-pull")
+		_, _ = k.Delete("configmap", "config-values")
+	})
+
+	Context("with configured resources for cloning downstream", func() {
+		BeforeEach(func() {
+			asset = "single-cluster/helmop_downstream_resources.yaml"
+			name = "helmop-downstream-copy"
+			deployNamespace = "helmop-downstream-copy-ns"
+			keepResources = false
+			downstreamResources = nil
+			valuesFrom = []fleet.ValuesFrom{
+				{
+					SecretKeyRef: &fleet.SecretKeySelector{
+						Namespace:            env.Namespace,
+						LocalObjectReference: fleet.LocalObjectReference{Name: "secret-values"},
+						Key:                  "values.yaml",
+					},
+				},
+			}
+		})
+
+		It("deploys the HelmOp and clones resources", func() {
+			By("copying resources")
+			Eventually(func(g Gomega) {
+				s, err := k.Namespace(deployNamespace).Get("secrets")
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(s).To(ContainSubstring("secret-values"))
+
+				cms, err := k.Namespace(deployNamespace).Get("configmaps")
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(cms).To(ContainSubstring("config-values"))
+			}).Should(Succeed())
+
+			By("preserving secret types upon copy")
+			Eventually(func(g Gomega) {
+				s, err := k.Namespace(deployNamespace).Get("secret", "secret-image-pull", "-o=jsonpath='{.type}'")
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(s).To(ContainSubstring("kubernetes.io/dockerconfigjson"))
+
+			}).Should(Succeed())
+
+			By("deploying resources with templated values taken from cloned resources")
+			Eventually(func(g Gomega) {
+				cms, err := k.Namespace(deployNamespace).Get("configmaps")
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(cms).To(ContainSubstring(cmName))
+
+				name, err := k.Namespace(deployNamespace).Get("configmaps", cmName, "-o", "jsonpath={.data.name}")
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(name).To(Equal("name-from-downstream-cluster-secret"))
+			}).Should(Succeed())
+
+			By("deleting cloned resources when the bundle deployment is deleted")
+			out, err := k.Delete("helmop", name)
+			Expect(err).ToNot(HaveOccurred(), out)
+
+			Eventually(func(g Gomega) {
+				cms, err := k.Namespace(deployNamespace).Get("configmaps")
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(cms).NotTo(ContainSubstring(cmName))
+
+				cms, err = k.Namespace(deployNamespace).Get("configmaps")
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(cms).NotTo(ContainSubstring("config-values"))
+
+				secrets, err := k.Namespace(deployNamespace).Get("secrets")
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(secrets).NotTo(ContainSubstring("secret-values"))
+			}).Should(Succeed())
+		})
+	})
+
+	Context("with configured resources for cloning downstream and keepresources is true", func() {
+		BeforeEach(func() {
+			asset = "single-cluster/helmop_downstream_resources.yaml"
+			name = "helmop-downstream-copy-keepresources"
+			deployNamespace = "helmop-downstream-copy-keepresources-ns"
+			keepResources = true
+			downstreamResources = nil
+			valuesFrom = []fleet.ValuesFrom{
+				{
+					ConfigMapKeyRef: &fleet.ConfigMapKeySelector{
+						Namespace:            env.Namespace,
+						LocalObjectReference: fleet.LocalObjectReference{Name: "config-values"},
+						Key:                  "values.yaml",
+					},
+				},
+			}
+		})
+
+		It("leaves the cloned resources in the cluster", func() {
+			cmName := "test-simple-chart-config"
+
+			By("copying resources")
+			Eventually(func(g Gomega) {
+				s, err := k.Namespace(deployNamespace).Get("secrets")
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(s).To(ContainSubstring("secret-values"))
+
+				cms, err := k.Namespace(deployNamespace).Get("configmaps")
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(cms).To(ContainSubstring("config-values"))
+			}).Should(Succeed())
+
+			By("deploying resources with templated values taken from cloned resources")
+			Eventually(func(g Gomega) {
+				cms, err := k.Namespace(deployNamespace).Get("configmaps")
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(cms).To(ContainSubstring(cmName))
+
+				name, err := k.Namespace(deployNamespace).Get("configmaps", cmName, "-o", "jsonpath={.data.name}")
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(name).To(Equal("name-from-downstream-cluster-configmap"))
+			}).Should(Succeed())
+
+			By("keeping cloned resources when the bundle deployment is deleted")
+			out, err := k.Delete("helmop", name)
+			Expect(err).ToNot(HaveOccurred(), out)
+
+			Eventually(func(g Gomega) {
+				cms, err := k.Namespace(deployNamespace).Get("configmaps")
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(cms).To(ContainSubstring(cmName))
+
+				cms, err = k.Namespace(deployNamespace).Get("configmaps")
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(cms).To(ContainSubstring("config-values"))
+
+				secrets, err := k.Namespace(deployNamespace).Get("secrets")
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(secrets).To(ContainSubstring("secret-values"))
+			}).Should(Succeed())
+		})
+	})
+})

--- a/internal/cmd/agent/controller/bundledeployment_controller.go
+++ b/internal/cmd/agent/controller/bundledeployment_controller.go
@@ -276,86 +276,131 @@ func (r *BundleDeploymentReconciler) copyResourcesFromUpstream(
 	requiresBDUpdate := false
 
 	for _, rsc := range bd.Spec.Options.DownstreamResources {
+		var updated bool
+		var err error
+
 		switch strings.ToLower(rsc.Kind) {
 		case "secret":
-			var s corev1.Secret
-			if err := r.Reader.Get(ctx, client.ObjectKey{Namespace: bd.Namespace, Name: rsc.Name}, &s); err != nil {
-				// The bundle deployment is actually created by the bundle reconciler _before_
-				// these objects are copied to the cluster's namespace, hence retries should happen if
-				// they are not found.
-
-				return false, fmt.Errorf(
-					"could not get secret %s/%s from upstream namespace for copying: %w",
-					bd.Namespace,
-					rsc.Name,
-					err,
-				)
-			}
-
-			s.Namespace = destNS
-			s.ResourceVersion = ""
-			if s.Labels == nil {
-				s.Labels = map[string]string{}
-			}
-			s.Labels[fleetv1.BundleDeploymentOwnershipLabel] = bd.Name
-
-			updated := s.DeepCopy()
-			op, err := controllerutil.CreateOrUpdate(ctx, r.LocalClient, &s, func() error {
-				s.Type = updated.Type // important for e.g. image pull secrets
-				s.Data = updated.Data
-				s.StringData = updated.StringData
-
-				return nil
-			})
-			if err != nil {
-				return false, fmt.Errorf("failed to create or update secret %s/%s downstream: %v", bd.Namespace, rsc.Name, err)
-			}
-
-			if !requiresBDUpdate {
-				requiresBDUpdate = op == controllerutil.OperationResultUpdated
-			}
-
+			updated, err = r.copySecret(ctx, bd, rsc.Name, destNS)
 		case "configmap":
-			var cm corev1.ConfigMap
-			if err := r.Reader.Get(ctx, client.ObjectKey{Namespace: bd.Namespace, Name: rsc.Name}, &cm); err != nil {
-				// The bundle deployment is actually created by the bundle reconciler _before_
-				// these objects are copied to the cluster's namespace, hence retries should happen if
-				// they are not found.
-
-				return false, fmt.Errorf(
-					"could not get config map %s/%s from upstream namespace for copying: %w",
-					bd.Namespace,
-					rsc.Name,
-					err,
-				)
-			}
-			cm.Namespace = destNS
-			cm.ResourceVersion = ""
-			if cm.Labels == nil {
-				cm.Labels = map[string]string{}
-			}
-			cm.Labels[fleetv1.BundleDeploymentOwnershipLabel] = bd.Name
-
-			updated := cm.DeepCopy()
-			op, err := controllerutil.CreateOrUpdate(ctx, r.LocalClient, &cm, func() error {
-				cm.Data = updated.Data
-				cm.BinaryData = updated.BinaryData
-
-				return nil
-			})
-			if err != nil {
-				return false, fmt.Errorf("failed to create or update configmap %s/%s downstream: %v", bd.Namespace, rsc.Name, err)
-			}
-
-			if !requiresBDUpdate {
-				requiresBDUpdate = op == controllerutil.OperationResultUpdated
-			}
+			updated, err = r.copyConfigMap(ctx, bd, rsc.Name, destNS)
 		default:
 			return false, fmt.Errorf("unknown resource type for copy to downstream cluster: %q", rsc.Kind)
+		}
+
+		if err != nil {
+			return false, err
+		}
+
+		if updated {
+			requiresBDUpdate = true
 		}
 	}
 
 	return requiresBDUpdate, nil
+}
+
+// copySecret copies a secret from the bundle deployment's namespace to the destination namespace
+func (r *BundleDeploymentReconciler) copySecret(
+	ctx context.Context,
+	bd *fleetv1.BundleDeployment,
+	name string,
+	destNS string,
+) (bool, error) {
+	var source corev1.Secret
+	if err := r.Reader.Get(ctx, client.ObjectKey{Namespace: bd.Namespace, Name: name}, &source); err != nil {
+		// The bundle deployment is actually created by the bundle reconciler _before_
+		// these objects are copied to the cluster's namespace, hence retries should happen if
+		// they are not found.
+		return false, fmt.Errorf(
+			"could not get secret %s/%s from upstream namespace for copying: %w",
+			bd.Namespace,
+			name,
+			err,
+		)
+	}
+
+	// Create a new Secret for the destination namespace
+	// We're not doing a DeepCopy here to avoid copying ResourceVersion and other metadata
+	// When using a single cluster environment, the downstream cluster is the same
+	// as the management cluster, and copying ResourceVersion or any other metadata would cause conflicts.
+	s := corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: destNS,
+		},
+	}
+
+	op, err := controllerutil.CreateOrUpdate(ctx, r.LocalClient, &s, func() error {
+		s.Type = source.Type // important for e.g. image pull secrets
+		s.Labels = source.Labels
+		s.Annotations = source.Annotations
+		s.Data = source.Data
+		s.StringData = source.StringData
+		// Ensure ownership label is preserved
+		if s.Labels == nil {
+			s.Labels = map[string]string{}
+		}
+		s.Labels[fleetv1.BundleDeploymentOwnershipLabel] = bd.Name
+
+		return nil
+	})
+	if err != nil {
+		return false, fmt.Errorf("failed to create or update secret %s/%s downstream: %w", bd.Namespace, name, err)
+	}
+
+	return op == controllerutil.OperationResultUpdated, nil
+}
+
+// copyConfigMap copies a configmap from the bundle deployment's namespace to the destination namespace
+func (r *BundleDeploymentReconciler) copyConfigMap(
+	ctx context.Context,
+	bd *fleetv1.BundleDeployment,
+	name string,
+	destNS string,
+) (bool, error) {
+	var source corev1.ConfigMap
+	if err := r.Reader.Get(ctx, client.ObjectKey{Namespace: bd.Namespace, Name: name}, &source); err != nil {
+		// The bundle deployment is actually created by the bundle reconciler _before_
+		// these objects are copied to the cluster's namespace, hence retries should happen if
+		// they are not found.
+		return false, fmt.Errorf(
+			"could not get config map %s/%s from upstream namespace for copying: %w",
+			bd.Namespace,
+			name,
+			err,
+		)
+	}
+
+	// Create a new ConfigMap for the destination namespace
+	// We're not doing a DeepCopy here to avoid copying ResourceVersion and other metadata
+	// When using a single cluster environment, the downstream cluster is the same
+	// as the management cluster, and copying ResourceVersion or any other metadata would cause conflicts.
+	cm := corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: destNS,
+		},
+	}
+
+	op, err := controllerutil.CreateOrUpdate(ctx, r.LocalClient, &cm, func() error {
+		cm.Labels = source.Labels
+		cm.Annotations = source.Annotations
+		cm.Data = source.Data
+		cm.BinaryData = source.BinaryData
+		// Ensure ownership label is preserved
+		if cm.Labels == nil {
+			cm.Labels = map[string]string{}
+		}
+		cm.Labels[fleetv1.BundleDeploymentOwnershipLabel] = bd.Name
+
+		return nil
+	})
+	if err != nil {
+		return false, fmt.Errorf("failed to create or update configmap %s/%s downstream: %w", bd.Namespace, name, err)
+	}
+
+	return op == controllerutil.OperationResultUpdated, nil
 }
 
 func (r *BundleDeploymentReconciler) updateStatus(ctx context.Context, orig *fleetv1.BundleDeployment, obj *fleetv1.BundleDeployment) error {


### PR DESCRIPTION
* Avoid using DeepCopy when copying Downstream Resources

This PR avoids copying ConfigMaps and Secrets using `DeepCopy`, since this is problematic when you want to copy the object into a different namespace but within the same cluster (this usually happens when using a single-cluster configuration).

E2E tests have been added to verify the copying of downstream resources also in a single-cluster environment, by reusing the multi-cluster tests and adapting them.

Refers to: https://github.com/rancher/fleet/issues/4575
Backport of: https://github.com/rancher/fleet/pull/4560

---------

## Additional Information

### Checklist

~- [ ] <!-- If applicable,--> I have updated the documentation via a pull request in the
[fleet-docs](https://github.com/rancher/fleet-docs) repository.~
