### PR TITLE
Prefer final chart over RC when computing latest release version

### DIFF
--- a/.github/scripts/compute-rancher-versions.sh
+++ b/.github/scripts/compute-rancher-versions.sh
@@ -46,7 +46,7 @@ chart_response=$(curl -fsSL \
 # RC would be selected even after the final chart has been published.
 all_charts=$(printf '%s' "$chart_response" \
     | jq -r '.[] | select(.type == "dir") | .name')
-latest_chart=$(printf '%s' "$all_charts" | grep -v '\+up.*-' | sort -V | tail -1)
+latest_chart=$(printf '%s' "$all_charts" | { grep -v '+up.*-' || true; } | sort -V | tail -1)
 if [ -z "$latest_chart" ]; then
     latest_chart=$(printf '%s' "$all_charts" | sort -V | tail -1)
 fi


### PR DESCRIPTION
`sort -V` in GNU coreutils ranks a pre-release suffix (e.g. `0.14.4-rc.5`) above the final tag (`0.14.4`) because the RC string is lexicographically longer. `compute-rancher-versions.sh` was therefore selecting the RC chart even after the final chart had been published in rancher/charts, causing the `release-against-rancher` workflow to target the already-deployed RC version and fail with `ERROR: rancher/rancher already contains Fleet <rc-version>`.

The fix filters the chart list to non-pre-release entries first — chart names whose fleet-version segment (the part after `+up`) contains no `-`. It falls back to the full list only when no final chart exists yet, preserving existing behaviour during the RC-only phase of a release cycle.

[Successful runs](https://github.com/rancher/fleet/actions/workflows/release-against-rancher.yml) with the fix.