### PR TITLE
Remove ineffective Renovate comments

### DIFF
--- a/.github/workflows/e2e-test-fleet-in-rancher.yml
+++ b/.github/workflows/e2e-test-fleet-in-rancher.yml
@@ -107,18 +107,14 @@ jobs:
         run: |
           mkdir -p ~/.local/bin
           if [ "${{ steps.deps-cache.outputs.cache-hit }}" != "true" ]; then
-            # renovate: datasource=github-releases depName=kubernetes/kubernetes
             KUBECTL_VERSION="v1.35.3"
-            # renovate: datasource=github-release-attachments depName=kubernetes/kubernetes digestVersion=v1.35.3
             KUBECTL_SUM_amd64="fd31c7d7129260e608f6faf92d5984c3267ad0b5ead3bced2fe125686e286ad6"
             curl -sSfL "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" -o kubectl
             echo "${KUBECTL_SUM_amd64}  kubectl" | sha256sum -c -
             mv kubectl ~/.local/bin/
             chmod +x ~/.local/bin/kubectl
 
-            # renovate: datasource=github-releases depName=helm/helm
             HELM_VERSION="v4.1.3"
-            # renovate: datasource=github-release-attachments depName=helm/helm digestVersion=v4.1.3
             HELM_SUM_amd64="02ce9722d541238f81459938b84cf47df2fdf1187493b4bfb2346754d82a4700"
             curl -sSfL "https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz" -o helm.tar.gz
             echo "${HELM_SUM_amd64}  helm.tar.gz" | sha256sum -c -


### PR DESCRIPTION
because Helm and kubernetes cli do not provide regular checksums in their Github assets, so Renovate can not extract a digest.

Preventing broken bumps like [this](https://github.com/rancher/fleet/pull/5049/changes#diff-9ac854164a34df7149225b04404c2e0f4509e212d139589eff2274786eeab82dL111-R113) or [this](https://github.com/rancher/fleet/pull/4992/changes#diff-9ac854164a34df7149225b04404c2e0f4509e212d139589eff2274786eeab82dL120-R122).