### PR TITLE
Propagate CATTLE_WRANGLER_CHECK_GVK_ERROR_MAPPING to fleet-agent

### DIFF
--- a/internal/cmd/agent/deployer/summary/summarizers.go
+++ b/internal/cmd/agent/deployer/summary/summarizers.go
@@ -10,6 +10,7 @@ import (
 	"github.com/rancher/fleet/internal/cmd/agent/deployer/data"
 	"github.com/rancher/fleet/internal/cmd/agent/deployer/data/convert"
 	"github.com/rancher/fleet/internal/cmd/agent/deployer/kv"
+	"github.com/rancher/fleet/internal/config"
 	fleetv1 "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1/summary"
 
 	"github.com/sirupsen/logrus"
@@ -22,9 +23,8 @@ import (
 )
 
 const (
-	kindSep                    = ", Kind="
-	reason                     = "%REASON%"
-	checkGVKErrorMappingEnvVar = "CATTLE_WRANGLER_CHECK_GVK_ERROR_MAPPING"
+	kindSep = ", Kind="
+	reason  = "%REASON%"
 )
 
 var (
@@ -152,7 +152,7 @@ func init() {
 }
 
 func initializeCheckErrors() {
-	gvkConfig := os.Getenv(checkGVKErrorMappingEnvVar)
+	gvkConfig := os.Getenv(config.EnvVarWranglerCheckGVKErrorMapping)
 	if gvkConfig != "" {
 		logrus.Debugf("GVK Error Mapping Provided")
 		gvkErrorMapping := ConditionTypeStatusErrorMapping{}

--- a/internal/cmd/agent/deployer/summary/summarizers_test.go
+++ b/internal/cmd/agent/deployer/summary/summarizers_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/rancher/fleet/internal/cmd/agent/deployer/data"
+	"github.com/rancher/fleet/internal/config"
 	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1/summary"
 	"github.com/stretchr/testify/assert"
 
@@ -173,7 +174,7 @@ func TestCheckErrors(t *testing.T) {
 				},
 			},
 			loadConditions: func() {
-				t.Setenv(checkGVKErrorMappingEnvVar, `
+				t.Setenv(config.EnvVarWranglerCheckGVKErrorMapping, `
 					[
 						{
 							"gvk": "sample.cattle.io/v1, Kind=Sample",
@@ -210,7 +211,7 @@ func TestCheckErrors(t *testing.T) {
 				},
 			},
 			loadConditions: func() {
-				t.Setenv(checkGVKErrorMappingEnvVar, `
+				t.Setenv(config.EnvVarWranglerCheckGVKErrorMapping, `
 					[
 						{
 							"gvk": "sample.cattle.io/v1, Kind=Sample",
@@ -294,7 +295,7 @@ func TestCheckErrors(t *testing.T) {
 				},
 			},
 			loadConditions: func() {
-				t.Setenv(checkGVKErrorMappingEnvVar, `
+				t.Setenv(config.EnvVarWranglerCheckGVKErrorMapping, `
 					[
 						{
 							"gvk": "sample.cattle.io/v1, Kind=Sample",
@@ -332,7 +333,7 @@ func TestCheckErrors(t *testing.T) {
 				},
 			},
 			loadConditions: func() {
-				t.Setenv(checkGVKErrorMappingEnvVar, `
+				t.Setenv(config.EnvVarWranglerCheckGVKErrorMapping, `
 					[
 						{
 							"gvk": "sample.cattle.io/v1, Kind=Sample",

--- a/internal/cmd/controller/agentmanagement/agent/manifest.go
+++ b/internal/cmd/controller/agentmanagement/agent/manifest.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"os"
 	"path"
 	"strconv"
 	"strings"
@@ -197,6 +198,7 @@ func agentApp(namespace string, agentScope string, opts ManifestOptions) *appsv1
 								{Name: "CATTLE_ELECTION_RETRY_PERIOD", Value: opts.RetryPeriod.String()},
 								{Name: "CATTLE_ELECTION_RENEW_DEADLINE", Value: opts.RenewDeadline.String()},
 								{Name: "EXPERIMENTAL_COPY_RESOURCES_DOWNSTREAM", Value: strconv.FormatBool(experimental.CopyResourcesDownstreamEnabled())},
+								{Name: config.EnvVarWranglerCheckGVKErrorMapping, Value: os.Getenv(config.EnvVarWranglerCheckGVKErrorMapping)},
 							},
 							Command: []string{
 								"fleetagent",

--- a/internal/cmd/controller/agentmanagement/agent/manifest.go
+++ b/internal/cmd/controller/agentmanagement/agent/manifest.go
@@ -198,7 +198,6 @@ func agentApp(namespace string, agentScope string, opts ManifestOptions) *appsv1
 								{Name: "CATTLE_ELECTION_RETRY_PERIOD", Value: opts.RetryPeriod.String()},
 								{Name: "CATTLE_ELECTION_RENEW_DEADLINE", Value: opts.RenewDeadline.String()},
 								{Name: "EXPERIMENTAL_COPY_RESOURCES_DOWNSTREAM", Value: strconv.FormatBool(experimental.CopyResourcesDownstreamEnabled())},
-								{Name: config.EnvVarWranglerCheckGVKErrorMapping, Value: os.Getenv(config.EnvVarWranglerCheckGVKErrorMapping)},
 							},
 							Command: []string{
 								"fleetagent",
@@ -306,6 +305,12 @@ func agentApp(namespace string, agentScope string, opts ManifestOptions) *appsv1
 		}
 
 		// additional env vars from cluster
+		if gvkVal := os.Getenv(config.EnvVarWranglerCheckGVKErrorMapping); gvkVal != "" && !envVarPresent(opts.AgentEnvVars, config.EnvVarWranglerCheckGVKErrorMapping) {
+			container.Env = append(container.Env, corev1.EnvVar{
+				Name:  config.EnvVarWranglerCheckGVKErrorMapping,
+				Value: gvkVal,
+			})
+		}
 		if opts.AgentEnvVars != nil {
 			container.Env = append(container.Env, opts.AgentEnvVars...)
 		}
@@ -324,6 +329,15 @@ func agentApp(namespace string, agentScope string, opts ManifestOptions) *appsv1
 	}
 
 	return app
+}
+
+func envVarPresent(vars []corev1.EnvVar, name string) bool {
+	for _, v := range vars {
+		if v.Name == name {
+			return true
+		}
+	}
+	return false
 }
 
 func serviceAccount(namespace, name string) *corev1.ServiceAccount {

--- a/internal/cmd/controller/agentmanagement/agent/manifest_test.go
+++ b/internal/cmd/controller/agentmanagement/agent/manifest_test.go
@@ -360,37 +360,57 @@ func TestManifestCheckGVKErrorMappingEnvVar(t *testing.T) {
 	for _, tc := range []struct {
 		name          string
 		envValue      string
+		agentEnvVars  []corev1.EnvVar
+		expectFound   bool
 		expectedValue string
 	}{
 		{
-			name:          "env var not set",
-			envValue:      "",
-			expectedValue: "",
+			name:        "env var not set",
+			envValue:    "",
+			expectFound: false,
 		},
 		{
 			name:          "single GVK mapping",
 			envValue:      singleMapping,
+			expectFound:   true,
 			expectedValue: singleMapping,
 		},
 		{
 			name:          "multiple GVK mappings",
 			envValue:      multiMapping,
+			expectFound:   true,
+			expectedValue: multiMapping,
+		},
+		{
+			name:     "env var already in AgentEnvVars is not duplicated",
+			envValue: singleMapping,
+			agentEnvVars: []corev1.EnvVar{
+				{Name: config.EnvVarWranglerCheckGVKErrorMapping, Value: multiMapping},
+			},
+			expectFound:   true,
 			expectedValue: multiMapping,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Setenv(config.EnvVarWranglerCheckGVKErrorMapping, tc.envValue)
 
-			d := getAgentFromManifests("test-scope", baseOpts)
+			opts := baseOpts
+			opts.AgentEnvVars = tc.agentEnvVars
+
+			d := getAgentFromManifests("test-scope", opts)
 			if d == nil {
 				t.Fatal("no deployment returned from manifests")
 			}
 
 			envVar, found := findEnvVar(d.Spec.Template.Spec.Containers, config.EnvVarWranglerCheckGVKErrorMapping)
-			if !found {
-				t.Fatalf("env var %s not found in agent container", config.EnvVarWranglerCheckGVKErrorMapping)
+			if found != tc.expectFound {
+				if tc.expectFound {
+					t.Fatalf("env var %s not found in agent container", config.EnvVarWranglerCheckGVKErrorMapping)
+				} else {
+					t.Fatalf("env var %s unexpectedly found in agent container with value %q", config.EnvVarWranglerCheckGVKErrorMapping, envVar.Value)
+				}
 			}
-			if envVar.Value != tc.expectedValue {
+			if tc.expectFound && envVar.Value != tc.expectedValue {
 				t.Fatalf("expected %s=%q, got %q", config.EnvVarWranglerCheckGVKErrorMapping, tc.expectedValue, envVar.Value)
 			}
 		})

--- a/internal/cmd/controller/agentmanagement/agent/manifest_test.go
+++ b/internal/cmd/controller/agentmanagement/agent/manifest_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/rancher/fleet/internal/cmd"
 	"github.com/rancher/fleet/internal/cmd/controller/agentmanagement/agent"
+	"github.com/rancher/fleet/internal/config"
 )
 
 const namespace = "fleet-system"
@@ -332,6 +333,65 @@ func TestPriorityClassName(t *testing.T) {
 			})
 			if d.Spec.Template.Spec.PriorityClassName != test.priorityClassName {
 				t.Fatalf("expected PriorityClassName to be %s, got %s", test.priorityClassName, d.Spec.Template.Spec.PriorityClassName)
+			}
+		})
+	}
+}
+
+func findEnvVar(containers []corev1.Container, name string) (corev1.EnvVar, bool) {
+	for _, c := range containers {
+		for _, e := range c.Env {
+			if e.Name == name {
+				return e, true
+			}
+		}
+	}
+	return corev1.EnvVar{}, false
+}
+
+func TestManifestCheckGVKErrorMappingEnvVar(t *testing.T) {
+	baseOpts := agent.ManifestOptions{
+		LeaderElectionOptions: leaderOpts,
+	}
+
+	singleMapping := `[{"gvk":"sample.cattle.io/v1, Kind=Sample","conditionMappings":[{"type":"Failed","status":["True"]}]}]`
+	multiMapping := `[{"gvk":"sample.cattle.io/v1, Kind=Sample","conditionMappings":[{"type":"Failed","status":["True"]}]},{"gvk":"helm.cattle.io/v1, Kind=HelmChart","conditionMappings":[{"type":"Failed","status":["True"]}]}]`
+
+	for _, tc := range []struct {
+		name          string
+		envValue      string
+		expectedValue string
+	}{
+		{
+			name:          "env var not set",
+			envValue:      "",
+			expectedValue: "",
+		},
+		{
+			name:          "single GVK mapping",
+			envValue:      singleMapping,
+			expectedValue: singleMapping,
+		},
+		{
+			name:          "multiple GVK mappings",
+			envValue:      multiMapping,
+			expectedValue: multiMapping,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(config.EnvVarWranglerCheckGVKErrorMapping, tc.envValue)
+
+			d := getAgentFromManifests("test-scope", baseOpts)
+			if d == nil {
+				t.Fatal("no deployment returned from manifests")
+			}
+
+			envVar, found := findEnvVar(d.Spec.Template.Spec.Containers, config.EnvVarWranglerCheckGVKErrorMapping)
+			if !found {
+				t.Fatalf("env var %s not found in agent container", config.EnvVarWranglerCheckGVKErrorMapping)
+			}
+			if envVar.Value != tc.expectedValue {
+				t.Fatalf("expected %s=%q, got %q", config.EnvVarWranglerCheckGVKErrorMapping, tc.expectedValue, envVar.Value)
 			}
 		})
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -43,6 +43,9 @@ const (
 	// server.
 	APIServerCAKey = "apiServerCA"
 
+	// EnvVarWranglerCheckGVKErrorMapping is the env var name used to configure Wrangler's GVK error mapping.
+	EnvVarWranglerCheckGVKErrorMapping = "CATTLE_WRANGLER_CHECK_GVK_ERROR_MAPPING"
+
 	// Default secret name for git credentials, used as a fallback if no secret is referenced by an app.
 	DefaultGitCredentialsSecretName = "gitcredential" //nolint:gosec // this is a resource name
 


### PR DESCRIPTION
The controller now forwards the CATTLE_WRANGLER_CHECK_GVK_ERROR_MAPPING env variable to the agent deployment, following the same pattern used by EXPERIMENTAL_COPY_RESOURCES_DOWNSTREAM.

The env var name is defined as a single exported constant (EnvVarWranglerCheckGVKErrorMapping) in internal/config, replacing the package-private copy that existed in the summary package.

Refers to: https://github.com/rancher/fleet/issues/5060


## Additional Information

### Checklist

~- [ ] <!-- If applicable,--> I have updated the documentation via a pull request in the [fleet-product-docs](https://github.com/rancher/fleet-product-docs) repository.~
