### PR TITLE
Fix `Upgrade Fleet in Rancher To HEAD` CI workflow

### DIFF
--- a/.github/scripts/register-downstream-clusters.sh
+++ b/.github/scripts/register-downstream-clusters.sh
@@ -26,8 +26,13 @@ if [ "$token" = "null" ] || [ -z "$token" ]; then
   exit 1
 fi
 
+# Get CA Cert from cattle-system/tls-rancher secret
+TMPCRT=$(mktemp)
+trap 'rm -rf "${TMPCRT}"' EXIT
+kubectl get secret tls-rancher -n cattle-system -o jsonpath='{.data.tls\.crt}' | base64 -d > "${TMPCRT}"
+
 # Log into the 4th project listed by `rancher login`, which should be the local cluster's default project.
-echo -e "4\n" | $rancher_cli login "https://$public_hostname" --token "$token" --skip-verify
+echo -e "4\n" | $rancher_cli login "https://$public_hostname" --token "$token" --cacert "${TMPCRT}"
 
 $rancher_cli clusters create second --import
 until $rancher_cli cluster ls --format json | jq -r 'select(.Name=="second") | .ID' | grep -Eq "c-[a-z0-9]" ; do sleep 1; done

--- a/.github/scripts/setup-rancher.sh
+++ b/.github/scripts/setup-rancher.sh
@@ -9,7 +9,7 @@ version="${1-}"
 
 kubectl config use-context "$upstream_ctx"
 
-kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.5.4/cert-manager.yaml
+kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.19.2/cert-manager.yaml
 kubectl wait --for=condition=Available deployment --timeout=2m -n cert-manager --all
 
 helm repo add rancher-latest https://releases.rancher.com/server-charts/latest

--- a/.github/scripts/setup-rancher.sh
+++ b/.github/scripts/setup-rancher.sh
@@ -28,8 +28,8 @@ helm upgrade rancher rancher-latest/rancher $args \
   --set bootstrapPassword=admin \
   --set "extraEnv[0].name=CATTLE_SERVER_URL" \
   --set "extraEnv[0].value=https://$public_hostname" \
-  --set "extraEnv[1].name=CATTLE_BOOTSTRAP_PASSWORD" \
-  --set "extraEnv[1].value=rancherpassword"
+  --set-string "fleet.extraEnv[0].name=EXPERIMENTAL_COPY_RESOURCES_DOWNSTREAM" \
+  --set-string "fleet.extraEnv[0].value=true"
 
 # wait for deployment of rancher
 kubectl -n cattle-system rollout status deploy/rancher

--- a/.github/scripts/upgrade-rancher-fleet-to-dev-fleet.sh
+++ b/.github/scripts/upgrade-rancher-fleet-to-dev-fleet.sh
@@ -19,13 +19,13 @@ downstream_ctx="${FLEET_E2E_CLUSTER_DOWNSTREAM-k3d-downstream}"
 
 kubectl config use-context k3d-upstream
 
-until helm -n cattle-fleet-system status fleet-crd  | grep -q "STATUS: deployed"; do echo waiting for original fleet-crd chart to be deployed; sleep 1; done
+until helm -n cattle-fleet-system status fleet-crd  | grep "STATUS: deployed"; do echo waiting for original fleet-crd chart to be deployed; sleep 1; done
 
 # avoid a downgrade by rancher
 sed -i 's/^version: 0/version: 9000/' charts/fleet-crd/Chart.yaml
 helm upgrade fleet-crd charts/fleet-crd  --wait -n cattle-fleet-system
 
-until helm -n cattle-fleet-system status fleet | grep -q "STATUS: deployed"; do echo waiting for original fleet chart to be deployed; sleep 3; done
+until helm -n cattle-fleet-system status fleet | grep "STATUS: deployed"; do echo waiting for original fleet chart to be deployed; sleep 3; done
 
 # avoid a downgrade by rancher
 sed -i 's/^version: 0/version: 9000/' charts/fleet/Chart.yaml

