### PR TITLE
[v0.11] Align Helm deployer client construction

### DIFF
--- a/internal/helmdeployer/deployer.go
+++ b/internal/helmdeployer/deployer.go
@@ -83,7 +83,7 @@ func (h *Helm) Setup(ctx context.Context, client client.Client, getter genericcl
 	h.client = client
 	h.getter = getter
 
-	cfg, err := h.createCfg(ctx, "")
+	cfg, err := h.createCfg(ctx, "", h.getter)
 	if err != nil {
 		return err
 	}
@@ -147,7 +147,7 @@ func (h *Helm) getCfg(ctx context.Context, namespace, serviceAccountName string)
 	kClient := kube.New(getter)
 	kClient.Namespace = namespace
 
-	cfg, err = h.createCfg(ctx, namespace)
+	cfg, err = h.createCfg(ctx, namespace, getter)
 	cfg.Releases.MaxHistory = MaxHelmHistory
 	cfg.KubeClient = kClient
 
@@ -156,12 +156,12 @@ func (h *Helm) getCfg(ctx context.Context, namespace, serviceAccountName string)
 	return cfg, err
 }
 
-func (h *Helm) createCfg(ctx context.Context, namespace string) (action.Configuration, error) {
+func (h *Helm) createCfg(ctx context.Context, namespace string, getter genericclioptions.RESTClientGetter) (action.Configuration, error) {
 	logger := log.FromContext(ctx).WithName("helmSDK")
 	info := func(format string, v ...interface{}) {
 		logger.V(1).Info(fmt.Sprintf(format, v...))
 	}
-	kc := kube.New(h.getter)
+	kc := kube.New(getter)
 	kc.Log = info
 	clientSet, err := kc.Factory.KubernetesClientSet()
 	if err != nil {
@@ -173,7 +173,7 @@ func (h *Helm) createCfg(ctx context.Context, namespace string) (action.Configur
 	store.MaxHistory = MaxHelmHistory
 
 	return action.Configuration{
-		RESTClientGetter: h.getter,
+		RESTClientGetter: getter,
 		Releases:         store,
 		KubeClient:       kc,
 		Log:              info,

--- a/internal/helmdeployer/install.go
+++ b/internal/helmdeployer/install.go
@@ -17,8 +17,10 @@ import (
 	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/types"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/yaml"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -67,12 +69,22 @@ func (h *Helm) install(ctx context.Context, bundleID string, manifest *manifest.
 	logger := log.FromContext(ctx).WithName("helm-deployer").WithName("install").WithValues("commit", manifest.Commit, "dryRun", dryRun)
 	timeout, defaultNamespace, releaseName := h.getOpts(bundleID, options)
 
-	values, err := h.getValues(ctx, options, defaultNamespace)
+	cfg, err := h.getCfg(ctx, defaultNamespace, options.ServiceAccount)
 	if err != nil {
 		return nil, err
 	}
 
-	cfg, err := h.getCfg(ctx, defaultNamespace, options.ServiceAccount)
+	// kubeClient is nil in template mode; getValues treats a nil client as
+	// "skip ValuesFrom lookup" and returns only the statically defined values.
+	var kubeClient kubernetes.Interface
+	if !h.template {
+		kubeClient, err = kubeClientFromGetter(cfg.RESTClientGetter)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	values, err := h.getValues(ctx, options, defaultNamespace, kubeClient)
 	if err != nil {
 		return nil, err
 	}
@@ -202,7 +214,7 @@ func (h *Helm) mustInstall(cfg *action.Configuration, releaseName string) (bool,
 	return false, err
 }
 
-func (h *Helm) getValues(ctx context.Context, options fleet.BundleDeploymentOptions, defaultNamespace string) (map[string]interface{}, error) {
+func (h *Helm) getValues(ctx context.Context, options fleet.BundleDeploymentOptions, defaultNamespace string, kubeClient kubernetes.Interface) (map[string]interface{}, error) {
 	if options.Helm == nil {
 		return nil, nil
 	}
@@ -216,8 +228,8 @@ func (h *Helm) getValues(ctx context.Context, options fleet.BundleDeploymentOpti
 	if values == nil {
 		values = map[string]interface{}{}
 	}
-	// do not run this when using template
-	if !h.template {
+	// kubeClient is nil in template mode; skip the cluster lookups in that case.
+	if kubeClient != nil {
 		for _, valuesFrom := range options.Helm.ValuesFrom {
 			var tempValues map[string]interface{}
 			if valuesFrom.ConfigMapKeyRef != nil {
@@ -230,8 +242,7 @@ func (h *Helm) getValues(ctx context.Context, options fleet.BundleDeploymentOpti
 				if key == "" {
 					key = DefaultKey
 				}
-				configMap := &corev1.ConfigMap{}
-				err := h.client.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, configMap)
+				configMap, err := kubeClient.CoreV1().ConfigMaps(namespace).Get(ctx, name, metav1.GetOptions{})
 				if err != nil {
 					return nil, err
 				}
@@ -256,8 +267,7 @@ func (h *Helm) getValues(ctx context.Context, options fleet.BundleDeploymentOpti
 				if key == "" {
 					key = DefaultKey
 				}
-				secret := &corev1.Secret{}
-				err := h.client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, secret)
+				secret, err := kubeClient.CoreV1().Secrets(namespace).Get(ctx, name, metav1.GetOptions{})
 				if err != nil {
 					return nil, err
 				}
@@ -273,6 +283,21 @@ func (h *Helm) getValues(ctx context.Context, options fleet.BundleDeploymentOpti
 	}
 
 	return values, nil
+}
+
+// restConfigGetter produces a *rest.Config. Both
+// genericclioptions.RESTClientGetter and action.RESTClientGetter satisfy it.
+type restConfigGetter interface {
+	ToRESTConfig() (*rest.Config, error)
+}
+
+func kubeClientFromGetter(getter restConfigGetter) (kubernetes.Interface, error) {
+	restConfig, err := getter.ToRESTConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	return kubernetes.NewForConfig(restConfig)
 }
 
 func valuesFromSecret(name, namespace, key string, secret *corev1.Secret) (map[string]interface{}, error) {

--- a/internal/helmdeployer/install_test.go
+++ b/internal/helmdeployer/install_test.go
@@ -1,14 +1,19 @@
 package helmdeployer
 
 import (
+	"context"
 	"fmt"
 	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
+	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubernetesfake "k8s.io/client-go/kubernetes/fake"
 )
 
 func TestValuesFrom(t *testing.T) {
@@ -59,4 +64,114 @@ func TestValuesFrom(t *testing.T) {
 	totalValues = mergeValues(totalValues, secretValues)
 	totalValues = mergeValues(totalValues, configMapValues)
 	a.Equal(expected, totalValues)
+}
+
+func TestValuesFromUsesExplicitNamespace(t *testing.T) {
+	a := assert.New(t)
+	r := require.New(t)
+
+	defaultNS := "helm-default"
+	explicitNS := "explicit-ns"
+
+	cm := corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "cm-explicit", Namespace: explicitNS},
+		Data:       map[string]string{DefaultKey: "cmVal: explicit"},
+	}
+
+	kubeClient := kubernetesfake.NewSimpleClientset(&cm)
+	h := &Helm{template: false}
+
+	opts := fleet.BundleDeploymentOptions{
+		Helm: &fleet.HelmOptions{
+			ValuesFrom: []fleet.ValuesFrom{{ConfigMapKeyRef: &fleet.ConfigMapKeySelector{
+				LocalObjectReference: fleet.LocalObjectReference{Name: "cm-explicit"},
+				Namespace:            explicitNS,
+			}}},
+		},
+	}
+
+	vals, err := h.getValues(context.TODO(), opts, defaultNS, kubeClient)
+	r.NoError(err)
+	a.Equal("explicit", vals["cmVal"])
+}
+
+func TestValuesFromUsesDefaultNamespaceWhenNoneSpecified(t *testing.T) {
+	a := assert.New(t)
+	r := require.New(t)
+
+	defaultNS := "helm-default"
+
+	cm := corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "cm-default", Namespace: defaultNS},
+		Data:       map[string]string{DefaultKey: "cmVal: fromDefault"},
+	}
+	sec := corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "sec-default", Namespace: defaultNS},
+		Data:       map[string][]byte{DefaultKey: []byte("secVal: fromDefault")},
+	}
+
+	kubeClient := kubernetesfake.NewSimpleClientset(&cm, &sec)
+	h := &Helm{template: false}
+
+	opts := fleet.BundleDeploymentOptions{
+		Helm: &fleet.HelmOptions{
+			ValuesFrom: []fleet.ValuesFrom{
+				{ConfigMapKeyRef: &fleet.ConfigMapKeySelector{LocalObjectReference: fleet.LocalObjectReference{Name: "cm-default"}}},
+				{SecretKeyRef: &fleet.SecretKeySelector{LocalObjectReference: fleet.LocalObjectReference{Name: "sec-default"}}},
+			},
+		},
+	}
+
+	vals, err := h.getValues(context.TODO(), opts, defaultNS, kubeClient)
+	r.NoError(err)
+	a.Equal("fromDefault", vals["cmVal"])
+	a.Equal("fromDefault", vals["secVal"])
+}
+
+func TestValuesFromReturnsNotFoundWhenResourceMissing(t *testing.T) {
+	r := require.New(t)
+
+	kubeClient := kubernetesfake.NewSimpleClientset()
+	h := &Helm{template: false}
+
+	opts := fleet.BundleDeploymentOptions{
+		Helm: &fleet.HelmOptions{
+			ValuesFrom: []fleet.ValuesFrom{
+				{ConfigMapKeyRef: &fleet.ConfigMapKeySelector{
+					LocalObjectReference: fleet.LocalObjectReference{Name: "missing"},
+					Namespace:            "some-ns",
+				}},
+			},
+		},
+	}
+
+	_, err := h.getValues(context.TODO(), opts, "default-ns", kubeClient)
+	r.Error(err)
+	r.True(apierrors.IsNotFound(err), "expected a NotFound error when valuesFrom references a missing resource")
+}
+
+func TestValuesFromSkipsLookupInTemplateMode(t *testing.T) {
+	a := assert.New(t)
+	r := require.New(t)
+
+	// nil kubeClient signals template mode — no lookups should be performed
+	h := &Helm{template: true}
+
+	opts := fleet.BundleDeploymentOptions{
+		Helm: &fleet.HelmOptions{
+			Values: &fleet.GenericMap{Data: map[string]interface{}{"static": "value"}},
+			ValuesFrom: []fleet.ValuesFrom{
+				{ConfigMapKeyRef: &fleet.ConfigMapKeySelector{
+					LocalObjectReference: fleet.LocalObjectReference{Name: "should-not-be-read"},
+					Namespace:            "some-ns",
+				}},
+			},
+		},
+	}
+
+	vals, err := h.getValues(context.TODO(), opts, "default", nil)
+	r.NoError(err)
+	a.Equal("value", vals["static"])
+	_, hasUnwanted := vals["should-not-be-read"]
+	a.False(hasUnwanted, "template mode should not read from cluster")
 }


### PR DESCRIPTION
The Helm deployer had two places where client construction did not consistently use the same getter.

Refers https://github.com/rancher/fleet/security/advisories/GHSA-765j-qfrp-hm3j