### PR TITLE
Update slsactl version annotation to use github-tags datasource

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,7 +83,7 @@ jobs:
       - name: Install Slsactl
         uses: rancherlabs/slsactl/actions/install-slsactl@a5177a3699b7cabfa4797e883314dde7e40523cc # v0.1.22
         with:
-          # renovate: datasource=github-releases depName=rancherlabs/slsactl
+          # renovate: datasource=github-tags depName=rancherlabs/slsactl
           version: v0.1.22
 
       - name: "Read Vault Secrets"


### PR DESCRIPTION
The Renovate custom regex manager for the `version:` field now matches only `datasource=github-tags` annotations, consistent with the manager's `datasourceTemplate` setting. Since `rancherlabs/slsactl` publishes only git tags and not GitHub Releases, `github-tags` is the correct datasource.

This change aligns the annotation with the manager configuration so Renovate can track the `version:` field alongside the action digest in a single grouped PR.

Pairs with rancher/renovate-config#733