### PR TITLE
Fixes race condition when BD secrets are transiently unavailable

### DIFF
--- a/charts/fleet-crd/templates/crds.yaml
+++ b/charts/fleet-crd/templates/crds.yaml
@@ -1144,6 +1144,18 @@ spec:
                     the bundle.
                   nullable: true
                   type: string
+                waitingForValues:
+                  description: 'WaitingForValues is set to true by the bundle controller
+                    when the
+
+                    options secret for this BundleDeployment could not be found (e.g.
+
+                    due to transient API server pressure). While true, the agent skips
+
+                    reconciliation to avoid deploying with missing Helm values. The
+
+                    controller clears this flag once the secret is successfully loaded.'
+                  type: boolean
               type: object
             status:
               properties:

--- a/internal/cmd/agent/controller/bundledeployment_controller.go
+++ b/internal/cmd/agent/controller/bundledeployment_controller.go
@@ -149,6 +149,12 @@ func (r *BundleDeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Req
 
 		return ctrl.Result{}, err
 	}
+	if bd.Spec.WaitingForValues {
+		logger.V(1).Info("BundleDeployment waiting for options secret to become available, skipping deployment")
+		err := r.DriftDetect.Clear(req.String())
+
+		return ctrl.Result{}, err
+	}
 
 	// load the bundledeployment options from the secret, if present
 	if bd.Spec.ValuesHash != "" {

--- a/internal/cmd/cli/target.go
+++ b/internal/cmd/cli/target.go
@@ -101,7 +101,7 @@ func (t *Target) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	builder := target.New(client, client)
-	matchedTargets, err := builder.Targets(ctx, bundle, manifestID)
+	matchedTargets, _, err := builder.Targets(ctx, bundle, manifestID)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/controller/reconciler/bundle_controller.go
+++ b/internal/cmd/controller/reconciler/bundle_controller.go
@@ -26,6 +26,7 @@ import (
 	"github.com/rancher/fleet/internal/metrics"
 	"github.com/rancher/fleet/internal/ocistorage"
 	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
+	"github.com/rancher/fleet/pkg/durations"
 	fleetevent "github.com/rancher/fleet/pkg/event"
 	"github.com/rancher/fleet/pkg/sharding"
 	corev1 "k8s.io/api/core/v1"
@@ -63,7 +64,7 @@ type Store interface {
 }
 
 type TargetBuilder interface {
-	Targets(ctx context.Context, bundle *fleet.Bundle, manifestID string) ([]*target.Target, error)
+	Targets(ctx context.Context, bundle *fleet.Bundle, manifestID string) ([]*target.Target, bool, error)
 }
 
 // BundleReconciler reconciles a Bundle object
@@ -257,7 +258,7 @@ func (r *BundleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		}
 	}
 
-	matchedTargets, err := r.Builder.Targets(ctx, bundle, manifestID)
+	matchedTargets, secretsMissing, err := r.Builder.Targets(ctx, bundle, manifestID)
 	if err != nil {
 		return ctrl.Result{},
 			r.updateErrorStatus(
@@ -342,13 +343,20 @@ func (r *BundleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		bd.Spec.OCIContents = contentsInOCI
 		bd.Spec.HelmChartOptions = bundle.Spec.HelmOpOptions
 
-		valuesHash, optionsSecret, err := r.manageOptionsSecret(ctx, bd)
-		if err != nil {
-			return r.computeResult(ctx, logger, bundleOrig, bundle, "failed to initialize options secret", err)
-		}
+		var optionsSecret *corev1.Secret
+		// If the options secret was unavailable during Targets(). Preserve the
+		// existing ValuesHash (already present in bd.Spec from BundleDeployment())
+		// and skip writing the secret so we don't overwrite it with empty values.
+		if !bd.Spec.WaitingForValues {
+			var valuesHash string
+			valuesHash, optionsSecret, err = r.manageOptionsSecret(ctx, bd)
+			if err != nil {
+				return r.computeResult(ctx, logger, bundleOrig, bundle, "failed to initialize options secret", err)
+			}
 
-		// Changes in the values hash trigger a bundle deployment reconcile.
-		bd.Spec.ValuesHash = valuesHash
+			// Changes in the values hash trigger a bundle deployment reconcile.
+			bd.Spec.ValuesHash = valuesHash
+		}
 
 		// When content resources are stored in etcd, we need to keep track of the content resource so they
 		// are properly gargabe-collected by the content controller.
@@ -414,6 +422,13 @@ func (r *BundleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	if err := r.updateStatus(ctx, bundleOrig, bundle); err != nil {
 		merr = append(merr, err)
 		return ctrl.Result{}, errutil.NewAggregate(merr)
+	}
+
+	if secretsMissing {
+		// At least one BundleDeployment had its options secret transiently
+		// unavailable. Requeue so we can retry loading those values; we cannot
+		// rely on an external event to re-trigger the reconcile.
+		return ctrl.Result{RequeueAfter: durations.DefaultRequeueAfter}, errutil.NewAggregate(merr)
 	}
 
 	return ctrl.Result{}, errutil.NewAggregate(merr)

--- a/internal/cmd/controller/reconciler/bundle_controller_test.go
+++ b/internal/cmd/controller/reconciler/bundle_controller_test.go
@@ -3,6 +3,7 @@ package reconciler_test
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -15,6 +16,7 @@ import (
 	"github.com/rancher/fleet/internal/cmd/controller/finalize"
 	"github.com/rancher/fleet/internal/cmd/controller/reconciler"
 	"github.com/rancher/fleet/internal/cmd/controller/target"
+	"github.com/rancher/fleet/internal/helmvalues"
 	"github.com/rancher/fleet/internal/mocks"
 	fleetv1 "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
 	"github.com/rancher/fleet/pkg/sharding"
@@ -27,11 +29,13 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -229,7 +233,7 @@ func TestReconcile_TargetsBuildingError(t *testing.T) {
 	recorderMock := mocks.NewMockEventRecorder(mockCtrl)
 
 	targetBuilderMock := mocks.NewMockTargetBuilder(mockCtrl)
-	targetBuilderMock.EXPECT().Targets(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("something went wrong"))
+	targetBuilderMock.EXPECT().Targets(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, false, errors.New("something went wrong"))
 
 	r := reconciler.BundleReconciler{
 		Client:   mockClient,
@@ -299,7 +303,7 @@ func TestReconcile_StatusResetFromTargetsError(t *testing.T) {
 		},
 	}
 	targetBuilderMock := mocks.NewMockTargetBuilder(mockCtrl)
-	targetBuilderMock.EXPECT().Targets(gomock.Any(), gomock.Any(), gomock.Any()).Return(matchedTargets, nil)
+	targetBuilderMock.EXPECT().Targets(gomock.Any(), gomock.Any(), gomock.Any()).Return(matchedTargets, false, nil)
 
 	storeMock := mocks.NewMockStore(mockCtrl)
 	storeMock.EXPECT().Store(gomock.Any(), gomock.Any()).Return(nil)
@@ -371,7 +375,7 @@ func TestReconcile_ManifestStorageError(t *testing.T) {
 
 			matchedTargets := []*target.Target{{DeploymentID: "foo"}} // just needs to be non-empty
 			targetBuilderMock := mocks.NewMockTargetBuilder(mockCtrl)
-			targetBuilderMock.EXPECT().Targets(gomock.Any(), gomock.Any(), gomock.Any()).Return(matchedTargets, nil)
+			targetBuilderMock.EXPECT().Targets(gomock.Any(), gomock.Any(), gomock.Any()).Return(matchedTargets, false, nil)
 
 			storeMock := mocks.NewMockStore(mockCtrl)
 			storeMock.EXPECT().Store(gomock.Any(), gomock.Any()).Return(c.storeErr)
@@ -482,7 +486,7 @@ func TestReconcile_OptionsSecretCreateUpdateError(t *testing.T) {
 				},
 			}
 			targetBuilderMock := mocks.NewMockTargetBuilder(mockCtrl)
-			targetBuilderMock.EXPECT().Targets(gomock.Any(), gomock.Any(), gomock.Any()).Return(matchedTargets, nil)
+			targetBuilderMock.EXPECT().Targets(gomock.Any(), gomock.Any(), gomock.Any()).Return(matchedTargets, false, nil)
 
 			storeMock := mocks.NewMockStore(mockCtrl)
 			storeMock.EXPECT().Store(gomock.Any(), gomock.Any()).Return(nil)
@@ -555,7 +559,7 @@ func TestReconcile_OptionsSecretDeletionError(t *testing.T) {
 		},
 	}
 	targetBuilderMock := mocks.NewMockTargetBuilder(mockCtrl)
-	targetBuilderMock.EXPECT().Targets(gomock.Any(), gomock.Any(), gomock.Any()).Return(matchedTargets, nil)
+	targetBuilderMock.EXPECT().Targets(gomock.Any(), gomock.Any(), gomock.Any()).Return(matchedTargets, false, nil)
 
 	storeMock := mocks.NewMockStore(mockCtrl)
 	storeMock.EXPECT().Store(gomock.Any(), gomock.Any()).Return(nil)
@@ -659,7 +663,7 @@ func TestReconcile_OCIReferenceSecretResolutionError(t *testing.T) {
 				},
 			}
 			targetBuilderMock := mocks.NewMockTargetBuilder(mockCtrl)
-			targetBuilderMock.EXPECT().Targets(gomock.Any(), gomock.Any(), gomock.Any()).Return(matchedTargets, nil)
+			targetBuilderMock.EXPECT().Targets(gomock.Any(), gomock.Any(), gomock.Any()).Return(matchedTargets, false, nil)
 
 			r := reconciler.BundleReconciler{
 				Client:   mockClient,
@@ -826,7 +830,7 @@ func TestReconcile_DownstreamObjectsHandlingError(t *testing.T) {
 				},
 			}
 			targetBuilderMock := mocks.NewMockTargetBuilder(mockCtrl)
-			targetBuilderMock.EXPECT().Targets(gomock.Any(), gomock.Any(), gomock.Any()).Return(matchedTargets, nil)
+			targetBuilderMock.EXPECT().Targets(gomock.Any(), gomock.Any(), gomock.Any()).Return(matchedTargets, false, nil)
 
 			storeMock := mocks.NewMockStore(mockCtrl)
 			storeMock.EXPECT().Store(gomock.Any(), gomock.Any()).Return(nil)
@@ -930,7 +934,7 @@ func TestReconcile_AccessSecretsHandlingError(t *testing.T) {
 		},
 	}
 	targetBuilderMock := mocks.NewMockTargetBuilder(mockCtrl)
-	targetBuilderMock.EXPECT().Targets(gomock.Any(), gomock.Any(), gomock.Any()).Return(matchedTargets, nil)
+	targetBuilderMock.EXPECT().Targets(gomock.Any(), gomock.Any(), gomock.Any()).Return(matchedTargets, false, nil)
 
 	r := reconciler.BundleReconciler{
 		Client:   mockClient,
@@ -1371,7 +1375,7 @@ func TestReconcile_DownstreamResourcesGeneration_Increment(t *testing.T) {
 			}
 
 			targetBuilderMock := mocks.NewMockTargetBuilder(mockCtrl)
-			targetBuilderMock.EXPECT().Targets(gomock.Any(), gomock.Any(), gomock.Any()).Return(matchedTargets, nil)
+			targetBuilderMock.EXPECT().Targets(gomock.Any(), gomock.Any(), gomock.Any()).Return(matchedTargets, false, nil)
 
 			storeMock := mocks.NewMockStore(mockCtrl)
 			storeMock.EXPECT().Store(gomock.Any(), gomock.Any()).Return(nil)
@@ -1494,7 +1498,7 @@ func TestReconcile_DownstreamResources_FeatureDisabled(t *testing.T) {
 	}
 
 	targetBuilderMock := mocks.NewMockTargetBuilder(mockCtrl)
-	targetBuilderMock.EXPECT().Targets(gomock.Any(), gomock.Any(), gomock.Any()).Return(matchedTargets, nil)
+	targetBuilderMock.EXPECT().Targets(gomock.Any(), gomock.Any(), gomock.Any()).Return(matchedTargets, false, nil)
 
 	storeMock := mocks.NewMockStore(mockCtrl)
 	storeMock.EXPECT().Store(gomock.Any(), gomock.Any()).Return(nil)
@@ -1549,5 +1553,326 @@ func TestReconcile_DownstreamResources_FeatureDisabled(t *testing.T) {
 
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+// secretNotFoundReader wraps a client.Reader and returns NotFound for a
+// specific secret name/namespace, simulating transient etcd/API-server
+// pressure where the options secret cannot be read inside Targets().
+type secretNotFoundReader struct {
+	client.Reader
+	name      string
+	namespace string
+}
+
+func (r *secretNotFoundReader) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+	if key.Name == r.name && key.Namespace == r.namespace {
+		return k8serrors.NewNotFound(schema.GroupResource{Resource: "secrets"}, key.Name)
+	}
+	return r.Reader.Get(ctx, key, obj, opts...)
+}
+
+// setupBundleRaceTest builds the shared fake client, bundle, cluster and
+// reconciler skeleton used by both race-condition tests. The caller provides
+// the client.Reader that the real Targets() manager will use; this is the
+// single injection point that distinguishes the bug scenario from the control.
+func setupBundleRaceTest(t *testing.T, reader client.Reader, helmValues map[string]interface{}) (
+	fakeClient client.Client,
+	r *reconciler.BundleReconciler,
+	req ctrl.Request,
+) {
+	t.Helper()
+
+	scheme := runtime.NewScheme()
+	utilruntime.Must(fleetv1.AddToScheme(scheme))
+	utilruntime.Must(corev1.AddToScheme(scheme))
+
+	const (
+		bundleName  = "my-bundle"
+		bundleNS    = "fleet-default"
+		clusterName = "cluster-one"
+		clusterNS   = "cluster-one-ns"
+	)
+
+	bundle := &fleetv1.Bundle{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       bundleName,
+			Namespace:  bundleNS,
+			Finalizers: []string{finalize.BundleFinalizer},
+		},
+		Spec: fleetv1.BundleSpec{
+			BundleDeploymentOptions: fleetv1.BundleDeploymentOptions{
+				Helm: &fleetv1.HelmOptions{
+					Values: &fleetv1.GenericMap{
+						Data: helmValues,
+					},
+				},
+			},
+			// An empty ClusterSelector matches all clusters, so the real
+			// Targets() picks up our test cluster without extra setup.
+			Targets: []fleetv1.BundleTarget{
+				{ClusterSelector: &metav1.LabelSelector{}},
+			},
+		},
+	}
+
+	// Cluster must live in bundleNS so Targets() finds it, and its
+	// Status.Namespace must point to the namespace where BDs are created.
+	cluster := &fleetv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      clusterName,
+			Namespace: bundleNS,
+		},
+		Status: fleetv1.ClusterStatus{
+			Namespace: clusterNS,
+		},
+	}
+
+	fc := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(
+			bundle, cluster,
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: clusterNS}},
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: bundleNS}},
+		).
+		WithStatusSubresource(&fleetv1.Bundle{}).
+		Build()
+
+	mockCtrl := gomock.NewController(t)
+	t.Cleanup(mockCtrl.Finish)
+
+	storeMock := mocks.NewMockStore(mockCtrl)
+	storeMock.EXPECT().Store(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+
+	// If no reader was provided, fall through to the real fake client
+	// (the "secret is always found" control scenario).
+	if reader == nil {
+		reader = fc
+	}
+
+	rec := &reconciler.BundleReconciler{
+		Client:  fc,
+		Scheme:  scheme,
+		Builder: target.New(fc, reader),
+		Store:   storeMock,
+	}
+
+	return fc, rec, ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: bundleName, Namespace: bundleNS},
+	}
+}
+
+// TestReconcile_OptionsSecretNotFound_ValuesPreserved verifies the fix for the
+// race condition described in the issue #4673.
+//
+// When Targets() encounters a NotFound error for an options secret it sets
+// WaitingForValues=true on the BundleDeployment (in memory) and signals the
+// caller to requeue. The controller skips manageOptionsSecret for that BD so
+// the original correct secret is never overwritten. The agent sees
+// WaitingForValues=true and skips reconciliation until the flag is cleared.
+func TestReconcile_OptionsSecretNotFound_ValuesPreserved(t *testing.T) {
+	const (
+		bundleName = "my-bundle"
+		clusterNS  = "cluster-one-ns"
+	)
+
+	bugReader := &secretNotFoundReader{
+		name:      bundleName,
+		namespace: clusterNS,
+	}
+
+	helmValues := map[string]interface{}{
+		"replicas": float64(3),
+		"image":    "nginx:latest",
+	}
+	fakeClient, r, req := setupBundleRaceTest(t, bugReader, helmValues)
+	// Wire the real fake client as the fallback so non-secret Gets still work.
+	bugReader.Reader = fakeClient
+
+	ctx := context.Background()
+
+	// ===================================================================
+	// FIRST RECONCILE: no BD exists yet, so Targets() never calls
+	// reader.Get (ValuesHash is empty). The reconciler creates the BD and
+	// writes the options secret with the correct Helm values.
+	// ===================================================================
+	if _, err := r.Reconcile(ctx, req); err != nil {
+		t.Fatalf("First Reconcile returned error: %v", err)
+	}
+
+	createdBD := &fleetv1.BundleDeployment{}
+	if err := fakeClient.Get(ctx, types.NamespacedName{Name: bundleName, Namespace: clusterNS}, createdBD); err != nil {
+		t.Fatalf("BD not created by first reconcile: %v", err)
+	}
+	if createdBD.Spec.ValuesHash == "" {
+		t.Fatal("First reconcile precondition failed: BD should have ValuesHash set")
+	}
+	originalHash := createdBD.Spec.ValuesHash
+
+	// ===================================================================
+	// SECOND RECONCILE: the BD now has ValuesHash set. Targets() tries
+	// reader.Get for the options secret, gets NotFound.
+	// Expected fixed behaviour:
+	//   - WaitingForValues=true is set on the BD so the agent skips it.
+	//   - manageOptionsSecret is NOT called → the original secret is intact.
+	//   - The reconciler returns RequeueAfter > 0 so it retries later.
+	// ===================================================================
+	result, err := r.Reconcile(ctx, req)
+	if err != nil {
+		t.Fatalf("Second Reconcile returned unexpected error: %v", err)
+	}
+	if result.RequeueAfter == 0 {
+		t.Fatal("FIX BROKEN: second Reconcile should return RequeueAfter > 0 when a secret is missing")
+	}
+
+	// BD must have WaitingForValues=true so the agent skips deployment.
+	bdAfterSecond := &fleetv1.BundleDeployment{}
+	if err := fakeClient.Get(ctx, types.NamespacedName{Name: bundleName, Namespace: clusterNS}, bdAfterSecond); err != nil {
+		t.Fatalf("Cannot get BD after second reconcile: %v", err)
+	}
+	if !bdAfterSecond.Spec.WaitingForValues {
+		t.Fatal("FIX BROKEN: BD should have WaitingForValues=true after secret NotFound")
+	}
+	if bdAfterSecond.Spec.ValuesHash != originalHash {
+		t.Fatalf("FIX BROKEN: BD ValuesHash changed from %q to %q; the original hash must be preserved",
+			originalHash, bdAfterSecond.Spec.ValuesHash)
+	}
+
+	// The original options secret must be intact — values must NOT be empty.
+	secret := &corev1.Secret{}
+	if err := fakeClient.Get(ctx, types.NamespacedName{Name: bundleName, Namespace: clusterNS}, secret); err != nil {
+		t.Fatalf("Options secret missing after second reconcile: %v", err)
+	}
+	valuesData := secret.Data[helmvalues.ValuesKey]
+	stagedData := secret.Data[helmvalues.StagedValuesKey]
+	t.Logf("Options secret after second reconcile: values=%d bytes, stagedValues=%d bytes",
+		len(valuesData), len(stagedData))
+	// At this point values are staged, so staged and values should both be non-empty.
+	// The important part of the fix is values must not be cleared by manageOptionsSecret.
+	if len(valuesData) == 0 {
+		t.Fatal("FIX BROKEN: options secret values must not be empty after a transient NotFound")
+	}
+	// Also verify that the values match the original Helm values we set up in the test,
+	// to confirm the secret is intact.
+	var valuesFromSecret map[string]interface{}
+	if err := json.Unmarshal(valuesData, &valuesFromSecret); err != nil {
+		t.Fatalf("Failed to unmarshal values from secret: %v", err)
+	}
+	if diff := cmp.Diff(helmValues, valuesFromSecret); diff != "" {
+		t.Fatalf("Options secret values mismatch (-want +got):\n%s", diff)
+	}
+	if err := json.Unmarshal(stagedData, &valuesFromSecret); err != nil {
+		t.Fatalf("Failed to unmarshal values from secret: %v", err)
+	}
+	if diff := cmp.Diff(helmValues, valuesFromSecret); diff != "" {
+		t.Fatalf("Options secret stagedData mismatch (-want +got):\n%s", diff)
+	}
+
+	// ===================================================================
+	// THIRD RECONCILE: the secret is now readable (bugReader no longer
+	// blocks). Targets() finds the secret, clears WaitingForValues, and
+	// the reconciler proceeds normally.
+	// ===================================================================
+	// Remove the NotFound injection so the third reconcile can read the secret.
+	bugReader.name = ""
+	result, err = r.Reconcile(ctx, req)
+	if err != nil {
+		t.Fatalf("Third Reconcile returned unexpected error: %v", err)
+	}
+
+	bdAfterThird := &fleetv1.BundleDeployment{}
+	if err := fakeClient.Get(ctx, types.NamespacedName{Name: bundleName, Namespace: clusterNS}, bdAfterThird); err != nil {
+		t.Fatalf("Cannot get BD after third reconcile: %v", err)
+	}
+	if bdAfterThird.Spec.WaitingForValues {
+		t.Fatal("FIX BROKEN: WaitingForValues should be cleared once the secret is available again")
+	}
+}
+
+// TestReconcile_WithOptionsSecret_ValuesPreserved is the control test that
+// verifies when the options secret IS available during Targets(), the values
+// are correctly preserved through reconciliation.
+//
+// The reader is the plain fake client, so Targets() finds the secret and
+// calls SetOptions — no race condition occurs.
+func TestReconcile_WithOptionsSecret_ValuesPreserved(t *testing.T) {
+	const (
+		bundleName = "my-bundle"
+		clusterNS  = "cluster-one-ns"
+	)
+
+	helmValues := map[string]interface{}{
+		"replicas": float64(3),
+		"image":    "nginx:latest",
+	}
+	// nil reader → setupBundleRaceTest falls through to fakeClient (secret
+	// is always findable).
+	fakeClient, r, req := setupBundleRaceTest(t, nil, helmValues)
+
+	ctx := context.Background()
+
+	// FIRST RECONCILE: creates BD and options secret.
+	if _, err := r.Reconcile(ctx, req); err != nil {
+		t.Fatalf("First Reconcile returned error: %v", err)
+	}
+
+	if err := fakeClient.Get(ctx, types.NamespacedName{Name: bundleName, Namespace: clusterNS}, &fleetv1.BundleDeployment{}); err != nil {
+		t.Fatalf("BD not created by first reconcile: %v", err)
+	}
+
+	// SECOND RECONCILE: Targets() reads the existing secret, calls
+	// SetOptions, and Options.Helm.Values is restored. Values are preserved.
+	result, err := r.Reconcile(ctx, req)
+	if err != nil {
+		t.Fatalf("Second Reconcile returned error: %v", err)
+	}
+	if result.RequeueAfter > 0 {
+		t.Fatalf("Second Reconcile returned RequeueAfter=%v, indicating a retryable error", result.RequeueAfter)
+	}
+
+	preservedSecret := &corev1.Secret{}
+	if err := fakeClient.Get(ctx, types.NamespacedName{Name: bundleName, Namespace: clusterNS}, preservedSecret); err != nil {
+		t.Fatalf("Options secret not found after second reconcile: %v", err)
+	}
+
+	valuesData := preservedSecret.Data[helmvalues.ValuesKey]
+	stagedData := preservedSecret.Data[helmvalues.StagedValuesKey]
+
+	if len(valuesData) == 0 {
+		t.Fatal("CONTROL FAILED: values should be non-empty when options secret was available in Targets()")
+	}
+	if len(stagedData) == 0 {
+		t.Fatal("CONTROL FAILED: stagedValues should be non-empty")
+	}
+
+	// Also verify that the values match the original Helm values we set up in the test,
+	// to confirm the secret is intact.
+	var valuesFromSecret map[string]interface{}
+	if err := json.Unmarshal(valuesData, &valuesFromSecret); err != nil {
+		t.Fatalf("Failed to unmarshal values from secret: %v", err)
+	}
+	if diff := cmp.Diff(helmValues, valuesFromSecret); diff != "" {
+		t.Fatalf("Options secret values mismatch (-want +got):\n%s", diff)
+	}
+	if err := json.Unmarshal(stagedData, &valuesFromSecret); err != nil {
+		t.Fatalf("Failed to unmarshal values from secret: %v", err)
+	}
+	if diff := cmp.Diff(helmValues, valuesFromSecret); diff != "" {
+		t.Fatalf("Options secret stagedData mismatch (-want +got):\n%s", diff)
+	}
+
+	// Verify SetOptions can fully restore from this secret.
+	testBD := &fleetv1.BundleDeployment{}
+	if err := helmvalues.SetOptions(testBD, preservedSecret.Data); err != nil {
+		t.Fatalf("SetOptions returned error: %v", err)
+	}
+	if testBD.Spec.Options.Helm == nil || testBD.Spec.Options.Helm.Values == nil {
+		t.Fatal("CONTROL FAILED: SetOptions should restore Options.Helm.Values from non-empty data")
+	}
+	if diff := cmp.Diff(helmValues, testBD.Spec.Options.Helm.Values.Data); diff != "" {
+		t.Fatalf("SetOptions restored values mismatch (-want +got):\n%s", diff)
+	}
+	if diff := cmp.Diff(helmValues, testBD.Spec.StagedOptions.Helm.Values.Data); diff != "" {
+		t.Fatalf("SetOptions restored staged options values mismatch (-want +got):\n%s", diff)
 	}
 }

