### PR TITLE
[v0.11] Remove k8s.io/kubernetes, use client-go scheme

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -60,7 +60,6 @@ require (
 	k8s.io/klog/v2 v2.130.1
 	k8s.io/kube-openapi v0.0.0-20250318190949-c8a335a9a2ff
 	k8s.io/kubectl v0.31.14
-	k8s.io/kubernetes v1.31.14
 	k8s.io/utils v0.0.0-20250502105355-0f33e8f1c979
 	oras.land/oras-go/v2 v2.5.0
 	sigs.k8s.io/cli-utils v0.37.2

--- a/go.sum
+++ b/go.sum
@@ -1139,8 +1139,8 @@ github.com/moby/patternmatcher v0.6.0 h1:GmP9lR19aU5GqSSFko+5pRqHi+Ohk1O69aFiKkV
 github.com/moby/patternmatcher v0.6.0/go.mod h1:hDPoyOpDY7OrrMDLaYoY3hf52gNCR/YOUYxkhApJIxc=
 github.com/moby/spdystream v0.4.0 h1:Vy79D6mHeJJjiPdFEL2yku1kl0chZpJfZcPpb16BRl8=
 github.com/moby/spdystream v0.4.0/go.mod h1:xBAYlnt/ay+11ShkdFKNAG7LsyK/tmNBVvVOwrfMgdI=
-github.com/moby/sys/mountinfo v0.7.1 h1:/tTvQaSJRr2FshkhXiIpux6fQ2Zvc4j7tAhMTStAG2g=
-github.com/moby/sys/mountinfo v0.7.1/go.mod h1:IJb6JQeOklcdMU9F5xQ8ZALD+CUr5VlGpwtX+VE0rpI=
+github.com/moby/sys/mountinfo v0.6.2 h1:BzJjoreD5BMFNmD9Rus6gdd1pLuecOFPt8wC+Vygl78=
+github.com/moby/sys/mountinfo v0.6.2/go.mod h1:IJb6JQeOklcdMU9F5xQ8ZALD+CUr5VlGpwtX+VE0rpI=
 github.com/moby/sys/sequential v0.5.0 h1:OPvI35Lzn9K04PBbCLW0g4LcFAJgHsvXsRyewg5lXtc=
 github.com/moby/sys/sequential v0.5.0/go.mod h1:tH2cOOs5V9MlPiXcQzRC+eEyab644PWKGRYaaV5ZZlo=
 github.com/moby/sys/user v0.3.0 h1:9ni5DlcW5an3SvRSx4MouotOygvzaXbaSrc/wGDFWPo=
@@ -2140,8 +2140,6 @@ k8s.io/kube-openapi v0.0.0-20250318190949-c8a335a9a2ff h1:/usPimJzUKKu+m+TE36gUy
 k8s.io/kube-openapi v0.0.0-20250318190949-c8a335a9a2ff/go.mod h1:5jIi+8yX4RIb8wk3XwBo5Pq2ccx4FP10ohkbSKCZoK8=
 k8s.io/kubectl v0.31.14 h1:3SsqtFmv6TwI7p0IjJ0C/HwfIrKscLQjhuE8Bdmo+FY=
 k8s.io/kubectl v0.31.14/go.mod h1:OUUYe8E7IjiiM/rR6CLCm4Ix2Fq1cY+DpE+BXfRbwAo=
-k8s.io/kubernetes v1.31.14 h1:UtjLfqvXLuSVDdJ4+NpQCIfFkKkLnAAVmxAEMsnkhjk=
-k8s.io/kubernetes v1.31.14/go.mod h1:9xmT2buyTYj8TRKwRae7FcuY8k5+xlxv7VivvO0KKfs=
 k8s.io/utils v0.0.0-20250502105355-0f33e8f1c979 h1:jgJW5IePPXLGB8e/1wvd0Ich9QE97RvvF3a8J3fP/Lg=
 k8s.io/utils v0.0.0-20250502105355-0f33e8f1c979/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 lukechampine.com/uint128 v1.1.1/go.mod h1:c4eWIwlEGaxC/+H1VguhU4PHXNWDCDMUlWdIWl2j1gk=

--- a/internal/cmd/agent/deployer/internal/diff/scheme/scheme.go
+++ b/internal/cmd/agent/deployer/internal/diff/scheme/scheme.go
@@ -1,30 +1,9 @@
 // +vendored https://github.com/argoproj/gitops-engine/blob/master/pkg/utils/kube/scheme/scheme.go
+// Modified to use k8s.io/client-go/kubernetes/scheme instead of k8s.io/kubernetes due to compilation issues in k8s.io/kubernetes.
 package scheme
 
 import (
-	"k8s.io/kubernetes/pkg/api/legacyscheme"
-
-	_ "k8s.io/kubernetes/pkg/apis/admission/install"
-	_ "k8s.io/kubernetes/pkg/apis/admissionregistration/install"
-	_ "k8s.io/kubernetes/pkg/apis/apps/install"
-	_ "k8s.io/kubernetes/pkg/apis/authentication/install"
-	_ "k8s.io/kubernetes/pkg/apis/authorization/install"
-	_ "k8s.io/kubernetes/pkg/apis/autoscaling/install"
-	_ "k8s.io/kubernetes/pkg/apis/batch/install"
-	_ "k8s.io/kubernetes/pkg/apis/certificates/install"
-	_ "k8s.io/kubernetes/pkg/apis/coordination/install"
-	_ "k8s.io/kubernetes/pkg/apis/core/install"
-	_ "k8s.io/kubernetes/pkg/apis/discovery/install"
-	_ "k8s.io/kubernetes/pkg/apis/events/install"
-	_ "k8s.io/kubernetes/pkg/apis/extensions/install"
-	_ "k8s.io/kubernetes/pkg/apis/flowcontrol/install"
-	_ "k8s.io/kubernetes/pkg/apis/imagepolicy/install"
-	_ "k8s.io/kubernetes/pkg/apis/networking/install"
-	_ "k8s.io/kubernetes/pkg/apis/node/install"
-	_ "k8s.io/kubernetes/pkg/apis/policy/install"
-	_ "k8s.io/kubernetes/pkg/apis/rbac/install"
-	_ "k8s.io/kubernetes/pkg/apis/scheduling/install"
-	_ "k8s.io/kubernetes/pkg/apis/storage/install"
+	kubescheme "k8s.io/client-go/kubernetes/scheme"
 )
 
-var Scheme = legacyscheme.Scheme
+var Scheme = kubescheme.Scheme


### PR DESCRIPTION
k8s.io/kubernetes publishes its go.mod without replace directives for its staging repos, listing them at v0.0.0. This causes Renovate's pre-tidy go get step to fail.

Instead of adding staging replace directives as a workaround, remove the direct k8s.io/kubernetes dependency. Switch scheme.go to use k8s.io/client-go/kubernetes/scheme, which is the canonical source for versioned Kubernetes API types and avoids the transitive import of the monorepo.