### PR TITLE
[v0.14] - Clear Reason when Ready condition transitions from non-ready to ready

### DIFF
--- a/internal/cmd/controller/summary/summary.go
+++ b/internal/cmd/controller/summary/summary.go
@@ -114,6 +114,11 @@ func SetReadyConditions(obj interface{}, referencedKind string, summary fleet.Bu
 	msg := ReadyMessage(summary, referencedKind)
 	c.SetStatusBool(obj, len(msg) == 0)
 	c.Message(obj, msg)
+	// Clear reason when status is True to avoid inconsistent state
+	// where reason="Error" persists from previous error state
+	if len(msg) == 0 {
+		c.Reason(obj, "")
+	}
 }
 
 func MessageFromCondition(conditionType string, conds []genericcondition.GenericCondition) string {

--- a/internal/cmd/controller/summary/summary_test.go
+++ b/internal/cmd/controller/summary/summary_test.go
@@ -1,10 +1,13 @@
 package summary_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/rancher/fleet/internal/cmd/controller/summary"
 	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
+
+	"github.com/rancher/wrangler/v3/pkg/condition"
 )
 
 func TestGetSummaryState(t *testing.T) {
@@ -60,5 +63,53 @@ func TestGetSummaryState(t *testing.T) {
 	bundleState = summary.GetSummaryState(s)
 	if bundleState != fleet.WaitApplied {
 		t.Errorf("Expected WaitApplied, got %s", bundleState)
+	}
+}
+
+// TestSetReadyConditions_ReasonNotClearedWhenBecomingReady tests that the Reason is
+// cleared when transitioning from error to ready state in SetReadyConditions.
+func TestSetReadyConditions_ReasonClearedWhenBecomingReady(t *testing.T) {
+	// Create a BundleStatus (which has Conditions field)
+	bundleStatus := &fleet.BundleStatus{}
+
+	// Simulate an error state by using SetError
+	c := condition.Cond("Ready")
+	c.SetError(bundleStatus, "", fmt.Errorf("some error occurred"))
+
+	// Verify the error state is set correctly
+	if c.GetStatus(bundleStatus) != "False" {
+		t.Errorf("Expected status 'False' after SetError, got %q", c.GetStatus(bundleStatus))
+	}
+	if c.GetReason(bundleStatus) != "Error" {
+		t.Errorf("Expected reason 'Error' after SetError, got %q", c.GetReason(bundleStatus))
+	}
+	if c.GetMessage(bundleStatus) != "some error occurred" {
+		t.Errorf("Expected message 'some error occurred' after SetError, got %q", c.GetMessage(bundleStatus))
+	}
+
+	// Now the resource becomes ready - create an empty summary (all resources ready)
+	readySummary := fleet.BundleSummary{
+		Ready:        5,
+		DesiredReady: 5,
+		// No NonReadyResources means everything is ready
+	}
+
+	// Call SetReadyConditions which should transition to ready state
+	summary.SetReadyConditions(bundleStatus, "Cluster", readySummary)
+
+	// Verify the status is now True (ready)
+	if c.GetStatus(bundleStatus) != "True" {
+		t.Errorf("Expected status 'True' after SetReadyConditions, got %q", c.GetStatus(bundleStatus))
+	}
+
+	// Verify the message is empty (ready)
+	if c.GetMessage(bundleStatus) != "" {
+		t.Errorf("Expected empty message after SetReadyConditions, got %q", c.GetMessage(bundleStatus))
+	}
+
+	// Verify the Reason is cleared
+	if c.GetReason(bundleStatus) != "" {
+		t.Errorf("Expected empty reason when Ready status is True, but got %q.",
+			c.GetReason(bundleStatus))
 	}
 }


### PR DESCRIPTION
This PR adds code to clear the Reason in the Ready condition when it transitions from non-ready to ready. The issue caused some Bundles to have a Ready condition with no message, and being True, but having Reason=Error.

That is interpreted by the UI as an error, and it shows the Bundle (and GitRepo, because the status is propagated) as if it were in an error state.

Refers to: https://github.com/rancher/fleet/issues/4579
Backport of: https://github.com/rancher/fleet/pull/4578


## Additional Information

### Checklist

~- [ ] <!-- If applicable,--> I have updated the documentation via a pull request in the
[fleet-docs](https://github.com/rancher/fleet-docs) repository.~
