### PR TITLE
Fix --gitrepo and --bundle filters including HelmOps

### DIFF
--- a/integrationtests/cli/dump/dump_test.go
+++ b/integrationtests/cli/dump/dump_test.go
@@ -631,6 +631,91 @@ var _ = Describe("Fleet dump", func() {
 			Expect(c.SHA256Sum).To(Equal("abc123def456"))
 		})
 	})
+
+	When("the cluster contains a GitRepo and a HelmOp in the same namespace", func() {
+		BeforeEach(func() {
+			testGitRepo := fleet.GitRepo{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-gitrepo",
+					Namespace: "test-gitrepo-filter",
+				},
+				Spec: fleet.GitRepoSpec{
+					Repo: "http://example.com/myrepo",
+				},
+			}
+
+			testBundle := fleet.Bundle{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-bundle",
+					Namespace: "test-gitrepo-filter",
+					Labels: map[string]string{
+						"fleet.cattle.io/repo-name": "my-gitrepo",
+					},
+				},
+			}
+
+			testHelmOp := fleet.HelmOp{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-helmop",
+					Namespace: "test-gitrepo-filter",
+				},
+			}
+
+			objs = []client.Object{&testGitRepo, &testBundle, &testHelmOp}
+		})
+
+		It("excludes HelmOp resources when filtering by --gitrepo", func() {
+			tgzPath := "test_gitrepo_filter.tgz"
+			opts := dump.Options{
+				Namespace: "test-gitrepo-filter",
+				GitRepo:   "my-gitrepo",
+			}
+			Expect(fleetDumpWithOptions(tgzPath, opts)).ToNot(HaveOccurred())
+			defer func() {
+				Expect(os.RemoveAll(tgzPath)).ToNot(HaveOccurred())
+			}()
+
+			found, _, err := findFileInArchive(tgzPath, "helmops_")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(found).To(BeFalse(), "HelmOp resources must not appear when filtering by --gitrepo")
+		})
+	})
+
+	When("the cluster contains a Bundle and a HelmOp in the same namespace", func() {
+		BeforeEach(func() {
+			testBundle := fleet.Bundle{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-bundle",
+					Namespace: "test-bundle-filter",
+				},
+			}
+
+			testHelmOp := fleet.HelmOp{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-helmop",
+					Namespace: "test-bundle-filter",
+				},
+			}
+
+			objs = []client.Object{&testBundle, &testHelmOp}
+		})
+
+		It("excludes HelmOp resources when filtering by --bundle", func() {
+			tgzPath := "test_bundle_filter.tgz"
+			opts := dump.Options{
+				Namespace: "test-bundle-filter",
+				Bundle:    "my-bundle",
+			}
+			Expect(fleetDumpWithOptions(tgzPath, opts)).ToNot(HaveOccurred())
+			defer func() {
+				Expect(os.RemoveAll(tgzPath)).ToNot(HaveOccurred())
+			}()
+
+			found, _, err := findFileInArchive(tgzPath, "helmops_")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(found).To(BeFalse(), "HelmOp resources must not appear when filtering by --bundle")
+		})
+	})
 })
 
 // areEqual checks if objects a and e are equal, by namespace, name, metadata (labels and annotations) and Spec or

--- a/internal/cmd/cli/dump/dump.go
+++ b/internal/cmd/cli/dump/dump.go
@@ -800,16 +800,22 @@ func addOtherNamespaceResources(ctx context.Context, d dynamic.Interface, logger
 }
 
 // addFilteredHelmOps adds HelmOps with appropriate filtering.
