### PR TITLE
Normalise replica counts of Deployments and StatefulSets

### DIFF
--- a/internal/cmd/agent/deployer/desiredset/diff.go
+++ b/internal/cmd/agent/deployer/desiredset/diff.go
@@ -300,6 +300,10 @@ func normalizeReplicasPatch(
 		}
 
 		for k, o := range live[gvk] {
+			if k.Namespace != key.Namespace {
+				continue
+			}
+
 			un, ok := o.(*unstructured.Unstructured)
 			if !ok {
 				continue

--- a/internal/cmd/agent/deployer/desiredset/diff_test.go
+++ b/internal/cmd/agent/deployer/desiredset/diff_test.go
@@ -503,7 +503,7 @@ func Test_Diff_HPA(t *testing.T) {
 				},
 				Objects: []runtime.Object{
 					hpa("my-other-ns", "my-hpa", ptr.To(int32(2)), 5, "apps/v1", "Deployment", "nginx"),
-					deployment("my-ns", "nginx", 6),
+					deployment("my-ns", "nginx", 4),
 				},
 			},
 			expectedPlan: desiredset.Plan{


### PR DESCRIPTION
When referenced by a HorizontalPodAutoscaler, a Deployment or StatefulSet may see its replica count change due to automated scaling.
When its updated replica count fits within the interval prescribed by the HPA, Fleet will no longer detect that Deployment or StatefulSet as _Modified_, even if the replica count differs from the one specified in the source bundle deployment.

Refers to #4029

## Additional Information

### Checklist

- [x] <!-- If applicable,--> I have updated the documentation via a [pull request](https://github.com/rancher/fleet-docs/pull/410) in the
[fleet-docs](https://github.com/rancher/fleet-docs) repository.
