### PR TITLE
[v0.14] Add k8s.io staging replace directives

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,35 @@ replace (
 	github.com/imdario/mergo => github.com/imdario/mergo v1.0.2
 	github.com/rancher/fleet/pkg/apis => ./pkg/apis
 	gopkg.in/go-playground/webhooks.v6 => github.com/go-playground/webhooks/v6 v6.4.0
+	k8s.io/api => k8s.io/api v0.34.5
+	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.34.5
+	k8s.io/apimachinery => k8s.io/apimachinery v0.34.5
+	k8s.io/apiserver => k8s.io/apiserver v0.34.5
+	k8s.io/cli-runtime => k8s.io/cli-runtime v0.34.5
+	k8s.io/client-go => k8s.io/client-go v0.34.5
+	k8s.io/cloud-provider => k8s.io/cloud-provider v0.34.5
+	k8s.io/cluster-bootstrap => k8s.io/cluster-bootstrap v0.34.5
+	k8s.io/code-generator => k8s.io/code-generator v0.34.5
+	k8s.io/component-base => k8s.io/component-base v0.34.5
+	k8s.io/component-helpers => k8s.io/component-helpers v0.34.5
+	k8s.io/controller-manager => k8s.io/controller-manager v0.34.5
+	k8s.io/cri-api => k8s.io/cri-api v0.34.5
+	k8s.io/cri-client => k8s.io/cri-client v0.34.5
+	k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.34.5
+	k8s.io/dynamic-resource-allocation => k8s.io/dynamic-resource-allocation v0.34.5
+	k8s.io/endpointslice => k8s.io/endpointslice v0.34.5
+	k8s.io/externaljwt => k8s.io/externaljwt v0.34.5
+	k8s.io/kms => k8s.io/kms v0.34.5
+	k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.34.5
+	k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.34.5
+	k8s.io/kube-proxy => k8s.io/kube-proxy v0.34.5
+	k8s.io/kube-scheduler => k8s.io/kube-scheduler v0.34.5
+	k8s.io/kubectl => k8s.io/kubectl v0.34.5
+	k8s.io/kubelet => k8s.io/kubelet v0.34.5
+	k8s.io/metrics => k8s.io/metrics v0.34.5
+	k8s.io/mount-utils => k8s.io/mount-utils v0.34.5
+	k8s.io/pod-security-admission => k8s.io/pod-security-admission v0.34.5
+	k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.34.5
 )
 
 require (

--- a/integrationtests/go.mod
+++ b/integrationtests/go.mod
@@ -7,6 +7,35 @@ toolchain go1.25.8
 replace (
 	github.com/rancher/fleet => ../
 	github.com/rancher/fleet/pkg/apis => ../pkg/apis
+	k8s.io/api => k8s.io/api v0.34.5
+	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.34.5
+	k8s.io/apimachinery => k8s.io/apimachinery v0.34.5
+	k8s.io/apiserver => k8s.io/apiserver v0.34.5
+	k8s.io/cli-runtime => k8s.io/cli-runtime v0.34.5
+	k8s.io/client-go => k8s.io/client-go v0.34.5
+	k8s.io/cloud-provider => k8s.io/cloud-provider v0.34.5
+	k8s.io/cluster-bootstrap => k8s.io/cluster-bootstrap v0.34.5
+	k8s.io/code-generator => k8s.io/code-generator v0.34.5
+	k8s.io/component-base => k8s.io/component-base v0.34.5
+	k8s.io/component-helpers => k8s.io/component-helpers v0.34.5
+	k8s.io/controller-manager => k8s.io/controller-manager v0.34.5
+	k8s.io/cri-api => k8s.io/cri-api v0.34.5
+	k8s.io/cri-client => k8s.io/cri-client v0.34.5
+	k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.34.5
+	k8s.io/dynamic-resource-allocation => k8s.io/dynamic-resource-allocation v0.34.5
+	k8s.io/endpointslice => k8s.io/endpointslice v0.34.5
+	k8s.io/externaljwt => k8s.io/externaljwt v0.34.5
+	k8s.io/kms => k8s.io/kms v0.34.5
+	k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.34.5
+	k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.34.5
+	k8s.io/kube-proxy => k8s.io/kube-proxy v0.34.5
+	k8s.io/kube-scheduler => k8s.io/kube-scheduler v0.34.5
+	k8s.io/kubectl => k8s.io/kubectl v0.34.5
+	k8s.io/kubelet => k8s.io/kubelet v0.34.5
+	k8s.io/metrics => k8s.io/metrics v0.34.5
+	k8s.io/mount-utils => k8s.io/mount-utils v0.34.5
+	k8s.io/pod-security-admission => k8s.io/pod-security-admission v0.34.5
+	k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.34.5
 )
 
 require (


### PR DESCRIPTION
k8s.io/kubernetes publishes its go.mod without the local replace directives that map its staging repos (k8s.io/api, k8s.io/client-go, etc.) to the monorepo. The published require entries list those modules at v0.0.0, which does not exist on the module proxy.

Renovate runs go get -d -t ./... before go mod tidy; that step fetches the k8s.io/kubernetes go.mod transitively and fails when it cannot resolve k8s.io/api@v0.0.0.

Adding replace directives here routes every k8s.io staging module to its real published version (v0.34.5), matching the pattern used in rancher/rancher.

Should fix broken Renovate Kubernetes bumps like: #4876