--- a/internal/cmd/controller/target/builder.go
+++ b/internal/cmd/controller/target/builder.go
@@ -46,35 +46,37 @@ func New(client client.Client, reader client.Reader) *Manager {
 // The returned target structs contain merged BundleDeploymentOptions, which
 // includes the "TargetCustomizations" from fleet.yaml.
 // Finally all existing bundledeployments are added to the targets.
-func (m *Manager) Targets(ctx context.Context, bundle *fleet.Bundle, manifestID string) ([]*Target, error) {
+// The returned bool is true when at least one options secret was transiently
+// unavailable; the caller should requeue to retry those BundleDeployments.
+func (m *Manager) Targets(ctx context.Context, bundle *fleet.Bundle, manifestID string) ([]*Target, bool, error) {
 	logger := log.FromContext(ctx).WithName("targets")
 
 	namespaceSelector, err := m.getNamespaceSelectorForBundle(ctx, bundle)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get namespace selector: %w", err)
+		return nil, false, fmt.Errorf("failed to get namespace selector: %w", err)
 	}
 
 	bm, err := matcher.New(bundle)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 
 	namespaces, err := m.getNamespacesForBundle(ctx, bundle)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 	var targets []*Target
 	for _, namespace := range namespaces {
 		clusters := &fleet.ClusterList{}
 		err := m.client.List(ctx, clusters, client.InNamespace(namespace))
 		if err != nil {
-			return nil, err
+			return nil, false, err
 		}
 		for _, cluster := range clusters.Items {
 			logger.V(4).Info("Cluster has namespace?", "cluster", cluster.Name, "namespace", cluster.Status.Namespace)
 			clusterGroups, err := m.clusterGroupsForCluster(ctx, &cluster)
 			if err != nil {
-				return nil, err
+				return nil, false, err
 			}
 
 			target := bm.Match(cluster.Name, ClusterGroupsToLabelMap(clusterGroups), cluster.Labels)
@@ -99,12 +101,12 @@ func (m *Manager) Targets(ctx context.Context, bundle *fleet.Bundle, manifestID 
 
 			err = preprocessHelmValues(logger, &opts, &cluster)
 			if err != nil {
-				return nil, fmt.Errorf("cluster %s in namespace %s: %w", cluster.Name, cluster.Namespace, err)
+				return nil, false, fmt.Errorf("cluster %s in namespace %s: %w", cluster.Name, cluster.Namespace, err)
 			}
 
 			deploymentID, err := options.DeploymentID(manifestID, opts)
 			if err != nil {
-				return nil, err
+				return nil, false, err
 			}
 
 			targets = append(targets, &Target{
@@ -128,9 +130,10 @@ func (m *Manager) Targets(ctx context.Context, bundle *fleet.Bundle, manifestID 
 		fleet.BundleNamespaceLabel: bundle.Namespace,
 	})
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 
+	secretsMissing := false
 	byNamespace := map[string]*fleet.BundleDeployment{}
 	for _, bd := range bundleDeployments.Items {
 		bd := bd.DeepCopy()
@@ -141,29 +144,40 @@ func (m *Manager) Targets(ctx context.Context, bundle *fleet.Bundle, manifestID 
 			secret := &corev1.Secret{}
 			if err := m.reader.Get(ctx, client.ObjectKey{Namespace: bd.Namespace, Name: bd.Name}, secret); err != nil {
 				if apierrors.IsNotFound(err) {
-					logger.V(1).Info("failed to get options secret for bundledeployment %s/%s, this is likely temporary", bd.Namespace, bd.Name)
+					// The options secret is transiently unavailable. Mark the BD so
+					// the controller skips manageOptionsSecret (preventing corruption)
+					// and the agent skips deployment until values are loaded.
+					logger.V(1).Info("Options secret not found for bundledeployment, flagging as WaitingForValues",
+						"bundledeployment", bd.Namespace+"/"+bd.Name)
+					bd.Spec.WaitingForValues = true
+					secretsMissing = true
 					continue
 				}
-				return nil, err
+				return nil, false, err
 			}
 
 			h := helmvalues.HashOptions(secret.Data[helmvalues.ValuesKey], secret.Data[helmvalues.StagedValuesKey])
 			if h != bd.Spec.ValuesHash {
-				return nil, fmt.Errorf("retrying, hash mismatch between secret and bundledeployment: actual %s != expected %s", h, bd.Spec.ValuesHash)
+				return nil, false, fmt.Errorf("retrying, hash mismatch between secret and bundledeployment: actual %s != expected %s", h, bd.Spec.ValuesHash)
 			}
 
 			if err := helmvalues.SetOptions(bd, secret.Data); err != nil {
-				return nil, err
+				return nil, false, err
 			}
-		}
 
+			// Secret found successfully; clear any previous WaitingForValues flag.
+			bd.Spec.WaitingForValues = false
+		} else {
+			// No options secret should be needed, but just in case, clear any previous WaitingForValues flag.
+			bd.Spec.WaitingForValues = false
+		}
 	}
 
 	for _, target := range targets {
 		target.Deployment = byNamespace[target.Cluster.Status.Namespace]
 	}
 
-	return targets, err
+	return targets, secretsMissing, nil
 }
 
 // getNamespacesForBundle returns the namespaces that bundledeployments could

--- a/internal/mocks/reconciler_mock.go
+++ b/internal/mocks/reconciler_mock.go
@@ -44,12 +44,13 @@ func (m *MockTargetBuilder) EXPECT() *MockTargetBuilderMockRecorder {
 }
 
 // Targets mocks base method.
-func (m *MockTargetBuilder) Targets(ctx context.Context, bundle *v1alpha1.Bundle, manifestID string) ([]*target.Target, error) {
+func (m *MockTargetBuilder) Targets(arg0 context.Context, arg1 *v1alpha1.Bundle, arg2 string) ([]*target.Target, bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Targets", ctx, bundle, manifestID)
+	ret := m.ctrl.Call(m, "Targets", arg0, arg1, arg2)
 	ret0, _ := ret[0].([]*target.Target)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret1, _ := ret[1].(bool)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
 // Targets indicates an expected call of Targets.

--- a/pkg/apis/fleet.cattle.io/v1alpha1/bundledeployment_types.go
+++ b/pkg/apis/fleet.cattle.io/v1alpha1/bundledeployment_types.go
@@ -376,6 +376,12 @@ type BundleDeploymentSpec struct {
 	// If true, BundleDeployments will be marked as out of sync
 	// when changes are detected.
 	OffSchedule bool `json:"offSchedule,omitempty"`
+	// WaitingForValues is set to true by the bundle controller when the
+	// options secret for this BundleDeployment could not be found (e.g.
+	// due to transient API server pressure). While true, the agent skips
+	// reconciliation to avoid deploying with missing Helm values. The
+	// controller clears this flag once the secret is successfully loaded.
+	WaitingForValues bool `json:"waitingForValues,omitempty"`
 }
 
 // BundleDeploymentResource contains the metadata of a deployed resource.


### PR DESCRIPTION
During the creation of a BD and its optional secret containing Helm values, under heavy load the API may not be fast enough to serve a newly created secret.

The process in the Bundle controller for the first call to `Reconcile` is as follows:

* The controller calls `Targets`
* `Targets` evaluates the possible matches where the *Bundle* must be deployed
* For each target:

  * `manageOptionsSecret` is called, which creates the secret for the *BundleDeployment*
  * The *BundleDeployment* is created

For the second call (this is where the bug occurred):

* The controller calls `Targets`
* `Targets` evaluates the matches
* `Targets` checks whether the *BundleDeployment* exists and, if so, loads its secret (**THIS IS WHERE THE BUG IS**)
* For each target:

  * `manageOptionsSecret` is called (IF THE BUG HAS OCCURRED, THIS OVERWRITES THE SECRET)
  * The *BundleDeployment* is updated

---

In the `Targets` call we have the following code:

```go
for _, bd := range bundleDeployments.Items {
        bd := bd.DeepCopy()
        byNamespace[bd.Namespace] = bd

        // and set their options
        if bd.Spec.ValuesHash != "" {
            secret := &corev1.Secret{}
            if err := m.reader.Get(ctx, client.ObjectKey{Namespace: bd.Namespace, Name: bd.Name}, secret); err != nil {
                if apierrors.IsNotFound(err) {
                    logger.V(1).Info("failed to get options secret for bundledeployment %s/%s, this is likely temporary", bd.Namespace, bd.Name)
                    continue
                }
                return nil, err
            }
```

Under heavy load, the secret created during the first `Reconcile` call may not yet be available in the database, resulting in an `ErrorNotFound`.

In that case, `continue` is executed, and the *BundleDeployment* has already been added to the `byNamespace` map, so it will still be considered.

However, the Helm values could not be retrieved from the secret, so they remain `nil`.

Later, `manageOptionsSecret` is called, which writes the secret using the data available in the *BundleDeployment* (empty), effectively deleting the original values.

Since this is the second `Reconcile`, `StagedDeploymentID` equals `DeploymentID`, so the values are not updated (although `StagedOptions` are correct).

As a result, the agent reads a secret containing:

* `values=""`
* `stagedValues=EXPECTED_VALUES`

---

In the scalability test, the same Helm chart is deployed multiple times, and the only difference is the value of the deployed *ConfigMap* (whose value is stored in the secret).

Additionally, the secret value is used not only for the data but also for the **name** of the *ConfigMap*.

Therefore:

* The first agent that receives an incorrect secret does not detect the issue and creates the *ConfigMap* using the default value from the Helm chart.
* Subsequent agents that receive the incorrect secret also attempt to create the *ConfigMap* with the default name, which results in an error.

When such an error occurs, the agent has protective logic:

```go
releaseID, err := d.helmdeploy(ctx, logger, bd, force)

    if err != nil {
        // When an error from DeployBundle is returned it causes DeployBundle
        // to requeue and keep trying to deploy on a loop. If there is something
        // wrong with the deployed manifests this will be a loop that re-deploying
        // cannot fix. Here we catch those errors and update the status to note
        // the problem while skipping the constant requeuing.
        if do, newStatus := deployErrToStatus(err, status); do {
            // Setting the release to an empty string removes the previous
            // release name. When a deployment fails the release name is not
            // returned. Keeping the old release name can lead to other functions
            // looking up old data in the history and presenting the wrong status.
            // For example, the deployManager.Deploy function will find the old
            // release and not return an error. It will set everything as if the
            // current one is running properly.
            newStatus.Release = ""
            newStatus.AppliedDeploymentID = bd.Spec.DeploymentID
            return newStatus, nil
        }
        return status, err
    }
```

This sets:

```go
newStatus.Release = ""
```

After that, the drift controller attempts to load the resources of a release but finds `status.Release = ""`, which results in another error.

---

The fix introduces the following changes:

* A new field is added to the *BundleDeployment* spec: `WaitingForValues`. This is set to `true` only if, during the second `Reconcile`, the secret cannot be found.
* If any target has an issue due to a missing secret, this is recorded. In that case:

  * The function that writes the secret is not called (to avoid overwriting it).
  * A new `Reconcile` is requeued.
* The agent checks `WaitingForValues=true` and ignores the *BundleDeployment*.

---

This avoids two problems:

For example, if encountering a missing secret caused an immediate error and triggered a `Reconcile`, and we were reconciling 3000 BDs where the failing one is number 2700, we would need to repeat reconciliation for the 2700 BDs that were already correct.

Another option considered was simply not adding the *BundleDeployment* to the `byNamespace` map (which had previously been done).

However, since this does not occur during the first `Reconcile`, the agent may have already deployed a release. If we exclude the BD from `byNamespace`, the *BundleDeployment* would be removed, causing the agent to uninstall the release.

On the next `Reconcile`, the secret might already be available, causing the agent to install it again.

To avoid these uninstall/install cycles, the additional field was introduced so that the *BundleDeployment* is simply ignored while the secret is not yet available.

Refers to: https://github.com/rancher/fleet/issues/4599

<!-- Specify the issue ID that this pull request is solving -->

<!-- Make sure that the referenced issue provides steps to reproduce it -->

<!-- Describe the changes introduced by this pull request -->

<!--
  Please provide a unit, integration (`./integrationtests/`) or e2e (`./e2e/`) test if possible.
-->

## Additional Information

### Checklist

~- [ ] <!-- If applicable,--> I have updated the documentation via a pull request in the
[fleet-docs](https://github.com/rancher/fleet-docs) repository.~
