### PR TITLE
Return cli List error closer to where was returned

### DIFF
--- a/internal/cmd/cli/apply/apply.go
+++ b/internal/cmd/cli/apply/apply.go
@@ -354,7 +354,9 @@ func pruneBundlesNotFoundInRepo(
 ) error {
 	filter := labels.SelectorFromSet(labels.Set{fleet.RepoLabel: repoName})
 	bundleList := &fleet.BundleList{}
-	err := c.List(ctx, bundleList, &client.ListOptions{LabelSelector: filter, Namespace: ns})
+	if err := c.List(ctx, bundleList, &client.ListOptions{LabelSelector: filter, Namespace: ns}); err != nil {
+		return err
+	}
 
 	for _, bundle := range bundleList.Items {
 		if _, ok := gitRepoBundlesMap[bundle.Name]; !ok {
@@ -404,13 +406,12 @@ func pruneBundlesNotFoundInRepo(
 					}
 				}
 			}
-			err = c.Delete(ctx, &bundle)
-			if err != nil {
+			if err := c.Delete(ctx, &bundle); err != nil {
 				return err
 			}
 		}
 	}
-	return err
+	return nil
 }
 
 // newBundle reads bundle data from a source and returns a bundle with the


### PR DESCRIPTION
When looking for a different issue I found this code that confused me. In case List returns an error we're still trying to iterate the returned list (that should be empty, we cannot guarantee) This PR returns the error earlier and avoids accessing the list, that in future implementations of List could be returning nil and make this panic.

<!-- Specify the issue ID that this pull request is solving -->
<!-- Make sure that the referenced issue provides steps to reproduce it -->

<!-- Describe the changes introduced by this pull request -->

<!--
  Please provide a unit, integration (`./integrationtests/`) or e2e (`./e2e/`) test if possible.
-->

## Additional Information

### Checklist

~- [ ] <!-- If applicable,--> I have updated the documentation via a pull request in the
[fleet-docs](https://github.com/rancher/fleet-docs) repository.~
