### PR TITLE
[v0.13] Require helmRepoURLRegex for Helm credential forwarding

### DIFF
--- a/charts/fleet-crd/templates/crds.yaml
+++ b/charts/fleet-crd/templates/crds.yaml
@@ -6396,9 +6396,9 @@ spec:
                   type: integer
                 helmRepoURLRegex:
                   description: 'HelmRepoURLRegex Helm credentials will be used if
-                    the helm repo matches this regex
+                    the helm repo matches this regex.
 
-                    Credentials will always be used if this is empty or not provided.'
+                    Credentials will not be used if this is empty or not provided.'
                   nullable: true
                   type: string
                 helmSecretName:

--- a/charts/fleet/templates/job_migrate_gitrepo_helmrepourl.yaml
+++ b/charts/fleet/templates/job_migrate_gitrepo_helmrepourl.yaml
@@ -1,0 +1,49 @@
+{{- if .Values.migrations.gitrepoHelmURLRegexMigration }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: fleet-migrate-gitrepo-helm-url-regex
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-delete-policy": hook-succeeded, before-hook-creation
+spec:
+  template:
+    metadata:
+      labels:
+        app: fleet-job
+    spec:
+      serviceAccountName: fleet-controller
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        runAsGroup: 1000
+        runAsUser: 1000
+      containers:
+      - name: migrate
+        image: "{{ template "system_default_registry" . }}{{.Values.image.repository}}:{{.Values.image.tag}}"
+        imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: false
+          privileged: false
+        command:
+        - fleet
+        args:
+        - migrate
+        - gitrepo-helm-url-regex
+        env:
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+      nodeSelector: {{ include "linux-node-selector" . | nindent 8 }}
+      tolerations: {{ include "linux-node-tolerations" . | nindent 8 }}
+{{- if $.Values.tolerations }}
+{{ toYaml $.Values.tolerations | indent 8 }}
+{{- end }}
+  backoffLimit: 1
+{{- end }}

--- a/charts/fleet/values.yaml
+++ b/charts/fleet/values.yaml
@@ -101,6 +101,7 @@ disableSecurityContext: false
 migrations:
   clusterRegistrationCleanup: true
   gitrepoJobsCleanup: true
+  gitrepoHelmURLRegexMigration: true
 
 ## Leader election configuration
 leaderElection:

--- a/e2e/assets/helm/repo/oci-with-auth-chart/fleet.yaml
+++ b/e2e/assets/helm/repo/oci-with-auth-chart/fleet.yaml
@@ -1,0 +1,29 @@
+# This file and all contents in it are OPTIONAL.
+
+# The namespace this chart will be installed and restricted to,
+# if not specified the chart will be installed to "default"
+namespace: fleet-helm-oci-with-auth
+
+# Custom helm options
+helm:
+  # The release name to use. If empty a generated release name will be used
+  releaseName: sleeper-chart
+
+  # The directory of the chart in the repo.  Any valid go-getter supported
+  # URL can also be used here to specify where to download the chart from.
+  # If repo below is set, this value is the chart name in the repo.
+  chart: "oci://zot-service.default.svc.cluster.local:8082/sleeper-chart"
+
+  # Used if repo is set to look up the version of the chart
+  version: "0.1.0"
+
+  # Force recreate resource that can not be updated
+  force: false
+
+  # How long for helm to wait for the release to be active. If the value
+  # is less that or equal to zero, we will not wait in Helm
+  timeoutSeconds: 0
+
+  # Custom values that will be passed as values.yaml to the installation
+  values:
+    replicas: 2

--- a/e2e/assets/single-cluster/helm-with-auth.yaml
+++ b/e2e/assets/single-cluster/helm-with-auth.yaml
@@ -7,6 +7,9 @@ spec:
   helmSecretName: {{ .SecretName }}
   paths:
   - {{ .Path }}
+{{- if .HelmRepoURLRegex }}
+  helmRepoURLRegex: {{ .HelmRepoURLRegex }}
+{{- end }}
   targets:
   - clusterSelector:
       matchExpressions:

--- a/e2e/single-cluster/helm_auth_test.go
+++ b/e2e/single-cluster/helm_auth_test.go
@@ -16,12 +16,13 @@ import (
 
 var _ = Describe("GitRepo using Helm chart with auth", Label("infra-setup"), func() {
 	var (
-		gitRepoPath     string
-		tmpdir          string
-		k               kubectl.Command
-		gh              *githelper.Git
-		targetNamespace string
-		helmSecretName  string
+		gitRepoPath      string
+		tmpdir           string
+		k                kubectl.Command
+		gh               *githelper.Git
+		targetNamespace  string
+		helmSecretName   string
+		helmRepoURLRegex string
 	)
 
 	JustBeforeEach(func() {
@@ -32,13 +33,15 @@ var _ = Describe("GitRepo using Helm chart with auth", Label("infra-setup"), fun
 
 		gitrepo := path.Join(tmpdir, "gitrepo.yaml")
 		err := testenv.Template(gitrepo, testenv.AssetPath("single-cluster/helm-with-auth.yaml"), struct {
-			Repo       string
-			Path       string
-			SecretName string
+			Repo             string
+			Path             string
+			SecretName       string
+			HelmRepoURLRegex string
 		}{
 			inClusterRepoURL,
 			gitRepoPath,
 			helmSecretName,
+			helmRepoURLRegex,
 		})
 		Expect(err).ToNot(HaveOccurred())
 
@@ -47,6 +50,10 @@ var _ = Describe("GitRepo using Helm chart with auth", Label("infra-setup"), fun
 	})
 
 	When("creating a gitrepo resource", func() {
+		BeforeEach(func() {
+			helmRepoURLRegex = ""
+		})
+
 		Context("containing a private OCI-based helm chart and setting insecureSkipVerify to false", Label("oci-registry"), func() {
 			BeforeEach(func() {
 				gitRepoPath = "oci-with-auth-external"
@@ -64,7 +71,54 @@ var _ = Describe("GitRepo using Helm chart with auth", Label("infra-setup"), fun
 
 				// create the gitrepo content on the fly, to set the external IP
 				// of the load balancer so it complains about the certificate.
-				repoBaseDir := createFleetYAMLWithExternalIP(k, gitRepoPath)
+				repoBaseDir := createFleetYAMLWithExternalIP(k, gitRepoPath, "chart")
+				tmpdir, gh = setupGitRepo(repoBaseDir, gitRepoPath, repoName, port)
+
+				DeferCleanup(func() {
+					_, _ = k.Delete("secret", helmSecretName)
+				})
+			})
+
+			It("fails to deploy the chart", func() {
+				By("checking that there is a pod in Failed state with name helm-*")
+				Eventually(func() string {
+					out, _ := k.Get("pods", "--field-selector=status.phase==Failed")
+					return out
+				}).Should(ContainSubstring("helm-"))
+				By("checking that the gitrepo reflects the expected error")
+				Eventually(func(g Gomega) {
+					status := getGitRepoStatus(g, k, "helm")
+					stalledMessage := ""
+					stalledFound := false
+					for _, cond := range status.Conditions {
+						if cond.Type == "Stalled" {
+							stalledMessage = cond.Message
+							stalledFound = true
+							break
+						}
+					}
+					g.Expect(stalledFound).To(BeTrue())
+					g.Expect(stalledMessage).To(ContainSubstring("failed to verify certificate"))
+				}).Should(Succeed())
+			})
+		})
+
+		Context("containing a private OCI-based helm chart using helm.chart (backwards compatibility) and setting insecureSkipVerify to false", Label("oci-registry"), func() {
+			BeforeEach(func() {
+				gitRepoPath = "oci-with-auth-external"
+				helmSecretName = "helm-secret-no-insecure"
+				targetNamespace = "fleet-helm-oci-with-auth"
+				k = env.Kubectl.Namespace(env.Namespace)
+
+				out, err := k.Create(
+					"secret", "generic", helmSecretName,
+					"--from-literal=username="+os.Getenv("CI_OCI_USERNAME"),
+					"--from-literal=password="+os.Getenv("CI_OCI_PASSWORD"),
+					"--from-literal=insecureSkipVerify=false",
+				)
+				Expect(err).ToNot(HaveOccurred(), out)
+
+				repoBaseDir := createFleetYAMLWithExternalIP(k, gitRepoPath, "chart")
 				tmpdir, gh = setupGitRepo(repoBaseDir, gitRepoPath, repoName, port)
 
 				DeferCleanup(func() {
@@ -100,6 +154,7 @@ var _ = Describe("GitRepo using Helm chart with auth", Label("infra-setup"), fun
 			BeforeEach(func() {
 				gitRepoPath = "oci-with-auth-external"
 				helmSecretName = "helm-secret-insecure"
+				helmRepoURLRegex = "oci://.*"
 				targetNamespace = "fleet-helm-oci-with-auth"
 				k = env.Kubectl.Namespace(env.Namespace)
 
@@ -113,7 +168,7 @@ var _ = Describe("GitRepo using Helm chart with auth", Label("infra-setup"), fun
 
 				// create the gitrepo content on the fly, to set the external IP
 				// of the load balancer so it complains about the certificate.
-				repoBaseDir := createFleetYAMLWithExternalIP(k, gitRepoPath)
+				repoBaseDir := createFleetYAMLWithExternalIP(k, gitRepoPath, "chart")
 				tmpdir, gh = setupGitRepo(repoBaseDir, gitRepoPath, repoName, port)
 
 				DeferCleanup(func() {
@@ -129,11 +184,63 @@ var _ = Describe("GitRepo using Helm chart with auth", Label("infra-setup"), fun
 			})
 		})
 
-		Context("containing a private OCI-based helm chart", Label("oci-registry"), func() {
+		Context("containing a private OCI-based helm chart using helm.chart (backwards compatibility) and setting insecureSkipVerify to true", Label("oci-registry"), func() {
+			BeforeEach(func() {
+				gitRepoPath = "oci-with-auth-external"
+				helmSecretName = "helm-secret-insecure"
+				helmRepoURLRegex = "oci://.*"
+				targetNamespace = "fleet-helm-oci-with-auth"
+				k = env.Kubectl.Namespace(env.Namespace)
+
+				out, err := k.Create(
+					"secret", "generic", helmSecretName,
+					"--from-literal=username="+os.Getenv("CI_OCI_USERNAME"),
+					"--from-literal=password="+os.Getenv("CI_OCI_PASSWORD"),
+					"--from-literal=insecureSkipVerify=true",
+				)
+				Expect(err).ToNot(HaveOccurred(), out)
+
+				repoBaseDir := createFleetYAMLWithExternalIP(k, gitRepoPath, "chart")
+				tmpdir, gh = setupGitRepo(repoBaseDir, gitRepoPath, repoName, port)
+
+				DeferCleanup(func() {
+					_, _ = k.Delete("secret", helmSecretName)
+				})
+			})
+
+			It("deploys the helm chart", func() {
+				Eventually(func() string {
+					out, _ := k.Namespace(targetNamespace).Get("pods", "--field-selector=status.phase==Running")
+					return out
+				}).Should(ContainSubstring("sleeper-"))
+			})
+		})
+
+		Context("containing a private OCI-based helm chart with helm.repo", Label("oci-registry"), func() {
 			BeforeEach(func() {
 				gitRepoPath = "oci-with-auth"
 				helmSecretName = "helm-secret"
-				targetNamespace = fmt.Sprintf("fleet-helm-%s", gitRepoPath)
+				helmRepoURLRegex = "oci://.*"
+				targetNamespace = "fleet-helm-" + gitRepoPath
+				k = env.Kubectl.Namespace(env.Namespace)
+
+				tmpdir, gh = setupGitRepo(testenv.AssetPath("helm/repo"), gitRepoPath, repoName, port)
+			})
+
+			It("deploys the helm chart", func() {
+				Eventually(func() string {
+					out, _ := k.Namespace(targetNamespace).Get("pods", "--field-selector=status.phase==Running")
+					return out
+				}).Should(ContainSubstring("sleeper-"))
+			})
+		})
+
+		Context("containing a private OCI-based helm chart with helm.chart (backwards compatibility)", Label("oci-registry"), func() {
+			BeforeEach(func() {
+				gitRepoPath = "oci-with-auth-chart"
+				helmSecretName = "helm-secret"
+				helmRepoURLRegex = "oci://.*"
+				targetNamespace = "fleet-helm-oci-with-auth"
 				k = env.Kubectl.Namespace(env.Namespace)
 
 				tmpdir, gh = setupGitRepo(testenv.AssetPath("helm/repo"), gitRepoPath, repoName, port)
@@ -150,7 +257,8 @@ var _ = Describe("GitRepo using Helm chart with auth", Label("infra-setup"), fun
 			BeforeEach(func() {
 				gitRepoPath = "http-with-auth-repo-path"
 				helmSecretName = "helm-secret-no-ca"
-				targetNamespace = fmt.Sprintf("fleet-helm-%s", gitRepoPath)
+				helmRepoURLRegex = "https://chartmuseum-service..*"
+				targetNamespace = "fleet-helm-" + gitRepoPath
 				k = env.Kubectl.Namespace(env.Namespace)
 
 				// No CA bundle in this secret
@@ -199,7 +307,8 @@ var _ = Describe("GitRepo using Helm chart with auth", Label("infra-setup"), fun
 			BeforeEach(func() {
 				gitRepoPath = "http-with-auth-repo-path"
 				helmSecretName = "helm-secret"
-				targetNamespace = fmt.Sprintf("fleet-helm-%s", gitRepoPath)
+				helmRepoURLRegex = "https://chartmuseum-service..*"
+				targetNamespace = "fleet-helm-" + gitRepoPath
 				k = env.Kubectl.Namespace(env.Namespace)
 
 				tmpdir, gh = setupGitRepo(testenv.AssetPath("helm/repo"), gitRepoPath, repoName, port)
@@ -216,7 +325,8 @@ var _ = Describe("GitRepo using Helm chart with auth", Label("infra-setup"), fun
 			BeforeEach(func() {
 				gitRepoPath = "http-with-auth-chart-path"
 				helmSecretName = "helm-secret"
-				targetNamespace = fmt.Sprintf("fleet-helm-%s", gitRepoPath)
+				helmRepoURLRegex = "https://chartmuseum-service..*"
+				targetNamespace = "fleet-helm-" + gitRepoPath
 				k = env.Kubectl.Namespace(env.Namespace)
 
 				tmpdir, gh = setupGitRepo(testenv.AssetPath("helm/repo"), gitRepoPath, repoName, port)
@@ -258,7 +368,7 @@ func setupGitRepo(basePath, repoPath, repo string, port int) (tmpdir string, gh 
 	return tmpdir, gh
 }
 
-func createFleetYAMLWithExternalIP(k kubectl.Command, gitRepoPath string) string {
+func createFleetYAMLWithExternalIP(k kubectl.Command, gitRepoPath string, ociField string) string { //nolint:unparam
 	tmpFolder := GinkgoT().TempDir()
 	ip := ""
 	ks := k.Namespace("")
@@ -270,7 +380,7 @@ func createFleetYAMLWithExternalIP(k kubectl.Command, gitRepoPath string) string
 	fleetYAML := `namespace: fleet-helm-oci-with-auth
 helm:
   releaseName: sleeper-chart
-  chart: "oci://%s:8082/sleeper-chart"
+  ` + ociField + `: "oci://%s:8082/sleeper-chart"
   version: "0.1.0"
   force: false
   timeoutSeconds: 0
@@ -282,7 +392,7 @@ helm:
 	Expect(err).ToNot(HaveOccurred())
 
 	fleetYamlPath := path.Join(gitrepoFolder, "fleet.yaml")
-	err = os.WriteFile(fleetYamlPath, []byte(fmt.Sprintf(fleetYAML, ip)), 0644)
+	err = os.WriteFile(fleetYamlPath, fmt.Appendf(nil, fleetYAML, ip), 0644)
 	Expect(err).ToNot(HaveOccurred())
 
 	return tmpFolder

--- a/integrationtests/cli/apply/apply_test.go
+++ b/integrationtests/cli/apply/apply_test.go
@@ -1,6 +1,7 @@
 package apply
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path"
@@ -279,6 +280,7 @@ var _ = Describe("Fleet apply driven", Ordered, func() {
 				cli.AssetsPath + "driven/kustomize" + ":prod.yaml",
 			}
 			// set credentials to download helm chart for mock repository
+			options.HelmRepoURLRegex = "http://localhost.*"
 			options.AuthByPath = map[string]bundlereader.Auth{
 				cli.AssetsPath + "driven/helm": {Username: username, Password: password},
 			}
@@ -464,6 +466,7 @@ var _ = Describe("Fleet apply driven", Ordered, func() {
 				cli.AssetsPath + "driven_fleet_yaml_subfolder/helm:test/fleet.yaml",
 			}
 			// set credentials to download helm chart for mock repository
+			options.HelmRepoURLRegex = "http://localhost.*"
 			options.AuthByPath = map[string]bundlereader.Auth{
 				cli.AssetsPath + "driven_fleet_yaml_subfolder/helm": {Username: username, Password: password},
 			}
@@ -740,11 +743,11 @@ var _ = Describe("Fleet apply with helm charts with dependencies", Ordered, func
 	})
 })
 
-func bePresentInBundleResources(expected interface{}) types.GomegaMatcher {
+func bePresentInBundleResources(expected any) types.GomegaMatcher {
 	return gcustom.MakeMatcher(func(path string) (bool, error) {
 		resources, ok := expected.([]v1alpha1.BundleResource)
 		if !ok {
-			return false, fmt.Errorf("BePresentInBundleResources matcher expects []v1alpha1.BundleResource")
+			return false, errors.New("BePresentInBundleResources matcher expects []v1alpha1.BundleResource")
 		}
 		isPresent, err := cli.IsResourcePresentInBundle(path, resources)
 		if err != nil {
@@ -754,11 +757,11 @@ func bePresentInBundleResources(expected interface{}) types.GomegaMatcher {
 	}).WithTemplate("Expected:\n{{.FormattedActual}}\n{{.To}} be present in \n{{format .Data 1}}").WithTemplateData(expected)
 }
 
-func bePresentOnlyInBundleResources(expected interface{}) types.GomegaMatcher {
+func bePresentOnlyInBundleResources(expected any) types.GomegaMatcher {
 	return gcustom.MakeMatcher(func(path string) (bool, error) {
 		resources, ok := expected.([]v1alpha1.BundleResource)
 		if !ok {
-			return false, fmt.Errorf("bePresentOnlyInBundleResources matcher expects []v1alpha1.BundleResource")
+			return false, errors.New("bePresentOnlyInBundleResources matcher expects []v1alpha1.BundleResource")
 		}
 		found := false
 		for _, resource := range resources {

--- a/integrationtests/cli/apply/helm_test.go
+++ b/integrationtests/cli/apply/helm_test.go
@@ -63,6 +63,7 @@ var _ = Describe("Fleet apply helm release", Serial, func() {
 			It("fleet apply works fine", func() {
 				Eventually(func() error {
 					return fleetApply("helm", []string{cli.AssetsPath + "helm_path_credentials"}, apply.Options{
+						HelmRepoURLRegex: "http://localhost.*",
 						AuthByPath: map[string]bundlereader.Auth{
 							cli.AssetsPath + "helm_path_credentials":           {Username: username, Password: password},
 							cli.AssetsPath + "helm_path_credentials/subfolder": {Username: username, Password: password},
@@ -102,7 +103,7 @@ var _ = Describe("Fleet apply helm release with HTTP OCI registry", Ordered, fun
 		out, err := cmd.CombinedOutput()
 		Expect(err).ToNot(HaveOccurred(), out)
 
-		cmd = exec.Command("helm", "push", "config-chart-0.1.0.tgz", fmt.Sprintf("oci://%s:%d", host, port.Int()))
+		cmd = exec.Command("helm", "push", "config-chart-0.1.0.tgz", fmt.Sprintf("oci://%s:%d", host, port.Int()), "--plain-http")
 		out, err = cmd.CombinedOutput()
 		Expect(err).ToNot(HaveOccurred(), out)
 
@@ -183,13 +184,12 @@ func testHelmRepo(path, port string) {
 		BeforeEach(func() {
 			authEnabled = true
 		})
-		It("fleet apply success", func() {
-			Eventually(func() error {
-				return fleetApply("helm", []string{cli.AssetsPath + path}, apply.Options{Auth: bundlereader.Auth{Username: username, Password: password}})
-			}).Should(Not(HaveOccurred()))
-			By("verifying Bundle is created with all the resources inside of the helm release", func() {
-				Eventually(verifyResourcesArePresent).Should(BeTrue())
-			})
+		It("fails fleet apply because credentials are not sent without a matching regex", func() {
+			Eventually(func() string {
+				err := fleetApply("helm", []string{cli.AssetsPath + path}, apply.Options{Auth: bundlereader.Auth{Username: username, Password: password}})
+				Expect(err).To(HaveOccurred())
+				return err.Error()
+			}).Should(ContainSubstring("401"))
 		})
 	})
 
@@ -270,7 +270,19 @@ func testHelmRepo(path, port string) {
 		})
 		It("fleet apply uses credentials from HelmSecretNameForPaths", func() {
 			Eventually(func() error {
-				return fleetApply("helm", []string{cli.AssetsPath + path}, apply.Options{AuthByPath: map[string]bundlereader.Auth{cli.AssetsPath + path: {Username: username, Password: password}}})
+				return fleetApply(
+					"helm",
+					[]string{cli.AssetsPath + path},
+					apply.Options{
+						HelmRepoURLRegex: "http://localhost.*",
+						AuthByPath: map[string]bundlereader.Auth{
+							cli.AssetsPath + path: {
+								Username: username,
+								Password: password,
+							},
+						},
+					},
+				)
 			}).Should(Not(HaveOccurred()))
 			By("verify Bundle is created with all the resources inside of the helm release", func() {
 				Eventually(verifyResourcesArePresent).Should(BeTrue())
@@ -284,7 +296,15 @@ func testHelmRepo(path, port string) {
 		})
 		It("fleet apply uses credentials from HelmSecretNameForPaths", func() {
 			Eventually(func() error {
-				return fleetApply("helm", []string{cli.AssetsPath + path}, apply.Options{Auth: bundlereader.Auth{Username: "wrong", Password: "wrong"}, AuthByPath: map[string]bundlereader.Auth{cli.AssetsPath + path: {Username: username, Password: password}}})
+				return fleetApply(
+					"helm",
+					[]string{cli.AssetsPath + path},
+					apply.Options{
+						HelmRepoURLRegex: "http://localhost.*",
+						Auth:             bundlereader.Auth{Username: "wrong", Password: "wrong"},
+						AuthByPath:       map[string]bundlereader.Auth{cli.AssetsPath + path: {Username: username, Password: password}},
+					},
+				)
 			}).Should(Not(HaveOccurred()))
 			By("verify Bundle is created with all the resources inside of the helm release", func() {
 				Eventually(verifyResourcesArePresent).Should(BeTrue())

--- a/integrationtests/gitjob/controller/helm_url_regex_migration_test.go
+++ b/integrationtests/gitjob/controller/helm_url_regex_migration_test.go
@@ -1,0 +1,265 @@
+package controller
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/rancher/fleet/integrationtests/utils"
+	"github.com/rancher/fleet/internal/cmd/cli/migrate"
+	"github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
+
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+const (
+	migrationSystemNamespace = "default"
+	migrationMarkerName      = "fleet-helm-url-regex-migrated"
+)
+
+func runHelmURLRegexMigration() error {
+	return migrate.GitRepoHelmURLRegex(ctx, k8sClient, migrationSystemNamespace)
+}
+
+func deleteHelmURLRegexMarker() {
+	marker := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      migrationMarkerName,
+			Namespace: migrationSystemNamespace,
+		},
+	}
+	err := k8sClient.Delete(ctx, marker)
+	if err != nil && !k8serrors.IsNotFound(err) {
+		Fail("failed to delete migration marker: " + err.Error())
+	}
+}
+
+// createBundle creates a Bundle in namespace owned by the named GitRepo,
+// with the given Helm Repo and Chart values.
+func createMigrationBundle(namespace, gitRepoName, name, helmRepo, helmChart string) {
+	bundle := &v1alpha1.Bundle{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				v1alpha1.RepoLabel: gitRepoName,
+			},
+		},
+		Spec: v1alpha1.BundleSpec{
+			BundleDeploymentOptions: v1alpha1.BundleDeploymentOptions{
+				Helm: &v1alpha1.HelmOptions{
+					Repo:  helmRepo,
+					Chart: helmChart,
+				},
+			},
+			Targets: []v1alpha1.BundleTarget{},
+		},
+	}
+	Expect(k8sClient.Create(ctx, bundle)).ToNot(HaveOccurred())
+	DeferCleanup(func() {
+		Expect(k8sClient.Delete(ctx, &v1alpha1.Bundle{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		})).ToNot(HaveOccurred())
+	})
+}
+
+var _ = Describe("HelmURLRegex migration", func() {
+	var namespace string
+
+	BeforeEach(func() {
+		var err error
+		namespace, err = utils.NewNamespaceName()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(k8sClient.Create(ctx, &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: namespace},
+		})).ToNot(HaveOccurred())
+
+		deleteHelmURLRegexMarker()
+
+		DeferCleanup(func() {
+			deleteHelmURLRegexMarker()
+			Expect(k8sClient.Delete(ctx, &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{Name: namespace},
+			})).ToNot(HaveOccurred())
+		})
+	})
+
+	createGitRepo := func(name string, helmSecretName, helmSecretNameForPaths, helmRepoURLRegex string) {
+		gr := &v1alpha1.GitRepo{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+			Spec: v1alpha1.GitRepoSpec{
+				Repo:                   "https://github.com/rancher/fleet-test-data/not-found",
+				HelmSecretName:         helmSecretName,
+				HelmSecretNameForPaths: helmSecretNameForPaths,
+				HelmRepoURLRegex:       helmRepoURLRegex,
+			},
+		}
+		Expect(k8sClient.Create(ctx, gr)).ToNot(HaveOccurred())
+		DeferCleanup(func() {
+			Expect(k8sClient.Delete(ctx, &v1alpha1.GitRepo{
+				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+			})).ToNot(HaveOccurred())
+		})
+	}
+
+	getGitRepo := func(name string) *v1alpha1.GitRepo {
+		gr := &v1alpha1.GitRepo{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, gr)).To(Succeed())
+		return gr
+	}
+
+	It("derives regex from https helm.repo URL in existing Bundle", func() {
+		createGitRepo("migrate-https", "some-secret", "", "")
+		createMigrationBundle(namespace, "migrate-https", "bundle-https",
+			"https://charts.example.com/stable", "")
+
+		Expect(runHelmURLRegexMigration()).To(Succeed())
+
+		gr := getGitRepo("migrate-https")
+		Expect(gr.Spec.HelmRepoURLRegex).To(Equal(`^https://charts\.example\.com/`))
+		Expect(gr.Annotations).To(HaveKeyWithValue(migrate.HelmRegexAutoMigratedAnnotation, "true"))
+	})
+
+	It("derives regex from oci helm.chart URL in existing Bundle", func() {
+		createGitRepo("migrate-oci", "", "some-secret", "")
+		createMigrationBundle(namespace, "migrate-oci", "bundle-oci",
+			"", "oci://registry.example.com/org/chart")
+
+		Expect(runHelmURLRegexMigration()).To(Succeed())
+
+		gr := getGitRepo("migrate-oci")
+		Expect(gr.Spec.HelmRepoURLRegex).To(Equal(`^oci://registry\.example\.com/`))
+		Expect(gr.Annotations).To(HaveKeyWithValue(migrate.HelmRegexAutoMigratedAnnotation, "true"))
+	})
+
+	It("includes port in derived regex when the URL has a non-standard port", func() {
+		createGitRepo("migrate-port", "some-secret", "", "")
+		createMigrationBundle(namespace, "migrate-port", "bundle-port",
+			"https://charts.example.com:8443/stable", "")
+
+		Expect(runHelmURLRegexMigration()).To(Succeed())
+
+		gr := getGitRepo("migrate-port")
+		Expect(gr.Spec.HelmRepoURLRegex).To(Equal(`^https://charts\.example\.com:8443/`))
+		Expect(gr.Annotations).To(HaveKeyWithValue(migrate.HelmRegexAutoMigratedAnnotation, "true"))
+	})
+
+	It("builds alternation regex for multiple distinct helm origins", func() {
+		createGitRepo("migrate-multi", "some-secret", "", "")
+		createMigrationBundle(namespace, "migrate-multi", "bundle-a",
+			"https://charts.example.com/stable", "")
+		createMigrationBundle(namespace, "migrate-multi", "bundle-b",
+			"", "oci://registry.example.com/org/chart")
+
+		Expect(runHelmURLRegexMigration()).To(Succeed())
+
+		gr := getGitRepo("migrate-multi")
+		Expect(gr.Spec.HelmRepoURLRegex).To(HavePrefix("^("))
+		Expect(gr.Spec.HelmRepoURLRegex).To(ContainSubstring(`https://charts\.example\.com/`))
+		Expect(gr.Spec.HelmRepoURLRegex).To(ContainSubstring(`oci://registry\.example\.com/`))
+		Expect(gr.Annotations).To(HaveKeyWithValue(migrate.HelmRegexAutoMigratedAnnotation, "true"))
+	})
+
+	It("deduplicates identical origins across Bundles", func() {
+		createGitRepo("migrate-dedup", "some-secret", "", "")
+		createMigrationBundle(namespace, "migrate-dedup", "bundle-c",
+			"https://charts.example.com/stable", "")
+		createMigrationBundle(namespace, "migrate-dedup", "bundle-d",
+			"https://charts.example.com/stable", "")
+
+		Expect(runHelmURLRegexMigration()).To(Succeed())
+
+		// Single distinct origin → no alternation group.
+		gr := getGitRepo("migrate-dedup")
+		Expect(gr.Spec.HelmRepoURLRegex).To(Equal(`^https://charts\.example\.com/`))
+		Expect(gr.Annotations).To(HaveKeyWithValue(migrate.HelmRegexAutoMigratedAnnotation, "true"))
+	})
+
+	It("leaves helmRepoURLRegex empty and skips annotation when no Bundles exist", func() {
+		createGitRepo("migrate-no-bundles", "some-secret", "", "")
+
+		Expect(runHelmURLRegexMigration()).To(Succeed())
+
+		gr := getGitRepo("migrate-no-bundles")
+		Expect(gr.Spec.HelmRepoURLRegex).To(BeEmpty())
+		Expect(gr.Annotations).NotTo(HaveKey(migrate.HelmRegexAutoMigratedAnnotation))
+	})
+
+	It("ignores plain chart names (non-URL) in Bundle helm.chart", func() {
+		createGitRepo("migrate-plain-chart", "some-secret", "", "")
+		createMigrationBundle(namespace, "migrate-plain-chart", "bundle-plain",
+			"", "stable/nginx")
+
+		Expect(runHelmURLRegexMigration()).To(Succeed())
+
+		// Non-URL chart → no regex derivable → left empty.
+		Expect(getGitRepo("migrate-plain-chart").Spec.HelmRepoURLRegex).To(BeEmpty())
+	})
+
+	It("does not migrate GitRepos without a helm secret", func() {
+		createGitRepo("no-secret", "", "", "")
+
+		Expect(runHelmURLRegexMigration()).To(Succeed())
+
+		Expect(getGitRepo("no-secret").Spec.HelmRepoURLRegex).To(BeEmpty())
+	})
+
+	It("does not overwrite an existing helmRepoURLRegex", func() {
+		createGitRepo("has-regex", "some-secret", "", `https://charts\.example\.com.*`)
+		createMigrationBundle(namespace, "has-regex", "bundle-existing",
+			"https://charts.example.com/stable", "")
+
+		Expect(runHelmURLRegexMigration()).To(Succeed())
+
+		Expect(getGitRepo("has-regex").Spec.HelmRepoURLRegex).To(Equal(`https://charts\.example\.com.*`))
+	})
+
+	It("skips migration when the marker ConfigMap already exists", func() {
+		createGitRepo("no-migrate", "some-secret", "", "")
+		createMigrationBundle(namespace, "no-migrate", "bundle-skip",
+			"https://charts.example.com/stable", "")
+
+		Expect(k8sClient.Create(ctx, &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      migrationMarkerName,
+				Namespace: migrationSystemNamespace,
+			},
+		})).To(Succeed())
+
+		Expect(runHelmURLRegexMigration()).To(Succeed())
+
+		// Marker was present → migration did not run.
+		Expect(getGitRepo("no-migrate").Spec.HelmRepoURLRegex).To(BeEmpty())
+	})
+
+	It("creates the marker ConfigMap after migration", func() {
+		Expect(runHelmURLRegexMigration()).To(Succeed())
+
+		marker := &corev1.ConfigMap{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{
+			Namespace: migrationSystemNamespace,
+			Name:      migrationMarkerName,
+		}, marker)).To(Succeed())
+	})
+
+	It("treats second run as no-op once marker is created", func() {
+		createGitRepo("run-twice", "some-secret", "", "")
+		createMigrationBundle(namespace, "run-twice", "bundle-twice",
+			"https://charts.example.com/stable", "")
+
+		// First run: migrates GitRepo and creates marker.
+		Expect(runHelmURLRegexMigration()).To(Succeed())
+		Expect(getGitRepo("run-twice").Spec.HelmRepoURLRegex).To(Equal(`^https://charts\.example\.com/`))
+
+		// Manually reset to simulate a hypothetical re-entry attempt.
+		gr := getGitRepo("run-twice")
+		gr.Spec.HelmRepoURLRegex = ""
+		Expect(k8sClient.Update(ctx, gr)).To(Succeed())
+
+		// Second run: marker present, migration skipped.
+		Expect(runHelmURLRegexMigration()).To(Succeed())
+		Expect(getGitRepo("run-twice").Spec.HelmRepoURLRegex).To(BeEmpty())
+	})
+})

--- a/internal/bundlereader/loaddirectory.go
+++ b/internal/bundlereader/loaddirectory.go
@@ -229,10 +229,16 @@ func GetContent(ctx context.Context, base, source, version string, auth Auth, di
 		source += fmt.Sprintf("sshkey=%s", base64.StdEncoding.EncodeToString(auth.SSHPrivateKey))
 	}
 
-	// copy getter.Getters before changing
+	// Only keep Git and File getters; replace HTTP(S) with our
+	// customized one and drop all other protocols (hg, smb)
 	getters := map[string]getter.Getter{}
 	for k, v := range getter.Getters {
-		getters[k] = v
+		switch v.(type) {
+		case *getter.HttpGetter:
+			continue
+		case *getter.GitGetter, *getter.FileGetter:
+			getters[k] = v
+		}
 	}
 
 	httpGetter := newHttpGetter(auth)

--- a/internal/bundlereader/loaddirectory_test.go
+++ b/internal/bundlereader/loaddirectory_test.go
@@ -565,6 +565,24 @@ func TestGetContent(t *testing.T) {
 				"bar/something2.yaml": []byte("something2"),
 			},
 		},
+		{
+			name: "hg:: source scheme is rejected",
+			directoryStructure: fsNode{
+				isDir: true,
+				name:  "hg-test",
+			},
+			source:      "hg::http://example.com/repo",
+			expectedErr: regexp.MustCompile("error downloading 'hg::"),
+		},
+		{
+			name: "smb:// source scheme is rejected",
+			directoryStructure: fsNode{
+				isDir: true,
+				name:  "smb-test",
+			},
+			source:      "smb://example.com/share",
+			expectedErr: regexp.MustCompile("error downloading 'smb://"),
+		},
 	}
 
 	base, err := os.MkdirTemp("", "test-fleet")

--- a/internal/bundlereader/loaddirectory_test.go
+++ b/internal/bundlereader/loaddirectory_test.go
@@ -572,7 +572,7 @@ func TestGetContent(t *testing.T) {
 				name:  "hg-test",
 			},
 			source:      "hg::http://example.com/repo",
-			expectedErr: regexp.MustCompile("error downloading 'hg::"),
+			expectedErr: regexp.MustCompile("not supported for scheme 'hg'"),
 		},
 		{
 			name: "smb:// source scheme is rejected",
@@ -581,7 +581,7 @@ func TestGetContent(t *testing.T) {
 				name:  "smb-test",
 			},
 			source:      "smb://example.com/share",
-			expectedErr: regexp.MustCompile("error downloading 'smb://"),
+			expectedErr: regexp.MustCompile("not supported for scheme 'smb'"),
 		},
 	}
 

--- a/internal/bundlereader/resources.go
+++ b/internal/bundlereader/resources.go
@@ -213,7 +213,10 @@ func addRemoteCharts(directories []directory, base string, charts []*fleet.HelmO
 				return nil, fmt.Errorf("failed to add auth to request for %s: %w", downloadChartError(*chart), err)
 			}
 			if !shouldAddAuthToRequest {
-				auth = Auth{}
+				// Only clear credentials; preserve transport settings (BasicHTTP, CABundle, InsecureSkipVerify)
+				auth.Username = ""
+				auth.Password = ""
+				auth.SSHPrivateKey = nil
 			}
 
 			chartURL, err := chartURL(*chart, auth, false)
@@ -244,13 +247,26 @@ func downloadChartError(c fleet.HelmOptions) string {
 
 func shouldAddAuthToRequest(helmRepoURLRegex, repo, chart string) (bool, error) {
 	if helmRepoURLRegex == "" {
-		return true, nil
+		return false, nil
 	}
+	// Validate the user-supplied regex before anchoring so that any error
+	// message references the original pattern, not the internally-anchored one.
+	if _, err := regexp.Compile(helmRepoURLRegex); err != nil {
+		return false, err
+	}
+	// Anchor to the start of the URL to prevent bypassing the restriction
+	// by embedding the trusted URL elsewhere (e.g. as a query parameter).
+	// Wrap in a non-capturing group so that top-level alternation is fully
+	// anchored: "^(?:a|b)" matches only at start for both alternatives,
+	// whereas "^a|b" would leave "b" unanchored.
+	helmRepoURLRegex = "^(?:" + helmRepoURLRegex + ")"
 	if repo == "" {
-		return regexp.MatchString(helmRepoURLRegex, chart)
+		// MatchString cannot fail here: the regex was already validated above.
+		match, _ := regexp.MatchString(helmRepoURLRegex, chart)
+		return match, nil
 	}
-
-	return regexp.MatchString(helmRepoURLRegex, repo)
+	match, _ := regexp.MatchString(helmRepoURLRegex, repo)
+	return match, nil
 }
 
 func checksum(helm *fleet.HelmOptions) string {

--- a/internal/bundlereader/resources_test.go
+++ b/internal/bundlereader/resources_test.go
@@ -4,8 +4,10 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
+	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/util/yaml"
 )
 
@@ -35,8 +37,8 @@ microService2:
 )
 
 func TestValueMerge(t *testing.T) {
-	first := &v1alpha1.GenericMap{}
-	second := &v1alpha1.GenericMap{}
+	first := &fleet.GenericMap{}
+	second := &fleet.GenericMap{}
 
 	err := yaml.NewYAMLToJSONDecoder(bytes.NewBufferString(valuesOneYaml)).Decode(first)
 	if err != nil {
@@ -94,4 +96,113 @@ func TestValueMerge(t *testing.T) {
 			t.Fatalf("unable to find key replicas in values for service %s", serviceName)
 		}
 	}
+}
+
+func TestShouldAddAuthToRequest(t *testing.T) {
+	cases := []struct {
+		name             string
+		helmRepoURLRegex string
+		repo             string
+		chart            string
+		want             bool
+		wantErr          bool
+	}{
+		{
+			name:             "empty regex always returns false",
+			helmRepoURLRegex: "",
+			repo:             "https://charts.example.com",
+			want:             false,
+		},
+		{
+			name:             "regex matches repo URL",
+			helmRepoURLRegex: "https://charts\\.example\\.com.*",
+			repo:             "https://charts.example.com/stable",
+			want:             true,
+		},
+		{
+			name:             "regex does not match repo URL",
+			helmRepoURLRegex: "https://charts\\.example\\.com.*",
+			repo:             "https://evil.attacker.com",
+			want:             false,
+		},
+		{
+			name:             "no repo falls back to chart URL match",
+			helmRepoURLRegex: "oci://registry\\.example\\.com.*",
+			chart:            "oci://registry.example.com/charts/mychart",
+			want:             true,
+		},
+		{
+			name:             "regex does not match URL injected as query parameter",
+			helmRepoURLRegex: "https://charts\\.example\\.com.*",
+			repo:             "https://evil.attacker.com/?url=https://charts.example.com",
+			want:             false,
+		},
+		{
+			name:             "pre-anchored regex still matches",
+			helmRepoURLRegex: "^https://charts\\.example\\.com.*",
+			repo:             "https://charts.example.com/stable",
+			want:             true,
+		},
+		{
+			name:             "alternation anchors both alternatives",
+			helmRepoURLRegex: "https://host1\\.example\\.com/.*|https://host2\\.example\\.com/.*",
+			repo:             "https://host2.example.com/charts",
+			want:             true,
+		},
+		{
+			name:             "alternation does not match unanchored second alternative",
+			helmRepoURLRegex: "https://host1\\.example\\.com/.*|https://host2\\.example\\.com/.*",
+			repo:             "evil.com?url=https://host2.example.com/x",
+			want:             false,
+		},
+		{
+			name:             "invalid regex returns error",
+			helmRepoURLRegex: "[invalid",
+			repo:             "https://charts.example.com",
+			wantErr:          true,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := shouldAddAuthToRequest(c.helmRepoURLRegex, c.repo, c.chart)
+			if c.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, c.want, got)
+		})
+	}
+}
+
+func TestAddRemoteChartsStripsCredentials(t *testing.T) {
+	// When helmRepoURLRegex is empty, addRemoteCharts must strip Username and
+	// Password from the Auth passed to each directory, while keeping transport
+	// flags (BasicHTTP, InsecureSkipVerify) intact.
+	auth := Auth{
+		Username:           "user",
+		Password:           "secret",
+		SSHPrivateKey:      []byte("fake-ssh-key"),
+		BasicHTTP:          true,
+		InsecureSkipVerify: true,
+	}
+
+	// Use a chart path that does not exist on disk so addRemoteCharts processes
+	// it, and an empty Repo so ChartURL returns the chart string directly
+	// without a network call.
+	charts := []*fleet.HelmOptions{
+		{Chart: "/nonexistent/chart"},
+	}
+
+	dirs, err := addRemoteCharts(nil, t.TempDir(), charts, auth, "")
+	require.NoError(t, err)
+	require.Len(t, dirs, 1)
+
+	got := dirs[0].auth
+	assert.Empty(t, got.Username, "Username must be stripped when helmRepoURLRegex is empty")
+	assert.Empty(t, got.Password, "Password must be stripped when helmRepoURLRegex is empty")
+	assert.Nil(t, got.SSHPrivateKey, "SSHPrivateKey must be stripped when helmRepoURLRegex is empty")
+	assert.True(t, got.BasicHTTP, "BasicHTTP must be preserved when stripping credentials")
+	assert.True(t, got.InsecureSkipVerify, "InsecureSkipVerify must be preserved when stripping credentials")
 }

--- a/internal/cmd/cli/apply.go
+++ b/internal/cmd/cli/apply.go
@@ -54,7 +54,7 @@ type Apply struct {
 	PasswordFile                 string            `usage:"Path of file containing basic auth password for helm repo"`
 	CACertsFile                  string            `usage:"Path of custom cacerts for helm repo" name:"cacerts-file"`
 	SSHPrivateKeyFile            string            `usage:"Path of ssh-private-key for helm repo" name:"ssh-privatekey-file"`
-	HelmRepoURLRegex             string            `usage:"Helm credentials will be used if the helm repo matches this regex. Credentials will always be used if this is empty or not provided" name:"helm-repo-url-regex"`
+	HelmRepoURLRegex             string            `usage:"Helm credentials will be used if the helm repo matches this regex. Credentials will not be used if this is empty or not provided" name:"helm-repo-url-regex"`
 	KeepResources                bool              `usage:"Keep resources created after the GitRepo or Bundle is deleted" name:"keep-resources"`
 	DeleteNamespace              bool              `usage:"Delete GitRepo target namespace after the GitRepo or Bundle is deleted" name:"delete-namespace"`
 	HelmCredentialsByPathFile    string            `usage:"Path of file containing helm credentials for paths" name:"helm-credentials-by-path-file"`

--- a/internal/cmd/cli/migrate.go
+++ b/internal/cmd/cli/migrate.go
@@ -1,0 +1,68 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	command "github.com/rancher/fleet/internal/cmd"
+	"github.com/rancher/fleet/internal/cmd/cli/migrate"
+)
+
+// newMigrateCmd returns the hidden migrate command invoked by Helm post-upgrade
+// Jobs. It is intentionally not shown in fleet --help because it is a one-time
+// internal operation, not a user-facing workflow.
+func newMigrateCmd() *cobra.Command {
+	m := command.Command(&Migrate{}, cobra.Command{
+		Short:         "Run one-time upgrade migrations",
+		Hidden:        true,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+	})
+	m.AddCommand(NewMigrateGitRepoHelmURLRegex())
+	return m
+}
+
+func NewMigrateGitRepoHelmURLRegex() *cobra.Command {
+	return command.Command(&MigrateGitRepoHelmURLRegex{}, cobra.Command{
+		Use:           "gitrepo-helm-url-regex [flags]",
+		Short:         "Set helmRepoURLRegex on GitRepos that have a Helm secret but no regex",
+		SilenceUsage:  true,
+		SilenceErrors: true,
+	})
+}
+
+type Migrate struct{}
+
+func (m *Migrate) Run(cmd *cobra.Command, _ []string) error {
+	return cmd.Help()
+}
+
+type MigrateGitRepoHelmURLRegex struct {
+	command.DebugConfig
+	SystemNamespace string `usage:"system namespace" env:"NAMESPACE" default:"cattle-fleet-system"`
+}
+
+func (m *MigrateGitRepoHelmURLRegex) PersistentPre(_ *cobra.Command, _ []string) error {
+	if err := m.SetupDebug(); err != nil {
+		return fmt.Errorf("failed to set up debug logging: %w", err)
+	}
+	return nil
+}
+
+func (m *MigrateGitRepoHelmURLRegex) Run(cmd *cobra.Command, _ []string) error {
+	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&zopts)))
+	ctx := log.IntoContext(cmd.Context(), ctrl.Log)
+
+	cfg := ctrl.GetConfigOrDie()
+	cl, err := client.New(cfg, client.Options{Scheme: scheme})
+	if err != nil {
+		return err
+	}
+
+	return migrate.GitRepoHelmURLRegex(ctx, cl, m.SystemNamespace)
+}

--- a/internal/cmd/cli/migrate/helmrepourl.go
+++ b/internal/cmd/cli/migrate/helmrepourl.go
@@ -1,0 +1,217 @@
+// Package migrate contains one-time migration functions that run as Helm hooks
+// during fleet upgrades. Each function checks a marker ConfigMap to avoid
+// re-running when the upgrade job is re-triggered.
+package migrate
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"regexp"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/retry"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
+)
+
+const (
+	helmURLRegexMigrationConfigMap = "fleet-helm-url-regex-migrated"
+
+	// HelmRegexAutoMigratedAnnotation marks a GitRepo whose helmRepoURLRegex
+	// was derived automatically from its existing Bundles during upgrade.
+	// Admins should review and replace the generated regex with a tighter
+	// pattern specific to their Helm repository.
+	HelmRegexAutoMigratedAnnotation = "fleet.cattle.io/helm-regex-auto-migrated"
+)
+
+// GitRepoHelmURLRegex sets helmRepoURLRegex on every GitRepo that has a Helm
+// credential secret but no regex. The regex is derived from the scheme+host of
+// the Helm repository URLs already stored in the GitRepo's existing Bundles.
+//
+// A ConfigMap in systemNamespace is created after the migration completes;
+// its presence prevents the migration from running again on a subsequent
+// upgrade.
+func GitRepoHelmURLRegex(ctx context.Context, cl client.Client, systemNamespace string) error {
+	logger := log.FromContext(ctx).WithName("helmurlregex-migration")
+
+	marker := &corev1.ConfigMap{}
+	err := cl.Get(ctx, client.ObjectKey{
+		Namespace: systemNamespace,
+		Name:      helmURLRegexMigrationConfigMap,
+	}, marker)
+	if err == nil {
+		logger.V(1).Info("Helm URL regex migration already completed, skipping")
+		return nil
+	}
+	if !k8serrors.IsNotFound(err) {
+		return fmt.Errorf("checking helm URL regex migration marker: %w", err)
+	}
+
+	logger.Info("Running Helm URL regex migration")
+	if err := migrateAllGitRepos(ctx, cl); err != nil {
+		return err
+	}
+
+	marker = &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      helmURLRegexMigrationConfigMap,
+			Namespace: systemNamespace,
+			Annotations: map[string]string{
+				"fleet.cattle.io/migration": "Marks that the one-time helmRepoURLRegex migration has run. Do not delete.",
+			},
+		},
+	}
+	if err := cl.Create(ctx, marker); err != nil && !k8serrors.IsAlreadyExists(err) {
+		return fmt.Errorf("creating helm URL regex migration marker: %w", err)
+	}
+
+	logger.Info("Helm URL regex migration completed")
+	return nil
+}
+
+func migrateAllGitRepos(ctx context.Context, cl client.Client) error {
+	logger := log.FromContext(ctx).WithName("helmurlregex-migration")
+
+	list := &v1alpha1.GitRepoList{}
+	if err := cl.List(ctx, list); err != nil {
+		return fmt.Errorf("listing GitRepos for migration: %w", err)
+	}
+
+	var migrationErr error
+	for i := range list.Items {
+		gr := &list.Items[i]
+		if !needsHelmURLRegexMigration(gr) {
+			continue
+		}
+		if err := migrateOne(ctx, cl, gr); err != nil {
+			logger.Error(err, "Failed to migrate GitRepo; continuing with remaining GitRepos",
+				"gitrepo", gr.Namespace+"/"+gr.Name)
+			migrationErr = errors.Join(migrationErr, err)
+		}
+	}
+	return migrationErr
+}
+
+func needsHelmURLRegexMigration(gr *v1alpha1.GitRepo) bool {
+	hasSecret := gr.Spec.HelmSecretName != "" || gr.Spec.HelmSecretNameForPaths != ""
+	return hasSecret && gr.Spec.HelmRepoURLRegex == ""
+}
+
+func migrateOne(ctx context.Context, cl client.Client, gr *v1alpha1.GitRepo) error {
+	logger := log.FromContext(ctx).WithName("helmurlregex-migration").
+		WithValues("gitrepo", gr.Namespace+"/"+gr.Name)
+
+	regex, err := deriveHelmRepoURLRegex(ctx, cl, gr)
+	if err != nil {
+		return err
+	}
+
+	if regex == "" {
+		logger.Info("No Helm repository URLs found in existing Bundles; " +
+			"helmRepoURLRegex left empty — credentials will not be forwarded. " +
+			"Set helmRepoURLRegex on the GitRepo manually to restore credential forwarding.")
+		return nil
+	}
+
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		current := &v1alpha1.GitRepo{}
+		if err := cl.Get(ctx, client.ObjectKeyFromObject(gr), current); err != nil {
+			return err
+		}
+		if !needsHelmURLRegexMigration(current) {
+			return nil
+		}
+		if current.Annotations == nil {
+			current.Annotations = map[string]string{}
+		}
+		current.Annotations[HelmRegexAutoMigratedAnnotation] = "true"
+		current.Spec.HelmRepoURLRegex = regex
+		logger.Info("Setting helmRepoURLRegex from existing Bundles",
+			"helmRepoURLRegex", regex,
+			"note", "review and tighten this auto-derived regex if the pattern is broader than necessary")
+		return cl.Update(ctx, current)
+	})
+}
+
+// deriveHelmRepoURLRegex lists existing Bundles for the GitRepo and builds a
+// regex anchored at the start that matches the scheme+host of every Helm
+// repository URL found. Returns "" if no Helm URLs are present in the Bundles.
+func deriveHelmRepoURLRegex(ctx context.Context, cl client.Client, gr *v1alpha1.GitRepo) (string, error) {
+	list := &v1alpha1.BundleList{}
+	if err := cl.List(ctx, list,
+		client.MatchingLabels{v1alpha1.RepoLabel: gr.Name},
+		client.InNamespace(gr.Namespace),
+	); err != nil {
+		return "", fmt.Errorf("listing Bundles for %s/%s: %w", gr.Namespace, gr.Name, err)
+	}
+
+	seen := map[string]struct{}{}
+	var prefixes []string
+	for i := range list.Items {
+		for _, rawURL := range collectBundleHelmURLs(&list.Items[i]) {
+			p := helmURLToRegexPrefix(rawURL)
+			if p == "" {
+				continue
+			}
+			if _, ok := seen[p]; !ok {
+				seen[p] = struct{}{}
+				prefixes = append(prefixes, p)
+			}
+		}
+	}
+
+	if len(prefixes) == 0 {
+		return "", nil
+	}
+	if len(prefixes) == 1 {
+		return "^" + prefixes[0], nil
+	}
+	return "^(" + strings.Join(prefixes, "|") + ")", nil
+}
+
+// collectBundleHelmURLs returns all Helm repository URLs stored in a Bundle,
+// covering the top-level options and any per-target customizations.
+func collectBundleHelmURLs(bundle *v1alpha1.Bundle) []string {
+	var urls []string
+	urls = append(urls, helmURLsFromOptions(bundle.Spec.Helm)...)
+	for i := range bundle.Spec.Targets {
+		urls = append(urls, helmURLsFromOptions(bundle.Spec.Targets[i].Helm)...)
+	}
+	return urls
+}
+
+// helmURLsFromOptions extracts Helm repository URLs from a HelmOptions struct.
+// For the Repo field this is always a URL; for Chart it is only a URL when it
+// uses the oci:// scheme (otherwise it is just a chart name or path).
+func helmURLsFromOptions(h *v1alpha1.HelmOptions) []string {
+	if h == nil {
+		return nil
+	}
+	var urls []string
+	if h.Repo != "" {
+		urls = append(urls, h.Repo)
+	}
+	if strings.HasPrefix(h.Chart, "oci://") {
+		urls = append(urls, h.Chart)
+	}
+	return urls
+}
+
+// helmURLToRegexPrefix parses rawURL and returns a regexp.QuoteMeta-escaped
+// string of the form "scheme://host/" that can be prefixed with "^" to form a
+// safe, anchored regex. Returns "" if rawURL cannot be parsed or has no host.
+func helmURLToRegexPrefix(rawURL string) string {
+	u, err := url.Parse(rawURL)
+	if err != nil || u.Scheme == "" || u.Host == "" {
+		return ""
+	}
+	// regexp.QuoteMeta escapes dots and other regex metacharacters in the host.
+	return regexp.QuoteMeta(u.Scheme + "://" + u.Host + "/")
+}

--- a/internal/cmd/cli/migrate/helmrepourl_test.go
+++ b/internal/cmd/cli/migrate/helmrepourl_test.go
@@ -1,0 +1,218 @@
+package migrate
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+)
+
+func TestHelmURLToRegexPrefix(t *testing.T) {
+	tests := []struct {
+		name     string
+		rawURL   string
+		expected string
+	}{
+		{
+			name:     "https URL with path",
+			rawURL:   "https://charts.example.com/stable",
+			expected: `https://charts\.example\.com/`,
+		},
+		{
+			name:     "https URL root",
+			rawURL:   "https://charts.example.com",
+			expected: `https://charts\.example\.com/`,
+		},
+		{
+			name:     "https URL with non-standard port",
+			rawURL:   "https://charts.example.com:8443/stable",
+			expected: `https://charts\.example\.com:8443/`,
+		},
+		{
+			name:     "oci URL",
+			rawURL:   "oci://registry.example.com/org/chart",
+			expected: `oci://registry\.example\.com/`,
+		},
+		{
+			name:     "http URL",
+			rawURL:   "http://chartmuseum.internal:8080/charts",
+			expected: `http://chartmuseum\.internal:8080/`,
+		},
+		{
+			name:     "dots in hostname are escaped",
+			rawURL:   "https://a.b.c.example.com/repo",
+			expected: `https://a\.b\.c\.example\.com/`,
+		},
+		{
+			name:     "empty string",
+			rawURL:   "",
+			expected: "",
+		},
+		{
+			name:     "plain chart name — not a URL",
+			rawURL:   "stable/nginx",
+			expected: "",
+		},
+		{
+			name:     "unparsable URL",
+			rawURL:   "://bad",
+			expected: "",
+		},
+		{
+			name:     "URL with no host",
+			rawURL:   "oci:///no-host",
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := helmURLToRegexPrefix(tt.rawURL)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+func TestCollectBundleHelmURLs(t *testing.T) {
+	bundle := &v1alpha1.Bundle{
+		ObjectMeta: metav1.ObjectMeta{Name: "test"},
+		Spec: v1alpha1.BundleSpec{
+			BundleDeploymentOptions: v1alpha1.BundleDeploymentOptions{
+				Helm: &v1alpha1.HelmOptions{
+					Repo:  "https://charts.example.com/stable",
+					Chart: "nginx", // plain chart name — not a URL
+				},
+			},
+			Targets: []v1alpha1.BundleTarget{
+				{
+					BundleDeploymentOptions: v1alpha1.BundleDeploymentOptions{
+						Helm: &v1alpha1.HelmOptions{
+							Chart: "oci://registry.example.com/org/chart",
+						},
+					},
+				},
+				{
+					// nil Helm — should not panic
+				},
+			},
+		},
+	}
+
+	urls := collectBundleHelmURLs(bundle)
+	assert.Equal(t, []string{
+		"https://charts.example.com/stable",
+		"oci://registry.example.com/org/chart",
+	}, urls)
+}
+
+func TestCollectBundleHelmURLsNilHelm(t *testing.T) {
+	bundle := &v1alpha1.Bundle{
+		ObjectMeta: metav1.ObjectMeta{Name: "no-helm"},
+		Spec: v1alpha1.BundleSpec{
+			Targets: []v1alpha1.BundleTarget{},
+		},
+	}
+	assert.Empty(t, collectBundleHelmURLs(bundle))
+}
+
+func TestNeedsHelmURLRegexMigration(t *testing.T) {
+	tests := []struct {
+		name                   string
+		helmSecretName         string
+		helmSecretNameForPaths string
+		helmRepoURLRegex       string
+		want                   bool
+	}{
+		{"secret + no regex → needs migration", "s", "", "", true},
+		{"secretForPaths + no regex → needs migration", "", "s", "", true},
+		{"both secrets + no regex → needs migration", "s", "s", "", true},
+		{"secret + regex already set → skip", "s", "", "^https://", false},
+		{"no secret → skip", "", "", "", false},
+		{"no secret + regex already set → skip", "", "", "^https://", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gr := &v1alpha1.GitRepo{
+				Spec: v1alpha1.GitRepoSpec{
+					HelmSecretName:         tt.helmSecretName,
+					HelmSecretNameForPaths: tt.helmSecretNameForPaths,
+					HelmRepoURLRegex:       tt.helmRepoURLRegex,
+				},
+			}
+			assert.Equal(t, tt.want, needsHelmURLRegexMigration(gr))
+		})
+	}
+}
+
+// TestMigrateAllErrors verifies that when multiple GitRepos fail to update,
+// all errors are aggregated and returned rather than stopping at the first one.
+func TestMigrateAllErrors(t *testing.T) {
+	scheme := runtime.NewScheme()
+	utilruntime.Must(v1alpha1.AddToScheme(scheme))
+	utilruntime.Must(corev1.AddToScheme(scheme))
+
+	makeGitRepo := func(name string) *v1alpha1.GitRepo {
+		return &v1alpha1.GitRepo{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+			Spec:       v1alpha1.GitRepoSpec{HelmSecretName: "s", Repo: "https://github.com/x/y"},
+		}
+	}
+	// One Bundle per GitRepo so deriveHelmRepoURLRegex returns a non-empty
+	// regex and migrateOne proceeds to the Update call.
+	makeBundle := func(gitRepoName string) *v1alpha1.Bundle {
+		return &v1alpha1.Bundle{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      gitRepoName + "-bundle",
+				Namespace: "default",
+				Labels:    map[string]string{v1alpha1.RepoLabel: gitRepoName},
+			},
+			Spec: v1alpha1.BundleSpec{
+				BundleDeploymentOptions: v1alpha1.BundleDeploymentOptions{
+					Helm: &v1alpha1.HelmOptions{Repo: "https://charts.example.com/stable"},
+				},
+			},
+		}
+	}
+
+	gr1 := makeGitRepo("gr1")
+	gr2 := makeGitRepo("gr2")
+
+	// Both Updates fail with distinct errors.
+	errGR1 := errors.New("injected failure for gr1")
+	errGR2 := errors.New("injected failure for gr2")
+
+	cl := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(gr1, gr2, makeBundle("gr1"), makeBundle("gr2")).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Update: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+				switch obj.GetName() {
+				case "gr1":
+					return errGR1
+				case "gr2":
+					return errGR2
+				}
+				return c.Update(ctx, obj, opts...)
+			},
+		}).
+		Build()
+
+	err := migrateAllGitRepos(context.Background(), cl)
+	require.Error(t, err)
+	require.ErrorIs(t, err, errGR1, "error for gr1 must be present in the aggregated error")
+	require.ErrorIs(t, err, errGR2, "error for gr2 must be present in the aggregated error")
+}

--- a/internal/cmd/cli/root.go
+++ b/internal/cmd/cli/root.go
@@ -25,6 +25,7 @@ func App() *cobra.Command {
 		NewApply(),
 		NewTest(),
 		NewCleanUp(),
+		newMigrateCmd(),
 
 		NewTarget(),
 		NewDeploy(),

--- a/pkg/apis/fleet.cattle.io/v1alpha1/gitrepo_types.go
+++ b/pkg/apis/fleet.cattle.io/v1alpha1/gitrepo_types.go
@@ -83,8 +83,8 @@ type GitRepoSpec struct {
 	// +nullable
 	HelmSecretNameForPaths string `json:"helmSecretNameForPaths,omitempty"`
 
-	// HelmRepoURLRegex Helm credentials will be used if the helm repo matches this regex
-	// Credentials will always be used if this is empty or not provided.
+	// HelmRepoURLRegex Helm credentials will be used if the helm repo matches this regex.
+	// Credentials will not be used if this is empty or not provided.
 	// +nullable
 	HelmRepoURLRegex string `json:"helmRepoURLRegex,omitempty"`
 


### PR DESCRIPTION
Restricts go-getter to Git and file protocols, and requires `helmRepoURLRegex` to be set for Helm repository credentials to be forwarded. A pre-upgrade migration Job populates the field on existing GitRepos automatically on upgrade.

Refers https://github.com/rancher/fleet/security/advisories/GHSA-hx4v-cxpf-vh8m