### PR TITLE
Fix PollingInterval update dropped by Status().Patch() in webhook handler

### DIFF
--- a/integrationtests/gitjob/controller/controller_test.go
+++ b/integrationtests/gitjob/controller/controller_test.go
@@ -913,6 +913,67 @@ var _ = Describe("GitJob controller", func() {
 		})
 	})
 
+	// Regression test for https://github.com/rancher/fleet/issues/5077: when polling is
+	// enabled a webhook commit must still trigger a new git job.
+	When("a new GitRepo is created with polling enabled and WebhookCommit changes", func() {
+		var (
+			gitRepo     v1alpha1.GitRepo
+			gitRepoName string
+			job         batchv1.Job
+		)
+		const webhookCommit = "af6116a6c5c3196043b4a456316ae257dad9b5db"
+
+		BeforeEach(func() {
+			gitRepoName = "polling-enabled-webhook-commit"
+			expectedCommit = stableCommit
+		})
+
+		JustBeforeEach(func() {
+			gitRepo = createGitRepo(gitRepoName)
+			// Use a very long polling interval so that polling does not interfere
+			// with the test timing after the initial run.
+			gitRepo.Spec.Branch = stableCommitBranch
+			Expect(k8sClient.Create(ctx, &gitRepo)).To(Succeed())
+
+			By("Waiting for the initial job created by polling")
+			Eventually(func() error {
+				jobName := names.SafeConcatName(gitRepoName, names.Hex(repo+stableCommit, 5))
+				return k8sClient.Get(ctx, types.NamespacedName{Name: jobName, Namespace: gitRepoNamespace}, &job)
+			}, testenv.MediumTimeout, testenv.ShortTimeout).Should(Not(HaveOccurred()))
+
+			By("Simulating the initial job completing successfully")
+			Eventually(func() error {
+				jobName := names.SafeConcatName(gitRepoName, names.Hex(repo+stableCommit, 5))
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: jobName, Namespace: gitRepoNamespace}, &job)
+				if client.IgnoreNotFound(err) != nil {
+					return err
+				}
+				job.Status = succeeded(job.Status)
+				return k8sClient.Status().Update(ctx, &job)
+			}).Should(Not(HaveOccurred()))
+
+			Eventually(func() bool {
+				jobName := names.SafeConcatName(gitRepoName, names.Hex(repo+stableCommit, 5))
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: jobName, Namespace: gitRepoNamespace}, &job)
+				return errors.IsNotFound(err)
+			}).Should(BeTrue())
+
+			By("Setting WebhookCommit to simulate a webhook event")
+			Expect(setGitRepoWebhookCommit(gitRepo, webhookCommit)).To(Succeed())
+		})
+
+		AfterEach(func() {
+			waitDeleteGitrepo(gitRepo)
+		})
+
+		It("creates a new Job for the webhook commit", func() {
+			Eventually(func() error {
+				jobName := names.SafeConcatName(gitRepoName, names.Hex(repo+webhookCommit, 5))
+				return k8sClient.Get(ctx, types.NamespacedName{Name: jobName, Namespace: gitRepoNamespace}, &job)
+			}, testenv.MediumTimeout, testenv.ShortTimeout).Should(Not(HaveOccurred()))
+		})
+	})
+
 	When("creating a gitRepo that references a helm secret", func() {
 		var (
 			gitRepo        v1alpha1.GitRepo

--- a/integrationtests/gitjob/controller/controller_test.go
+++ b/integrationtests/gitjob/controller/controller_test.go
@@ -930,8 +930,9 @@ var _ = Describe("GitJob controller", func() {
 
 		JustBeforeEach(func() {
 			gitRepo = createGitRepo(gitRepoName)
-			// Use a very long polling interval so that polling does not interfere
-			// with the test timing after the initial run.
+			// Set a very long polling interval so that polling does not trigger
+			// additional jobs after the initial run and interfere with test timing.
+			gitRepo.Spec.PollingInterval = &metav1.Duration{Duration: 24 * time.Hour}
 			gitRepo.Spec.Branch = stableCommitBranch
 			Expect(k8sClient.Create(ctx, &gitRepo)).To(Succeed())
 

--- a/integrationtests/gitjob/controller/webhook_handler_test.go
+++ b/integrationtests/gitjob/controller/webhook_handler_test.go
@@ -1,0 +1,104 @@
+package controller
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	v1alpha1 "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
+	"github.com/rancher/fleet/pkg/webhook"
+)
+
+// webhookTestRepo is a unique URL that won't match any GitRepo created by other tests.
+const webhookTestRepo = "https://github.com/rancher/fleet-webhook-integration-test"
+
+// sendGitHubPush fires a simulated GitHub push event for the given commit against
+// the integration test's k8sClient (backed by the envtest API server).
+func sendGitHubPush(commit string) {
+	w, err := webhook.New(gitRepoNamespace, k8sClient)
+	Expect(err).ToNot(HaveOccurred())
+
+	body := []byte(`{"ref":"refs/heads/main","after":"` + commit +
+		`","repository":{"html_url":"` + webhookTestRepo + `"}}`)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "/", bytes.NewReader(body))
+	Expect(err).ToNot(HaveOccurred())
+	req.Header.Set("X-GitHub-Event", "push")
+
+	rr := httptest.NewRecorder()
+	w.ServeHTTP(rr, req)
+	Expect(rr.Code).To(Equal(http.StatusOK))
+}
+
+// These tests exercise the webhook HTTP handler against the real envtest API server,
+// which enforces the status subresource restriction: a Status().Patch() silently drops
+// any spec fields included in the patch.  Only a separate client.Patch() can persist
+// spec changes, so the correct two-patch approach is the only way to pass these tests.
+var _ = Describe("Webhook handler", func() {
+	var gitRepo v1alpha1.GitRepo
+
+	BeforeEach(func() {
+		gitRepo = v1alpha1.GitRepo{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "webhook-handler",
+				Namespace: gitRepoNamespace,
+			},
+			Spec: v1alpha1.GitRepoSpec{
+				Repo: webhookTestRepo,
+			},
+		}
+	})
+
+	JustBeforeEach(func() {
+		Expect(k8sClient.Create(ctx, &gitRepo)).To(Succeed())
+	})
+
+	AfterEach(func() {
+		waitDeleteGitrepo(gitRepo)
+	})
+
+	When("no PollingInterval is configured", func() {
+		const pushCommit = "aaaa1111bbbb2222cccc3333dddd4444eeee5555"
+
+		It("sets WebhookCommit and PollingInterval to 1h", func() {
+			sendGitHubPush(pushCommit)
+
+			var updated v1alpha1.GitRepo
+			Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name: gitRepo.Name, Namespace: gitRepo.Namespace,
+			}, &updated)).To(Succeed())
+
+			Expect(updated.Status.WebhookCommit).To(Equal(pushCommit))
+			Expect(updated.Spec.PollingInterval).ToNot(BeNil())
+			Expect(updated.Spec.PollingInterval.Duration).To(Equal(time.Hour))
+		})
+	})
+
+	When("PollingInterval is already configured", func() {
+		const pushCommit = "bbbb2222cccc3333dddd4444eeee5555ffff6666"
+		const existingInterval = 24 * time.Hour
+
+		BeforeEach(func() {
+			gitRepo.Spec.PollingInterval = &metav1.Duration{Duration: existingInterval}
+		})
+
+		It("sets WebhookCommit without overwriting PollingInterval", func() {
+			sendGitHubPush(pushCommit)
+
+			var updated v1alpha1.GitRepo
+			Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name: gitRepo.Name, Namespace: gitRepo.Namespace,
+			}, &updated)).To(Succeed())
+
+			Expect(updated.Status.WebhookCommit).To(Equal(pushCommit))
+			Expect(updated.Spec.PollingInterval).ToNot(BeNil())
+			Expect(updated.Spec.PollingInterval.Duration).To(Equal(existingInterval))
+		})
+	})
+})

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -168,16 +168,22 @@ func (w *Webhook) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 				}
 				orig := gitRepoFromCluster.DeepCopy()
 				gitRepoFromCluster.Status.WebhookCommit = revision
