### PR TITLE
Remove set -ex from sourced setup-cluster-config

### DIFF
--- a/dev/setup-cluster-config
+++ b/dev/setup-cluster-config
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-set -ex
-
 if [ "$1" = "teardown" ]; then
     go run ./e2e/testenv/infra/main.go teardown
     return 0


### PR DESCRIPTION
`setup-cluster-config` is always `source`d by `setup-single-cluster` and `setup-multi-cluster`, so `set -ex` propagated `set -e` into the user's interactive shell. When any subsequent subprocess failed (e.g. `helm` not installed), the shell exited silently instead of displaying the error and returning control to the user. The script already uses explicit `return` statements for all error paths and does not need `set -e`.