### PR TITLE
[v0.14] Avoid uninstalling releases in PendingInstall status (#4647) 

### DIFF
--- a/integrationtests/cli/deploy/deploy_test.go
+++ b/integrationtests/cli/deploy/deploy_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 
 	"github.com/onsi/gomega/gbytes"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	clihelper "github.com/rancher/fleet/integrationtests/cli"
 	"github.com/rancher/fleet/integrationtests/utils"
@@ -15,6 +16,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -154,55 +156,132 @@ var _ = Describe("Fleet CLI Deploy", func() {
 
 	When("deploying on top of a release in `pending-install` status", func() {
 		BeforeEach(func() {
-			release := map[string]interface{}{
-				"name": "testbundle-simple-chart",
-				"info": map[string]string{
-					"status": "pending-install",
+			// Create release v1 (deployed)
+			releaseV1 := map[string]interface{}{
+				"name":      "testbundle-simple-chart",
+				"version":   1,
+				"namespace": namespace,
+				"info": map[string]interface{}{
+					"status": "deployed",
 				},
-				// Other release fields (e.g. chart, manifests) omitted for simplicity, not needed to
-				// check for a `pending-install` release.
+				"chart": map[string]interface{}{
+					"metadata": map[string]interface{}{
+						"name":    "testbundle-simple-chart",
+						"version": "0.1.0",
+					},
+				},
+				"config":   map[string]interface{}{},
+				"manifest": "",
+				"labels":   map[string]string{},
 			}
-			releaseJSON, err := json.Marshal(release)
+			releaseV1JSON, err := json.Marshal(releaseV1)
 			Expect(err).ToNot(HaveOccurred())
 
-			var gzBuf bytes.Buffer
-			gzWriter := gzip.NewWriter(&gzBuf)
-			_, err = gzWriter.Write(releaseJSON)
+			var gzBufV1 bytes.Buffer
+			gzWriterV1 := gzip.NewWriter(&gzBufV1)
+			_, err = gzWriterV1.Write(releaseV1JSON)
 			Expect(err).ToNot(HaveOccurred())
+			Expect(gzWriterV1.Close()).ToNot(HaveOccurred())
 
-			Expect(gzWriter.Close()).ToNot(HaveOccurred())
+			relV1 := make([]byte, base64.StdEncoding.EncodedLen(gzBufV1.Len()))
+			base64.StdEncoding.Encode(relV1, gzBufV1.Bytes())
 
-			rel := make([]byte, base64.StdEncoding.EncodedLen(gzBuf.Len()))
-			base64.StdEncoding.Encode(rel, gzBuf.Bytes())
-
-			releaseSecret := corev1.Secret{
+			releaseSecretV1 := corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "sh.helm.release.v1.testbundle-simple-chart.v1",
-					Namespace: "default",
+					Namespace: namespace,
 					Labels: map[string]string{
 						"name":    "testbundle-simple-chart",
 						"owner":   "helm",
-						"status":  "pending-install",
+						"status":  "deployed",
 						"version": "1",
 					},
 				},
 				Type: "helm.sh/release.v1",
-				Data: map[string][]byte{"release": rel},
+				Data: map[string][]byte{"release": relV1},
 			}
-			// Fleet creates release secrets into the default namespace, therefore a cleanup is needed here
-			// to prevent conflicts with other test cases.
-			_ = k8sClient.Delete(ctx, &releaseSecret)
-			Expect(k8sClient.Create(ctx, &releaseSecret)).ToNot(HaveOccurred())
+
+			// Create release v2 (pending-install)
+			releaseV2 := map[string]interface{}{
+				"name":      "testbundle-simple-chart",
+				"version":   2,
+				"namespace": namespace,
+				"info": map[string]interface{}{
+					"status": "pending-install",
+				},
+				"chart": map[string]interface{}{
+					"metadata": map[string]interface{}{
+						"name":    "testbundle-simple-chart",
+						"version": "0.1.0",
+					},
+				},
+				"config":   map[string]interface{}{},
+				"manifest": "",
+				"labels":   map[string]string{},
+			}
+			releaseV2JSON, err := json.Marshal(releaseV2)
+			Expect(err).ToNot(HaveOccurred())
+
+			var gzBufV2 bytes.Buffer
+			gzWriterV2 := gzip.NewWriter(&gzBufV2)
+			_, err = gzWriterV2.Write(releaseV2JSON)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(gzWriterV2.Close()).ToNot(HaveOccurred())
+
+			relV2 := make([]byte, base64.StdEncoding.EncodedLen(gzBufV2.Len()))
+			base64.StdEncoding.Encode(relV2, gzBufV2.Bytes())
+
+			releaseSecretV2 := corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "sh.helm.release.v1.testbundle-simple-chart.v2",
+					Namespace: namespace,
+					Labels: map[string]string{
+						"name":    "testbundle-simple-chart",
+						"owner":   "helm",
+						"status":  "pending-install",
+						"version": "2",
+					},
+				},
+				Type: "helm.sh/release.v1",
+				Data: map[string][]byte{"release": relV2},
+			}
+
+			Expect(k8sClient.Create(ctx, &releaseSecretV1)).ToNot(HaveOccurred())
+			Expect(k8sClient.Create(ctx, &releaseSecretV2)).ToNot(HaveOccurred())
+
+			// check that the secret was created using List with a label selector
+			// that uses owner=helm and name=testbundle-simple-chart
+			Eventually(func(g Gomega) {
+				secrets := &corev1.SecretList{}
+				err := k8sClient.List(ctx, secrets, &client.ListOptions{
+					Namespace: namespace,
+					LabelSelector: labels.SelectorFromSet(map[string]string{
+						"name":  "testbundle-simple-chart",
+						"owner": "helm",
+					}),
+				})
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(len(secrets.Items)).To(BeNumerically(">=", 2))
+			}, "5s", "500ms").Should(Succeed())
+
 			args = []string{
 				"--input-file", clihelper.AssetsPath + "bundledeployment/bd.yaml",
 				"--namespace", namespace,
 			}
+
 			DeferCleanup(func() {
-				Expect(k8sClient.Delete(ctx, &releaseSecret)).ToNot(HaveOccurred())
+				err := k8sClient.Delete(ctx, &releaseSecretV1)
+				if err != nil && !apierrors.IsNotFound(err) {
+					Expect(err).ToNot(HaveOccurred())
+				}
+				err = k8sClient.Delete(ctx, &releaseSecretV2)
+				if err != nil && !apierrors.IsNotFound(err) {
+					Expect(err).ToNot(HaveOccurred())
+				}
 			})
 		})
 
-		It("installs the release successfully", func() {
+		It("upgrades an orphaned pending-install release while preserving history", func() {
 			buf, err := act(args)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -214,6 +293,183 @@ var _ = Describe("Fleet CLI Deploy", func() {
 			cm := &corev1.ConfigMap{}
 			err = k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "test-simple-chart-config"}, cm)
 			Expect(err).NotTo(HaveOccurred())
+
+			By("verifying the release was upgraded (not deleted and reinstalled)")
+			secrets := &corev1.SecretList{}
+			err = k8sClient.List(ctx, secrets, &client.ListOptions{
+				Namespace: namespace,
+				LabelSelector: labels.SelectorFromSet(map[string]string{
+					"name":  "testbundle-simple-chart",
+					"owner": "helm",
+				}),
+			})
+			Expect(err).NotTo(HaveOccurred())
+			// Should have v1 (original pending-install) + v2 (successful upgrade)
+			Expect(len(secrets.Items)).To(BeNumerically(">=", 2))
+
+			// Verify the latest release is deployed
+			var latestVersion int
+			for _, secret := range secrets.Items {
+				if secret.Labels["status"] == "deployed" {
+					latestVersion++
+				}
+			}
+			Expect(latestVersion).To(Equal(1), "should have exactly one deployed release")
+		})
+	})
+
+	When("deploying on top of a release in `pending-install` status with no previous version", func() {
+		BeforeEach(func() {
+			// Create ONLY release v1 (pending-install) - no v0 deployed version exists
+			// This simulates a failed initial install or lost history scenario
+			releaseV1 := map[string]interface{}{
+				"name":      "testbundle-simple-chart",
+				"version":   1,
+				"namespace": namespace,
+				"info": map[string]interface{}{
+					"status": "pending-install",
+				},
+				"chart": map[string]interface{}{
+					"metadata": map[string]interface{}{
+						"name":    "testbundle-simple-chart",
+						"version": "0.1.0",
+					},
+				},
+				"config":   map[string]interface{}{},
+				"manifest": "",
+				"labels":   map[string]string{},
+			}
+			releaseV1JSON, err := json.Marshal(releaseV1)
+			Expect(err).ToNot(HaveOccurred())
+
+			var gzBufV1 bytes.Buffer
+			gzWriterV1 := gzip.NewWriter(&gzBufV1)
+			_, err = gzWriterV1.Write(releaseV1JSON)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(gzWriterV1.Close()).ToNot(HaveOccurred())
+
+			relV1 := make([]byte, base64.StdEncoding.EncodedLen(gzBufV1.Len()))
+			base64.StdEncoding.Encode(relV1, gzBufV1.Bytes())
+
+			releaseSecretV1 := corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "sh.helm.release.v1.testbundle-simple-chart.v1",
+					Namespace: namespace,
+					Labels: map[string]string{
+						"name":    "testbundle-simple-chart",
+						"owner":   "helm",
+						"status":  "pending-install",
+						"version": "1",
+					},
+				},
+				Type: "helm.sh/release.v1",
+				Data: map[string][]byte{"release": relV1},
+			}
+
+			// Clean up any existing secrets from previous tests to prevent conflicts
+			// Previous tests might have created multiple versions (v1, v2, v3, etc.)
+			secrets := &corev1.SecretList{}
+			err = k8sClient.List(ctx, secrets, &client.ListOptions{
+				Namespace: namespace,
+				LabelSelector: labels.SelectorFromSet(map[string]string{
+					"name":  "testbundle-simple-chart",
+					"owner": "helm",
+				}),
+			})
+			Expect(err).ToNot(HaveOccurred())
+			for _, secret := range secrets.Items {
+				_ = k8sClient.Delete(ctx, &secret)
+			}
+
+			// Wait for all secrets to be deleted before creating the new one
+			Eventually(func(g Gomega) {
+				secrets := &corev1.SecretList{}
+				err := k8sClient.List(ctx, secrets, &client.ListOptions{
+					Namespace: namespace,
+					LabelSelector: labels.SelectorFromSet(map[string]string{
+						"name":  "testbundle-simple-chart",
+						"owner": "helm",
+					}),
+				})
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(secrets.Items).To(BeEmpty())
+			}, "5s", "500ms").Should(Succeed())
+
+			// Create only the pending-install secret
+			Expect(k8sClient.Create(ctx, &releaseSecretV1)).ToNot(HaveOccurred())
+
+			// Verify the secret was created
+			Eventually(func(g Gomega) {
+				secrets := &corev1.SecretList{}
+				err := k8sClient.List(ctx, secrets, &client.ListOptions{
+					Namespace: namespace,
+					LabelSelector: labels.SelectorFromSet(map[string]string{
+						"name":  "testbundle-simple-chart",
+						"owner": "helm",
+					}),
+				})
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(secrets.Items).To(HaveLen(1))
+			}, "5s", "500ms").Should(Succeed())
+
+			args = []string{
+				"--input-file", clihelper.AssetsPath + "bundledeployment/bd.yaml",
+				"--namespace", namespace,
+			}
+
+			DeferCleanup(func() {
+				// Clean up all helm release secrets created during this test
+				secrets := &corev1.SecretList{}
+				err := k8sClient.List(ctx, secrets, &client.ListOptions{
+					Namespace: namespace,
+					LabelSelector: labels.SelectorFromSet(map[string]string{
+						"name":  "testbundle-simple-chart",
+						"owner": "helm",
+					}),
+				})
+				if err != nil && !apierrors.IsNotFound(err) {
+					Expect(err).ToNot(HaveOccurred())
+				}
+				for _, secret := range secrets.Items {
+					_ = k8sClient.Delete(ctx, &secret)
+				}
+			})
+		})
+
+		It("upgrades an orphaned pending-install release while preserving history", func() {
+			buf, err := act(args)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("creating resources")
+			Expect(buf).To(gbytes.Say("- apiVersion: v1"))
+			Expect(buf).To(gbytes.Say("  data:"))
+			Expect(buf).To(gbytes.Say("    name: example-value"))
+
+			cm := &corev1.ConfigMap{}
+			err = k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "test-simple-chart-config"}, cm)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("verifying the release was upgraded (not deleted and reinstalled)")
+			secrets := &corev1.SecretList{}
+			err = k8sClient.List(ctx, secrets, &client.ListOptions{
+				Namespace: namespace,
+				LabelSelector: labels.SelectorFromSet(map[string]string{
+					"name":  "testbundle-simple-chart",
+					"owner": "helm",
+				}),
+			})
+			Expect(err).NotTo(HaveOccurred())
+			// Should have v1 (original pending-install) + v2 (successful upgrade)
+			Expect(len(secrets.Items)).To(BeNumerically(">=", 2))
+
+			// Verify the latest release is deployed
+			var latestVersion int
+			for _, secret := range secrets.Items {
+				if secret.Labels["status"] == "deployed" {
+					latestVersion++
+				}
+			}
+			Expect(latestVersion).To(Equal(1), "should have exactly one deployed release")
 		})
 	})
 

