### PR TITLE
[v0.12] Fix namespace label equality check and nil map panic

### DIFF
--- a/integrationtests/gitjob/controller/helm_url_regex_migration_test.go
+++ b/integrationtests/gitjob/controller/helm_url_regex_migration_test.go
@@ -254,10 +254,13 @@ var _ = Describe("HelmURLRegex migration", func() {
 		Expect(getGitRepo("run-twice").Spec.HelmRepoURLRegex).To(Equal(`^https://charts\.example\.com/`))
 
 		// Manually reset to simulate a hypothetical re-entry attempt.
-		gr := getGitRepo("run-twice")
-		gr.Spec.HelmRepoURLRegex = ""
-		Expect(k8sClient.Update(ctx, gr)).To(Succeed())
-
+		// Retry on conflict: the controller may concurrently update
+		// the GitRepo (e.g. status), bumping its resource version.
+		Eventually(func() error {
+			gr := getGitRepo("run-twice")
+			gr.Spec.HelmRepoURLRegex = ""
+			return k8sClient.Update(ctx, gr)
+		}).Should(Succeed())
 		// Second run: marker present, migration skipped.
 		Expect(runHelmURLRegexMigration()).To(Succeed())
 		Expect(getGitRepo("run-twice").Spec.HelmRepoURLRegex).To(BeEmpty())

--- a/internal/cmd/agent/deployer/deployer.go
+++ b/internal/cmd/agent/deployer/deployer.go
@@ -184,6 +184,9 @@ func (d *Deployer) setNamespaceLabelsAndAnnotations(ctx context.Context, bd *fle
 
 	desiredLabels := maps.Clone(ns.Labels)
 	if bd.Spec.Options.NamespaceLabels != nil {
+		if desiredLabels == nil {
+			desiredLabels = make(map[string]string)
+		}
 		addLabelsFromOptions(log.FromContext(ctx), desiredLabels, bd.Spec.Options.NamespaceLabels)
 	}
 	desiredAnnotations := maps.Clone(ns.Annotations)
@@ -227,7 +230,10 @@ func (d *Deployer) fetchNamespace(ctx context.Context, releaseID string) (*corev
 
 const podSecurityLabelPrefix = "pod-security.kubernetes.io/"
 
-// addLabelsFromOptions updates nsLabels so that it only contains all labels specified in optLabels, plus the `kubernetes.io/metadata.name` labels added by kubernetes when creating the namespace.
+// addLabelsFromOptions updates nsLabels to contain labels from optLabels, while preserving
+// the `kubernetes.io/metadata.name` label added by Kubernetes when creating the namespace
+// and any existing `pod-security.kubernetes.io/*` labels. Labels with the
+// `pod-security.kubernetes.io/` prefix in optLabels are ignored.
 func addLabelsFromOptions(logger logr.Logger, nsLabels map[string]string, optLabels map[string]string) {
 	for k, v := range optLabels {
 		if strings.HasPrefix(k, podSecurityLabelPrefix) {

--- a/internal/cmd/agent/deployer/deployer.go
+++ b/internal/cmd/agent/deployer/deployer.go
@@ -3,7 +3,7 @@ package deployer
 import (
 	"context"
 	"fmt"
-	"reflect"
+	"maps"
 	"regexp"
 	"strconv"
 	"strings"
@@ -182,25 +182,25 @@ func (d *Deployer) setNamespaceLabelsAndAnnotations(ctx context.Context, bd *fle
 		return err
 	}
 
-	if reflect.DeepEqual(bd.Spec.Options.NamespaceLabels, ns.Labels) && reflect.DeepEqual(bd.Spec.Options.NamespaceAnnotations, ns.Annotations) {
+	desiredLabels := maps.Clone(ns.Labels)
+	if bd.Spec.Options.NamespaceLabels != nil {
+		addLabelsFromOptions(log.FromContext(ctx), desiredLabels, bd.Spec.Options.NamespaceLabels)
+	}
+	desiredAnnotations := maps.Clone(ns.Annotations)
+	if bd.Spec.Options.NamespaceAnnotations != nil {
+		if desiredAnnotations == nil {
+			desiredAnnotations = make(map[string]string)
+		}
+		addAnnotationsFromOptions(desiredAnnotations, bd.Spec.Options.NamespaceAnnotations)
+	}
+
+	if maps.Equal(desiredLabels, ns.Labels) && maps.Equal(desiredAnnotations, ns.Annotations) {
 		return nil
 	}
 
-	if bd.Spec.Options.NamespaceLabels != nil {
-		addLabelsFromOptions(log.FromContext(ctx), ns.Labels, bd.Spec.Options.NamespaceLabels)
-	}
-	if bd.Spec.Options.NamespaceAnnotations != nil {
-		if ns.Annotations == nil {
-			ns.Annotations = map[string]string{}
-		}
-		addAnnotationsFromOptions(ns.Annotations, bd.Spec.Options.NamespaceAnnotations)
-	}
-	err = d.updateNamespace(ctx, ns)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	ns.Labels = desiredLabels
+	ns.Annotations = desiredAnnotations
+	return d.updateNamespace(ctx, ns)
 }
 
 // updateNamespace updates a namespace resource in the cluster.


### PR DESCRIPTION
Backports two fixes from #5156 to release/v0.12.

The previous `reflect.DeepEqual` comparison checked raw `BundleDeployment` options directly against `ns.Labels`, which always includes `kubernetes.io/metadata.name` and preserved pod-security labels. The check never held, causing an unnecessary `updateNamespace` call on every reconcile. Replace with `maps.Clone` + `maps.Equal` on the computed desired state.

`maps.Clone` returns nil when its source is nil, so when `ns.Labels` is nil and `NamespaceLabels` options are non-empty the pod-security check would panic. Add a nil guard matching the one already present for annotations.