-				// if PollingInterval is not set and webhook is configured, set it to 1 hour
-				if gitRepoFromCluster.Spec.PollingInterval == nil {
+				if err := w.client.Status().Patch(ctx, &gitRepoFromCluster, client.MergeFrom(orig)); err != nil {
+					w.logAndReturn(rw, err)
+					return
+				}
+				// if PollingInterval is not set, set it to 1 hour to reduce polling load
+				// now that a webhook handles commit notifications. Use a separate spec
+				// patch because Status().Patch() only applies status subresource changes.
+				if orig.Spec.PollingInterval == nil {
+					specOrig := gitRepoFromCluster.DeepCopy()
 					gitRepoFromCluster.Spec.PollingInterval = &metav1.Duration{
 						Duration: webhookDefaultSyncInterval * time.Second,
 					}
-				}
-				p := client.MergeFrom(orig)
-				if err := w.client.Status().Patch(ctx, &gitRepoFromCluster, p); err != nil {
-					w.logAndReturn(rw, err)
-					return
+					if err := w.client.Patch(ctx, &gitRepoFromCluster, client.MergeFrom(specOrig)); err != nil {
+						w.logAndReturn(rw, err)
+						return
+					}
 				}
 			}
 		}

--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -713,8 +713,17 @@ func TestGitHubSecretAndCommitUpdated(t *testing.T) {
 					if repo.Status.WebhookCommit != expectedCommit {
 						t.Errorf("expecting gitrepo webhook commit %s, got %s", expectedCommit, repo.Status.WebhookCommit)
 					}
-					if repo.Spec.PollingInterval.Duration != time.Hour {
-						t.Errorf("expecting gitrepo polling interval 1h, got %s", repo.Spec.PollingInterval.Duration)
+					// PollingInterval must NOT be set via Status().Patch(); it uses a separate spec patch
+					if repo.Spec.PollingInterval != nil {
+						t.Errorf("PollingInterval must not appear in the status patch, got %s", repo.Spec.PollingInterval.Duration)
+					}
+				},
+			).Times(1)
+			// PollingInterval is nil on the GitRepo fixture, so a separate spec Patch() must follow
+			mockClient.EXPECT().Patch(gomock.Any(), gomock.Any(), gomock.Any()).Do(
+				func(ctx context.Context, repo *v1alpha1.GitRepo, _ client.Patch, opts ...any) {
+					if repo.Spec.PollingInterval == nil || repo.Spec.PollingInterval.Duration != time.Hour {
+						t.Errorf("expecting polling interval 1h in spec patch, got %v", repo.Spec.PollingInterval)
 					}
 				},
 			).Times(1)
