### PR TITLE
Use Custom CAs when pulling OCI artifact

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -18,4 +18,5 @@ extend-exclude = [
 extend-ignore-re = [
     "-{5}BEGIN RSA PRIVATE KEY-{5}(?:$|[^-]{63,}-{5}END)",
     "-{5}BEGIN PRIVATE KEY-{5}(?:$|[^-]{63,}-{5}END)",
+    "-{5}BEGIN CERTIFICATE-{5}(?:$|[^-]{63,}-{5}END CERTIFICATE)"
 ]

--- a/e2e/single-cluster/oci_registry_test.go
+++ b/e2e/single-cluster/oci_registry_test.go
@@ -54,6 +54,7 @@ func createOCIRegistrySecret(
 			Namespace: namespace,
 		},
 		Data: map[string][]byte{
+			ocistorage.OCISecretCABundle:        []byte(""),
 			ocistorage.OCISecretReference:       []byte(reference),
 			ocistorage.OCISecretUsername:        []byte(username),
 			ocistorage.OCISecretPassword:        []byte(password),

--- a/e2e/single-cluster/oci_registry_test.go
+++ b/e2e/single-cluster/oci_registry_test.go
@@ -54,7 +54,6 @@ func createOCIRegistrySecret(
 			Namespace: namespace,
 		},
 		Data: map[string][]byte{
-			ocistorage.OCISecretCABundle:        []byte(""),
 			ocistorage.OCISecretReference:       []byte(reference),
 			ocistorage.OCISecretUsername:        []byte(username),
 			ocistorage.OCISecretPassword:        []byte(password),

--- a/internal/cmd/cli/apply/apply.go
+++ b/internal/cmd/cli/apply/apply.go
@@ -575,6 +575,7 @@ func shouldStoreInOCIRegistry(ctx context.Context, c client.Reader, ociSecretKey
 	ociOpts.AgentPassword = opts.AgentPassword
 	ociOpts.BasicHTTP = opts.BasicHTTP
 	ociOpts.InsecureSkipTLS = opts.InsecureSkipTLS
+	ociOpts.CABundle = opts.CABundle
 
 	return true, nil
 }
@@ -764,6 +765,7 @@ func newOCISecret(manifestID string, bundle *fleet.Bundle, opts ocistorage.OCIOp
 			ocistorage.OCISecretAgentPassword:   []byte(opts.AgentPassword),
 			ocistorage.OCISecretBasicHTTP:       []byte(strconv.FormatBool(opts.BasicHTTP)),
 			ocistorage.OCISecretInsecureSkipTLS: []byte(strconv.FormatBool(opts.InsecureSkipTLS)),
+			ocistorage.OCISecretCABundle:        opts.CABundle,
 		},
 		Type: fleet.SecretTypeOCIStorage,
 	}

--- a/internal/cmd/cli/apply/apply.go
+++ b/internal/cmd/cli/apply/apply.go
@@ -757,18 +757,25 @@ func newOCISecret(manifestID string, bundle *fleet.Bundle, opts ocistorage.OCIOp
 				},
 			},
 		},
-		Data: map[string][]byte{
-			ocistorage.OCISecretReference:       []byte(opts.Reference),
-			ocistorage.OCISecretUsername:        []byte(opts.Username),
-			ocistorage.OCISecretPassword:        []byte(opts.Password),
-			ocistorage.OCISecretAgentUsername:   []byte(opts.AgentUsername),
-			ocistorage.OCISecretAgentPassword:   []byte(opts.AgentPassword),
-			ocistorage.OCISecretBasicHTTP:       []byte(strconv.FormatBool(opts.BasicHTTP)),
-			ocistorage.OCISecretInsecureSkipTLS: []byte(strconv.FormatBool(opts.InsecureSkipTLS)),
-			ocistorage.OCISecretCABundle:        opts.CABundle,
-		},
+		Data: newOCISecretData(opts),
 		Type: fleet.SecretTypeOCIStorage,
 	}