--- a/.github/workflows/e2e-rancher-upgrade-fleet-to-head-ci.yml
+++ b/.github/workflows/e2e-rancher-upgrade-fleet-to-head-ci.yml
@@ -177,9 +177,21 @@ jobs:
             --k3s-arg "--cluster-init@server:0"
       -
         name: Set up Rancher
-        env:
-          public_hostname: "172.18.0.1.sslip.io"
         run: |
+          ip=""
+
+          kubectl config use-context k3d-upstream
+
+          while [ -z "$ip" ]; do
+            ip=$(kubectl get service -n kube-system traefik -o jsonpath='{.status.loadBalancer.ingress[0].ip}' || true)
+            if [ -z "$ip" ]; then
+              echo "Waiting for traefik load balancer ingress..."
+              sleep 3
+            fi
+          done
+
+          export public_hostname=$ip.sslip.io
+
           ./.github/scripts/setup-rancher.sh
           ./.github/scripts/wait-for-loadbalancer.sh
           ./.github/scripts/register-downstream-clusters.sh

--- a/.github/workflows/e2e-rancher-upgrade-fleet-to-head-ci.yml
+++ b/.github/workflows/e2e-rancher-upgrade-fleet-to-head-ci.yml
@@ -61,7 +61,7 @@ jobs:
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         id: rancher-cli-cache
         with:
-          path: /home/runner/.local/bin
+          path: ~/.local/bin/rancher
           key: ${{ runner.os }}-rancher-cli-2.14.0
       -
         name: Install Rancher CLI

--- a/.github/workflows/e2e-rancher-upgrade-fleet-to-head-ci.yml
+++ b/.github/workflows/e2e-rancher-upgrade-fleet-to-head-ci.yml
@@ -179,13 +179,20 @@ jobs:
         name: Set up Rancher
         run: |
           ip=""
+          attempts=0
+          max_attempts=50
 
           kubectl config use-context k3d-upstream
 
           while [ -z "$ip" ]; do
+            attempts=$((attempt +1))
             ip=$(kubectl get service -n kube-system traefik -o jsonpath='{.status.loadBalancer.ingress[0].ip}' || true)
             if [ -z "$ip" ]; then
-              echo "Waiting for traefik load balancer ingress..."
+              if [ "$attempts" -ge "$max_attempts" ]; then
+                echo "Timed out waiting for traefik load balancer ingress IP after $((max_attempts * 3)) seconds."
+                exit 1
+              fi
+              echo "Waiting for traefik load balancer ingress... (attempt $attempts/$max_attempts)"
               sleep 3
             fi
           done

--- a/.github/workflows/e2e-rancher-upgrade-fleet-to-head-ci.yml
+++ b/.github/workflows/e2e-rancher-upgrade-fleet-to-head-ci.yml
@@ -90,7 +90,13 @@ jobs:
       -
         name: Get uuid
         id: uuid
-        run: echo "::set-output name=uuid::$(uuidgen)"
+        run: |
+          if ! command -v uuidgen >/dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt install -y uuid-runtime # should provide uuidgen
+          fi
+
+          echo "uuid=$(uuidgen)" >> $GITHUB_OUTPUT
       -
         id: meta-fleet
         uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0

--- a/.github/workflows/e2e-rancher-upgrade-fleet-to-head-ci.yml
+++ b/.github/workflows/e2e-rancher-upgrade-fleet-to-head-ci.yml
@@ -62,18 +62,20 @@ jobs:
         id: rancher-cli-cache
         with:
           path: /home/runner/.local/bin
-          key: ${{ runner.os }}-rancher-cli-2.6.0
+          key: ${{ runner.os }}-rancher-cli-2.14.0
       -
         name: Install Rancher CLI
         if: steps.rancher-cli-cache.outputs.cache-hit != 'true'
         run: |
