### PR TITLE
fleet-cli: add missing flag wiring for apply, cleanup subcommands

### DIFF
--- a/internal/cmd/cli/apply.go
+++ b/internal/cmd/cli/apply.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bytes"
 	"errors"
+	"flag"
 	"fmt"
 	"os"
 
@@ -33,10 +34,15 @@ type readFile func(name string) ([]byte, error)
 
 // NewApply returns a subcommand to create bundles from directories
 func NewApply() *cobra.Command {
-	return command.Command(&Apply{}, cobra.Command{
+	cmd := command.Command(&Apply{}, cobra.Command{
 		Use:   "apply [flags] BUNDLE_NAME PATH...",
 		Short: "Create bundles from directories, and output them or apply them on a cluster",
 	})
+
+	fs := flag.NewFlagSet("", flag.ExitOnError)
+	ctrl.RegisterFlags(fs)
+	cmd.Flags().AddGoFlagSet(fs)
+	return cmd
 }
 
 type Apply struct {

--- a/internal/cmd/cli/apply_test.go
+++ b/internal/cmd/cli/apply_test.go
@@ -11,6 +11,7 @@ import (
 	gogit "github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/google/go-cmp/cmp"
+	"k8s.io/client-go/util/homedir"
 	"sigs.k8s.io/yaml"
 
 	"github.com/rancher/fleet/internal/bundlereader"
@@ -202,4 +203,47 @@ func TestCurrentCommit(t *testing.T) {
 			t.Errorf("expected a 40-char hex SHA from nested subdir, got %q", got)
 		}
 	})
+}
+
+func TestNewApplyKubeconfigFlag(t *testing.T) {
+	customPath := filepath.Join(homedir.HomeDir(), "custom", "config")
+	testCases := []struct {
+		name                       string
+		args                       []string
+		expectedKubeconfig         string
+		shouldUseDefaultKubeconfig bool
+	}{
+		{
+			name:                       "custom kubeconfig",
+			args:                       []string{"--kubeconfig", customPath, "test-bundle"},
+			expectedKubeconfig:         customPath,
+			shouldUseDefaultKubeconfig: false,
+		},
+		{
+			name:                       "no custom kubeconfig",
+			args:                       []string{"test-bundle"},
+			expectedKubeconfig:         "",
+			shouldUseDefaultKubeconfig: true,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := NewApply()
+
+			err := cmd.ParseFlags(tc.args)
+			if err != nil {
+				t.Fatalf("failed to parse flags: %v", err)
+			}
+
+			kubeconfigFlag := cmd.Flag("kubeconfig")
+			if kubeconfigFlag == nil {
+				t.Fatal("kubeconfig flag not registered")
+			}
+
+			gotKubeconfig := kubeconfigFlag.Value.String()
+			if gotKubeconfig != tc.expectedKubeconfig {
+				t.Errorf("kubeconfig flag value mismatch: expected %q, got %q", tc.expectedKubeconfig, gotKubeconfig)
+			}
+		})
+	}
 }

--- a/internal/cmd/cli/cleanup.go
+++ b/internal/cmd/cli/cleanup.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"errors"
+	"flag"
 	"fmt"
 	"math"
 	"strconv"
