### PR TITLE
Retain relevant kubernetes.io labels when syncing namespaces

### DIFF
--- a/internal/cmd/agent/deployer/deployer.go
+++ b/internal/cmd/agent/deployer/deployer.go
@@ -220,7 +220,7 @@ func (d *Deployer) setNamespaceLabelsAndAnnotations(ctx context.Context, bd *fle
 	}
 
 	if bd.Spec.Options.NamespaceLabels != nil {
-		addLabelsFromOptions(ns.Labels, bd.Spec.Options.NamespaceLabels)
+		addLabelsFromOptions(log.FromContext(ctx), ns.Labels, bd.Spec.Options.NamespaceLabels)
 	}
 	if bd.Spec.Options.NamespaceAnnotations != nil {
 		if ns.Annotations == nil {
@@ -258,13 +258,25 @@ func (d *Deployer) fetchNamespace(ctx context.Context, releaseID string) (*corev
 	return ns, nil
 }
 
+const podSecurityLabelPrefix = "pod-security.kubernetes.io/"
+
 // addLabelsFromOptions updates nsLabels so that it only contains all labels specified in optLabels, plus the `kubernetes.io/metadata.name` labels added by kubernetes when creating the namespace.
-func addLabelsFromOptions(nsLabels map[string]string, optLabels map[string]string) {
-	maps.Copy(nsLabels, optLabels)
+func addLabelsFromOptions(logger logr.Logger, nsLabels map[string]string, optLabels map[string]string) {
+	for k, v := range optLabels {
+		if strings.HasPrefix(k, podSecurityLabelPrefix) {
+			logger.V(1).Info("Ignoring label from options", "label", k)
+			continue
+		}
+		nsLabels[k] = v
+	}
 
 	// Delete labels not defined in the options.
 	// Keep the `kubernetes.io/metadata.name` label as it is added by kubernetes when creating the namespace.
+	// Keep pod-security.kubernetes.io/ labels as they are managed by cluster administrators.
 	for k := range nsLabels {
+		if strings.HasPrefix(k, podSecurityLabelPrefix) {
+			continue
+		}
 		if _, ok := optLabels[k]; k != corev1.LabelMetadataName && !ok {
 			delete(nsLabels, k)
 		}

--- a/internal/cmd/agent/deployer/deployer.go
+++ b/internal/cmd/agent/deployer/deployer.go
@@ -216,6 +216,9 @@ func (d *Deployer) setNamespaceLabelsAndAnnotations(ctx context.Context, bd *fle
 
 	desiredLabels := maps.Clone(ns.Labels)
 	if bd.Spec.Options.NamespaceLabels != nil {
+		if desiredLabels == nil {
+			desiredLabels = make(map[string]string)
+		}
 		addLabelsFromOptions(log.FromContext(ctx), desiredLabels, bd.Spec.Options.NamespaceLabels)
 	}
 	desiredAnnotations := maps.Clone(ns.Annotations)
@@ -259,7 +262,10 @@ func (d *Deployer) fetchNamespace(ctx context.Context, releaseID string) (*corev
 
 const podSecurityLabelPrefix = "pod-security.kubernetes.io/"
 
-// addLabelsFromOptions updates nsLabels so that it only contains all labels specified in optLabels, plus the `kubernetes.io/metadata.name` labels added by kubernetes when creating the namespace.
+// addLabelsFromOptions updates nsLabels to contain labels from optLabels, while preserving
+// the `kubernetes.io/metadata.name` label added by Kubernetes when creating the namespace
+// and any existing `pod-security.kubernetes.io/*` labels. Labels with the
+// `pod-security.kubernetes.io/` prefix in optLabels are ignored.
 func addLabelsFromOptions(logger logr.Logger, nsLabels map[string]string, optLabels map[string]string) {
 	for k, v := range optLabels {
 		if strings.HasPrefix(k, podSecurityLabelPrefix) {

--- a/internal/cmd/agent/deployer/deployer.go
+++ b/internal/cmd/agent/deployer/deployer.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"maps"
-	"reflect"
 	"regexp"
 	"slices"
 	"strings"
@@ -215,25 +214,25 @@ func (d *Deployer) setNamespaceLabelsAndAnnotations(ctx context.Context, bd *fle
 		return err
 	}
 
-	if reflect.DeepEqual(bd.Spec.Options.NamespaceLabels, ns.Labels) && reflect.DeepEqual(bd.Spec.Options.NamespaceAnnotations, ns.Annotations) {
+	desiredLabels := maps.Clone(ns.Labels)
+	if bd.Spec.Options.NamespaceLabels != nil {
+		addLabelsFromOptions(log.FromContext(ctx), desiredLabels, bd.Spec.Options.NamespaceLabels)
+	}
+	desiredAnnotations := maps.Clone(ns.Annotations)
+	if bd.Spec.Options.NamespaceAnnotations != nil {
+		if desiredAnnotations == nil {
+			desiredAnnotations = make(map[string]string)
+		}
+		addAnnotationsFromOptions(desiredAnnotations, bd.Spec.Options.NamespaceAnnotations)
+	}
+
+	if maps.Equal(desiredLabels, ns.Labels) && maps.Equal(desiredAnnotations, ns.Annotations) {
 		return nil
 	}
 
-	if bd.Spec.Options.NamespaceLabels != nil {
-		addLabelsFromOptions(log.FromContext(ctx), ns.Labels, bd.Spec.Options.NamespaceLabels)
-	}
-	if bd.Spec.Options.NamespaceAnnotations != nil {
-		if ns.Annotations == nil {
-			ns.Annotations = map[string]string{}
-		}
-		addAnnotationsFromOptions(ns.Annotations, bd.Spec.Options.NamespaceAnnotations)
-	}
-	err = d.updateNamespace(ctx, ns)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	ns.Labels = desiredLabels
+	ns.Annotations = desiredAnnotations
+	return d.updateNamespace(ctx, ns)
 }
 
 // updateNamespace updates a namespace resource in the cluster.

--- a/internal/cmd/agent/deployer/deployer_test.go
+++ b/internal/cmd/agent/deployer/deployer_test.go
@@ -14,7 +14,9 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 )
 
 func TestSetNamespaceLabelsAndAnnotations(t *testing.T) {
@@ -171,6 +173,51 @@ func TestSetNamespaceLabelsAndAnnotationsError(t *testing.T) {
 
 	if !apierrors.IsNotFound(err) {
 		t.Errorf("expected not found error: got %v", err)
+	}
+}
+
+// TestSetNamespaceLabelsAndAnnotations_NoUpdateWhenAlreadyCorrect verifies that
+// updateNamespace is not called when the namespace already reflects the desired state.
+// This guards against the broken reflect.DeepEqual check that compared raw option
+// labels to ns.Labels; ns.Labels always includes kubernetes.io/metadata.name and
+// may include preserved pod-security labels, so a direct equality check never holds.
+func TestSetNamespaceLabelsAndAnnotations_NoUpdateWhenAlreadyCorrect(t *testing.T) {
+	bd := &fleet.BundleDeployment{Spec: fleet.BundleDeploymentSpec{
+		Options: fleet.BundleDeploymentOptions{
+			NamespaceLabels:      map[string]string{"optLabel": "optValue"},
+			NamespaceAnnotations: map[string]string{"optAnn": "optValue"},
+		},
+	}}
+	ns := corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "namespace",
+			Labels:      map[string]string{"kubernetes.io/metadata.name": "namespace", "optLabel": "optValue"},
+			Annotations: map[string]string{"optAnn": "optValue"},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+
+	updateCalled := false
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(&ns).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Update: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+				updateCalled = true
+				return c.Update(ctx, obj, opts...)
+			},
+		}).
+		Build()
+
+	h := Deployer{client: fakeClient}
+	err := h.setNamespaceLabelsAndAnnotations(context.Background(), bd, "namespace/foo/bar")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if updateCalled {
+		t.Error("updateNamespace was called when namespace was already in the desired state")
 	}
 }
 


### PR DESCRIPTION
`addLabelsFromOptions` previously replaced all namespace labels with the options-provided set. Labels managed by the cluster are now preserved during the sync.

Refers https://github.com/rancher/fleet/security/advisories/GHSA-864g-863m-vcvq