### PR TITLE
Add workflow to retry failed PR jobs once

### DIFF
--- a/.github/workflows/retry-failed-jobs.yml
+++ b/.github/workflows/retry-failed-jobs.yml
@@ -1,0 +1,32 @@
+name: Retry failed PR jobs once
+
+on:
+  workflow_run:
+    workflows:
+      - "CI"
+      - "E2E Fleet"
+      - "E2E Upgrade Fleet Standalone to HEAD"
+      - "E2E Multi-Cluster Fleet"
+    types: [completed]
+
+permissions:
+  actions: write
+
+jobs:
+  retry:
+    # Only retry once, only on pull_request runs, only on failure.
+    # Skipped runs (e.g. path filters) have conclusion 'skipped', not 'failure'.
+    if: >-
+      github.event.workflow_run.conclusion == 'failure' &&
+      github.event.workflow_run.run_attempt == 1 &&
+      github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Rerun failed jobs
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          gh api \
+            --method POST \
+            "repos/${{ github.repository }}/actions/runs/$RUN_ID/rerun-failed-jobs"


### PR DESCRIPTION
When a workflow run triggered by a pull request fails on its first attempt, automatically rerun only the failed jobs. This catches transient failures (flaky tests, network timeouts, resource contention) without manual intervention.

- `retry-failed-jobs.yml` listens for `workflow_run` completions, guards on `run_attempt == 1` and `event == 'pull_request'`, and calls the GitHub API `rerun-failed-jobs` endpoint. Only the `actions: write` permission from the default `GITHUB_TOKEN` is required — no GitHub App or custom token needed.