### PR TITLE
Print consistent message when bundlediff finds no modifications

### DIFF
--- a/integrationtests/cli/bundlediff/bundlediff_test.go
+++ b/integrationtests/cli/bundlediff/bundlediff_test.go
@@ -394,6 +394,24 @@ var _ = Describe("Fleet bundlediff", func() {
 
 			Expect(output.BundleDeploymentDiffs).To(BeEmpty())
 		})
+
+		It("should indicate no modified resources found when querying a specific unmodified BundleDeployment", func() {
+			buf, _, err := act([]string{"--bundle-deployment", bundleDeploymentName}, namespace)
+			Expect(err).NotTo(HaveOccurred())
+
+			output := string(buf.Contents())
+			Expect(output).To(ContainSubstring("No modified resources found"))
+		})
+
+		It("should indicate no modified resources found with --fleet-yaml when BundleDeployment has no modifications", func() {
+			buf, errBuf, err := act([]string{"--bundle-deployment", bundleDeploymentName, "--fleet-yaml"}, namespace)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Message goes to stderr, stdout should be empty
+			Expect(string(buf.Contents())).To(BeEmpty())
+			errOutput := string(errBuf.Contents())
+			Expect(errOutput).To(ContainSubstring("No modified resources found"))
+		})
 	})
 
 	When("default view with multiple bundles having diffs", func() {

--- a/internal/cmd/cli/bundlediff.go
+++ b/internal/cmd/cli/bundlediff.go
@@ -149,15 +149,13 @@ func (d *BundleDiff) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(diffs) == 0 {
-		if !d.JSON && !d.FleetYAML {
-			fmt.Fprintln(cmd.OutOrStdout(), "No modified resources found.")
-			return nil
-		}
 		if d.JSON {
 			return d.encodeJSON(cmd.OutOrStdout(), diffs)
 		}
 		if d.FleetYAML {
-			return d.printFleetYAML(ctx, k8sClient, cmd.OutOrStdout(), diffs)
+			fmt.Fprintln(cmd.ErrOrStderr(), "No modified resources found.")
+		} else {
+			fmt.Fprintln(cmd.OutOrStdout(), "No modified resources found.")
 		}
 		return nil
 	}


### PR DESCRIPTION
When no modified resources exist, now all output formats but json show the same 'No modified resources found.' message:

- Plain text output (default): message to stdout (consistent with the rest of the output)
- `--fleet-yaml` output: message to stderr (clean stdout for file redirect)
- `--json` output: empty array to stdout (machine-readable and easy to comprehend without additional messages)

<!-- Specify the issue ID that this pull request is solving -->
Refers to #4534