### PR TITLE
Pin base image platform in Dockerfiles

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,8 +1,9 @@
 ARG BUILD_ENV=docker
 ARG TARGETPLATFORM
-ARG ARCH
+ARG TARGETARCH
+ARG ARCH=${TARGETARCH}
 
-FROM registry.suse.com/bci/bci-base:15.7 AS base
+FROM --platform=linux/${ARCH} registry.suse.com/bci/bci-base:15.7 AS base
 COPY package/log.sh /usr/bin/
 RUN zypper rm -y container-suseconnect && \
     zypper ar --priority=500 https://download.opensuse.org/repositories/Virtualization:containers/5.5/Virtualization:containers.repo && \

--- a/package/Dockerfile.agent
+++ b/package/Dockerfile.agent
@@ -1,8 +1,9 @@
 ARG BUILD_ENV=docker
 ARG TARGETPLATFORM
-ARG ARCH
+ARG TARGETARCH
+ARG ARCH=${TARGETARCH}
 
-FROM registry.suse.com/bci/bci-busybox:15.7 AS base
+FROM --platform=linux/${ARCH} registry.suse.com/bci/bci-busybox:15.7 AS base
 
 FROM base AS copy_docker
 ONBUILD ARG ARCH


### PR DESCRIPTION
Without an explicit `--platform` on the `FROM` line, the builder may pull a base image for the host architecture rather than the target. When cross-building (e.g. `amd64` host building an `arm64` image), this causes the binary copied into the image to be mismatched with the base OS ABI.

Use `${TARGETPLATFORM:-linux/$ARCH}` so that:
- `docker build --build-arg ARCH=amd64` (dev/CI docker mode) pins to the `ARCH` argument as before.
- `docker buildx --platform linux/arm64` (buildx mode) uses the `TARGETPLATFORM` variable that buildx injects automatically.
- `goreleaser` `dockers_v2` (which always sets `TARGETPLATFORM` via buildx) continues to work unchanged.