### PR TITLE
Extract and fix verify-CI step in release.yml

### DIFF
--- a/.github/scripts/verify-ci-on-commit.sh
+++ b/.github/scripts/verify-ci-on-commit.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Verifies that CI passed on the tagged commit before releasing.
+# For commits merged via a PR, checks that all required PR CI checks passed.
+# For hotfix commits (pushed directly without a PR), checks that all
+# commit-level check-runs completed successfully.
+#
+# Required environment variables:
+#   RELEASE_TAG  - the release tag to verify
+#   REPO         - the GitHub repository in "owner/repo" form
+#   GH_TOKEN     - a token with pull-requests:read and checks:read
+
+: "${RELEASE_TAG:?RELEASE_TAG is required}"
+: "${REPO:?REPO is required}"
+: "${GH_TOKEN:?GH_TOKEN is required}"
+
+COMMIT_SHA=$(git rev-list -n 1 "$RELEASE_TAG")
+echo "Verifying CI checks for ${RELEASE_TAG} (${COMMIT_SHA})"
+
+PR_NUMBER=$(gh api \
+    "repos/${REPO}/commits/${COMMIT_SHA}/pulls" \
+    --jq "[.[] | select(.merge_commit_sha == \"${COMMIT_SHA}\")] | first | .number // empty")
+
+if [[ -n "${PR_NUMBER:-}" ]]; then
+    echo "Found PR #${PR_NUMBER}, verifying required checks..."
+    gh pr checks "${PR_NUMBER}" --repo "${REPO}" --required
+else
+    echo "No merged PR found (hotfix), verifying all commit checks..."
+    ISSUES=$(gh api \
+        "repos/${REPO}/commits/${COMMIT_SHA}/check-runs" \
+        --jq 'if .total_count == 0 then "no CI checks found" else ([.check_runs[] | select(.status != "completed" or (.conclusion != "success" and .conclusion != "skipped")) | .name] | join(", ")) end')
+
+    if [[ -n "${ISSUES}" ]]; then
+        echo "ERROR: ${ISSUES}" >&2
+        exit 1
+    fi
+
+    echo "✓ All checks passed for ${RELEASE_TAG} (${COMMIT_SHA})"
+fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,8 +9,6 @@ on:
 permissions:
   contents: write
   id-token: write # this is important, it's how we authenticate with Vault
-  pull-requests: read
-  checks: read
 
 env:
   GOARCH: amd64
@@ -20,6 +18,11 @@ env:
 jobs:
   build-fleet:
     runs-on: runs-on,runner=8cpu-linux-x64,mem=16,run-id=${{ github.run_id }}
+    permissions:
+      contents: write
+      id-token: write
+      pull-requests: read
+      checks: read
 
     env:
       IS_HOTFIX: ${{ contains(github.ref, '-hotfix-') }}
@@ -34,33 +37,8 @@ jobs:
       - name: Verify CI passed on tagged commit
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          COMMIT_SHA=$(git rev-list -n 1 "$RELEASE_TAG")
-          echo "Verifying CI checks for ${RELEASE_TAG} (${COMMIT_SHA})"
-
-          PR_NUMBER=$(gh api \
-            "repos/${{ github.repository }}/commits/${COMMIT_SHA}/pulls" \
-            --jq '[.[] | select(.merged_at != null)] | first | .number // empty')
-
-          if [[ -n "${PR_NUMBER:-}" ]]; then
-            echo "Found PR #${PR_NUMBER}, verifying required checks..."
-            gh pr checks "${PR_NUMBER}" \
-              --repo "${{ github.repository }}" \
-              --required
-          else
-            echo "No merged PR found (hotfix), verifying all commit checks..."
-            ISSUES=$(gh api \
-              "repos/${{ github.repository }}/commits/${COMMIT_SHA}/check-runs" \
-              --jq 'if .total_count == 0 then "no CI checks found" else ([.check_runs[] | select(.status != "completed" or (.conclusion != "success" and .conclusion != "skipped")) | .name] | join(", ")) end')
-
-            if [[ -n "${ISSUES}" ]]; then
-              echo "ERROR: ${ISSUES}"
-              exit 1
-            fi
-
-            echo "✓ All checks passed for ${RELEASE_TAG} (${COMMIT_SHA})"
-          fi
+          REPO: ${{ github.repository }}
+        run: ./.github/scripts/verify-ci-on-commit.sh
 
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0


### PR DESCRIPTION
The CI verification logic in `release.yml` was embedded inline in a `run:` block, making it impossible to shellcheck or test locally. This extracts it into `.github/scripts/verify-ci-on-commit.sh`.

The PR lookup is changed from `select(.merged_at != null)` to `select(.merge_commit_sha == COMMIT_SHA)`, which ties the selection to the exact PR whose merge produced the tagged commit. The old filter could match the wrong PR when the same commit appears in multiple merged PRs. `GH_TOKEN` validation is added alongside the other required variables so a missing token fails immediately with a clear message. `pull-requests: read` and `checks: read` are moved from the workflow-level `permissions` block to the `build-fleet` job level, which is the only job that needs them.