-          # download an older CLI to avoid https://github.com/rancher/rancher/issues/37574
-          # renovate: datasource=github-release-attachments depName=rancher/cli digestVersion=v2.6.0
-          RANCHER_CLI_SUM="e3f2f8bc04b763759d027ba30a6563b81a1ba6d881b1f3c95b24931a7804fb79"
-          mkdir -p /home/runner/.local/bin
-          wget -q https://github.com/rancher/cli/releases/download/v2.6.0/rancher-linux-amd64-v2.6.0.tar.gz
-          echo "${RANCHER_CLI_SUM}  rancher-linux-amd64-v2.6.0.tar.gz" | sha256sum -c -
-          tar -xz --strip-components=2 -f rancher-linux-amd64-v2.6.0.tar.gz -C /home/runner/.local/bin
+          mkdir -p ~/.local/bin
+          # renovate: datasource=github-releases depName=rancher/cli
+          RANCHER_CLI_VERSION="v2.14.0"
+          # renovate: datasource=github-release-attachments depName=rancher/cli digestVersion=v2.14.0
+          RANCHER_CLI_SUM_amd64="d05e207d9830f22171e62801dc51a32417125ecb7aaf50c073bf423e7da36a94"
+          curl -fsSL -o "rancher-linux-amd64-${RANCHER_CLI_VERSION}.tar.gz" \
+            "https://github.com/rancher/cli/releases/download/${RANCHER_CLI_VERSION}/rancher-linux-amd64-${RANCHER_CLI_VERSION}.tar.gz"
+          echo "${RANCHER_CLI_SUM_amd64}  rancher-linux-amd64-${RANCHER_CLI_VERSION}.tar.gz" | sha256sum -c -
+          tar -xz --strip-components=2 -f "rancher-linux-amd64-${RANCHER_CLI_VERSION}.tar.gz" -C ~/.local/bin
           rancher --version
       -
         name: Build fleet binaries

--- a/e2e/multi-cluster/downstream_clone_objects_test.go
+++ b/e2e/multi-cluster/downstream_clone_objects_test.go
@@ -345,7 +345,7 @@ var _ = Describe("Downstream objects cloning", Ordered, func() {
 			clusterName := ""
 			By("getting the downstream cluster name with label env=test")
 			Eventually(func(g Gomega) {
-				out, err := k.Namespace(env.ClusterRegistrationNamespace).Get("clusters", "-l", "env=test", "-o", "jsonpath={.items[0].metadata.name}")
+				out, err := k.Namespace(env.ClusterRegistrationNamespace).Get("clusters.fleet.cattle.io", "-l", "env=test", "-o", "jsonpath={.items[0].metadata.name}")
 				g.Expect(err).ToNot(HaveOccurred())
 				g.Expect(out).ToNot(BeEmpty())
 				clusterName = out
@@ -353,7 +353,7 @@ var _ = Describe("Downstream objects cloning", Ordered, func() {
 
 			By("getting the cluster namespace for the downstream cluster")
 			Eventually(func(g Gomega) {
-				out, err := k.Namespace(env.ClusterRegistrationNamespace).Get("clusters", clusterName, "-o", "jsonpath={.status.namespace}")
+				out, err := k.Namespace(env.ClusterRegistrationNamespace).Get("clusters.fleet.cattle.io", clusterName, "-o", "jsonpath={.status.namespace}")
 				g.Expect(err).ToNot(HaveOccurred())
 				g.Expect(out).ToNot(BeEmpty())
 				clusterNameSpace = out


### PR DESCRIPTION
That workflow needed some love, received in the shape of:
* `uuidgen` being sourced to prevent command-not-found errors
* the availability of the `traefik` service being checked through non-emptiness of its load-balancer ingress IP, which is more effective than checking that the corresponding `kubectl get` command does not error (when it could still be returning an empty IP)
* the experimental downstream resource copy feature being enabled when installing Rancher, to allow multi-cluster end-to-end tests to pass, along with clusters being queried as `clusters.fleet.cattle.io` to reduce the risk of ambiguity
* `rancher login`, using version 2.14.0 of the CLI, now working with `--cacert`, instead of the now defunct `--skip-verify`.

Example of a successful run: [here](https://github.com/rancher/fleet/actions/runs/24843928839).

Refers to #4601
Related to #5041 (a few similar changes).