### PR TITLE
fix(gitjob): add fsGroup to PodSecurityContext for secret readability

### DIFF
--- a/internal/cmd/controller/gitops/reconciler/gitjob.go
+++ b/internal/cmd/controller/gitops/reconciler/gitjob.go
@@ -452,6 +452,7 @@ func (r *GitJobReconciler) newJobSpec(ctx context.Context, gitrepo *v1alpha1.Git
 				Volumes: volumes,
 				SecurityContext: &corev1.PodSecurityContext{
 					RunAsUser: &[]int64{1000}[0],
+					FSGroup:   &[]int64{1000}[0],
 				},
 				ServiceAccountName: saName,
 				RestartPolicy:      corev1.RestartPolicyNever,


### PR DESCRIPTION
Secrets mounted as non-root (runAsUser: 1000) are unreadable without fsGroup, causing SSH key auth failures on CIS-hardened clusters.

<!-- Specify the issue ID that this pull request is solving -->
Refers to #4696 
<!-- Make sure that the referenced issue provides steps to reproduce it -->

<!-- Describe the changes introduced by this pull request -->
Adds `FSGroup: 1000` to the gitjob PodSecurityContext to match the existing `RunAsUser: 1000`. This allows mounted secrets (SSH keys, tokens) to be readable by the non-root user via group ownership.

<!--
  Please provide a unit, integration (`./integrationtests/`) or e2e (`./e2e/`) test if possible.
-->

## Additional Information

### Checklist

- [ ] <!-- If applicable,--> I have updated the documentation via a pull request in the
[fleet-docs](https://github.com/rancher/fleet-docs) repository.