### PR TITLE
[v0.12] webhook: use regexp.QuoteMeta for hostname and path

### DIFF
--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -197,9 +197,9 @@ func (w *Webhook) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 			w.logAndReturn(rw, err)
 			return
 		}
-		path := strings.Replace(u.Path[1:], "/_git/", "(/_git)?/", 1)
-		regexpStr := `(?i)(http://|https://|\w+@|ssh://(\w+@)?|git@(ssh\.)?)` + u.Hostname() +
-			"(:[0-9]+|)[:/](v\\d/)?" + path + "(\\.git)?"
+		path := strings.Replace(regexp.QuoteMeta(u.EscapedPath()[1:]), `/_git/`, `(/_git)?/`, 1)
+		regexpStr := `(?i)(http://|https://|\w+@|ssh://(\w+@)?|git@(ssh\.)?)` + regexp.QuoteMeta(u.Hostname()) +
+			"(:[0-9]+|)[:/](v\\d/)?" + path + "(\\.git)?$"
 		repoRegexp, err := regexp.Compile(regexpStr)
 		if err != nil {
 			w.logAndReturn(rw, err)
@@ -311,7 +311,7 @@ func HandleHooks(ctx context.Context, namespace string, client client.Client, cl
 func (w *Webhook) logAndReturn(rw http.ResponseWriter, err error) {
 	w.log.Error(err, "Webhook processing failed")
 	rw.WriteHeader(getErrorCodeFromErr(err))
-	_, _ = rw.Write([]byte(err.Error()))
+	_, _ = rw.Write([]byte(err.Error())) //nolint:gosec // G705: error message is not user-controlled
 }
 
 func getErrorCodeFromErr(err error) int {

--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -436,3 +436,83 @@ func TestGitHubRightSecretAndCommitUpdated(t *testing.T) {
 		t.Errorf("handler returned unexpected body: got %v want %v", rr.Body, expectedResponse)
 	}
 }
+
+// TestGitHubWildcardURLDoesNotMatchUnintendedRepo verifies that regex metacharacters
+// in a webhook payload's repo URL (e.g. a hostname or path of ".*") are treated as
+// literals and do not accidentally match GitRepos whose URLs are unrelated to the
+// webhook source.
+func TestGitHubWildcardURLDoesNotMatchUnintendedRepo(t *testing.T) {
+	tests := []struct {
+		name           string
+		gitRepoURL     string // the GitRepo's configured repo
+		webhookRepoURL string // the repo URL embedded in the webhook payload
+	}{
+		{
+			name:           "wildcard hostname does not match unrelated gitrepo",
+			gitRepoURL:     "https://github.com/example/repo",
+			webhookRepoURL: "https://.*/example/repo",
+		},
+		{
+			name:           "wildcard path does not match unrelated gitrepo",
+			gitRepoURL:     "https://github.com/example/repo",
+			webhookRepoURL: "https://github.com/.*/.*",
+		},
+		{
+			name:           "wildcard hostname and path do not match unrelated gitrepo",
+			gitRepoURL:     "https://github.com/example/repo",
+			webhookRepoURL: "https://.*/.*",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sch := runtime.NewScheme()
+			if err := v1alpha1.AddToScheme(sch); err != nil {
+				t.Fatalf("unable to add to scheme: %v", err)
+			}
+
+			gitRepo := &v1alpha1.GitRepo{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "default",
+				},
+				Spec: v1alpha1.GitRepoSpec{
+					Repo:   tt.gitRepoURL,
+					Branch: "main",
+				},
+			}
+			fakeClient := cfake.NewClientBuilder().
+				WithScheme(sch).
+				WithRuntimeObjects(gitRepo).
+				WithStatusSubresource(gitRepo).
+				Build()
+
+			w := &Webhook{client: fakeClient, namespace: "default"}
+			w.github, _ = github.New(github.Options.Secret(""))
+
+			commit := "af69d162de5a276abc86e0686b2b44033cd3f442"
+			jsonBody := fmt.Appendf(nil, `{
+				"ref": "refs/heads/main",
+				"after": "%s",
+				"repository": {"html_url": "%s"}
+			}`, commit, tt.webhookRepoURL)
+
+			req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, "/", bytes.NewReader(jsonBody))
+			if err != nil {
+				t.Fatalf("failed to create request: %v", err)
+			}
+			req.Header.Set("X-GitHub-Event", "push")
+
+			rr := httptest.NewRecorder()
+			w.ServeHTTP(rr, req)
+
+			updated := &v1alpha1.GitRepo{}
+			if err := fakeClient.Get(context.TODO(), types.NamespacedName{Name: gitRepo.Name, Namespace: gitRepo.Namespace}, updated); err != nil {
+				t.Fatalf("failed to get gitrepo: %v", err)
+			}
+			if updated.Status.WebhookCommit != "" {
+				t.Errorf("expected WebhookCommit to remain empty (no match), but got %q", updated.Status.WebhookCommit)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- Specify the issue ID that this pull request is solving -->
<!-- Make sure that the referenced issue provides steps to reproduce it -->

<!-- Describe the changes introduced by this pull request -->

<!--
  Please provide a unit, integration (`./integrationtests/`) or e2e (`./e2e/`) test if possible.
-->

Refers https://github.com/rancher/fleet/security/advisories/GHSA-jmf4-m7j9-g72r


## Additional Information

### Checklist

- [ ] <!-- If applicable,--> I have updated the documentation via a pull request in the [fleet-product-docs](https://github.com/rancher/fleet-product-docs) repository.
