### PR TITLE
Upgrade CI to 1.35.0-k3s1 using etcd

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -25,7 +25,7 @@ env:
   GOARCH: amd64
   CGO_ENABLED: 0
   SETUP_K3D_VERSION: "v5.8.3"
-  SETUP_K3S_VERSION: "v1.35.0-k3s1"
+  SETUP_K3S_VERSION: "v1.35.1-k3s1"
   # Defaults for both manual and scheduled runs
   BENCH_TIMEOUT: ${{ github.event.inputs.timeout || '2m' }}
   BENCH_NAMESPACE: ${{ github.event.inputs.namespace || 'fleet-local' }}
@@ -73,7 +73,7 @@ jobs:
           k3d cluster create upstream --wait \
             --agents 1 \
             --image docker.io/rancher/k3s:${{ env.SETUP_K3S_VERSION }} \
-
+            --k3s-arg "--cluster-init@server:0"
 
       - name: Import Images Into k3d
         run: |

--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -23,9 +23,9 @@ jobs:
           # k3d version list k3s | sed 's/+/-/' | sort -h
           # https://hub.docker.com/r/rancher/k3s/tags
           - name: k3s-new
-            version: v1.35.0-k3s1
+            version: v1.35.1-k3s1
           - name: k3s-old
-            version: v1.34.1-k3s1
+            version: v1.33.8-k3s1
         test_type:
           - name: default
           - name: sharding

--- a/.github/workflows/e2e-fleet-upgrade-ci.yml
+++ b/.github/workflows/e2e-fleet-upgrade-ci.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         k3s:
           - name: k3s-new
-            version: v1.35.0-k3s1
+            version: v1.35.1-k3s1
     name: fleet-upgrade-test-${{ matrix.k3s.name }}
 
     steps:

--- a/.github/workflows/e2e-nightly-ci.yml
+++ b/.github/workflows/e2e-nightly-ci.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
     inputs:
       k3s_version:
-        description: 'K3s version to test (e.g., v1.35.0-k3s1)'
+        description: 'K3s version to test (e.g., v1.35.1-k3s1)'
         required: false
         default: 'v1.35.0-k3s1'
       test_type:

--- a/.github/workflows/e2e-rancher-upgrade-fleet-to-head-ci.yml
+++ b/.github/workflows/e2e-rancher-upgrade-fleet-to-head-ci.yml
@@ -20,7 +20,7 @@ env:
   GOARCH: amd64
   CGO_ENABLED: 0
   SETUP_K3D_VERSION: 'v5.8.3'
-  SETUP_K3S_VERSION: 'v1.35.0-k3s1'
+  SETUP_K3S_VERSION: 'v1.35.1-k3s1'
 
 jobs:
   rancher-fleet-integration:

--- a/.github/workflows/e2e-rancher-upgrade-fleet.yml
+++ b/.github/workflows/e2e-rancher-upgrade-fleet.yml
@@ -13,7 +13,7 @@ on:
         # k3d version list k3s | sed 's/+/-/' | sort -h
         description: "K3s version to use"
         required: true
-        default: "v1.35.0-k3s1"
+        default: "v1.35.1-k3s1"
       rancher_version:
         description: "Rancher version to install"
         required: true

--- a/.github/workflows/e2e-test-fleet-in-rancher.yml
+++ b/.github/workflows/e2e-test-fleet-in-rancher.yml
@@ -26,7 +26,7 @@ env:
   GOARCH: amd64
   CGO_ENABLED: 0
   SETUP_K3D_VERSION: 'v5.8.3'
-  SETUP_K3S_VERSION: 'v1.35.0-k3s1'
+  SETUP_K3S_VERSION: 'v1.35.1-k3s1'
 
 jobs:
   release-against-test-charts:
@@ -147,7 +147,8 @@ jobs:
             --k3s-arg '--kubelet-arg=eviction-minimum-reclaim=imagefs.available=1%,nodefs.available=1%@agent:*' \
             --network "nw01" \
             --image docker.io/rancher/k3s:${{ env.SETUP_K3S_VERSION }} \
-            --k3s-arg "--cluster-init@server:0" 
+            --k3s-arg "--cluster-init@server:0"
+
       -
         name: Set up k3d downstream cluster
         run: |


### PR DESCRIPTION
This PR upgrades the `k3s` version used in our CI to `v1.35.0-k3s1` and enables `etcd` instead to `kine` meanwhile the reported issue https://github.com/k3s-io/k3s/issues/13656 is fixed.

## Additional Information

### Checklist

~- [ ] <!-- If applicable,--> I have updated the documentation via a pull request in the
[fleet-docs](https://github.com/rancher/fleet-docs) repository.~
