### PR TITLE
Downgrade k3s image from v1.35.0-k3s1 to v1.34.1-k3s1

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -25,7 +25,7 @@ env:
   GOARCH: amd64
   CGO_ENABLED: 0
   SETUP_K3D_VERSION: "v5.8.3"
-  SETUP_K3S_VERSION: "v1.35.0-k3s1"
+  SETUP_K3S_VERSION: "v1.34.1-k3s1"
   # Defaults for both manual and scheduled runs
   BENCH_TIMEOUT: ${{ github.event.inputs.timeout || '2m' }}
   BENCH_NAMESPACE: ${{ github.event.inputs.namespace || 'fleet-local' }}

--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -23,7 +23,7 @@ jobs:
           # k3d version list k3s | sed 's/+/-/' | sort -h
           # https://hub.docker.com/r/rancher/k3s/tags
           - name: k3s-new
-            version: v1.35.0-k3s1
+            version: v1.34.1-k3s1
           - name: k3s-old
             version: v1.33.5-k3s1
         test_type:

--- a/.github/workflows/e2e-fleet-upgrade-ci.yml
+++ b/.github/workflows/e2e-fleet-upgrade-ci.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         k3s:
           - name: k3s-new
-            version: v1.35.0-k3s1
+            version: v1.34.1-k3s1
     name: fleet-upgrade-test-${{ matrix.k3s.name }}
 
     steps:

--- a/.github/workflows/e2e-nightly-ci.yml
+++ b/.github/workflows/e2e-nightly-ci.yml
@@ -8,9 +8,9 @@ on:
   workflow_dispatch:
     inputs:
       k3s_version:
-        description: 'K3s version to test (e.g., v1.35.0-k3s1)'
+        description: 'K3s version to test (e.g., v1.34.1-k3s1)'
         required: false
-        default: 'v1.35.0-k3s1'
+        default: 'v1.34.1-k3s1'
       test_type:
         description: 'Test type to run'
         required: false
@@ -35,7 +35,7 @@ jobs:
         k3s_version:
           # k3d version list k3s | sed 's/+/-/' | sort -h
           # https://hub.docker.com/r/rancher/k3s/tags
-          - ${{ github.event.inputs.k3s_version || 'v1.35.0-k3s1' }}
+          - ${{ github.event.inputs.k3s_version || 'v1.34.1-k3s1' }}
           - ${{ github.event_name == 'schedule' && 'v1.33.5-k3s1' || '' }}
         test_type:
           - ${{ github.event.inputs.test_type || 'acceptance' }}

--- a/.github/workflows/e2e-rancher-upgrade-fleet-to-head-ci.yml
+++ b/.github/workflows/e2e-rancher-upgrade-fleet-to-head-ci.yml
@@ -20,7 +20,7 @@ env:
   GOARCH: amd64
   CGO_ENABLED: 0
   SETUP_K3D_VERSION: 'v5.8.3'
-  SETUP_K3S_VERSION: 'v1.35.0-k3s1'
+  SETUP_K3S_VERSION: 'v1.34.1-k3s1'
 
 jobs:
   rancher-fleet-integration:

--- a/.github/workflows/e2e-rancher-upgrade-fleet.yml
+++ b/.github/workflows/e2e-rancher-upgrade-fleet.yml
@@ -13,7 +13,7 @@ on:
         # k3d version list k3s | sed 's/+/-/' | sort -h
         description: "K3s version to use"
         required: true
-        default: "v1.35.0-k3s1"
+        default: "v1.34.1-k3s1"
       rancher_version:
         description: "Rancher version to install"
         required: true


### PR DESCRIPTION
because v1.35.0-k3s1 makes some CI tests flaky (e.g. this [run](https://github.com/rancher/fleet/actions/runs/21908840272/job/63256551035?pr=4631)).