### PR TITLE
fleet dump CLI: Internal pagination when fetching resources

### DIFF
--- a/e2e/single-cluster/cli_dump_test.go
+++ b/e2e/single-cluster/cli_dump_test.go
@@ -12,6 +12,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
 	"github.com/rancher/fleet/e2e/testenv"
 	"github.com/rancher/fleet/internal/cmd/cli/dump"
 )

--- a/integrationtests/cli/dump/suite_test.go
+++ b/integrationtests/cli/dump/suite_test.go
@@ -10,6 +10,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/scheme"
 	"k8s.io/client-go/rest"

--- a/internal/cmd/builder.go
+++ b/internal/cmd/builder.go
@@ -108,6 +108,8 @@ func Command(obj Runnable, cmd cobra.Command) *cobra.Command {
 
 		flags := c.PersistentFlags()
 		switch fieldType.Type.Kind() {
+		case reflect.Int64:
+			flags.Int64VarP((*int64)(unsafe.Pointer(v.Addr().Pointer())), name, alias, int64(defInt), usage)
 		case reflect.Int:
 			flags.IntVarP((*int)(unsafe.Pointer(v.Addr().Pointer())), name, alias, defInt, usage)
 		case reflect.String:
@@ -149,6 +151,11 @@ func Command(obj Runnable, cmd cobra.Command) *cobra.Command {
 				case reflect.Int:
 					fv, err := flags.GetInt(name)
 					if err == nil && fv == defInt {
+						_ = flags.Set(name, v)
+					}
+				case reflect.Int64:
+					fv, err := flags.GetInt64(name)
+					if err == nil && fv == int64(defInt) {
 						_ = flags.Set(name, v)
 					}
 				default:


### PR DESCRIPTION
Instead of holding all resources in memory, write them in batches. Also eases the load on the cluster by only fetching a certain amount of resources at a time.

Also fixes an issue with collecting duplicated namespaces from cluster resources.


<!-- Specify the issue ID that this pull request is solving -->
Refers to #4419
<!-- Make sure that the referenced issue provides steps to reproduce it -->

<!-- Describe the changes introduced by this pull request -->

<!--
  Please provide a unit, integration (`./integrationtests/`) or e2e (`./e2e/`) test if possible.
-->

## Additional Information

### Checklist

- [ ] <!-- If applicable,--> I have updated the documentation via a pull request in the
[fleet-docs](https://github.com/rancher/fleet-docs) repository.
