### PR TITLE
Propagate per-target DownstreamResources to clusters

### DIFF
--- a/integrationtests/controller/bundle/bundle_downstream_resources_test.go
+++ b/integrationtests/controller/bundle/bundle_downstream_resources_test.go
@@ -78,7 +78,7 @@ var _ = Describe("Bundle target DownstreamResources", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(bundle).NotTo(BeNil())
 
-			By("verifying three BundleDeployments are created")
+			By("verifying that a BundleDeployment is created for each matched cluster")
 			bdLabels := map[string]string{
 				"fleet.cattle.io/bundle-name":      bundleName,
 				"fleet.cattle.io/bundle-namespace": namespace,
@@ -199,7 +199,7 @@ var _ = Describe("Bundle target DownstreamResources", Ordered, func() {
 			}
 			Expect(k8sClient.Create(ctx, bundle)).To(Succeed())
 
-			By("verifying three BundleDeployments are created")
+			By("verifying that a BundleDeployment is created for each matched cluster")
 			bdLabels := map[string]string{
 				"fleet.cattle.io/bundle-name":      bundleName,
 				"fleet.cattle.io/bundle-namespace": namespace,

--- a/integrationtests/controller/bundle/bundle_downstream_resources_test.go
+++ b/integrationtests/controller/bundle/bundle_downstream_resources_test.go
@@ -1,0 +1,253 @@
+package bundle
+
+import (
+	"os"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/rancher/fleet/integrationtests/utils"
+	"github.com/rancher/fleet/internal/experimental"
+	"github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("Bundle target DownstreamResources", Ordered, func() {
+	BeforeAll(func() {
+		var err error
+		namespace, err = utils.NewNamespaceName()
+		Expect(err).ToNot(HaveOccurred())
+
+		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}
+		Expect(k8sClient.Create(ctx, ns)).ToNot(HaveOccurred())
+
+		createClustersAndClusterGroups()
+
+		// Enable the experimental downstream copy feature.
+		Expect(os.Setenv(experimental.CopyResourcesDownstreamFlag, "true")).To(Succeed())
+
+		DeferCleanup(func() {
+			os.Unsetenv(experimental.CopyResourcesDownstreamFlag)
+			Expect(k8sClient.Delete(ctx, ns)).ToNot(HaveOccurred())
+		})
+	})
+
+	When("a target has DownstreamResources", func() {
+		const bundleName = "target-downstream-resources"
+
+		BeforeEach(func() {
+			// Create a secret in the bundle namespace to be copied downstream.
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "target-secret",
+					Namespace: namespace,
+				},
+				Data: map[string][]byte{"key": []byte("value")},
+			}
+			Expect(k8sClient.Create(ctx, secret)).To(Succeed())
+			DeferCleanup(func() {
+				Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, secret))).To(Succeed())
+				Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, &v1alpha1.Bundle{
+					ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: bundleName},
+				}))).NotTo(HaveOccurred())
+				cleanupBundleDeployments(bundleName, namespace)
+			})
+		})
+
+		It("copies the secret to the matching cluster's namespace only", func() {
+			By("creating a bundle with per-target DownstreamResources targeting cluster one")
+			targets := []v1alpha1.BundleTarget{
+				{
+					BundleDeploymentOptions: v1alpha1.BundleDeploymentOptions{
+						DownstreamResources: []v1alpha1.DownstreamResource{
+							{Kind: "Secret", Name: "target-secret"},
+						},
+					},
+					ClusterGroup: "one",
+				},
+				{
+					ClusterGroup: "all",
+				},
+			}
+			bundle, err := utils.CreateBundle(ctx, k8sClient, bundleName, namespace, targets, targets)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(bundle).NotTo(BeNil())
+
+			By("verifying three BundleDeployments are created")
+			bdLabels := map[string]string{
+				"fleet.cattle.io/bundle-name":      bundleName,
+				"fleet.cattle.io/bundle-namespace": namespace,
+			}
+			bdList := verifyBundlesDeploymentsAreCreated(3, bdLabels, bundleName)
+
+			By("finding the BundleDeployment for cluster one")
+			var clusterOneBD *v1alpha1.BundleDeployment
+			for i := range bdList.Items {
+				if strings.Contains(bdList.Items[i].Namespace, "cluster-one") {
+					clusterOneBD = &bdList.Items[i]
+					break
+				}
+			}
+			Expect(clusterOneBD).NotTo(BeNil(), "expected BundleDeployment for cluster one")
+
+			By("verifying DownstreamResources is set in cluster one's BundleDeployment options")
+			Eventually(func(g Gomega) {
+				bd := &v1alpha1.BundleDeployment{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name:      clusterOneBD.Name,
+					Namespace: clusterOneBD.Namespace,
+				}, bd)).To(Succeed())
+				g.Expect(bd.Spec.Options.DownstreamResources).To(ConsistOf(
+					v1alpha1.DownstreamResource{Kind: "Secret", Name: "target-secret"},
+				))
+			}).Should(Succeed())
+
+			By("verifying the secret is copied to cluster one's namespace")
+			Eventually(func(g Gomega) {
+				copied := &corev1.Secret{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name:      "target-secret",
+					Namespace: clusterOneBD.Namespace,
+				}, copied)).To(Succeed())
+				g.Expect(copied.Data).To(HaveKeyWithValue("key", []byte("value")))
+			}).Should(Succeed())
+
+			By("verifying the secret is NOT copied to other clusters' namespaces")
+			for _, bd := range bdList.Items {
+				if bd.Namespace == clusterOneBD.Namespace {
+					continue
+				}
+				bdNs := bd.Namespace
+				Consistently(func(g Gomega) {
+					err := k8sClient.Get(ctx, types.NamespacedName{
+						Name:      "target-secret",
+						Namespace: bdNs,
+					}, &corev1.Secret{})
+					g.Expect(client.IgnoreNotFound(err)).To(Succeed())
+					g.Expect(err).To(HaveOccurred(), "secret should not exist in namespace %s", bdNs)
+				}).Should(Succeed())
+			}
+		})
+	})
+
+	When("root-level and per-target DownstreamResources are both specified", func() {
+		const bundleName = "mixed-downstream-resources"
+
+		BeforeEach(func() {
+			rootSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: "root-secret", Namespace: namespace},
+				Data:       map[string][]byte{"root": []byte("data")},
+			}
+			targetSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: "target-secret-two", Namespace: namespace},
+				Data:       map[string][]byte{"target": []byte("data")},
+			}
+			Expect(k8sClient.Create(ctx, rootSecret)).To(Succeed())
+			Expect(k8sClient.Create(ctx, targetSecret)).To(Succeed())
+			DeferCleanup(func() {
+				Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, rootSecret))).To(Succeed())
+				Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, targetSecret))).To(Succeed())
+				Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, &v1alpha1.Bundle{
+					ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: bundleName},
+				}))).NotTo(HaveOccurred())
+				cleanupBundleDeployments(bundleName, namespace)
+			})
+		})
+
+		It("copies root-level secret to all clusters and target secret only to cluster one", func() {
+			By("creating a bundle with root-level and per-target DownstreamResources")
+			targets := []v1alpha1.BundleTarget{
+				{
+					BundleDeploymentOptions: v1alpha1.BundleDeploymentOptions{
+						DownstreamResources: []v1alpha1.DownstreamResource{
+							{Kind: "Secret", Name: "target-secret-two"},
+						},
+					},
+					ClusterGroup: "one",
+				},
+				{
+					ClusterGroup: "all",
+				},
+			}
+			bundle := &v1alpha1.Bundle{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      bundleName,
+					Namespace: namespace,
+				},
+				Spec: v1alpha1.BundleSpec{
+					BundleDeploymentOptions: v1alpha1.BundleDeploymentOptions{
+						DownstreamResources: []v1alpha1.DownstreamResource{
+							{Kind: "Secret", Name: "root-secret"},
+						},
+					},
+					Targets: targets,
+					TargetRestrictions: func() []v1alpha1.BundleTargetRestriction {
+						out := make([]v1alpha1.BundleTargetRestriction, len(targets))
+						for i, t := range targets {
+							out[i] = v1alpha1.BundleTargetRestriction{
+								ClusterGroup: t.ClusterGroup,
+							}
+						}
+						return out
+					}(),
+				},
+			}
+			Expect(k8sClient.Create(ctx, bundle)).To(Succeed())
+
+			By("verifying three BundleDeployments are created")
+			bdLabels := map[string]string{
+				"fleet.cattle.io/bundle-name":      bundleName,
+				"fleet.cattle.io/bundle-namespace": namespace,
+			}
+			bdList := verifyBundlesDeploymentsAreCreated(3, bdLabels, bundleName)
+
+			By("verifying root-secret is copied to all cluster namespaces")
+			for _, bd := range bdList.Items {
+				bdNs := bd.Namespace
+				Eventually(func(g Gomega) {
+					copied := &corev1.Secret{}
+					g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+						Name:      "root-secret",
+						Namespace: bdNs,
+					}, copied)).To(Succeed())
+				}).Should(Succeed())
+			}
+
+			By("verifying target-secret-two is copied to cluster one's namespace")
+			for _, bd := range bdList.Items {
+				if !strings.Contains(bd.Namespace, "cluster-one") {
+					continue
+				}
+				bdNs := bd.Namespace
+				Eventually(func(g Gomega) {
+					copied := &corev1.Secret{}
+					g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+						Name:      "target-secret-two",
+						Namespace: bdNs,
+					}, copied)).To(Succeed())
+				}).Should(Succeed())
+			}
+
+			By("verifying target-secret-two is NOT copied to other cluster namespaces")
+			for _, bd := range bdList.Items {
+				if strings.Contains(bd.Namespace, "cluster-one") {
+					continue
+				}
+				bdNs := bd.Namespace
+				Consistently(func(g Gomega) {
+					err := k8sClient.Get(ctx, types.NamespacedName{
+						Name:      "target-secret-two",
+						Namespace: bdNs,
+					}, &corev1.Secret{})
+					g.Expect(client.IgnoreNotFound(err)).To(Succeed())
+					g.Expect(err).To(HaveOccurred(), "target-secret-two should not exist in namespace %s", bdNs)
+				}).Should(Succeed())
+			}
+		})
+	})
+})

