### PR TITLE
Retry nightly and benchmark failures once

### DIFF
--- a/.github/workflows/retry-failed-jobs.yml
+++ b/.github/workflows/retry-failed-jobs.yml
@@ -1,4 +1,4 @@
-name: Retry failed PR jobs once
+name: Retry failed jobs once
 
 on:
   workflow_run:
@@ -7,6 +7,8 @@ on:
       - "E2E Fleet"
       - "E2E Upgrade Fleet Standalone to HEAD"
       - "E2E Multi-Cluster Fleet"
+      - "E2E Nightly Fleet"
+      - "Benchmarks"
     types: [completed]
 
 permissions:
@@ -14,12 +16,16 @@ permissions:
 
 jobs:
   retry:
-    # Only retry once, only on pull_request runs, only on failure.
+    # Only retry once, only on failure.
     # Skipped runs (e.g. path filters) have conclusion 'skipped', not 'failure'.
+    # Retry pull_request runs for all listed PR workflows.
+    # Retry schedule/workflow_dispatch runs only for nightly and benchmark workflows.
     if: >-
       github.event.workflow_run.conclusion == 'failure' &&
       github.event.workflow_run.run_attempt == 1 &&
-      github.event.workflow_run.event == 'pull_request'
+      (github.event.workflow_run.event == 'pull_request' ||
+       github.event.workflow_run.name == 'E2E Nightly Fleet' ||
+       github.event.workflow_run.name == 'Benchmarks')
     runs-on: ubuntu-latest
     steps:
       - name: Rerun failed jobs


### PR DESCRIPTION
Add "E2E Nightly Fleet" and "Benchmarks" to the workflow_run trigger list.

This should help nightly runs to provide more representative results.