### PR TITLE
Catch unknown-field errors in deployErrToStatus

### DIFF
--- a/integrationtests/controller/bundle/bundle_error_handling_test.go
+++ b/integrationtests/controller/bundle/bundle_error_handling_test.go
@@ -442,4 +442,115 @@ var _ = Describe("Bundle controller error handling", Ordered, func() {
 			Expect(readyCond.Reason).To(BeEmpty(), "Ready condition Reason should be empty when Status is True")
 		})
 	})
+
+	// Issue #594 - stale error is suppressed once the spec advances past the bad commit, even
+	// when the cluster agent is offline and has not applied the fix yet.
+	// This covers the scenario where the agent's deployErrToStatus routes an "unknown field"
+	// type error into the Installed condition (Deployed=True, AppliedDeploymentID=errorID).
+	// The controller must suppress that stale Installed message once DeploymentID advances.
+	Context("Issue #594 - stale error suppressed when cluster is offline after unknown-field deploy failure", func() {
+		var (
+			bundle     *v1alpha1.Bundle
+			cluster    *v1alpha1.Cluster
+			bundleName string
+			testID     string
+			clusterNS  string
+		)
+
+		BeforeEach(func() {
+			testID = generateTestID()
+			bundleName = "bundle-594-" + testID
+			clusterNS = "cluster-ns-594-" + testID
+
+			createNamespace(clusterNS)
+			cluster = createCluster("cluster-594-"+testID, bundleNS, clusterNS, map[string]string{"env": "test-594-" + testID})
+			bundle = createBundle(bundleName, bundleNS, "default", "cm-594", []v1alpha1.BundleTarget{{
+				ClusterSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"env": "test-594-" + testID}},
+			}})
+		})
+
+		AfterEach(func() {
+			_ = k8sClient.Delete(ctx, bundle)
+			Eventually(func() int {
+				return len(getBundleDeployments(bundleName, bundleNS).Items)
+			}).Should(Equal(0))
+			_ = k8sClient.Delete(ctx, cluster)
+			_ = k8sClient.Delete(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: clusterNS}})
+		})
+
+		It("does not retain stale unknown-field error while cluster is offline and spec has advanced", func() {
+			By("waiting for the bundle deployment to be created")
+			var bd v1alpha1.BundleDeployment
+			var errorCommitID string
+			Eventually(func(g Gomega) {
+				bdList := getBundleDeployments(bundleName, bundleNS)
+				g.Expect(bdList.Items).To(HaveLen(1))
+				bd = bdList.Items[0]
+				errorCommitID = bd.Spec.DeploymentID
+				g.Expect(errorCommitID).NotTo(BeEmpty())
+			}).Should(Succeed())
+
+			By("simulating the agent reporting an unknown-field error via deployErrToStatus")
+			// deployErrToStatus now matches "unknown field" errors and:
+			//   - sets AppliedDeploymentID = Spec.DeploymentID (errorCommitID)
+			//   - returns (status, nil), so the reconciler sets Deployed=True
+			//   - stores the error in the Installed condition
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: bd.Name, Namespace: bd.Namespace}, &bd)).To(Succeed())
+				bd.Status.Ready = false
+				bd.Status.NonModified = true
+				bd.Status.AppliedDeploymentID = errorCommitID
+				bd.Status.Conditions = []genericcondition.GenericCondition{
+					{Type: "Deployed", Status: "True"},
+					{
+						Type:   "Installed",
+						Status: "False",
+						Message: `not installed: Deployment.apps "test" is invalid: ` +
+							`spec.template.spec.containers[0].lifecycle.preStart: ` +
+							`Invalid value: "null": unknown field`,
+					},
+				}
+				g.Expect(k8sClient.Status().Update(ctx, &bd)).To(Succeed())
+			}).Should(Succeed())
+
+			By("verifying the bundle surfaces the unknown-field error before the spec advances")
+			// IDs match (AppliedDeploymentID == Spec.DeploymentID), Deployed=True, Ready=false
+			// → GetDeploymentState → NotReady
+			// → MessageFromDeployment: IDs match → surfaces Installed message → "unknown field" appears
+			Eventually(func(g Gomega) {
+				b := &v1alpha1.Bundle{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: bundleName, Namespace: bundleNS}, b)).To(Succeed())
+				g.Expect(b.Status.Summary.NotReady).To(Equal(1))
+				readyCond := getCondition(b.Status.Conditions, "Ready")
+				g.Expect(readyCond).NotTo(BeNil())
+				g.Expect(readyCond.Message).To(ContainSubstring("unknown field"))
+			}).Should(Succeed())
+
+			By("advancing the bundle spec to simulate a fix commit while the cluster stays offline")
+			// Changing DefaultNamespace causes the bundle controller to compute a new DeploymentID.
+			// The cluster is "offline": we do not update BD.Status, so AppliedDeploymentID stays at errorCommitID.
+			updateBundleDefaultNamespace(bundle, "kube-system")
+
+			By("waiting for the controller to write the new DeploymentID into the bundle deployment spec")
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: bd.Name, Namespace: bd.Namespace}, &bd)).To(Succeed())
+				g.Expect(bd.Spec.DeploymentID).NotTo(Equal(errorCommitID))
+			}).Should(Succeed())
+
+			By("verifying the stale unknown-field error is suppressed while the cluster is still offline")
+			// effectiveDeployment uses the new spec ID (fixID), which differs from AppliedDeploymentID (errorCommitID).
+			// IDs differ, Deployed=True → WaitApplied (not ErrApplied).
+			// MessageFromDeployment: IDs differ → Installed message suppressed → no "unknown field" in bundle.
+			Eventually(func(g Gomega) {
+				b := &v1alpha1.Bundle{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: bundleName, Namespace: bundleNS}, b)).To(Succeed())
+				g.Expect(b.Status.Summary.WaitApplied).To(Equal(1), "expected WaitApplied while agent is offline")
+				g.Expect(b.Status.Summary.ErrApplied).To(Equal(0), "should not be ErrApplied since Deployed=True")
+				readyCond := getCondition(b.Status.Conditions, "Ready")
+				g.Expect(readyCond).NotTo(BeNil())
+				g.Expect(readyCond.Message).NotTo(ContainSubstring("unknown field"),
+					"stale unknown-field error should be suppressed once spec advances past the bad commit")
+			}).Should(Succeed())
+		})
+	})
 })

