### PR TITLE
Fix `Test Fleet in Rancher` CI workflow

### DIFF
--- a/.github/scripts/register-downstream-clusters.sh
+++ b/.github/scripts/register-downstream-clusters.sh
@@ -26,8 +26,13 @@ if [ "$token" = "null" ] || [ -z "$token" ]; then
   exit 1
 fi
 
+# Get CA Cert from cattle-system/tls-rancher secret
+TMPCRT=$(mktemp)
+trap 'rm -rf "${TMPCRT}"' EXIT
+kubectl get secret tls-rancher -n cattle-system -o jsonpath='{.data.tls\.crt}' | base64 -d > "${TMPCRT}"
+
 # Log into the 4th project listed by `rancher login`, which should be the local cluster's default project.
-echo -e "4\n" | $rancher_cli login "https://$public_hostname" --token "$token" --skip-verify
+echo -e "4\n" | $rancher_cli login "https://$public_hostname" --token "$token" --cacert "${TMPCRT}"
 
 $rancher_cli clusters create second --import
 until $rancher_cli cluster ls --format json | jq -r 'select(.Name=="second") | .ID' | grep -Eq "c-[a-z0-9]" ; do sleep 1; done

--- a/.github/workflows/e2e-test-fleet-in-rancher.yml
+++ b/.github/workflows/e2e-test-fleet-in-rancher.yml
@@ -198,8 +198,14 @@ jobs:
 
           kubectl config use-context k3d-upstream
 