+}
+
+func newOCISecretData(opts ocistorage.OCIOpts) map[string][]byte {
+	data := map[string][]byte{
+		ocistorage.OCISecretReference:       []byte(opts.Reference),
+		ocistorage.OCISecretUsername:        []byte(opts.Username),
+		ocistorage.OCISecretPassword:        []byte(opts.Password),
+		ocistorage.OCISecretAgentUsername:   []byte(opts.AgentUsername),
+		ocistorage.OCISecretAgentPassword:   []byte(opts.AgentPassword),
+		ocistorage.OCISecretBasicHTTP:       []byte(strconv.FormatBool(opts.BasicHTTP)),
+		ocistorage.OCISecretInsecureSkipTLS: []byte(strconv.FormatBool(opts.InsecureSkipTLS)),
+	}
+	if len(opts.CABundle) > 0 {
+		data[ocistorage.OCISecretCABundle] = opts.CABundle
+	}
+	return data
 }
 
 func newValuesSecret(bundle *fleet.Bundle, data map[string][]byte) *corev1.Secret {

--- a/internal/ocistorage/ociwrapper.go
+++ b/internal/ocistorage/ociwrapper.go
@@ -88,7 +88,9 @@ func getHTTPClient(insecureSkipTLS bool, caBundle []byte) *http.Client {
 		if !tmpPool.AppendCertsFromPEM(proxyBytes) {
 			logrus.Warnf("%s is set but contains no valid PEM certificates; ignoring proxy CA bundle", fleetgit.ProxyCABundleEnvVar)
 		} else {
-			caBundle = append(caBundle, '\n')
+			if len(caBundle) > 0 && caBundle[len(caBundle)-1] != '\n' {
+				caBundle = append(caBundle, '\n')
+			}
 			caBundle = append(caBundle, proxyBytes...)
 		}
 	}
@@ -98,18 +100,23 @@ func getHTTPClient(insecureSkipTLS bool, caBundle []byte) *http.Client {
 		return retry.DefaultClient
 	}
 
-	// Build custom transport with TLS config
-	transport := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: insecureSkipTLS, // #nosec G402
-		},
+	// Clone the default transport to preserve proxy, timeout, and
+	// connection-pooling settings.
+	baseTransport, ok := http.DefaultTransport.(*http.Transport)
+	if !ok {
+		baseTransport = &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
+		}
+	}
+	transport := baseTransport.Clone()
+	transport.TLSClientConfig = &tls.Config{
+		InsecureSkipVerify: insecureSkipTLS, // #nosec G402
 	}
 
 	// Merge custom CA bundle with system cert pool
 	if len(caBundle) > 0 {
 		pool, err := x509.SystemCertPool()
 		if err != nil {
-			// Fall back to empty pool if system pool unavailable
 			pool = x509.NewCertPool()
 		}
 		if !pool.AppendCertsFromPEM(caBundle) {
@@ -119,7 +126,7 @@ func getHTTPClient(insecureSkipTLS bool, caBundle []byte) *http.Client {
 		transport.TLSClientConfig.MinVersion = tls.VersionTLS12
 	}
 
-	return &http.Client{Transport: transport}
+	return &http.Client{Transport: retry.NewTransport(transport)}
 }
 
 func getAuthClient(opts OCIOpts) *auth.Client {

--- a/internal/ocistorage/ociwrapper.go
+++ b/internal/ocistorage/ociwrapper.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -16,13 +17,16 @@ import (
 
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/rancher/fleet/internal/manifest"
+	"github.com/sirupsen/logrus"
 	"oras.land/oras-go/v2"
 	"oras.land/oras-go/v2/content"
 	"oras.land/oras-go/v2/content/memory"
 	"oras.land/oras-go/v2/registry/remote"
 	"oras.land/oras-go/v2/registry/remote/auth"
 	"oras.land/oras-go/v2/registry/remote/retry"
+
+	"github.com/rancher/fleet/internal/manifest"
+	fleetgit "github.com/rancher/fleet/pkg/git"
 )
 
 const (
@@ -40,6 +44,7 @@ type OCIOpts struct {
 	AgentPassword   string
 	BasicHTTP       bool
 	InsecureSkipTLS bool
+	CABundle        []byte
 }
 
 type OrasOps interface {
@@ -72,20 +77,54 @@ func NewOCIWrapper() *OCIWrapper {
 	}
 }
 
-func getHTTPClient(insecureSkipTLS bool) *http.Client {
-	if !insecureSkipTLS {
+func getHTTPClient(insecureSkipTLS bool, caBundle []byte) *http.Client {
+	// Defensive copy to avoid mutations
+	caBundle = append([]byte(nil), caBundle...)
+
+	// Merge proxy CA bundle if present
+	if proxyCAPEM, ok := os.LookupEnv(fleetgit.ProxyCABundleEnvVar); ok && proxyCAPEM != "" {
+		proxyBytes := []byte(proxyCAPEM)
+		tmpPool := x509.NewCertPool()
+		if !tmpPool.AppendCertsFromPEM(proxyBytes) {
+			logrus.Warnf("%s is set but contains no valid PEM certificates; ignoring proxy CA bundle", fleetgit.ProxyCABundleEnvVar)
+		} else {
+			caBundle = append(caBundle, '\n')
+			caBundle = append(caBundle, proxyBytes...)
+		}
+	}
+
+	// If no custom TLS config needed, use default ORAS client
+	if !insecureSkipTLS && len(caBundle) == 0 {
 		return retry.DefaultClient
 	}
-	return &http.Client{
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, // #nosec G402
+
+	// Build custom transport with TLS config
+	transport := &http.Transport{
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: insecureSkipTLS, // #nosec G402
 		},
 	}
+
+	// Merge custom CA bundle with system cert pool
+	if len(caBundle) > 0 {
+		pool, err := x509.SystemCertPool()
+		if err != nil {
+			// Fall back to empty pool if system pool unavailable
+			pool = x509.NewCertPool()
+		}
+		if !pool.AppendCertsFromPEM(caBundle) {
+			logrus.Warnf("CA bundle contains no valid PEM certificates; proceeding with system cert pool only")
+		}
+		transport.TLSClientConfig.RootCAs = pool
+		transport.TLSClientConfig.MinVersion = tls.VersionTLS12
+	}
+
+	return &http.Client{Transport: transport}
 }
 
 func getAuthClient(opts OCIOpts) *auth.Client {
 	client := &auth.Client{
-		Client: getHTTPClient(opts.InsecureSkipTLS),
+		Client: getHTTPClient(opts.InsecureSkipTLS, opts.CABundle),
 		Cache:  auth.NewCache(),
 	}
 	if opts.Username != "" {

--- a/internal/ocistorage/ociwrapper_test.go
+++ b/internal/ocistorage/ociwrapper_test.go
@@ -178,11 +178,6 @@ DXZDjC5Ty3zfDBeWUA==
 		Expect(transport.TLSClientConfig.RootCAs).ToNot(BeNil())
 		Expect(transport.TLSClientConfig.MinVersion).To(Equal(uint16(tls.VersionTLS12)))
 		Expect(transport.TLSClientConfig.InsecureSkipVerify).To(BeFalse())
-
-		// Verify the CA bundle was actually loaded by testing it can be parsed
-		testPool := x509.NewCertPool()
-		ok = testPool.AppendCertsFromPEM(caBundle)
-		Expect(ok).To(BeTrue(), "CA bundle should be valid PEM that was loaded into the pool")
 	})
 	It("should merge proxy CA bundle from environment variable", func() {
 		// Use a valid certificate for proxy CA (same as custom test)
@@ -276,17 +271,46 @@ DXZDjC5Ty3zfDBeWUA==
 		Expect(ok).To(BeTrue(), "CA bundle should be valid PEM")
 	})
 	It("should not mutate the original CA bundle slice", func() {
-		originalCA := []byte("-----BEGIN CERTIFICATE-----\noriginal\n-----END CERTIFICATE-----")
-		originalCopy := make([]byte, len(originalCA))
-		copy(originalCopy, originalCA)
+		// validPEM is a real certificate so that AppendCertsFromPEM succeeds and
+		// getHTTPClient actually reaches the append(caBundle, proxyBytes...) path.
+		// An invalid PEM would make the function return early without appending,
+		// meaning the defensive copy would never be exercised.
+		validPEM := []byte(`-----BEGIN CERTIFICATE-----
+MIICGTCCAZ+gAwIBAgIQCeCTZaz32ci5PhwLBCou8zAKBggqhkjOPQQDAzBOMQsw
+CQYDVQQGEwJVUzEXMBUGA1UEChMORGlnaUNlcnQsIEluYy4xJjAkBgNVBAMTHURp
+Z2lDZXJ0IFRMUyBFQ0MgUDM4NCBSb290IEc1MB4XDTIxMDExNTAwMDAwMFoXDTQ2
+MDExNDIzNTk1OVowTjELMAkGA1UEBhMCVVMxFzAVBgNVBAoTDkRpZ2lDZXJ0LCBJ
+bmMuMSYwJAYDVQQDEx1EaWdpQ2VydCBUTFMgRUNDIFAzODQgUm9vdCBHNTB2MBAG
+ByqGSM49AgEGBSuBBAAiA2IABMFEoc8Rl1Ca3iOCNQfN0MsYndLxf3c1TzvdlHJS
+7cI7+Oz6e2tYIOyZrsn8aLN1udsJ7MgT9U7GCh1mMEy7H0cKPGEQQil8pQgO4CLp
+0zVozptjn4S1mU1YoI71VOeVyaNCMEAwHQYDVR0OBBYEFMFRRVBZqz7nLFr6ICIS
+B4CIfBFqMA4GA1UdDwEB/wQEAwIBhjAPBgNVHRMBAf8EBTADAQH/MAoGCCqGSM49
+BAMDA2gAMGUCMQCJao1H5+z8blUD2WdsJk6Dxv3J+ysTvLd6jLRl0mlpYxNjOyZQ
+LgGheQaRnUi/wr4CMEfDFXuxoJGZSZOoPHzoRgaLLPIxAJSdYsiJvRmEFOml+wG4
+DXZDjC5Ty3zfDBeWUA==
+-----END CERTIFICATE-----`)
 
-		os.Setenv("PROXY_CA_BUNDLE", "-----BEGIN CERTIFICATE-----\nproxy\n-----END CERTIFICATE-----")
+		os.Setenv("PROXY_CA_BUNDLE", string(validPEM))
 		defer os.Unsetenv("PROXY_CA_BUNDLE")
+
+		// Allocate with excess capacity so that append can write into the backing
+		// array without reallocating. With len == cap (e.g. []byte("literal")),
+		// append always reallocates and the defensive copy makes no observable
+		// difference — the test would pass even without it.
+		originalCA := make([]byte, len(validPEM), len(validPEM)+512)
+		copy(originalCA, validPEM)
+
+		// backing covers the full allocation so we can detect writes past len(originalCA).
+		backing := originalCA[:cap(originalCA)]
 
 		_ = getHTTPClient(false, originalCA)
 
-		// Original slice should be unchanged
-		Expect(originalCA).To(Equal(originalCopy))
+		// The slice header and visible content must be unchanged.
+		Expect(originalCA).To(Equal(validPEM))
+		// Without the defensive copy, getHTTPClient would append '\n'+proxyBytes
+		// directly into the excess capacity of the caller's backing array.
+		Expect(backing[len(validPEM):]).To(Equal(make([]byte, 512)),
+			"backing array beyond len(originalCA) must not be written to")
 	})
 	It("return the expected credentials", func() {
 		opts := OCIOpts{

--- a/internal/ocistorage/ociwrapper_test.go
+++ b/internal/ocistorage/ociwrapper_test.go
@@ -138,12 +138,15 @@ var _ = Describe("OCIUtils tests", func() {
 	})
 	It("return the expected tls client", func() {
 		client := getHTTPClient(true, nil)
-		expected := &http.Client{
-			Transport: &http.Transport{
-				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-			},
-		}
-		Expect(client).To(Equal(expected))
+
+		// Custom path wraps transport in retry.Transport
+		retryTransport, ok := client.Transport.(*retry.Transport)
+		Expect(ok).To(BeTrue())
+		innerTransport, ok := retryTransport.Base.(*http.Transport)
+		Expect(ok).To(BeTrue())
+		Expect(innerTransport.TLSClientConfig).ToNot(BeNil())
+		Expect(innerTransport.TLSClientConfig.InsecureSkipVerify).To(BeTrue())
+		Expect(innerTransport.Proxy).ToNot(BeNil())
 
 		client = getHTTPClient(false, nil)
 		Expect(client).To(Equal(retry.DefaultClient))
@@ -167,7 +170,9 @@ DXZDjC5Ty3zfDBeWUA==
 		client := getHTTPClient(false, caBundle)
 
 		// Verify transport is configured with custom TLS config
-		transport, ok := client.Transport.(*http.Transport)
+		retryT, ok := client.Transport.(*retry.Transport)
+		Expect(ok).To(BeTrue())
+		transport, ok := retryT.Base.(*http.Transport)
 		Expect(ok).To(BeTrue())
 		Expect(transport.TLSClientConfig).ToNot(BeNil())
 		Expect(transport.TLSClientConfig.RootCAs).ToNot(BeNil())
@@ -203,7 +208,9 @@ DXZDjC5Ty3zfDBeWUA==
 		client := getHTTPClient(false, customCA)
 
 		// Should have merged both CAs
-		transport, ok := client.Transport.(*http.Transport)
+		retryT, ok := client.Transport.(*retry.Transport)
+		Expect(ok).To(BeTrue())
+		transport, ok := retryT.Base.(*http.Transport)
 		Expect(ok).To(BeTrue())
 		Expect(transport.TLSClientConfig).ToNot(BeNil())
 		Expect(transport.TLSClientConfig.RootCAs).ToNot(BeNil())
@@ -221,7 +228,9 @@ DXZDjC5Ty3zfDBeWUA==
 		client := getHTTPClient(false, invalidCA)
 
 		// Should still create a client with TLS config (warning logged)
-		transport, ok := client.Transport.(*http.Transport)
+		retryT, ok := client.Transport.(*retry.Transport)
+		Expect(ok).To(BeTrue())
+		transport, ok := retryT.Base.(*http.Transport)
 		Expect(ok).To(BeTrue())
 		Expect(transport.TLSClientConfig).ToNot(BeNil())
 		Expect(transport.TLSClientConfig.RootCAs).ToNot(BeNil())
@@ -252,7 +261,9 @@ DXZDjC5Ty3zfDBeWUA==
 -----END CERTIFICATE-----`)
 		client := getHTTPClient(true, caBundle)
 
-		transport, ok := client.Transport.(*http.Transport)
+		retryT, ok := client.Transport.(*retry.Transport)
+		Expect(ok).To(BeTrue())
+		transport, ok := retryT.Base.(*http.Transport)
 		Expect(ok).To(BeTrue())
 		Expect(transport.TLSClientConfig).ToNot(BeNil())
 		Expect(transport.TLSClientConfig.InsecureSkipVerify).To(BeTrue())

--- a/internal/ocistorage/ociwrapper_test.go
+++ b/internal/ocistorage/ociwrapper_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
+	"crypto/x509"
 	"errors"
 	"net/http"
 	"os"
@@ -136,7 +137,7 @@ var _ = Describe("OCIUtils tests", func() {
 		Expect(repo.PlainHTTP).To(BeFalse())
 	})
 	It("return the expected tls client", func() {
-		client := getHTTPClient(true)
+		client := getHTTPClient(true, nil)
 		expected := &http.Client{
 			Transport: &http.Transport{
 				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
@@ -144,8 +145,137 @@ var _ = Describe("OCIUtils tests", func() {
 		}
 		Expect(client).To(Equal(expected))
 
-		client = getHTTPClient(false)
+		client = getHTTPClient(false, nil)
 		Expect(client).To(Equal(retry.DefaultClient))
+	})
+	It("should use custom CA bundle when provided", func() {
+		// Use a valid test certificate from the codebase pattern (same as netutils_test.go)
+		caBundle := []byte(`-----BEGIN CERTIFICATE-----
+MIICGTCCAZ+gAwIBAgIQCeCTZaz32ci5PhwLBCou8zAKBggqhkjOPQQDAzBOMQsw
+CQYDVQQGEwJVUzEXMBUGA1UEChMORGlnaUNlcnQsIEluYy4xJjAkBgNVBAMTHURp
+Z2lDZXJ0IFRMUyBFQ0MgUDM4NCBSb290IEc1MB4XDTIxMDExNTAwMDAwMFoXDTQ2
+MDExNDIzNTk1OVowTjELMAkGA1UEBhMCVVMxFzAVBgNVBAoTDkRpZ2lDZXJ0LCBJ
+bmMuMSYwJAYDVQQDEx1EaWdpQ2VydCBUTFMgRUNDIFAzODQgUm9vdCBHNTB2MBAG
+ByqGSM49AgEGBSuBBAAiA2IABMFEoc8Rl1Ca3iOCNQfN0MsYndLxf3c1TzvdlHJS
+7cI7+Oz6e2tYIOyZrsn8aLN1udsJ7MgT9U7GCh1mMEy7H0cKPGEQQil8pQgO4CLp
+0zVozptjn4S1mU1YoI71VOeVyaNCMEAwHQYDVR0OBBYEFMFRRVBZqz7nLFr6ICIS
+B4CIfBFqMA4GA1UdDwEB/wQEAwIBhjAPBgNVHRMBAf8EBTADAQH/MAoGCCqGSM49
+BAMDA2gAMGUCMQCJao1H5+z8blUD2WdsJk6Dxv3J+ysTvLd6jLRl0mlpYxNjOyZQ
+LgGheQaRnUi/wr4CMEfDFXuxoJGZSZOoPHzoRgaLLPIxAJSdYsiJvRmEFOml+wG4
+DXZDjC5Ty3zfDBeWUA==
+-----END CERTIFICATE-----`)
+		client := getHTTPClient(false, caBundle)
+
+		// Verify transport is configured with custom TLS config
+		transport, ok := client.Transport.(*http.Transport)
+		Expect(ok).To(BeTrue())
+		Expect(transport.TLSClientConfig).ToNot(BeNil())
+		Expect(transport.TLSClientConfig.RootCAs).ToNot(BeNil())
+		Expect(transport.TLSClientConfig.MinVersion).To(Equal(uint16(tls.VersionTLS12)))
+		Expect(transport.TLSClientConfig.InsecureSkipVerify).To(BeFalse())
+
+		// Verify the CA bundle was actually loaded by testing it can be parsed
+		testPool := x509.NewCertPool()
+		ok = testPool.AppendCertsFromPEM(caBundle)
+		Expect(ok).To(BeTrue(), "CA bundle should be valid PEM that was loaded into the pool")
+	})
+	It("should merge proxy CA bundle from environment variable", func() {
+		// Use a valid certificate for proxy CA (same as custom test)
+		proxyCA := `-----BEGIN CERTIFICATE-----
+MIICGTCCAZ+gAwIBAgIQCeCTZaz32ci5PhwLBCou8zAKBggqhkjOPQQDAzBOMQsw
+CQYDVQQGEwJVUzEXMBUGA1UEChMORGlnaUNlcnQsIEluYy4xJjAkBgNVBAMTHURp
+Z2lDZXJ0IFRMUyBFQ0MgUDM4NCBSb290IEc1MB4XDTIxMDExNTAwMDAwMFoXDTQ2
+MDExNDIzNTk1OVowTjELMAkGA1UEBhMCVVMxFzAVBgNVBAoTDkRpZ2lDZXJ0LCBJ
+bmMuMSYwJAYDVQQDEx1EaWdpQ2VydCBUTFMgRUNDIFAzODQgUm9vdCBHNTB2MBAG
+ByqGSM49AgEGBSuBBAAiA2IABMFEoc8Rl1Ca3iOCNQfN0MsYndLxf3c1TzvdlHJS
+7cI7+Oz6e2tYIOyZrsn8aLN1udsJ7MgT9U7GCh1mMEy7H0cKPGEQQil8pQgO4CLp
+0zVozptjn4S1mU1YoI71VOeVyaNCMEAwHQYDVR0OBBYEFMFRRVBZqz7nLFr6ICIS
+B4CIfBFqMA4GA1UdDwEB/wQEAwIBhjAPBgNVHRMBAf8EBTADAQH/MAoGCCqGSM49
+BAMDA2gAMGUCMQCJao1H5+z8blUD2WdsJk6Dxv3J+ysTvLd6jLRl0mlpYxNjOyZQ
+LgGheQaRnUi/wr4CMEfDFXuxoJGZSZOoPHzoRgaLLPIxAJSdYsiJvRmEFOml+wG4
+DXZDjC5Ty3zfDBeWUA==
+-----END CERTIFICATE-----`
+		os.Setenv("PROXY_CA_BUNDLE", proxyCA)
+		defer os.Unsetenv("PROXY_CA_BUNDLE")
+
+		// Use the same valid certificate for custom CA (simpler for testing)
+		customCA := []byte(proxyCA)
+		client := getHTTPClient(false, customCA)
+
+		// Should have merged both CAs
+		transport, ok := client.Transport.(*http.Transport)
+		Expect(ok).To(BeTrue())
+		Expect(transport.TLSClientConfig).ToNot(BeNil())
+		Expect(transport.TLSClientConfig.RootCAs).ToNot(BeNil())
+		Expect(transport.TLSClientConfig.MinVersion).To(Equal(uint16(tls.VersionTLS12)))
+
+		// Verify both CAs are valid and would have been loaded
+		testPool := x509.NewCertPool()
+		ok = testPool.AppendCertsFromPEM(customCA)
+		Expect(ok).To(BeTrue(), "custom CA bundle should be valid PEM")
+		ok = testPool.AppendCertsFromPEM([]byte(proxyCA))
+		Expect(ok).To(BeTrue(), "proxy CA bundle should be valid PEM")
+	})
+	It("should handle invalid CA bundle gracefully", func() {
+		invalidCA := []byte("not a valid PEM certificate")
+		client := getHTTPClient(false, invalidCA)
+
+		// Should still create a client with TLS config (warning logged)
+		transport, ok := client.Transport.(*http.Transport)
+		Expect(ok).To(BeTrue())
+		Expect(transport.TLSClientConfig).ToNot(BeNil())
+		Expect(transport.TLSClientConfig.RootCAs).ToNot(BeNil())
+	})
+	It("should handle invalid proxy CA bundle gracefully", func() {
+		os.Setenv("PROXY_CA_BUNDLE", "invalid proxy PEM")
+		defer os.Unsetenv("PROXY_CA_BUNDLE")
+
+		client := getHTTPClient(false, nil)
+
+		// Should return default client when no valid CA and not insecure
+		Expect(client).To(Equal(retry.DefaultClient))
+	})
+	It("should combine insecureSkipTLS with CA bundle", func() {
+		caBundle := []byte(`-----BEGIN CERTIFICATE-----
+MIICGTCCAZ+gAwIBAgIQCeCTZaz32ci5PhwLBCou8zAKBggqhkjOPQQDAzBOMQsw
+CQYDVQQGEwJVUzEXMBUGA1UEChMORGlnaUNlcnQsIEluYy4xJjAkBgNVBAMTHURp
+Z2lDZXJ0IFRMUyBFQ0MgUDM4NCBSb290IEc1MB4XDTIxMDExNTAwMDAwMFoXDTQ2
+MDExNDIzNTk1OVowTjELMAkGA1UEBhMCVVMxFzAVBgNVBAoTDkRpZ2lDZXJ0LCBJ
+bmMuMSYwJAYDVQQDEx1EaWdpQ2VydCBUTFMgRUNDIFAzODQgUm9vdCBHNTB2MBAG
+ByqGSM49AgEGBSuBBAAiA2IABMFEoc8Rl1Ca3iOCNQfN0MsYndLxf3c1TzvdlHJS
+7cI7+Oz6e2tYIOyZrsn8aLN1udsJ7MgT9U7GCh1mMEy7H0cKPGEQQil8pQgO4CLp
+0zVozptjn4S1mU1YoI71VOeVyaNCMEAwHQYDVR0OBBYEFMFRRVBZqz7nLFr6ICIS
+B4CIfBFqMA4GA1UdDwEB/wQEAwIBhjAPBgNVHRMBAf8EBTADAQH/MAoGCCqGSM49
+BAMDA2gAMGUCMQCJao1H5+z8blUD2WdsJk6Dxv3J+ysTvLd6jLRl0mlpYxNjOyZQ
+LgGheQaRnUi/wr4CMEfDFXuxoJGZSZOoPHzoRgaLLPIxAJSdYsiJvRmEFOml+wG4
+DXZDjC5Ty3zfDBeWUA==
+-----END CERTIFICATE-----`)
+		client := getHTTPClient(true, caBundle)
+
+		transport, ok := client.Transport.(*http.Transport)
+		Expect(ok).To(BeTrue())
+		Expect(transport.TLSClientConfig).ToNot(BeNil())
+		Expect(transport.TLSClientConfig.InsecureSkipVerify).To(BeTrue())
+		Expect(transport.TLSClientConfig.RootCAs).ToNot(BeNil())
+		Expect(transport.TLSClientConfig.MinVersion).To(Equal(uint16(tls.VersionTLS12)))
+
+		// Verify the CA bundle is valid PEM (even though InsecureSkipVerify is set)
+		testPool := x509.NewCertPool()
+		ok = testPool.AppendCertsFromPEM(caBundle)
+		Expect(ok).To(BeTrue(), "CA bundle should be valid PEM")
+	})
+	It("should not mutate the original CA bundle slice", func() {
+		originalCA := []byte("-----BEGIN CERTIFICATE-----\noriginal\n-----END CERTIFICATE-----")
+		originalCopy := make([]byte, len(originalCA))
+		copy(originalCopy, originalCA)
+
+		os.Setenv("PROXY_CA_BUNDLE", "-----BEGIN CERTIFICATE-----\nproxy\n-----END CERTIFICATE-----")
+		defer os.Unsetenv("PROXY_CA_BUNDLE")
+
+		_ = getHTTPClient(false, originalCA)
+
+		// Original slice should be unchanged
+		Expect(originalCA).To(Equal(originalCopy))
 	})
 	It("return the expected credentials", func() {
 		opts := OCIOpts{

--- a/internal/ocistorage/secret.go
+++ b/internal/ocistorage/secret.go
@@ -21,6 +21,7 @@ const (
 	OCISecretBasicHTTP       = "basicHTTP"
 	OCISecretInsecureSkipTLS = "insecureSkipTLS"
 	OCISecretInsecure        = "insecure" // legacy alias
+	OCISecretCABundle        = "cacerts"
 )
 
 // ReadOptsFromSecret reads the secret identified by the given NamespacedName and
@@ -83,6 +84,9 @@ func ReadOptsFromSecret(ctx context.Context, c client.Reader, ns client.ObjectKe
 	if err != nil {
 		return OCIOpts{}, err
 	}
+
+	// Read optional CA bundle
+	opts.CABundle = secret.Data[OCISecretCABundle]
 
 	return opts, nil
 }

--- a/internal/ocistorage/secret_test.go
+++ b/internal/ocistorage/secret_test.go
@@ -2,6 +2,7 @@ package ocistorage
 
 import (
 	"context"
+	"crypto/x509"
 	"errors"
 	"fmt"
 
@@ -168,6 +169,66 @@ var _ = Describe("OCIOpts loaded from secret", func() {
 			Expect(opts.AgentPassword).To(BeEmpty())
 			Expect(opts.BasicHTTP).To(BeFalse())
 			Expect(opts.InsecureSkipTLS).To(BeFalse())
+			Expect(opts.CABundle).To(BeNil())
+		})
+	})
+
+	When("the given oci storage secret contains a CA bundle", func() {
+		BeforeEach(func() {
+			secretName = "test"
+			secretData = map[string][]byte{
+				OCISecretReference: []byte("reference"),
+				OCISecretCABundle: []byte(`-----BEGIN CERTIFICATE-----
+MIICGTCCAZ+gAwIBAgIQCeCTZaz32ci5PhwLBCou8zAKBggqhkjOPQQDAzBOMQsw
+CQYDVQQGEwJVUzEXMBUGA1UEChMORGlnaUNlcnQsIEluYy4xJjAkBgNVBAMTHURp
+Z2lDZXJ0IFRMUyBFQ0MgUDM4NCBSb290IEc1MB4XDTIxMDExNTAwMDAwMFoXDTQ2
+MDExNDIzNTk1OVowTjELMAkGA1UEBhMCVVMxFzAVBgNVBAoTDkRpZ2lDZXJ0LCBJ
+bmMuMSYwJAYDVQQDEx1EaWdpQ2VydCBUTFMgRUNDIFAzODQgUm9vdCBHNTB2MBAG
+ByqGSM49AgEGBSuBBAAiA2IABMFEoc8Rl1Ca3iOCNQfN0MsYndLxf3c1TzvdlHJS
+7cI7+Oz6e2tYIOyZrsn8aLN1udsJ7MgT9U7GCh1mMEy7H0cKPGEQQil8pQgO4CLp
+0zVozptjn4S1mU1YoI71VOeVyaNCMEAwHQYDVR0OBBYEFMFRRVBZqz7nLFr6ICIS
+B4CIfBFqMA4GA1UdDwEB/wQEAwIBhjAPBgNVHRMBAf8EBTADAQH/MAoGCCqGSM49
+BAMDA2gAMGUCMQCJao1H5+z8blUD2WdsJk6Dxv3J+ysTvLd6jLRl0mlpYxNjOyZQ
+LgGheQaRnUi/wr4CMEfDFXuxoJGZSZOoPHzoRgaLLPIxAJSdYsiJvRmEFOml+wG4
+DXZDjC5Ty3zfDBeWUA==
+-----END CERTIFICATE-----`),
+			}
+			secretType = fleet.SecretTypeOCIStorage
+			secretGetErrorMessage = ""
+			secretGetNotFoundError = false
+		})
+		It("returns the CA bundle in OCIOpts", func() {
+			ns := client.ObjectKey{Name: secretName, Namespace: "test"}
+			opts, err := ReadOptsFromSecret(context.TODO(), mockClient, ns)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(opts.Reference).To(Equal(string(secretData[OCISecretReference])))
+			Expect(opts.CABundle).To(Equal(secretData[OCISecretCABundle]))
+			Expect(string(opts.CABundle)).To(ContainSubstring("BEGIN CERTIFICATE"))
+
+			// Verify the CA bundle is valid PEM that can be parsed
+			testPool := x509.NewCertPool()
+			ok := testPool.AppendCertsFromPEM(opts.CABundle)
+			Expect(ok).To(BeTrue(), "CA bundle should be valid PEM")
+		})
+	})
+
+	When("the given oci storage secret has an empty CA bundle field", func() {
+		BeforeEach(func() {
+			secretName = "test"
+			secretData = map[string][]byte{
+				OCISecretReference: []byte("reference"),
+				OCISecretCABundle:  []byte(""),
+			}
+			secretType = fleet.SecretTypeOCIStorage
+			secretGetErrorMessage = ""
+			secretGetNotFoundError = false
+		})
+		It("returns an empty CA bundle in OCIOpts", func() {
+			ns := client.ObjectKey{Name: secretName, Namespace: "test"}
+			opts, err := ReadOptsFromSecret(context.TODO(), mockClient, ns)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(opts.Reference).To(Equal(string(secretData[OCISecretReference])))
+			Expect(opts.CABundle).To(Equal([]byte("")))
 		})
 	})
 


### PR DESCRIPTION
This PR adds custom CAs when downloading OCI artifacts in a similar way we already use them when downloading helm charts.

Refers to: https://github.com/rancher/fleet/issues/4897

## Additional Information

### Checklist

[x] <!-- If applicable,--> I have updated the documentation via a pull request in the [fleet-product-docs](https://github.com/rancher/fleet-product-docs) repository.
