### PR TITLE
Add version reference to Renovate Github Action

### DIFF
--- a/.github/workflows/renovate-vault.yml
+++ b/.github/workflows/renovate-vault.yml
@@ -51,7 +51,7 @@ permissions:
 
 jobs:
   call-workflow:
-    uses: rancher/renovate-config/.github/workflows/renovate-vault.yml@f62bbe9fec9bef07a9f15addc2f9c6ea278ac736 # release
+    uses: rancher/renovate-config/.github/workflows/renovate-vault.yml@f62bbe9fec9bef07a9f15addc2f9c6ea278ac736 # v1.0.0
     with:
       configMigration: ${{ inputs.configMigration || 'true' }}
       logLevel: ${{ inputs.logLevel || 'info' }}


### PR DESCRIPTION
to allow updates with Renovate only when a new version is released and not on every commit.