### PR TITLE
Remove unused validateURL function

### DIFF
--- a/pkg/git/validate.go
+++ b/pkg/git/validate.go
@@ -33,13 +33,6 @@ const (
 	branchInvalidSuffix = ".lock"
 	branchInvalidPrefix = "."
 	branchInvalidValues = "@"
-
-	// urlMaxLength represents the max length accepted for git URLs.
-	//
-	// Value is based on libgit2's:
-	// - https://github.com/libgit2/libgit2/blob/936b184e7494158c20e522981f4a324cac6ffa47/src/util/win32/w32_common.h#L13-L18
-	// - https://github.com/libgit2/libgit2/blob/936b184e7494158c20e522981f4a324cac6ffa47/include/git2/common.h#L103-L106
-	urlMaxLength = 4096
 )
 
 // validateBranch validates a branch name and return an error in case it is
@@ -85,16 +78,5 @@ func validateCommit(commit string) error {
 		return nil
 	default:
 		return fmt.Errorf("invalid commit ID: %q", commit)
-	}
-}
-
-func validateURL(u string) error {
-	switch {
-	case u == "":
-		return errors.New("invalid url: cannot be empty")
-	case len(u) > urlMaxLength:
-		return fmt.Errorf("invalid url: exceeds max length %d", urlMaxLength)
-	default:
-		return nil
 	}
 }

--- a/pkg/git/validate_test.go
+++ b/pkg/git/validate_test.go
@@ -116,22 +116,4 @@ var _ = Describe("git's validate tests", func() {
 		Expect(err).To(HaveOccurred())
 		Expect(err).To(Equal(fmt.Errorf("invalid commit ID: %q is not a valid hex", commit)))
 	})
-
-	It("Returns no error when url is not longer than 4096 chars nor empty", func() {
-		url := getRandomString(10)
-		err := validateURL(url)
-		Expect(err).ToNot(HaveOccurred())
-	})
-
-	It("Returns an error when url is empty", func() {
-		err := validateURL("")
-		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(Equal("invalid url: cannot be empty"))
-	})
-
-	It("Returns an error when url is too long", func() {
-		err := validateURL(getRandomString(5000))
-		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(Equal("invalid url: exceeds max length 4096"))
-	})
 })


### PR DESCRIPTION
The function was not called from any code path. Removing it along with its tests and the `urlMaxLength` constant.