--- a/internal/cmd/agent/deployer/deployer.go
+++ b/internal/cmd/agent/deployer/deployer.go
@@ -279,12 +279,13 @@ func deployErrToStatus(err error, status fleet.BundleDeploymentStatus) (bool, fl
 	// Note: these error strings are returned by the Helm SDK and its dependencies
 	re := regexp.MustCompile(
 		"(timed out waiting for the condition)|" + // a Helm wait occurs and it times out
-			"(error validating data)|" + // manifests fail to pass validation
+			"(error validating data)|" + // manifests fail to pass validation (client-side OpenAPI schema)
 			"(chart requires kubeVersion)|" + // kubeVersion mismatch
 			"(annotation validation error)|" + // annotations fail to pass validation
 			"(failed, and has been rolled back due to atomic being set)|" + // atomic is set and a rollback occurs
 			"(YAML parse error)|" + // YAML is broken in source files (Helm v3)
 			"(MalformedYAMLError)|" + // YAML is broken in source files (Helm v4)
+			"(unknown field)|" + // unknown field rejected by the API server (e.g. via server-side apply strict validation)
 			"(Forbidden: updates to [0-9A-Za-z]+ spec for fields other than [0-9A-Za-z ']+ are forbidden)|" + // trying to update fields that cannot be updated
 			"(Forbidden: spec is immutable after creation)|" + // trying to modify immutable spec
 			"(chart requires kubeVersion: [0-9A-Za-z\\.\\-<>=]+ which is incompatible with Kubernetes)", // trying to deploy to incompatible Kubernetes

--- a/internal/cmd/agent/deployer/deployer.go
+++ b/internal/cmd/agent/deployer/deployer.go
@@ -27,6 +27,22 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
+// deployErrPattern matches Helm/Kubernetes error messages that should be
+// recorded as status conditions rather than returned as reconciler errors.
+var deployErrPattern = regexp.MustCompile(
+	"(timed out waiting for the condition)|" + // a Helm wait occurs and it times out
+		"(error validating data)|" + // manifests fail to pass validation (client-side OpenAPI schema)
+		"(chart requires kubeVersion)|" + // kubeVersion mismatch
+		"(annotation validation error)|" + // annotations fail to pass validation
+		"(failed, and has been rolled back due to atomic being set)|" + // atomic is set and a rollback occurs
+		"(YAML parse error)|" + // YAML is broken in source files (Helm v3)
+		"(MalformedYAMLError)|" + // YAML is broken in source files (Helm v4)
+		"(unknown field)|" + // unknown field rejected by the API server (e.g. via server-side apply strict validation)
+		"(Forbidden: updates to [0-9A-Za-z]+ spec for fields other than [0-9A-Za-z ']+ are forbidden)|" + // trying to update fields that cannot be updated
+		"(Forbidden: spec is immutable after creation)|" + // trying to modify immutable spec
+		"(chart requires kubeVersion: [0-9A-Za-z\\.\\-<>=]+ which is incompatible with Kubernetes)", // trying to deploy to incompatible Kubernetes
+)
+
 type NotReadyDependenciesError struct {
 	Pending []string
 }
@@ -277,20 +293,7 @@ func deployErrToStatus(err error, status fleet.BundleDeploymentStatus) (bool, fl
 
 	// The following error conditions are turned into a status
 	// Note: these error strings are returned by the Helm SDK and its dependencies
-	re := regexp.MustCompile(
-		"(timed out waiting for the condition)|" + // a Helm wait occurs and it times out
-			"(error validating data)|" + // manifests fail to pass validation (client-side OpenAPI schema)
-			"(chart requires kubeVersion)|" + // kubeVersion mismatch
-			"(annotation validation error)|" + // annotations fail to pass validation
-			"(failed, and has been rolled back due to atomic being set)|" + // atomic is set and a rollback occurs
-			"(YAML parse error)|" + // YAML is broken in source files (Helm v3)
-			"(MalformedYAMLError)|" + // YAML is broken in source files (Helm v4)
-			"(unknown field)|" + // unknown field rejected by the API server (e.g. via server-side apply strict validation)
-			"(Forbidden: updates to [0-9A-Za-z]+ spec for fields other than [0-9A-Za-z ']+ are forbidden)|" + // trying to update fields that cannot be updated
-			"(Forbidden: spec is immutable after creation)|" + // trying to modify immutable spec
-			"(chart requires kubeVersion: [0-9A-Za-z\\.\\-<>=]+ which is incompatible with Kubernetes)", // trying to deploy to incompatible Kubernetes
-	)
-	if re.MatchString(msg) {
+	if deployErrPattern.MatchString(msg) {
 		status.Ready = false
 		status.NonModified = true
 

--- a/internal/cmd/agent/deployer/deployer_test.go
+++ b/internal/cmd/agent/deployer/deployer_test.go
@@ -2,6 +2,7 @@ package deployer
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
@@ -195,6 +196,40 @@ func TestIsStateAccepted(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			if got := isStateAccepted(tc.state, tc.accepted); got != tc.want {
 				t.Errorf("isStateAccepted(%q, %v) = %v, want %v", tc.state, tc.accepted, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDeployErrToStatus(t *testing.T) {
+	tests := []struct {
+		name      string
+		errMsg    string
+		wantMatch bool
+	}{
+		{"nil error", "", false},
+		{"YAML parse error (Helm v3)", "YAML parse error on foo.yaml: yaml: line 1: did not find expected node content", true},
+		{"MalformedYAMLError (Helm v4)", "MalformedYAMLError on foo.yaml: yaml: unmarshal errors", true},
+		{"error validating data (client-side schema)", `error validating "": error validating data: ValidationError(Deployment.spec.template.spec.containers[0].lifecycle): unknown field "preStart" in io.k8s.api.core.v1.Lifecycle`, true},
+		{"unknown field via SSA (API server strict validation)", `Deployment.apps "test" is invalid: spec.template.spec.containers[0].lifecycle.preStart: Invalid value: "null": unknown field`, true},
+		{"unknown field via strict decoding", `strict decoding error: unknown field "spec.template.spec.containers[0].lifecycle.preStart"`, true},
+		{"immutable spec", "Forbidden: spec is immutable after creation", true},
+		{"forbidden update", "Forbidden: updates to statefulset spec for fields other than 'replicas' are forbidden", true},
+		{"timed out", "timed out waiting for the condition", true},
+		{"transient error (should not match)", "dial tcp: connection refused", false},
+		{"not found (should not match)", "resource not found", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var err error
+			if tc.errMsg != "" {
+				err = fmt.Errorf("%s", tc.errMsg)
+			}
+			status := fleet.BundleDeploymentStatus{}
+			got, _ := deployErrToStatus(err, status)
+			if got != tc.wantMatch {
+				t.Errorf("deployErrToStatus(%q) matched = %v, want %v", tc.errMsg, got, tc.wantMatch)
 			}
 		})
 	}


### PR DESCRIPTION
When Helm v4 uses server-side apply with strict field validation and the API server rejects a resource containing an unknown field, the error format is `<resource> is invalid: <field>: unknown field` — it does not contain `"error validating data"`. The old `deployErrToStatus` regex did not match this format, so the error was propagated to the agent reconciler which set `Deployed=False` and left `AppliedDeploymentID` pointing at a prior successful deployment ID.
With `Deployed=False` and mismatched IDs, `GetDeploymentState` returned `ErrApplied` and the staleness guard in `MessageFromDeployment` never triggered — the stale error persisted through every subsequent spec
update including the fix commit.

Adding `"(unknown field)"` to the pattern list ensures server-side-apply strict-validation rejections take the same path as YAML/schema errors: the error is stored in `Installed`, `Deployed` is set to `True`, and `AppliedDeploymentID` advances to the failing commit's ID. The ID-mismatch guard in `MessageFromDeployment` then correctly suppresses the stale message once the fix commit is pushed.

Refers #594