--- a/integrationtests/controller/bundle/suite_test.go
+++ b/integrationtests/controller/bundle/suite_test.go
@@ -128,3 +128,14 @@ func expectedLabelValue(bdLabels map[string]string, key, value string) (*v1alpha
 	}
 	return nil, false
 }
+
+func cleanupBundleDeployments(bundleName, bundleNamespace string) {
+	bdList := &v1alpha1.BundleDeploymentList{}
+	Expect(k8sClient.List(ctx, bdList, client.MatchingLabels{
+		"fleet.cattle.io/bundle-name":      bundleName,
+		"fleet.cattle.io/bundle-namespace": bundleNamespace,
+	})).To(Succeed())
+	for _, bd := range bdList.Items {
+		Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, &bd))).NotTo(HaveOccurred())
+	}
+}

--- a/internal/cmd/controller/operator.go
+++ b/internal/cmd/controller/operator.go
@@ -296,6 +296,14 @@ func AddBundleDownstreamResourceIndexer(ctx context.Context, mgr manager.Manager
 					resources = append(resources, fmt.Sprintf("%s/%s", lowerKind, dr.Name))
 				}
 			}
+			for _, target := range bundle.Spec.Targets {
+				for _, dr := range target.DownstreamResources {
+					lowerKind := strings.ToLower(dr.Kind)
+					if lowerKind == "secret" || lowerKind == "configmap" {
+						resources = append(resources, fmt.Sprintf("%s/%s", lowerKind, dr.Name))
+					}
+				}
+			}
 			return resources
 		},
 	)

