### PR TITLE
Remove redundant JsonPointers from bundlediff cli

### DIFF
--- a/e2e/assets/single-cluster/bundlediff-fleet-snippet.yaml
+++ b/e2e/assets/single-cluster/bundlediff-fleet-snippet.yaml
@@ -4,8 +4,6 @@ diff:
     kind: ConfigMap
     name: test-bundlediff-cm
     namespace: ${TARGET_NAMESPACE}
-    jsonPointers:
-    - /data/key
     operations:
     - op: remove
       path: /data/key

--- a/integrationtests/cli/bundlediff/testdata/fleet-yaml-empty-op.yaml
+++ b/integrationtests/cli/bundlediff/testdata/fleet-yaml-empty-op.yaml
@@ -1,9 +1,6 @@
 diff:
   comparePatches:
   - apiVersion: v1
-    jsonPointers:
-    - /data/key
-    - /data/valid
     kind: ConfigMap
     name: empty-op-cm
     namespace: test-ns

--- a/integrationtests/cli/bundlediff/testdata/fleet-yaml-merge-patch.yaml
+++ b/integrationtests/cli/bundlediff/testdata/fleet-yaml-merge-patch.yaml
@@ -1,8 +1,6 @@
 diff:
   comparePatches:
   - apiVersion: apps/v1
-    jsonPointers:
-    - /spec/replicas
     kind: Deployment
     name: nginx-deploy
     namespace: test-ns
@@ -10,8 +8,6 @@ diff:
     - op: remove
       path: /spec/replicas
   - apiVersion: v1
-    jsonPointers:
-    - /data/key
     kind: ConfigMap
     name: config-map
     namespace: test-ns

--- a/integrationtests/cli/bundlediff/testdata/fleet-yaml-multiple-ops.yaml
+++ b/integrationtests/cli/bundlediff/testdata/fleet-yaml-multiple-ops.yaml
@@ -1,9 +1,6 @@
 diff:
   comparePatches:
   - apiVersion: apps/v1
-    jsonPointers:
-    - /spec/replicas
-    - /spec/template/metadata/labels/old-label
     kind: Deployment
     name: my-deployment
     namespace: test-ns

--- a/integrationtests/cli/bundlediff/testdata/fleet-yaml-multiple-resources.yaml
+++ b/integrationtests/cli/bundlediff/testdata/fleet-yaml-multiple-resources.yaml
@@ -1,8 +1,6 @@
 diff:
   comparePatches:
   - apiVersion: v1
-    jsonPointers:
-    - /data/key1
     kind: ConfigMap
     name: cm1
     namespace: ns1
@@ -10,8 +8,6 @@ diff:
     - op: remove
       path: /data/key1
   - apiVersion: v1
-    jsonPointers:
-    - /data/password
     kind: Secret
     name: secret1
     namespace: ns2

--- a/integrationtests/cli/bundlediff/testdata/fleet-yaml-single.yaml
+++ b/integrationtests/cli/bundlediff/testdata/fleet-yaml-single.yaml
@@ -1,8 +1,6 @@
 diff:
   comparePatches:
   - apiVersion: v1
-    jsonPointers:
-    - /data
     kind: ConfigMap
     name: app-config
     namespace: bundle-diffs-example

--- a/internal/cmd/cli/bundlediff.go
+++ b/internal/cmd/cli/bundlediff.go
@@ -271,15 +271,6 @@ func mergeComparePatches(existing, new []fleet.ComparePatch) []fleet.ComparePatc
 					merged.Operations = append(merged.Operations, op)
 				}
 			}
-			pointerSet := make(map[string]bool)
-			for _, pointer := range existingPatch.JsonPointers {
-				pointerSet[pointer] = true
-			}
-			for _, pointer := range newPatch.JsonPointers {
-				if !pointerSet[pointer] {
-					merged.JsonPointers = append(merged.JsonPointers, pointer)
-				}
-			}
 			patchMap[key] = merged
 		} else {
 			patchMap[key] = newPatch
@@ -326,14 +317,9 @@ func (d *BundleDiff) printFleetYAML(ctx context.Context, k8sClient client.Client
 			patchOps := convertMergePatchToRemoveOps(mergePatch, "")
 
 			operations := make([]fleet.Operation, 0, len(patchOps))
-			// Record JSON pointers so the ignore normalizer can skip these paths directly.
-			jsonPointers := make([]string, 0, len(patchOps))
 			for _, p := range patchOps {
 				if p.Op == "" {
 					continue
-				}
-				if p.Path != "" {
-					jsonPointers = append(jsonPointers, p.Path)
 				}
 
 				operations = append(operations, fleet.Operation{
@@ -344,12 +330,11 @@ func (d *BundleDiff) printFleetYAML(ctx context.Context, k8sClient client.Client
 
 			if len(operations) > 0 {
 				comparePatches = append(comparePatches, fleet.ComparePatch{
-					APIVersion:   mod.APIVersion,
-					Kind:         mod.Kind,
-					Name:         mod.Name,
-					Namespace:    mod.Namespace,
-					Operations:   operations,
-					JsonPointers: jsonPointers,
+					APIVersion: mod.APIVersion,
+					Kind:       mod.Kind,
+					Name:       mod.Name,
+					Namespace:  mod.Namespace,
+					Operations: operations,
 				})
 			}
 		}

--- a/internal/cmd/cli/bundlediff_test.go
+++ b/internal/cmd/cli/bundlediff_test.go
@@ -15,9 +15,6 @@ func TestMergeComparePatches(t *testing.T) {
 			Name:       "app-config",
 			Namespace:  "default",
 			Operations: []fleet.Operation{{Op: "remove", Path: "/data/a"}},
-			JsonPointers: []string{
-				"/data/a",
-			},
 		},
 	}
 
@@ -28,9 +25,6 @@ func TestMergeComparePatches(t *testing.T) {
 			Name:       "app-config",
 			Namespace:  "default",
 			Operations: []fleet.Operation{{Op: "remove", Path: "/data/b"}},
-			JsonPointers: []string{
-				"/data/b",
-			},
 		},
 		{
 			APIVersion: "v1",
@@ -38,9 +32,6 @@ func TestMergeComparePatches(t *testing.T) {
 			Name:       "app-secret",
 			Namespace:  "default",
 			Operations: []fleet.Operation{{Op: "remove", Path: "/data/key"}},
-			JsonPointers: []string{
-				"/data/key",
-			},
 		},
 	}
 
@@ -54,10 +45,6 @@ func TestMergeComparePatches(t *testing.T) {
 				{Op: "remove", Path: "/data/a"},
 				{Op: "remove", Path: "/data/b"},
 			},
-			JsonPointers: []string{
-				"/data/a",
-				"/data/b",
-			},
 		},
 		{
 			APIVersion: "v1",
@@ -65,9 +52,6 @@ func TestMergeComparePatches(t *testing.T) {
 			Name:       "app-secret",
 			Namespace:  "default",
 			Operations: []fleet.Operation{{Op: "remove", Path: "/data/key"}},
-			JsonPointers: []string{
-				"/data/key",
-			},
 		},
 	}
 


### PR DESCRIPTION
Both `JsonPointers` and `Operations` fields were duplicating the same drift ignore data.
`Operations` is more flexible and handles both field ignores (via op: 'remove') and entire resource ignores (via op: 'ignore').

Refers to #4534 