### PR TITLE
Avoids race condition on first gitjob creation whith polling enabled

### DIFF
--- a/internal/cmd/controller/gitops/reconciler/gitjob_controller.go
+++ b/internal/cmd/controller/gitops/reconciler/gitjob_controller.go
@@ -315,12 +315,19 @@ func monitorLatestCommit(obj metav1.Object, fetch func() (string, error)) (strin
 
 // manageGitJob is responsible for creating, updating and deleting the GitJob and setting the GitRepo's status accordingly
 func (r *GitJobReconciler) manageGitJob(ctx context.Context, logger logr.Logger, gitrepo *v1alpha1.GitRepo, oldCommit string) (ctrl.Result, error) {
-	if err := r.deletePreviousJob(ctx, logger, *gitrepo, oldCommit); err != nil {
+	deleted, err := r.deletePreviousJob(ctx, logger, *gitrepo, oldCommit)
+	if err != nil {
 		return ctrl.Result{}, err
+	}
+	// Requeue to give the deleted job's pod time to terminate before creating the new job.
+	// Without this, both the old and the new fleet-apply pods may run concurrently and
+	// race to create the same Bundle.
+	if deleted {
+		return ctrl.Result{RequeueAfter: durations.DefaultRequeueAfter}, nil
 	}
 
 	var job batchv1.Job
-	err := r.Get(ctx, types.NamespacedName{
+	err = r.Get(ctx, types.NamespacedName{
 		Namespace: gitrepo.Namespace,
 		Name:      jobName(gitrepo),
 	}, &job)
@@ -431,9 +438,9 @@ func (r *GitJobReconciler) manageGitJob(ctx context.Context, logger logr.Logger,
 	return ctrl.Result{}, nil
 }
 
-func (r *GitJobReconciler) deletePreviousJob(ctx context.Context, logger logr.Logger, gitrepo v1alpha1.GitRepo, oldCommit string) error {
-	if oldCommit == "" || oldCommit == gitrepo.Status.Commit {
-		return nil
+func (r *GitJobReconciler) deletePreviousJob(ctx context.Context, logger logr.Logger, gitrepo v1alpha1.GitRepo, oldCommit string) (bool, error) {
+	if oldCommit == gitrepo.Status.Commit {
+		return false, nil
 	}
 
 	// the GitRepo is passed by value, just use the old commit
@@ -447,16 +454,20 @@ func (r *GitJobReconciler) deletePreviousJob(ctx context.Context, logger logr.Lo
 	}, &job)
 	if err != nil {
 		if !apierrors.IsNotFound(err) {
-			return err
+			return false, err
 		}
 
-		return nil
+		return false, nil
 	}
 
 	// At this point we know the previous job still exists and the commit already changed.
-	// Delete the previous one so we don't incur in conflicts
+	// Delete the previous one with background propagation so its pods are also terminated,
+	// preventing concurrent fleet-apply runs from racing to create the same Bundle.
 	logger.Info("Deleting previous job to avoid conflicts")
-	return r.Delete(ctx, &job)
+	if err := r.Delete(ctx, &job, client.PropagationPolicy(metav1.DeletePropagationBackground)); err != nil && !apierrors.IsNotFound(err) {
+		return false, err
+	}
+	return true, nil
 }
 
 func (r *GitJobReconciler) handleDelete(ctx context.Context, logger logr.Logger, gitrepo *v1alpha1.GitRepo) (ctrl.Result, error) {
@@ -525,6 +536,13 @@ func (r *GitJobReconciler) handleDelete(ctx context.Context, logger logr.Logger,
 // It checks for all the conditions so, in case more than one is met, it sets all the
 // values related in one single reconciler loop
 func (r *GitJobReconciler) shouldCreateJob(gitrepo *v1alpha1.GitRepo, oldCommit string, helmSecretsChanged bool) bool {
+	// When polling is enabled and we don't have a commit yet, wait for the polling
+	// job to provide one. Creating a job without a commit is wasteful and risks
+	// racing with the job created once polling returns the first commit.
+	if gitrepo.Status.Commit == "" && !gitrepo.Spec.DisablePolling {
+		return false
+	}
+
 	if gitrepo.Status.Commit != "" && gitrepo.Status.Commit != oldCommit {
 		return true
 	}

--- a/internal/cmd/controller/gitops/reconciler/gitjob_test.go
+++ b/internal/cmd/controller/gitops/reconciler/gitjob_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-logr/logr"
 	"github.com/google/go-cmp/cmp"
 	fleetapply "github.com/rancher/fleet/internal/cmd/cli/apply"
 	"github.com/rancher/fleet/internal/cmd/controller/finalize"
@@ -3048,5 +3049,148 @@ func TestUpdateSecretDataHashes_AggregatesNonNotFoundErrors(t *testing.T) {
 	}
 	if !strings.Contains(errStr, "helm-paths-secret") {
 		t.Errorf("expected error to contain 'helm-paths-secret', got: %v", err)
+	}
+}
+
+// TestDeletePreviousJob_EmptyOldCommit_DeletesJobCreatedWithNoCommit tests the
+// race where two fleet-apply jobs run concurrently:
+//
+//  1. A job is created when generationChanged is true but Status.Commit is still ""
+//     (the polling job hasn't resolved a commit yet).
+//  2. The polling job sets PollingCommit; a new reconcile runs, getNextCommit promotes
+//     it into Status.Commit, and a second job is created for the real commit.
+//
+// Because deletePreviousJob used to short-circuit on `oldCommit == ""`, the first
+// (empty-commit) job was never deleted.  Both jobs ran fleet apply against the same
+// repo and the second one hit "bundle already exists".
+func TestDeletePreviousJob_EmptyOldCommit_DeletesJobCreatedWithNoCommit(t *testing.T) {
+	const repoURL = "https://git.example.com/org/repo"
+	const newCommit = "a05144a086e80dd1b6ea0499eef72a6797e5150f"
+
+	gitrepo := &fleetv1.GitRepo{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-gitrepo",
+			Namespace: "fleet-local",
+		},
+		Spec: fleetv1.GitRepoSpec{
+			Repo: repoURL,
+		},
+		Status: fleetv1.GitRepoStatus{
+			// Commit has just been discovered by the polling job.
+			Commit: newCommit,
+		},
+	}
+
+	// job-X: the job that was created earlier when commit was still "".
+	emptyCommitJobName := jobName(&fleetv1.GitRepo{
+		ObjectMeta: gitrepo.ObjectMeta,
+		Spec:       gitrepo.Spec,
+		Status:     fleetv1.GitRepoStatus{Commit: ""},
+	})
+
+	emptyCommitJob := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      emptyCommitJobName,
+			Namespace: gitrepo.Namespace,
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	utilruntime.Must(batchv1.AddToScheme(scheme))
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(emptyCommitJob).
+		Build()
+
+	r := &GitJobReconciler{Client: fakeClient}
+
+	// oldCommit is "" — the value Status.Commit held before getNextCommit ran.
+	deleted, err := r.deletePreviousJob(context.Background(), logr.Discard(), *gitrepo, "")
+	if err != nil {
+		t.Fatalf("deletePreviousJob returned unexpected error: %v", err)
+	}
+	if !deleted {
+		t.Errorf("deletePreviousJob returned deleted=false; expected true so manageGitJob requeues instead of immediately creating the next job")
+	}
+
+	// The empty-commit job must have been deleted
+	var job batchv1.Job
+	getErr := fakeClient.Get(context.Background(), types.NamespacedName{
+		Name:      emptyCommitJobName,
+		Namespace: gitrepo.Namespace,
+	}, &job)
+	if getErr == nil {
+		t.Errorf("job %q was NOT deleted even though a new commit is now known; "+
+			"this leaves two fleet-apply jobs running concurrently and causes 'bundle already exists'",
+			emptyCommitJobName)
+	} else if !apierrors.IsNotFound(getErr) {
+		t.Fatalf("unexpected error checking for job: %v", getErr)
+	}
+}
+
+// TestShouldCreateJob_NoCommitWithPolling verifies that shouldCreateJob returns
+// false when the commit is empty and polling is enabled.
+// This prevents job-X (empty-commit job) from being created in the first place,
+// eliminating the race with job-Y that would be created once polling returns a commit.
+func TestShouldCreateJob_NoCommitWithPolling(t *testing.T) {
+	r := &GitJobReconciler{}
+
+	gitrepo := &fleetv1.GitRepo{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "my-gitrepo",
+			Namespace:       "fleet-local",
+			Generation:      2,
+			ResourceVersion: "1",
+		},
+		Spec: fleetv1.GitRepoSpec{
+			Repo:           "https://git.example.com/org/repo",
+			DisablePolling: false, // polling enabled
+		},
+		Status: fleetv1.GitRepoStatus{
+			Commit:             "", // no commit yet
+			ObservedGeneration: 1,  // generationChanged() would return true
+		},
+	}
+
+	// Regardless of generationChanged(), ForceSyncGeneration, or helmSecretsChanged,
+	// we must not create a job when there is no commit and polling is enabled.
+	// In that case the commit will be fetched asynchronously by the polling job, so we can just wait
+	got := r.shouldCreateJob(gitrepo, "", true)
+	if got {
+		t.Error("shouldCreateJob returned true with empty commit and polling enabled; " +
+			"this would create a wasted empty-commit job that races with the first real job")
+	}
+}
+
+// TestShouldCreateJob_NoCommitDisablePolling verifies that shouldCreateJob is
+// allowed to return true when polling is disabled and the commit is empty.
+// In that case the commit is fetched synchronously by monitorLatestCommit before
+// this function is reached, so an empty commit just means the fetch failed and
+// we still need to attempt a job (or at least honour generationChanged etc.).
+func TestShouldCreateJob_NoCommitDisablePolling(t *testing.T) {
+	r := &GitJobReconciler{}
+
+	gitrepo := &fleetv1.GitRepo{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "my-gitrepo",
+			Namespace:       "fleet-local",
+			Generation:      2,
+			ResourceVersion: "1",
+		},
+		Spec: fleetv1.GitRepoSpec{
+			Repo:           "https://git.example.com/org/repo",
+			DisablePolling: true, // polling disabled — synchronous fetch path
+		},
+		Status: fleetv1.GitRepoStatus{
+			Commit:             "",
+			ObservedGeneration: 1, // generationChanged() returns true
+		},
+	}
+
+	got := r.shouldCreateJob(gitrepo, "", false)
+	if !got {
+		t.Error("shouldCreateJob returned false with DisablePolling=true and generationChanged()=true; " +
+			"job should still be created when polling is disabled")
 	}
 }


### PR DESCRIPTION
When polling is enabled Fleet is creating the gijob for calling fleet apply twice. The first time we're creating the gitjob because of the creation of the GitRepo itself and the second time it is because we receive the pollingCommi asynchronously from the quartz scheduler.

This was producing a concurrent execution of fleet apply, which was ending up in Bundle creation conflicts.

Also, when deleting a previous job Fleet was not deleting the child pods. The PR is also doing this and requeuing after deleting a previous job so k8s has time to effectively delete fleet apply pods and avoid race conditions.

Refers to: https://github.com/rancher/fleet/issues/4984

## Additional Information

### Checklist

~- [ ] <!-- If applicable,--> I have updated the documentation via a pull request in the [fleet-product-docs](https://github.com/rancher/fleet-product-docs) repository.~