@@ -832,8 +841,17 @@ func TestGitRepoURLMatch(t *testing.T) {
 			if repo.Status.WebhookCommit != expectedCommit {
 				t.Errorf("expecting gitrepo webhook commit %s, got %s", expectedCommit, repo.Status.WebhookCommit)
 			}
-			if repo.Spec.PollingInterval.Duration != time.Hour {
-				t.Errorf("expecting gitrepo polling interval 1h, got %s", repo.Spec.PollingInterval.Duration)
+			// PollingInterval must NOT be set via Status().Patch(); it uses a separate spec patch
+			if repo.Spec.PollingInterval != nil {
+				t.Errorf("PollingInterval must not appear in the status patch, got %s", repo.Spec.PollingInterval.Duration)
+			}
+		},
+	).Times(1)
+	// PollingInterval is nil on both GitRepo fixtures, so a spec Patch() must follow for the matching one
+	mockClient.EXPECT().Patch(gomock.Any(), gomock.Any(), gomock.Any()).Do(
+		func(ctx context.Context, repo *v1alpha1.GitRepo, _ client.Patch, opts ...any) {
+			if repo.Spec.PollingInterval == nil || repo.Spec.PollingInterval.Duration != time.Hour {
+				t.Errorf("expecting polling interval 1h in spec patch, got %v", repo.Spec.PollingInterval)
 			}
 		},
 	).Times(1)


### PR DESCRIPTION
The webhook handler set Spec.PollingInterval to 1 hour when a webhook fired on a GitRepo with no polling interval configured. However, the spec change was bundled with Status.WebhookCommit and sent via `client.Status().Patch()`. Since `Status().Patch()` targets the status subresource, the API server silently drops any spec fields, so `PollingInterval` was never persisted.

Split the update into two patches: `Status().Patch()` for `WebhookCommit` only, followed by a separate `client.Patch()` for `PollingInterval` when previously unset. The status patch fires first to trigger the reconciler immediately.

Add an integration test exercising the webhook HTTP handler directly against envtest. Also add an integration test covering the reconciler path: a `WebhookCommit` change on a polling-enabled GitRepo triggers a new git job.

Refers #5077