-          until kubectl get service -n kube-system traefik -o jsonpath='{.status.loadBalancer.ingress[0].ip}'; do sleep 3; done
-          ip=$(kubectl get service -n kube-system traefik -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+          ip=""
+          while [ -z "$ip" ]; do
+            ip=$(kubectl get service -n kube-system traefik -o jsonpath='{.status.loadBalancer.ingress[0].ip}' || true)
+            if [ -z "$ip" ]; then
+              echo "Waiting for traefik load balancer ingress..."
+              sleep 3
+            fi
+          done
 
           helm repo add jetstack https://charts.jetstack.io
           helm install cert-manager jetstack/cert-manager \

--- a/.github/workflows/e2e-test-fleet-in-rancher.yml
+++ b/.github/workflows/e2e-test-fleet-in-rancher.yml
@@ -235,6 +235,8 @@ jobs:
             --set "extraEnv[2].value=${fleet_version}" \
             --set "extraEnv[3].name=CATTLE_SERVER_URL" \
             --set "extraEnv[3].value=https://$ip.sslip.io" \
+            --set-string fleet.extraEnv[0].name=EXPERIMENTAL_COPY_RESOURCES_DOWNSTREAM \
+            --set-string fleet.extraEnv[0].value=true
 
           # wait for deployment of rancher
           kubectl -n cattle-system rollout status deploy/rancher

--- a/.github/workflows/e2e-test-fleet-in-rancher.yml
+++ b/.github/workflows/e2e-test-fleet-in-rancher.yml
@@ -71,7 +71,7 @@ jobs:
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: ~/.local/bin/crust-gather
-          key: ${{ runner.os }}-crust-gather-${{ hashFiles('.github/scripts/install-crust-gather.sh') }}
+          key: ${{ runner.os }}-crust-gather-${{ hashFiles('./fleet/.github/scripts/install-crust-gather.sh') }}
           restore-keys: |
             ${{ runner.os }}-crust-gather-
       -
@@ -90,7 +90,7 @@ jobs:
         id: rancher-cli-cache
         with:
           path: ~/.local/bin/rancher
-          key: ${{ runner.os }}-rancher-cli-${{ hashFiles('.github/workflows/e2e-test-fleet-in-rancher.yml') }}
+          key: ${{ runner.os }}-rancher-cli-${{ hashFiles('./fleet/.github/workflows/e2e-test-fleet-in-rancher.yml') }}
 
       -
         name: Cache kubectl and helm
@@ -100,7 +100,7 @@ jobs:
           path: |
             ~/.local/bin/kubectl
             ~/.local/bin/helm
-          key: ${{ runner.os }}-deps-${{ hashFiles('.github/workflows/e2e-test-fleet-in-rancher.yml') }}
+          key: ${{ runner.os }}-deps-${{ hashFiles('./fleet/.github/workflows/e2e-test-fleet-in-rancher.yml') }}
 
       -
         name: Install Dependencies
@@ -146,7 +146,7 @@ jobs:
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: ~/.local/bin/k3d
-          key: ${{ runner.os }}-k3d-${{ hashFiles('.github/scripts/install-k3d.sh') }}
+          key: ${{ runner.os }}-k3d-${{ hashFiles('./fleet/.github/scripts/install-k3d.sh') }}
           restore-keys: |
             ${{ runner.os }}-k3d-
       -

--- a/.github/workflows/e2e-test-fleet-in-rancher.yml
+++ b/.github/workflows/e2e-test-fleet-in-rancher.yml
@@ -78,7 +78,7 @@ jobs:
         name: Install crust-gather CLI
         run: |
           if [ "${{ steps.cache-crust.outputs.cache-hit }}" != "true" ]; then
-            ./.github/scripts/install-crust-gather.sh
+            ./fleet/.github/scripts/install-crust-gather.sh
           else
             echo "Using cached crust-gather CLI"
             chmod +x ~/.local/bin/crust-gather
@@ -153,7 +153,7 @@ jobs:
         name: Install k3d
         run: |
           if [ "${{ steps.cache-k3d.outputs.cache-hit }}" != "true" ]; then
-            ./.github/scripts/install-k3d.sh
+            ./fleet/.github/scripts/install-k3d.sh
           else
             echo "Using cached k3d"
             chmod +x ~/.local/bin/k3d
@@ -287,6 +287,7 @@ jobs:
           FLEET_E2E_NS_DOWNSTREAM: fleet-default
         run: |
           kubectl config use-context k3d-upstream
+          cd fleet
           ginkgo --github-output --trace e2e/acceptance/single-cluster-examples
 
           export CI_REGISTERED_CLUSTER=$(kubectl get clusters.fleet.cattle.io -n $FLEET_E2E_NS_DOWNSTREAM -o jsonpath='{..name}')

--- a/.github/workflows/release-against-test-charts.yml
+++ b/.github/workflows/release-against-test-charts.yml
@@ -152,15 +152,17 @@ jobs:
         run: |
           cd charts
           # Add upstream remote and fetch from it
-          git remote add -f upstream https://github.com/rancher/charts
+          # Name it `origin` for compatibility with `make pull-scripts`
+          git remote rename origin fleetoci
+          git remote add -f origin https://github.com/rancher/charts
 
           target_branch=${{steps.compute_target_branch.outputs.target_branch}}
           base_branch=${{steps.compute_env.outputs.charts_base_branch}}
 
-          git checkout -b $target_branch upstream/$base_branch
+          git checkout -b $target_branch origin/$base_branch
           if [ $? -eq 128 ]; then # branch already exists
             git checkout $target_branch
-            git rebase upstream/$base_branch
+            git rebase origin/$base_branch
           fi
 
       - name: Install dependencies
@@ -187,4 +189,4 @@ jobs:
       - name: Push to custom branch
         run: |
           cd charts
-          git push -u origin ${{ steps.compute_target_branch.outputs.target_branch }}
+          git push -u fleetoci ${{ steps.compute_target_branch.outputs.target_branch }}

--- a/e2e/multi-cluster/downstream_clone_objects_test.go
+++ b/e2e/multi-cluster/downstream_clone_objects_test.go
@@ -345,7 +345,7 @@ var _ = Describe("Downstream objects cloning", Ordered, func() {
 			clusterName := ""
 			By("getting the downstream cluster name with label env=test")
 			Eventually(func(g Gomega) {
-				out, err := k.Namespace(env.ClusterRegistrationNamespace).Get("clusters", "-l", "env=test", "-o", "jsonpath={.items[0].metadata.name}")
+				out, err := k.Namespace(env.ClusterRegistrationNamespace).Get("clusters.fleet.cattle.io", "-l", "env=test", "-o", "jsonpath={.items[0].metadata.name}")
 				g.Expect(err).ToNot(HaveOccurred())
 				g.Expect(out).ToNot(BeEmpty())
 				clusterName = out
@@ -353,7 +353,7 @@ var _ = Describe("Downstream objects cloning", Ordered, func() {
 
 			By("getting the cluster namespace for the downstream cluster")
 			Eventually(func(g Gomega) {
-				out, err := k.Namespace(env.ClusterRegistrationNamespace).Get("clusters", clusterName, "-o", "jsonpath={.status.namespace}")
+				out, err := k.Namespace(env.ClusterRegistrationNamespace).Get("clusters.fleet.cattle.io", clusterName, "-o", "jsonpath={.status.namespace}")
 				g.Expect(err).ToNot(HaveOccurred())
 				g.Expect(out).ToNot(BeEmpty())
 				clusterNameSpace = out


### PR DESCRIPTION
That workflow needed some love, received in the shape of:
* scripts from the `fleet` repo now being called with their proper paths, following #4927
* the availability of the `traefik` service being checked through non-emptiness of its load-balancer ingress IP, which is more effective than checking that the corresponding `kubectl get` command does not error (when it could still be returning an empty IP)
* the experimental downstream resource copy feature being enabled when installing Rancher, to allow multi-cluster end-to-end tests to pass, along with clusters being queried as `clusters.fleet.cattle.io` to reduce the risk of ambiguity
* when building a test state for `fleetrepoci/charts`, `release-against-test-charts.yml` using `origin` (instead of `upstream`) as the name of the remote pointing to `rancher/charts`, to cater for new versions of `scripts/pull-scripts` in that repository (more context in [this commit](https://github.com/rancher/charts/commit/d381300150574ba423589a0a167c4ed528a99f50#diff-12597a6c65aa7d63cb630da39e89795c31769f028db7db86d048b8852bbcae39R215))
* `rancher login` now working with `--cacert`, instead of the now defunct `--skip-verify`.

Example of a successful run: [here](https://github.com/rancher/fleet/actions/runs/24843960599).

Refers to #4601.