### PR TITLE
[v0.11] Switch non-release workflows to GitHub runners

### DIFF
--- a/.github/workflows/check-changes.yml
+++ b/.github/workflows/check-changes.yml
@@ -10,7 +10,7 @@ env:
 
 jobs:
   check-changes:
-    runs-on: runs-on,runner=4cpu-linux-x64,run-id=${{ github.run_id }}
+    runs-on: ubuntu-latest
 
     steps:
       -

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   unit-test:
-    runs-on: runs-on,runner=16cpu-linux-x64,mem=16,run-id=${{ github.run_id }}
+    runs-on: ubuntu-latest
 
     steps:
       -

--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   e2e-fleet-test:
-    runs-on: runs-on,runner=16cpu-linux-x64,mem=16,run-id=${{ github.run_id }}
+    runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false

--- a/.github/workflows/e2e-multicluster-ci.yml
+++ b/.github/workflows/e2e-multicluster-ci.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   e2e-fleet-mc-test:
-    runs-on: runs-on,runner=8cpu-linux-x64,mem=16,run-id=${{ github.run_id }}
+    runs-on: ubuntu-latest
 
     steps:
       -

--- a/.github/workflows/e2e-nightly-ci.yml
+++ b/.github/workflows/e2e-nightly-ci.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   e2e-fleet-nightly-test:
-    runs-on: runs-on,runner=8cpu-linux-x64,mem=16,run-id=${{ github.run_id }}
+    runs-on: ubuntu-latest
 
     strategy:
       matrix:

--- a/.github/workflows/e2e-rancher-upgrade-fleet-to-head-ci.yml
+++ b/.github/workflows/e2e-rancher-upgrade-fleet-to-head-ci.yml
@@ -23,7 +23,7 @@ env:
 
 jobs:
   rancher-fleet-integration:
-    runs-on: runs-on,runner=8cpu-linux-x64,mem=16,run-id=${{ github.run_id }}
+    runs-on: ubuntu-latest
 
     steps:
       -

--- a/.github/workflows/e2e-rancher-upgrade-fleet.yml
+++ b/.github/workflows/e2e-rancher-upgrade-fleet.yml
@@ -41,7 +41,7 @@ env:
 
 jobs:
   rancher-fleet-upgrade:
-    runs-on: runs-on,runner=8cpu-linux-x64,mem=16,run-id=${{ github.run_id }}
+    runs-on: ubuntu-latest
 
     steps:
       -

--- a/.github/workflows/e2e-test-fleet-in-rancher.yml
+++ b/.github/workflows/e2e-test-fleet-in-rancher.yml
@@ -49,7 +49,7 @@ env:
 
 jobs:
   rancher-integration:
-    runs-on: runs-on,runner=4cpu-linux-x64,run-id=${{ github.run_id }}
+    runs-on: ubuntu-latest
 
     steps:
       -

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   golangci:
     name: golangci-lint
-    runs-on: runs-on,runner=4cpu-linux-x64,run-id=${{ github.run_id }}
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout

--- a/.github/workflows/release-against-charts.yml
+++ b/.github/workflows/release-against-charts.yml
@@ -29,7 +29,7 @@ on:
 
 jobs:
   create-rancher-charts-pr:
-    runs-on: runs-on,runner=4cpu-linux-x64,run-id=${{ github.run_id }}
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4

--- a/.github/workflows/release-against-rancher.yml
+++ b/.github/workflows/release-against-rancher.yml
@@ -30,7 +30,7 @@ env:
 
 jobs:
   create-rancher-pr:
-    runs-on: runs-on,runner=4cpu-linux-x64,run-id=${{ github.run_id }}
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4

--- a/.github/workflows/release-against-test-charts.yml
+++ b/.github/workflows/release-against-test-charts.yml
@@ -28,7 +28,7 @@ permissions:
 
 jobs:
   push-test-rancher-charts:
-    runs-on: runs-on,runner=8cpu-linux-x64,run-id=${{ github.run_id }}
+    runs-on: ubuntu-latest
 
     outputs:
       target_branch: ${{ steps.compute_target_branch.outputs.target_branch }}

--- a/.github/workflows/typos.yaml
+++ b/.github/workflows/typos.yaml
@@ -4,7 +4,7 @@ on: [pull_request]
 jobs:
   run:
     name: Spell Check with Typos
-    runs-on: runs-on,runner=4cpu-linux-x64,run-id=${{ github.run_id }}
+    runs-on: ubuntu-latest
 
     steps:
     - name: Checkout Repository

--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   updatecli:
-    runs-on: runs-on,runner=4cpu-linux-x64,run-id=${{ github.run_id }}
+    runs-on: ubuntu-latest
 
     if: github.ref == 'refs/heads/main'
     steps:


### PR DESCRIPTION
Fourteen workflows were using the custom `runs-on,runner=…` runner label instead of `ubuntu-latest`. Only `release-fleet.yml` is intended to run on our own runners.