### PR TITLE
[v0.11] Disable Go workspace mode in goreleaser

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -5,6 +5,7 @@ project_name: fleet
 
 env:
   - CGO_ENABLED=0
+  - GOWORK=off
   - IS_HOTFIX={{ if isEnvSet "IS_HOTFIX"}}{{ .Env.IS_HOTFIX }}{{else}}false{{end}}
   - REGISTRY={{ if isEnvSet "REGISTRY" }}{{ .Env.REGISTRY }}{{else}}docker.io{{end}}
 


### PR DESCRIPTION
Add `GOWORK=off` to the goreleaser `env` block so all goreleaser operations  run against the root module only. The existing `replace` directive for  `pkg/apis` handles local cross-module resolution without workspace mode.