### PR TITLE
Migrate httpstream usage to `k8s.io/streaming/pkg/httpstream`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -61,6 +61,7 @@ require (
 	k8s.io/klog/v2 v2.140.0
 	k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a
 	k8s.io/kubectl v0.36.0
+	k8s.io/streaming v0.36.0
 	oras.land/oras-go/v2 v2.6.0
 	sigs.k8s.io/cli-utils v0.37.2
 	sigs.k8s.io/controller-runtime v0.24.0
@@ -201,7 +202,6 @@ require (
 	k8s.io/component-base v0.36.0 // indirect
 	k8s.io/gengo v0.0.0-20250130153323-76c5745d3511 // indirect
 	k8s.io/gengo/v2 v2.0.0-20250922181213-ec3ebc5fd46b // indirect
-	k8s.io/streaming v0.36.0 // indirect
 	k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect

--- a/internal/cmd/cli/dump/dump.go
+++ b/internal/cmd/cli/dump/dump.go
@@ -33,11 +33,11 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	errutil "k8s.io/apimachinery/pkg/util/errors"
-	"k8s.io/apimachinery/pkg/util/httpstream"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/portforward"
 	"k8s.io/client-go/transport/spdy"
+	"k8s.io/streaming/pkg/httpstream"
 
 	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
 	"github.com/rancher/fleet/pkg/sharding"
@@ -661,7 +661,7 @@ func createDialer(ctx context.Context, cfg *rest.Config, c client.Client, svc *c
 
 	httpCli := http.Client{Transport: rt}
 
-	return spdy.NewDialer(up, &httpCli, http.MethodPost, u), &httpCli, nil
+	return spdy.NewDialerForStreaming(up, &httpCli, http.MethodPost, u), &httpCli, nil
 }
 
 // filterConfig holds the filtering configuration determined from options
@@ -870,7 +870,7 @@ func forwardPorts(
 		ports := []string{fmt.Sprintf("%d:%d", port, svcPort)}
 		stopChan := make(chan struct{})
 		readyChan := make(chan struct{})
-		fwder, err := portforward.New(dl, ports, stopChan, readyChan, os.Stdout, os.Stderr)
+		fwder, err := portforward.NewForStreaming(dl, ports, stopChan, readyChan, os.Stdout, os.Stderr)
 		if err != nil {
 			msg := "failed to create ports forwarder for fetching metrics"
 			logger.Error(err, "%s%s", prefix, msg)


### PR DESCRIPTION
Module `k8s.io/apimachinery/pkg/util/httpstream` is deprecated, which led to linting errors.

## Additional Information

### Checklist

~- [ ] <!-- If applicable,--> I have updated the documentation via a pull request in the [fleet-product-docs](https://github.com/rancher/fleet-product-docs) repository.~
