### PR TITLE
Fix integrationtests on distros with specific umask

### DIFF
--- a/integrationtests/gitcloner/clone_test.go
+++ b/integrationtests/gitcloner/clone_test.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -354,6 +355,16 @@ func createGogsContainerWithHTTPS() (testcontainers.Container, error) {
 	err := cp.Copy("assets/gitserver", tmpDir)
 	if err != nil {
 		return nil, err
+	}
+	// The .ssh directory may end up group-writable depending on the system
+	// umask, which causes OpenSSH StrictModes to reject authorized_keys.
+	err = os.Chmod(filepath.Join(tmpDir, "git"), 0700)
+	if err != nil {
+		return nil, fmt.Errorf("failed to change permissions for .ssh directory: %w", err)
+	}
+	err = os.Chmod(filepath.Join(tmpDir, "git", ".ssh"), 0700)
+	if err != nil {
+		return nil, fmt.Errorf("failed to change permissions for .ssh directory: %w", err)
 	}
 	req := testcontainers.ContainerRequest{
 		Image:        "gogs/gogs:0.13",


### PR DESCRIPTION
Git only stores executable bits of file permissions. On a system with a different `umask`, checking out the repository can lead to directories having permissions `0775`. The `.ssh` directory, for SSH strict mode, at least requires `0755` (recommended to be `0700`).

<!-- Specify the issue ID that this pull request is solving -->
Refers to no issue.
<!-- Make sure that the referenced issue provides steps to reproduce it -->

<!-- Describe the changes introduced by this pull request -->

<!--
  Please provide a unit, integration (`./integrationtests/`) or e2e (`./e2e/`) test if possible.
-->

## Additional Information

### Checklist

- [ ] <!-- If applicable,--> I have updated the documentation via a pull request in the
[fleet-docs](https://github.com/rancher/fleet-docs) repository.