@@ -32,21 +33,33 @@ func NewCleanUp() *cobra.Command {
 }
 
 func NewClusterRegistration() *cobra.Command {
-	return command.Command(&ClusterRegistration{}, cobra.Command{
+	cmd := command.Command(&ClusterRegistration{}, cobra.Command{
 		Use:           "clusterregistration [flags]",
 		Short:         "Clean up outdated cluster registrations",
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	})
+
+	fs := flag.NewFlagSet("", flag.ExitOnError)
+	zopts.BindFlags(fs)
+	ctrl.RegisterFlags(fs)
+	cmd.Flags().AddGoFlagSet(fs)
+	return cmd
 }
 
 func NewGitjob() *cobra.Command {
-	return command.Command(&Gitjob{}, cobra.Command{
+	cmd := command.Command(&Gitjob{}, cobra.Command{
 		Use:           "gitjob [flags]",
 		Short:         "Clean up outdated git jobs",
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	})
+
+	fs := flag.NewFlagSet("", flag.ExitOnError)
+	zopts.BindFlags(fs)
+	ctrl.RegisterFlags(fs)
+	cmd.Flags().AddGoFlagSet(fs)
+	return cmd
 }
 
 type Cleanup struct {

--- a/internal/cmd/cli/cleanup_test.go
+++ b/internal/cmd/cli/cleanup_test.go
@@ -1,0 +1,69 @@
+package cli
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"k8s.io/client-go/util/homedir"
+)
+
+func TestNewCleanupKubeConfigFlag(t *testing.T) {
+	customPath := filepath.Join(homedir.HomeDir(), "custom", "config")
+	testCases := []struct {
+		name                       string
+		args                       []string
+		subcommand                 func() *cobra.Command
+		expectedKubeconfig         string
+		shouldUseDefaultKubeconfig bool
+	}{
+		{
+			name:                       "custom kubeconfig for cluster registration",
+			args:                       []string{"--kubeconfig", customPath, "test-bundle"},
+			subcommand:                 NewClusterRegistration,
+			expectedKubeconfig:         customPath,
+			shouldUseDefaultKubeconfig: false,
+		},
+		{
+			name:                       "custom kubeconfig for git job",
+			args:                       []string{"--kubeconfig", customPath, "test-bundle"},
+			subcommand:                 NewGitjob,
+			expectedKubeconfig:         customPath,
+			shouldUseDefaultKubeconfig: false,
+		},
+		{
+			name:                       "no custom kubeconfig for cluster registration",
+			args:                       []string{"test-bundle"},
+			subcommand:                 NewClusterRegistration,
+			expectedKubeconfig:         "",
+			shouldUseDefaultKubeconfig: true,
+		},
+		{
+			name:                       "no custom kubeconfig for git job",
+			args:                       []string{"test-bundle"},
+			subcommand:                 NewGitjob,
+			expectedKubeconfig:         "",
+			shouldUseDefaultKubeconfig: true,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := tc.subcommand()
+
+			err := cmd.ParseFlags(tc.args)
+			if err != nil {
+				t.Fatalf("failed to parse flags: %v", err)
+			}
+
+			kubeconfigFlag := cmd.Flag("kubeconfig")
+			if kubeconfigFlag == nil {
+				t.Fatal("kubeconfig flag not registered")
+			}
+
+			gotKubeconfig := kubeconfigFlag.Value.String()
+			if gotKubeconfig != tc.expectedKubeconfig {
+				t.Errorf("kubeconfig flag value mismatch: expected %q, got %q", tc.expectedKubeconfig, gotKubeconfig)
+			}
+		})
+	}
+}

--- a/internal/cmd/cli/root.go
+++ b/internal/cmd/cli/root.go
@@ -49,9 +49,7 @@ func (r *Fleet) Run(cmd *cobra.Command, _ []string) error {
 
 type FleetClient struct {
 	command.DebugConfig
-	Namespace  string `usage:"namespace" env:"NAMESPACE" default:"fleet-local" short:"n"`
-	Kubeconfig string `usage:"kubeconfig for authentication" short:"k"`
-	Context    string `usage:"kubeconfig context for authentication"`
+	Namespace string `usage:"namespace" env:"NAMESPACE" default:"fleet-local" short:"n"`
 }
 
 type BundleInputArgs struct {


### PR DESCRIPTION
<!-- Specify the issue ID that this pull request is solving -->
Refers to #5170 
<!-- Make sure that the referenced issue provides steps to reproduce it -->

<!-- Describe the changes introduced by this pull request -->
This commit adds `AddGoFlagSet` to subcommands that were missing it:
- fleet apply
- fleet cleanup clusterregistration
- fleet cleanup gitjob

With this controller-runtime's `--kubeconfig` and zap's `--zap-*` flags (for clusterregistration & gitjob ) are correctly bridged from the stdlib flag set into cobra's pflag set.

<!--
  Please provide a unit, integration (`./integrationtests/`) or e2e (`./e2e/`) test if possible.
-->

## Additional Information

### Checklist

- [ ] <!-- If applicable,--> I have updated the documentation via a pull request in the [fleet-product-docs](https://github.com/rancher/fleet-product-docs) repository.
