### PR TITLE
[v0.14] Disable Go workspace mode in goreleaser

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -5,6 +5,7 @@ project_name: fleet
 
 env:
   - CGO_ENABLED=0
+  - GOWORK=off
   - IS_HOTFIX={{ if isEnvSet "IS_HOTFIX"}}{{ .Env.IS_HOTFIX }}{{else}}false{{end}}
 
 release:


### PR DESCRIPTION
`go mod download` in workspace mode resolves the union of all workspace
modules' dependencies. The `integrationtests` module depends on
`k8s.io/kubernetes`, whose `go.mod` lists internal staging packages (e.g.
`k8s.io/kubelet`, `k8s.io/cloud-provider`) at `v0.0.0` — versions that are
never published as standalone modules, causing the download hook to fail.

- Add `GOWORK=off` to the goreleaser `env` block so all goreleaser operations
  run against the root module only. The existing `replace` directive for
  `pkg/apis` handles local cross-module resolution without workspace mode.