### PR TITLE
Enables drift correction after the Bundle is deployed

### DIFF
--- a/integrationtests/agent/bundle_deployment_drift_test.go
+++ b/integrationtests/agent/bundle_deployment_drift_test.go
@@ -105,6 +105,59 @@ var _ = Describe("BundleDeployment drift correction", Ordered, func() {
 		})
 	})
 
+	When("Drift correction is enabled after drift has been detected", func() {
+		BeforeAll(func() {
+			namespace = createNamespace()
+			deplID = "v1"
+			correctDrift = v1alpha1.CorrectDrift{Enabled: false}
+			env = &specEnv{namespace: namespace}
+
+			name = "drift-enabled-after-detected-test"
+			createBundleDeployment(name)
+			Eventually(env.isBundleDeploymentReadyAndNotModified).WithArguments(name).Should(BeTrue())
+
+			DeferCleanup(func() {
+				Expect(k8sClient.Delete(context.TODO(), &v1alpha1.BundleDeployment{
+					ObjectMeta: metav1.ObjectMeta{Namespace: clusterNS, Name: name},
+				})).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("Enabling drift correction after a service was modified", func() {
+			It("Corrects the previously detected drift", func() {
+				By("Receiving a modification on a service")
+				svc, err := env.getService("svc-ext")
+				Expect(err).NotTo(HaveOccurred())
+				patchedSvc := svc.DeepCopy()
+				patchedSvc.Spec.ExternalName = "modified"
+				Expect(k8sClient.Patch(ctx, patchedSvc, client.StrategicMergeFrom(&svc))).NotTo(HaveOccurred())
+
+				By("Waiting for the bundle deployment to detect the drift")
+				Eventually(func(g Gomega) {
+					bd := &v1alpha1.BundleDeployment{}
+					err := k8sClient.Get(ctx, types.NamespacedName{Namespace: clusterNS, Name: name}, bd)
+					g.Expect(err).NotTo(HaveOccurred())
+					g.Expect(bd.Status.ModifiedStatus).NotTo(BeEmpty())
+				}).Should(Succeed())
+
+				By("Enabling drift correction on the bundle deployment")
+				bd := &v1alpha1.BundleDeployment{}
+				Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: clusterNS, Name: name}, bd)).NotTo(HaveOccurred())
+				patchedBD := bd.DeepCopy()
+				patchedBD.Spec.CorrectDrift = &v1alpha1.CorrectDrift{Enabled: true}
+				patchedBD.Spec.Options.CorrectDrift = &v1alpha1.CorrectDrift{Enabled: true}
+				Expect(k8sClient.Patch(ctx, patchedBD, client.MergeFrom(bd))).NotTo(HaveOccurred())
+
+				By("Restoring the service resource to its previous state")
+				Eventually(func(g Gomega) {
+					svc, err := env.getService("svc-ext")
+					g.Expect(err).NotTo(HaveOccurred())
+					g.Expect(svc.Spec.ExternalName).Should(Equal("svc-ext"))
+				}).Should(Succeed())
+			})
+		})
+	})
+
 	When("Drift correction is enabled without force", func() {
 		JustBeforeEach(func() {
 			correctDrift = v1alpha1.CorrectDrift{Enabled: true}

--- a/integrationtests/agent/suite_test.go
+++ b/integrationtests/agent/suite_test.go
@@ -216,6 +216,8 @@ func newReconciler(ctx context.Context, mgr manager.Manager, lookup *lookup, dri
 		DriftDetect: driftdetect,
 		Cleanup:     cleanup,
 
+		DriftChan: driftChan,
+
 		AgentScope: agentScope,
 		Workers:    50,
 	}

--- a/internal/cmd/agent/controller/bundledeployment_controller.go
+++ b/internal/cmd/agent/controller/bundledeployment_controller.go
@@ -300,7 +300,7 @@ func (r *BundleDeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	// If drift correction was just enabled (or any spec change occurred while
 	// drift is already present), the resource watcher won't re-emit for
 	// already-drifted resources, so wake up the DriftReconciler ourselves.
-	// Non-blocking: if the channel buffer is full a subsequent reconcile or
+	// Non-blocking: if no receiver is ready, a subsequent reconcile or
 	// resource event will deliver the signal.
 	if bd.Spec.CorrectDrift != nil && bd.Spec.CorrectDrift.Enabled && len(bd.Status.ModifiedStatus) > 0 && r.DriftChan != nil {
 		select {

--- a/internal/cmd/agent/controller/bundledeployment_controller.go
+++ b/internal/cmd/agent/controller/bundledeployment_controller.go
@@ -52,6 +52,13 @@ type BundleDeploymentReconciler struct {
 	DriftDetect *driftdetect.DriftDetect
 	Cleanup     *cleanup.Cleanup
 
+	// DriftChan is shared with the DriftReconciler. Sending a BundleDeployment
+	// here wakes up the drift controller so it can run drift correction. It is
+	// used to handle the case where CorrectDrift is enabled after the drift has
+	// already been detected — no further resource watch event would otherwise
+	// fire to trigger correction.
+	DriftChan chan event.TypedGenericEvent[*fleetv1.BundleDeployment]
+
 	DefaultNamespace string
 
 	// AgentInfo is the labelSuffix used by the helm deployer
@@ -288,6 +295,18 @@ func (r *BundleDeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	if err := r.DriftDetect.Refresh(ctx, req.String(), bd, resources); err != nil {
 		logger.V(1).Info("Failed to refresh drift detection", "step", "drift", "error", err)
 		merr = append(merr, fmt.Errorf("failed refreshing drift detection: %w", err))
+	}
+
+	// If drift correction was just enabled (or any spec change occurred while
+	// drift is already present), the resource watcher won't re-emit for
+	// already-drifted resources, so wake up the DriftReconciler ourselves.
+	// Non-blocking: if the channel buffer is full a subsequent reconcile or
+	// resource event will deliver the signal.
+	if bd.Spec.CorrectDrift != nil && bd.Spec.CorrectDrift.Enabled && len(bd.Status.ModifiedStatus) > 0 && r.DriftChan != nil {
+		select {
+		case r.DriftChan <- event.TypedGenericEvent[*fleetv1.BundleDeployment]{Object: bd}:
+		default:
+		}
 	}
 
 	// Check if this bundle deployment has overlapping resources with a previously deleted bundle (Overwrites

--- a/internal/cmd/agent/operator.go
+++ b/internal/cmd/agent/operator.go
@@ -288,6 +288,8 @@ func newReconciler(
 		DriftDetect: driftdetect,
 		Cleanup:     cleanup,
 
+		DriftChan: driftChan,
+
 		DefaultNamespace: defaultNamespace,
 
 		AgentScope: agentScope,

--- a/internal/cmd/controller/options/calculate.go
+++ b/internal/cmd/controller/options/calculate.go
@@ -17,6 +17,9 @@ func DeploymentID(manifestID string, opts fleet.BundleDeploymentOptions) (string
 	sanitized := *opts.DeepCopy()
 	// Diff-only changes should not trigger a new DeploymentID; they only affect drift detection.
 	sanitized.Diff = nil
+	// CorrectDrift governs how drift is reconciled, not what is deployed and it
+	// should not trigger a new DeploymentID.
+	sanitized.CorrectDrift = nil
 	if err := json.NewEncoder(h).Encode(&sanitized); err != nil {
 		return "", err
 	}


### PR DESCRIPTION
This PR enables drift correction for Bundles that are already deployed. It was previously not working because drift correction was not being triggered once the resources were already checked for drift.

Also the DeploymentID calculation was taking the correctDrift field into account, which was also preventing re-triggering drift correction.

Refers to: https://github.com/rancher/fleet/issues/4945

## Additional Information

### Checklist

~- [ ] <!-- If applicable,--> I have updated the documentation via a pull request in the [fleet-product-docs](https://github.com/rancher/fleet-product-docs) repository.~
