### PR TITLE
Fix bundlediff --fleet-yaml for empty object patches

### DIFF
--- a/integrationtests/cli/bundlediff/bundlediff_test.go
+++ b/integrationtests/cli/bundlediff/bundlediff_test.go
@@ -110,6 +110,33 @@ var _ = Describe("Fleet bundlediff", func() {
 			Expect(output.BundleDeploymentDiffs[0].ModifiedResources).To(HaveLen(1))
 			Expect(output.BundleDeploymentDiffs[0].ModifiedResources[0].Name).To(Equal("my-service"))
 		})
+
+		It("should display empty object patches in text format", func() {
+			// Test that patches with empty objects like {"data":{}} display properly in text format
+			bd := &fleet.BundleDeployment{}
+			Expect(k8sClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: bundleDeploymentName}, bd)).ToNot(HaveOccurred())
+
+			bd.Status.ModifiedStatus = []fleet.ModifiedStatus{
+				{
+					Kind:       "ConfigMap",
+					APIVersion: "v1",
+					Namespace:  "nginx",
+					Name:       "simple-config",
+					Patch:      `{"data":{}}`,
+				},
+			}
+			Expect(k8sClient.Status().Update(ctx, bd)).ToNot(HaveOccurred())
+
+			buf, _, err := act([]string{"--bundle-deployment", bundleDeploymentName}, namespace)
+			Expect(err).NotTo(HaveOccurred())
+
+			output := string(buf.Contents())
+			Expect(output).To(ContainSubstring("ConfigMap.v1 nginx/simple-config"))
+			Expect(output).To(ContainSubstring("Status: Modified"))
+			// The patch should be formatted and displayed
+			Expect(output).To(ContainSubstring(`"data"`))
+			Expect(output).To(ContainSubstring(`{}`))
+		})
 	})
 
 	When("a BundleDeployment has missing resources", func() {
@@ -1006,6 +1033,34 @@ var _ = Describe("Fleet bundlediff", func() {
 			output := string(buf.Contents())
 			// The path should have '/' escaped as '~1': /metadata/annotations/kubectl.kubernetes.io~1lastAppliedConfiguration
 			Expect(output).To(ContainSubstring("kubectl.kubernetes.io~1lastAppliedConfiguration"))
+		})
+
+		It("should generate remove op for empty object patch (e.g. ConfigMap data cleared to {})", func() {
+			// Reproduces the case where a ConfigMap's data field is deleted in the cluster,
+			// resulting in a patch of {"data":{}}.
+			// The --fleet-yaml output was previously empty because convertMergePatchToRemoveOps
+			// recursed into the empty map and produced no operations.
+			bd := &fleet.BundleDeployment{}
+			Expect(k8sClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: bundleDeploymentName}, bd)).ToNot(HaveOccurred())
+
+			bd.Status.ModifiedStatus = []fleet.ModifiedStatus{
+				{
+					Kind:       "ConfigMap",
+					APIVersion: "v1",
+					Namespace:  "nginx",
+					Name:       "simple-config",
+					Patch:      `{"data":{}}`,
+				},
+			}
+			Expect(k8sClient.Status().Update(ctx, bd)).ToNot(HaveOccurred())
+
+			buf, _, err := act([]string{"--bundle-deployment", bundleDeploymentName, "--fleet-yaml"}, namespace)
+			Expect(err).NotTo(HaveOccurred())
+
+			expected, err := os.ReadFile(filepath.Join("testdata", "fleet-yaml-empty-data.yaml"))
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(strings.TrimSpace(string(buf.Contents()))).To(Equal(strings.TrimSpace(string(expected))))
 		})
 
 		It("should require --bundle-deployment when using --fleet-yaml", func() {

--- a/integrationtests/cli/bundlediff/testdata/fleet-yaml-empty-data.yaml
+++ b/integrationtests/cli/bundlediff/testdata/fleet-yaml-empty-data.yaml
@@ -1,0 +1,9 @@
+diff:
+  comparePatches:
+  - apiVersion: v1
+    kind: ConfigMap
+    name: simple-config
+    namespace: nginx
+    operations:
+    - op: remove
+      path: /data

--- a/internal/cmd/cli/bundlediff.go
+++ b/internal/cmd/cli/bundlediff.go
@@ -223,7 +223,17 @@ func convertMergePatchToRemoveOps(patch map[string]interface{}, basePath string)
 		path := basePath + "/" + escapedKey
 
 		if nested, ok := value.(map[string]interface{}); ok {
-			ops = append(ops, convertMergePatchToRemoveOps(nested, path)...)
+			if len(nested) == 0 {
+				// An empty object {} means the entire field was cleared/emptied.
+				// Generate a remove operation for the field itself rather than
+				// recursing into an empty map that would produce nothing.
+				ops = append(ops, patchOperation{
+					Op:   "remove",
+					Path: path,
+				})
+			} else {
+				ops = append(ops, convertMergePatchToRemoveOps(nested, path)...)
+			}
 		} else {
 			// Both null and non-null values should generate remove operations
 			// Remove = "ignore this field in drift detection"

--- a/internal/cmd/cli/bundlediff_test.go
+++ b/internal/cmd/cli/bundlediff_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -59,5 +60,71 @@ func TestMergeComparePatches(t *testing.T) {
 
 	if diff := cmp.Diff(expected, merged); diff != "" {
 		t.Errorf("mergeComparePatches() mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestConvertMergePatchToRemoveOps(t *testing.T) {
+	tests := []struct {
+		name     string
+		patch    string
+		basePath string
+		want     []patchOperation
+	}{
+		{
+			name:     "null leaf generates remove",
+			patch:    `{"data":null}`,
+			basePath: "",
+			want: []patchOperation{
+				{Op: "remove", Path: "/data"},
+			},
+		},
+		{
+			name:     "non-null leaf generates remove",
+			patch:    `{"data":{"key":"value"}}`,
+			basePath: "",
+			want: []patchOperation{
+				{Op: "remove", Path: "/data/key"},
+			},
+		},
+		{
+			name:     "empty object generates remove for parent path",
+			patch:    `{"data":{}}`,
+			basePath: "",
+			want: []patchOperation{
+				{Op: "remove", Path: "/data"},
+			},
+		},
+		{
+			name:     "nested empty object generates remove for its path",
+			patch:    `{"spec":{"template":{"metadata":{}}}}`,
+			basePath: "",
+			want: []patchOperation{
+				{Op: "remove", Path: "/spec/template/metadata"},
+			},
+		},
+		{
+			name:     "mixed null and empty object",
+			patch:    `{"data":{},"metadata":null}`,
+			basePath: "",
+			want: []patchOperation{
+				{Op: "remove", Path: "/data"},
+				{Op: "remove", Path: "/metadata"},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var mergePatch map[string]interface{}
+			if err := json.Unmarshal([]byte(tc.patch), &mergePatch); err != nil {
+				t.Fatalf("failed to parse patch: %v", err)
+			}
+
+			got := convertMergePatchToRemoveOps(mergePatch, tc.basePath)
+
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("convertMergePatchToRemoveOps() mismatch (-want +got):\n%s", diff)
+			}
+		})
 	}
 }


### PR DESCRIPTION
An empty merge patch like {"data":{}} was not generating any remove operations when converting to fleet.yaml comparePatches. The function recursed into the empty map and produced nothing, leaving --fleet-yaml output empty while --json correctly showed the drift.

Now empty nested objects immediately generate a remove operation for the field's path instead of recursing to nothing.

Includes unit tests covering null leafs, non-null leafs, empty objects, and nested empty objects. Integration tests verify all three output formats (text, JSON, fleet-yaml) properly handle empty object patches. The text format displays the patch as formatted JSON, JSON format shows it as-is, and fleet-yaml converts it to a remove operation.

Refers to #4534