### PR TITLE
Switch non-release workflows to GitHub runners

### DIFF
--- a/.github/workflows/e2e-nightly-ci.yml
+++ b/.github/workflows/e2e-nightly-ci.yml
@@ -27,7 +27,7 @@ env:
 
 jobs:
   e2e-fleet-nightly-test:
-    runs-on: runs-on,runner=8cpu-linux-x64,mem=16,run-id=${{ github.run_id }}
+    runs-on: ubuntu-latest
 
     strategy:
       matrix:

--- a/.github/workflows/e2e-nightly-ci.yml
+++ b/.github/workflows/e2e-nightly-ci.yml
@@ -27,7 +27,7 @@ env:
 
 jobs:
   e2e-fleet-nightly-test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-8-cores
 
     strategy:
       matrix:

--- a/.github/workflows/e2e-test-fleet-in-rancher.yml
+++ b/.github/workflows/e2e-test-fleet-in-rancher.yml
@@ -36,7 +36,7 @@ jobs:
     secrets: inherit # needed to enable access to repo secrets from the called workflow
 
   rancher-integration:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-16-cores
     needs: release-against-test-charts
 
     steps:

--- a/.github/workflows/e2e-test-fleet-in-rancher.yml
+++ b/.github/workflows/e2e-test-fleet-in-rancher.yml
@@ -36,7 +36,7 @@ jobs:
     secrets: inherit # needed to enable access to repo secrets from the called workflow
 
   rancher-integration:
-    runs-on: runs-on,runner=16cpu-linux-x64,run-id=${{ github.run_id }}
+    runs-on: ubuntu-latest
     needs: release-against-test-charts
 
     steps:

--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   updatecli:
-    runs-on: runs-on,runner=8cpu-linux-x64,mem=16,run-id=${{ github.run_id }}
+    runs-on: ubuntu-latest
 
     if: github.ref == 'refs/heads/main'
     steps:


### PR DESCRIPTION
Three workflows (`e2e-nightly-ci`, `e2e-test-fleet-in-rancher`, `updatecli`) were using the custom `runs-on,runner=…` runner label instead of `ubuntu-latest`. Only `release.yml` is intended to run on our own runners.

The nightly ci was still failing besides the restart ci activation for it, so I would like to try use Github runners for them too.