--- a/internal/helmdeployer/install.go
+++ b/internal/helmdeployer/install.go
@@ -3,6 +3,7 @@ package helmdeployer
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -11,6 +12,8 @@ import (
 	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/chart/loader"
 	"helm.sh/helm/v3/pkg/release"
+	"helm.sh/helm/v3/pkg/storage"
+	"helm.sh/helm/v3/pkg/storage/driver"
 
 	"github.com/rancher/fleet/internal/experimental"
 	"github.com/rancher/fleet/internal/helmdeployer/render"
@@ -153,6 +156,12 @@ func (h *Helm) install(ctx context.Context, bundleID string, manifest *manifest.
 		return u.Run(chart, values)
 	}
 
+	// Before running upgrade, check if we're upgrading from a pending-install with no previous version.
+	// In this case, ensure any orphaned pending-install release is marked as failed so the upgrade can proceed cleanly.
+	if err := h.ensureForceOnOrphanedPendingInstall(ctx, &cfg, releaseName); err != nil {
+		return nil, err
+	}
+
 	u := action.NewUpgrade(&cfg)
 	u.TakeOwnership = true
 	u.EnableDNS = !options.Helm.DisableDNS
@@ -181,6 +190,29 @@ func (h *Helm) install(ctx context.Context, bundleID string, manifest *manifest.
 	}
 	rel, err := u.Run(releaseName, chart, values)
 	if err != nil && err.Error() == HelmUpgradeInterruptedError {
+		// Check if there's a previous version to rollback to
+		lastRelease, err := cfg.Releases.Last(releaseName)
+		if err != nil {
+			return nil, fmt.Errorf("cannot get last release for rollback: %w", err)
+		}
+
+		// Check if this is an orphaned release and patch if needed
+		patched, err := handleOrphanedRelease(ctx, &cfg, lastRelease, releaseName)
+		if err != nil {
+			return nil, err
+		}
+
+		if patched {
+			// Retry the upgrade after patching status
+			logger.Info("Retrying upgrade after patching release to failed")
+			rel, err := u.Run(releaseName, chart, values)
+			if err != nil {
+				return nil, fmt.Errorf("upgrade failed after patching release status: %w", err)
+			}
+			return rel, nil
+		}
+
+		// Previous version exists, proceed with rollback
 		logger.Info("Helm doing a rollback", "error", HelmUpgradeInterruptedError)
 		r := action.NewRollback(&cfg)
 		err = r.Run(releaseName)
@@ -200,15 +232,91 @@ func (h *Helm) mustUninstall(cfg *action.Configuration, releaseName string) (boo
 	if err != nil {
 		return false, nil
 	}
-	return r.Info.Status == release.StatusUninstalling || r.Info.Status == release.StatusPendingInstall, err
+	return r.Info.Status == release.StatusUninstalling, nil
 }
 
 func (h *Helm) mustInstall(cfg *action.Configuration, releaseName string) (bool, error) {
 	_, err := cfg.Releases.Deployed(releaseName)
 	if err != nil && strings.Contains(err.Error(), "has no deployed releases") {
+		_, err := cfg.Releases.Last(releaseName)
+		if err == nil {
+			// There is a release, but not deployed (e.g., failed install/upgrade)
+			return false, nil
+		}
 		return true, nil
 	}
 	return false, err
+}
+
+// ensureForceOnOrphanedPendingInstall checks if we're about to upgrade from a pending-install
+// release that has no previous version. This handles the case where:
+// 1. A release is stuck in pending-install status
+// 2. No previous successful version exists (lost history or initial install failure)
+// 3. Normal upgrade will fail with "another operation is in progress"
+// In this scenario, we patch the release status to "failed" to allow the upgrade to proceed.
+// This avoids an unnecessary upgrade attempt that would fail and require a retry.
+func (h *Helm) ensureForceOnOrphanedPendingInstall(ctx context.Context, cfg *action.Configuration, releaseName string) error {
+	// Get the last release to check its status
+	lastRelease, err := cfg.Releases.Last(releaseName)
+	if err != nil {
+		// If we can't get the last release, proceed normally
+		if errors.Is(err, driver.ErrReleaseNotFound) {
+			return nil
+		}
+		return err
+	}
+
+	// Only handle pending-install status
+	if lastRelease.Info.Status != release.StatusPendingInstall {
+		return nil
+	}
+
+	// Check if a previous version exists and patch if needed
+	_, err = handleOrphanedRelease(ctx, cfg, lastRelease, releaseName)
+	return err
+}
+
+// handleOrphanedRelease checks if a release has no valid previous version to rollback to
+// and patches its status to failed if needed. This handles cases where a release is stuck
+// in a transient state (like pending-install) but has no previous version to rollback to.
+// Returns true if the release was patched, false otherwise.
+func handleOrphanedRelease(ctx context.Context, cfg *action.Configuration, lastRelease *release.Release, releaseName string) (bool, error) {
+	logger := log.FromContext(ctx)
+
+	// Check if a previous version exists
+	previousVersion := lastRelease.Version - 1
+	if previousVersion < 1 {
+		// Version 1 with no v0 - patch status to failed
+		logger.Info("No previous version exists, patching release to failed",
+			"releaseName", releaseName,
+			"currentVersion", lastRelease.Version)
+
+		if err := patchReleaseStatus(cfg.Releases, lastRelease, release.StatusFailed); err != nil {
+			return false, fmt.Errorf("failed to patch release status: %w", err)
+		}
+		return true, nil
+	}
+
+	// Try to get the previous version
+	_, err := cfg.Releases.Get(releaseName, previousVersion)
+	if err != nil {
+		if errors.Is(err, driver.ErrReleaseNotFound) {
+			// Previous version doesn't exist - patch status to failed
+			logger.Info("Previous version missing, patching release to failed",
+				"releaseName", releaseName,
+				"currentVersion", lastRelease.Version,
+				"missingVersion", previousVersion)
+
+			if err := patchReleaseStatus(cfg.Releases, lastRelease, release.StatusFailed); err != nil {
+				return false, fmt.Errorf("failed to patch release status: %w", err)
+			}
+			return true, nil
+		}
+		return false, err
+	}
+
+	// Previous version exists, no patching needed
+	return false, nil
 }
 
 func (h *Helm) getValues(ctx context.Context, options fleet.BundleDeploymentOptions, defaultNamespace string) (map[string]interface{}, error) {
@@ -391,4 +499,15 @@ func getDryRunConfig(chart *chart.Chart, dryRun bool) dryRunConfig {
 	}
 
 	return cfg
+}
+
+// patchReleaseStatus updates the status of a release in storage.
+// This is useful for transitioning releases from transient states like "pending-install"
+// to terminal states like "failed" to allow operations to proceed.
+func patchReleaseStatus(store *storage.Storage, rel *release.Release, newStatus release.Status) error {
+	// Update the release status
+	rel.Info.Status = newStatus
+
+	// Update the release in storage
+	return store.Update(rel)
 }


### PR DESCRIPTION
Re-adding  https://github.com/rancher/fleet/pull/4600 as QA tested an image that included this plus a fix that will come next and it passed:
https://github.com/rancher/fleet/issues/4673#issuecomment-3973090057



This PR prevents Fleet from uninstalling a release that is in **PendingInstall** status, opting instead to attempt an **Upgrade**.

The following approach is taken:

* If a valid previous version is found, an **Upgrade** is attempted (which would trigger a rollback followed by an upgrade).
* If no valid previous version is found, the current release is patched to mark it as **failed**, and then an **Upgrade** is performed.

This avoids uninstalling any resources in cases where a previous release may have ended up in a stuck state.

Refers to: https://github.com/rancher/fleet/issues/4637
Backport of: https://github.com/rancher/fleet/pull/4600

<!-- Specify the issue ID that this pull request is solving -->
<!-- Make sure that the referenced issue provides steps to reproduce it -->

<!-- Describe the changes introduced by this pull request -->

<!--
  Please provide a unit, integration (`./integrationtests/`) or e2e (`./e2e/`) test if possible.
-->

## Additional Information

### Checklist

~- [ ] <!-- If applicable,--> I have updated the documentation via a pull request in the
[fleet-docs](https://github.com/rancher/fleet-docs) repository.~