--- a/internal/cmd/controller/options/calculate.go
+++ b/internal/cmd/controller/options/calculate.go
@@ -110,6 +110,9 @@ func Merge(base, custom fleet.BundleDeploymentOptions) fleet.BundleDeploymentOpt
 	if custom.CorrectDrift != nil {
 		result.CorrectDrift = custom.CorrectDrift
 	}
+	if len(custom.DownstreamResources) > 0 {
+		result.DownstreamResources = append(result.DownstreamResources, custom.DownstreamResources...)
+	}
 
 	return result
 }

--- a/internal/cmd/controller/options/calculate_test.go
+++ b/internal/cmd/controller/options/calculate_test.go
@@ -1,0 +1,60 @@
+package options_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/rancher/fleet/internal/cmd/controller/options"
+	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
+)
+
+func TestMerge_DownstreamResources(t *testing.T) {
+	a := assert.New(t)
+
+	base := fleet.BundleDeploymentOptions{
+		DownstreamResources: []fleet.DownstreamResource{
+			{Kind: "Secret", Name: "base-secret"},
+		},
+	}
+	custom := fleet.BundleDeploymentOptions{
+		DownstreamResources: []fleet.DownstreamResource{
+			{Kind: "ConfigMap", Name: "target-cm"},
+		},
+	}
+
+	result := options.Merge(base, custom)
+	a.Len(result.DownstreamResources, 2)
+	a.Equal(fleet.DownstreamResource{Kind: "Secret", Name: "base-secret"}, result.DownstreamResources[0])
+	a.Equal(fleet.DownstreamResource{Kind: "ConfigMap", Name: "target-cm"}, result.DownstreamResources[1])
+
+	// base and custom must remain unchanged (pure function)
+	a.Len(base.DownstreamResources, 1)
+	a.Len(custom.DownstreamResources, 1)
+}
+
+func TestMerge_DownstreamResources_EmptyCustom(t *testing.T) {
+	a := assert.New(t)
+
+	base := fleet.BundleDeploymentOptions{
+		DownstreamResources: []fleet.DownstreamResource{
+			{Kind: "Secret", Name: "base-secret"},
+		},
+	}
+
+	result := options.Merge(base, fleet.BundleDeploymentOptions{})
+	a.Equal(base.DownstreamResources, result.DownstreamResources)
+}
+
+func TestMerge_DownstreamResources_EmptyBase(t *testing.T) {
+	a := assert.New(t)
+
+	custom := fleet.BundleDeploymentOptions{
+		DownstreamResources: []fleet.DownstreamResource{
+			{Kind: "Secret", Name: "target-secret"},
+		},
+	}
+
+	result := options.Merge(fleet.BundleDeploymentOptions{}, custom)
+	a.Equal(custom.DownstreamResources, result.DownstreamResources)
+}

