### PR TITLE
Fix govet linter issues

### DIFF
--- a/internal/cmd/agent/deployer/monitor/condition.go
+++ b/internal/cmd/agent/deployer/monitor/condition.go
@@ -85,7 +85,7 @@ func getStatus(obj any, condName string) string {
 }
 
 func setStatus(obj any, condName, status string) {
-	if reflect.TypeOf(obj).Kind() != reflect.Ptr {
+	if reflect.TypeOf(obj).Kind() != reflect.Pointer {
 		panic("obj passed must be a pointer")
 	}
 	cond := findOrCreateCond(obj, condName)
@@ -149,7 +149,7 @@ func getValue(obj any, name ...string) reflect.Value {
 	}
 	v := reflect.ValueOf(obj)
 	t := v.Type()
-	if t.Kind() == reflect.Ptr {
+	if t.Kind() == reflect.Pointer {
 		v = v.Elem()
 	}
 

--- a/internal/cmd/controller/agentmanagement/scheduling/scheduling_test.go
+++ b/internal/cmd/controller/agentmanagement/scheduling/scheduling_test.go
@@ -13,7 +13,6 @@ import (
 	schedulingv1 "k8s.io/api/scheduling/v1"
 )
 
-//go:fix inline
 func ptr[T any](v T) *T {
 	return new(v)
 }

--- a/internal/cmd/controller/reconciler/predicate.go
+++ b/internal/cmd/controller/reconciler/predicate.go
@@ -15,7 +15,7 @@ type TypedResourceVersionUnchangedPredicate[T metav1.Object] struct {
 }
 
 func isNil(arg any) bool {
-	if v := reflect.ValueOf(arg); !v.IsValid() || ((v.Kind() == reflect.Ptr ||
+	if v := reflect.ValueOf(arg); !v.IsValid() || ((v.Kind() == reflect.Pointer ||
 		v.Kind() == reflect.Interface ||
 		v.Kind() == reflect.Slice ||
 		v.Kind() == reflect.Map ||

--- a/internal/cmd/controller/summary/summary.go
+++ b/internal/cmd/controller/summary/summary.go
@@ -107,7 +107,7 @@ func GetDeploymentState(bundleDeployment *fleet.BundleDeployment) fleet.BundleSt
 // SetReadyConditions expects a status object as obj and updates its ready conditions according to summary
 // as per ReadyMessage
 func SetReadyConditions(obj any, referencedKind string, summary fleet.BundleSummary) {
-	if reflect.ValueOf(obj).Kind() != reflect.Ptr {
+	if reflect.ValueOf(obj).Kind() != reflect.Pointer {
 		panic("obj passed must be a pointer")
 	}
 	c := condition.Cond("Ready")

--- a/internal/helmdeployer/lookup.go
+++ b/internal/helmdeployer/lookup.go
@@ -150,7 +150,7 @@ func nodeIsNil(node parse.Node) bool {
 		return true
 	}
 	rv := reflect.ValueOf(node)
-	if rv.Kind() == reflect.Ptr && rv.IsNil() {
+	if rv.Kind() == reflect.Pointer && rv.IsNil() {
 		return true
 	}
 	return false


### PR DESCRIPTION
Replace deprecated reflect.Ptr constant with reflect.Pointer across condition.go, predicate.go, summary.go, and lookup.go. Remove the //go:fix inline directive from the generic ptr helper in scheduling_test.go, which the inliner cannot process due to type parameter inference not being supported.