### PR TITLE
Add unit tests for overwritten resources detection

### DIFF
--- a/internal/cmd/cli/apply/apply_test.go
+++ b/internal/cmd/cli/apply/apply_test.go
@@ -82,7 +82,7 @@ data:
 			}
 
 			if or != tc.expectedOutput {
-				t.Fatalf("expected OverwrittenResource\n\t%v,got\n\t%v", tc.expectedOutput, or)
+				t.Fatalf("expected OverwrittenResource\n\t%v, got\n\t%v", tc.expectedOutput, or)
 			}
 		})
 	}


### PR DESCRIPTION
Templated resource names and namespaces are less likely than templated contents, but those cases are now covered through unit tests.