-// HelmOps are namespace-scoped resources like GitRepos, so they use namespace filtering only.
+// HelmOps are namespace-scoped resources like GitRepos. They are:
+//   - excluded entirely when filtering by GitRepo or Bundle,
+//   - name-filtered when a specific HelmOp is requested, and
+//   - otherwise included using namespace filtering only.
 func addFilteredHelmOps(ctx context.Context, d dynamic.Interface, logger logr.Logger, w *tar.Writer, opt Options) error {
 	switch {
+	case opt.GitRepo != "" || opt.Bundle != "":
+		// When filtering by GitRepo or Bundle, HelmOps are unrelated resources and must not be included.
+		return nil
 	case opt.HelmOp != "":
 		// Add only the specific HelmOp
 		if err := addObjectsWithNameFilter(ctx, d, logger, "helmops", w, []string{opt.HelmOp}, opt); err != nil {
 			return fmt.Errorf("failed to add helmops to archive: %w", err)
 		}
 	default:
-		// HelmOps are namespace-scoped like GitRepos, use namespace filtering
+		// In unfiltered mode, HelmOps are namespace-scoped like GitRepos and use namespace filtering only.
 		if err := addObjectsToArchive(ctx, d, logger, "helmops", w, opt); err != nil {
 			return fmt.Errorf("failed to add helmops to archive: %w", err)
 		}

--- a/internal/cmd/cli/dump/dump_test.go
+++ b/internal/cmd/cli/dump/dump_test.go
@@ -1606,3 +1606,126 @@ func Test_HelmOpFiltering(t *testing.T) {
 
 	t.Logf("Archive contains %d entries (expected 5)", len(entries))
 }
+
+func Test_addFilteredHelmOps(t *testing.T) {
+	ctx := context.Background()
+	logger := log.FromContext(ctx).WithName("test-fleet-dump")
+
+	scheme := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(v1alpha1.AddToScheme(scheme))
+
+	helmOpObjs := []runtime.Object{
+		&v1alpha1.HelmOp{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "helmop-1",
+				Namespace: "fleet-local",
+			},
+		},
+		&v1alpha1.HelmOp{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "helmop-2",
+				Namespace: "fleet-local",
+			},
+		},
+	}
+
+	tests := []struct {
+		name          string
+		opt           Options
+		expectedNames []string
+	}{
+		{
+			name: "gitrepo filter: no helmops must be added",
+			opt: Options{
+				FetchLimit: 0,
+				Namespace:  "fleet-local",
+				GitRepo:    "my-gitrepo",
+			},
+			expectedNames: nil,
+		},
+		{
+			name: "bundle filter: no helmops must be added",
+			opt: Options{
+				FetchLimit: 0,
+				Namespace:  "fleet-local",
+				Bundle:     "my-bundle",
+			},
+			expectedNames: nil,
+		},
+		{
+			name: "helmop filter: only the specified helmop must be added",
+			opt: Options{
+				FetchLimit: 0,
+				Namespace:  "fleet-local",
+				HelmOp:     "helmop-1",
+			},
+			expectedNames: []string{"helmop-1"},
+		},
+		{
+			name: "no filter: all helmops in the namespace must be added",
+			opt: Options{
+				FetchLimit: 0,
+				Namespace:  "fleet-local",
+			},
+			expectedNames: []string{"helmop-1", "helmop-2"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fakeDynClient := fake.NewSimpleDynamicClient(scheme, helmOpObjs...)
+
+			var buf bytes.Buffer
+			gz := gzip.NewWriter(&buf)
+			tw := tar.NewWriter(gz)
+
+			err := addFilteredHelmOps(ctx, fakeDynClient, logger, tw, tt.opt)
+			tw.Close()
+			gz.Close()
+
+			if err != nil {
+				t.Fatalf("addFilteredHelmOps() error = %v", err)
+			}
+
+			gzReader, err := gzip.NewReader(&buf)
+			if err != nil {
+				t.Fatalf("failed to create gzip reader: %v", err)
+			}
+			defer gzReader.Close()
+			tarReader := tar.NewReader(gzReader)
+
+			var foundNames []string
+			for {
+				header, err := tarReader.Next()
+				if errors.Is(err, io.EOF) {
+					break
+				}
+				if err != nil {
+					t.Fatalf("failed to read tar: %v", err)
+				}
+				if _, err := io.ReadAll(tarReader); err != nil {
+					t.Fatalf("failed to drain tar entry: %v", err)
+				}
+				parts := strings.SplitN(header.Name, "_", 3)
+				if len(parts) == 3 && parts[0] == "helmops" {
+					foundNames = append(foundNames, parts[2])
+				}
+			}
+
+			slices.Sort(foundNames)
+			expected := append([]string(nil), tt.expectedNames...)
+			slices.Sort(expected)
+
+			if len(foundNames) != len(expected) {
+				t.Errorf("expected %d helmops %v, got %d: %v", len(expected), expected, len(foundNames), foundNames)
+				return
+			}
+			for i := range expected {
+				if foundNames[i] != expected[i] {
+					t.Errorf("expected helmop %q at index %d, got %q", expected[i], i, foundNames[i])
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
When `fleet dump` was invoked with `--gitrepo` or `--bundle`, the `addFilteredHelmOps` function fell through to its default case and added all `HelmOp` resources from the namespace, contrary to the intent of the filter.

Refers #4759 