--- a/internal/cmd/controller/reconciler/bundle_controller.go
+++ b/internal/cmd/controller/reconciler/bundle_controller.go
@@ -796,7 +796,7 @@ func (r *BundleReconciler) handleDownstreamObjects(ctx context.Context, bundle *
 	// Track if any resources were created or updated
 	resourcesUpdated := false
 
-	for _, dr := range bundle.Spec.DownstreamResources {
+	for _, dr := range bd.Spec.Options.DownstreamResources {
 		switch strings.ToLower(dr.Kind) {
 		case "secret":
 			result, err := r.cloneSecret(ctx, bundle.Namespace, dr.Name, "", bd)

--- a/internal/cmd/controller/reconciler/bundle_controller_test.go
+++ b/internal/cmd/controller/reconciler/bundle_controller_test.go
@@ -1479,9 +1479,9 @@ func TestReconcile_DownstreamResourcesGeneration_Increment(t *testing.T) {
 			mockClient.EXPECT().Delete(gomock.Any(), gomock.AssignableToTypeOf(&corev1.Secret{}), gomock.Any()).
 				Return(&k8serrors.StatusError{ErrStatus: metav1.Status{Code: http.StatusNotFound}})
 
-			// Target builder returns our test bundle deployment
-			// Simulate what options.Merge would produce: root-level DownstreamResources
-			// end up in the BD's Options after the first reconcile.
+			// Target builder returns our test bundle deployment. Set Options as the
+			// real target builder would after options.Merge: DownstreamResources end
+			// up in bd.Spec.Options. The builder is mocked here, so we set it directly.
 			tc.existingBundleDeployment.Spec.Options.DownstreamResources = tc.downstreamResources
 			matchedTargets := []*target.Target{
 				{

--- a/internal/cmd/controller/reconciler/bundle_controller_test.go
+++ b/internal/cmd/controller/reconciler/bundle_controller_test.go
@@ -820,6 +820,9 @@ func TestReconcile_DownstreamObjectsHandlingError(t *testing.T) {
 							Namespace: "my-bd", // non-empty
 						},
 					},
+					Options: fleetv1.BundleDeploymentOptions{
+						DownstreamResources: c.downstreamResources,
+					},
 					DeploymentID: "foo",
 				},
 			}
@@ -1477,6 +1480,9 @@ func TestReconcile_DownstreamResourcesGeneration_Increment(t *testing.T) {
 				Return(&k8serrors.StatusError{ErrStatus: metav1.Status{Code: http.StatusNotFound}})
 
 			// Target builder returns our test bundle deployment
+			// Simulate what options.Merge would produce: root-level DownstreamResources
+			// end up in the BD's Options after the first reconcile.
+			tc.existingBundleDeployment.Spec.Options.DownstreamResources = tc.downstreamResources
 			matchedTargets := []*target.Target{
 				{
 					Bundle: &bundle,


### PR DESCRIPTION
Three separate bugs prevented `downstreamResources` in `HelmOp.spec.targets[*]` (and `fleet.yaml` `targetCustomizations[*].downstreamResources`) from being copied to downstream cluster namespaces. `options.Merge` did not copy the `DownstreamResources` field from target customizations, so the merged result in `bd.Spec.Options` was always empty for per-target entries. `handleDownstreamObjects` read only `bundle.Spec.DownstreamResources` (the root-level field) rather than `bd.Spec.Options.DownstreamResources`, which holds the post-merge value. The bundle change-trigger indexer also only walked root-level resources, so modifying a per-target secret or configmap did not cause reconciliation.

The indexer fix iterates `bundle.Spec.Targets` so that changes to per-target secrets/configmaps re-trigger bundle reconciliation.

Fixes #4727