### PR TITLE
Revert to ubuntu-latest for nightly and Rancher integration

### DIFF
--- a/.github/workflows/e2e-nightly-ci.yml
+++ b/.github/workflows/e2e-nightly-ci.yml
@@ -27,7 +27,7 @@ env:
 
 jobs:
   e2e-fleet-nightly-test:
-    runs-on: ubuntu-latest-8-cores
+    runs-on: ubuntu-latest
 
     strategy:
       matrix:

--- a/.github/workflows/e2e-test-fleet-in-rancher.yml
+++ b/.github/workflows/e2e-test-fleet-in-rancher.yml
@@ -36,7 +36,7 @@ jobs:
     secrets: inherit # needed to enable access to repo secrets from the called workflow
 
   rancher-integration:
-    runs-on: ubuntu-latest-16-cores
+    runs-on: ubuntu-latest
     needs: release-against-test-charts
 
     steps:


### PR DESCRIPTION
`ubuntu-latest-8-cores` and `ubuntu-latest-16-cores` are not pre-defined GitHub runner labels — Ubuntu larger runners require manual org-level configuration under GitHub Team/Enterprise Cloud plans. Jobs were stuck in queue waiting for a runner that doesn't exist.