### PR TITLE
docs: clarify Helm timeout behavior

### DIFF
--- a/charts/fleet-crd/templates/crds.yaml
+++ b/charts/fleet-crd/templates/crds.yaml
@@ -506,9 +506,10 @@ spec:
                           type: object
                         timeoutSeconds:
                           description: TimeoutSeconds is the number of seconds Fleet
-                            passes to Helm operations. Omitted or zero values disable
-                            Helm status waiting; positive values enable Helm status
-                            waiting up to the configured timeout.
+                            passes to Helm operations. Omitted or zero values use hook-only
+                            waiting. Positive values enable Helm status waiting during
+                            install and upgrade operations up to the configured timeout;
+                            uninstall and rollback operations keep hook-only waiting.
                           type: integer
                         values:
                           description: 'Values passed to Helm. It is possible to specify
@@ -974,9 +975,10 @@ spec:
                           type: object
                         timeoutSeconds:
                           description: TimeoutSeconds is the number of seconds Fleet
-                            passes to Helm operations. Omitted or zero values disable
-                            Helm status waiting; positive values enable Helm status
-                            waiting up to the configured timeout.
+                            passes to Helm operations. Omitted or zero values use hook-only
+                            waiting. Positive values enable Helm status waiting during
+                            install and upgrade operations up to the configured timeout;
+                            uninstall and rollback operations keep hook-only waiting.
                           type: integer
                         values:
                           description: 'Values passed to Helm. It is possible to specify
@@ -2015,9 +2017,10 @@ spec:
                       type: object
                     timeoutSeconds:
                       description: TimeoutSeconds is the number of seconds Fleet
-                        passes to Helm operations. Omitted or zero values disable
-                        Helm status waiting; positive values enable Helm status waiting
-                        up to the configured timeout.
+                        passes to Helm operations. Omitted or zero values use hook-only
+                        waiting. Positive values enable Helm status waiting during install
+                        and upgrade operations up to the configured timeout; uninstall
+                        and rollback operations keep hook-only waiting.
                       type: integer
                     values:
                       description: 'Values passed to Helm. It is possible to specify
@@ -3044,9 +3047,10 @@ spec:
                             type: object
                           timeoutSeconds:
                             description: TimeoutSeconds is the number of seconds Fleet
-                              passes to Helm operations. Omitted or zero values disable
-                              Helm status waiting; positive values enable Helm status
-                              waiting up to the configured timeout.
+                              passes to Helm operations. Omitted or zero values use hook-only
+                              waiting. Positive values enable Helm status waiting during
+                              install and upgrade operations up to the configured timeout;
+                              uninstall and rollback operations keep hook-only waiting.
                             type: integer
                           values:
                             description: 'Values passed to Helm. It is possible to
@@ -8243,9 +8247,10 @@ spec:
                       type: object
                     timeoutSeconds:
                       description: TimeoutSeconds is the number of seconds Fleet
-                        passes to Helm operations. Omitted or zero values disable
-                        Helm status waiting; positive values enable Helm status waiting
-                        up to the configured timeout.
+                        passes to Helm operations. Omitted or zero values use hook-only
+                        waiting. Positive values enable Helm status waiting during install
+                        and upgrade operations up to the configured timeout; uninstall
+                        and rollback operations keep hook-only waiting.
                       type: integer
                     values:
                       description: 'Values passed to Helm. It is possible to specify
@@ -9296,9 +9301,10 @@ spec:
                             type: object
                           timeoutSeconds:
                             description: TimeoutSeconds is the number of seconds Fleet
-                              passes to Helm operations. Omitted or zero values disable
-                              Helm status waiting; positive values enable Helm status
-                              waiting up to the configured timeout.
+                              passes to Helm operations. Omitted or zero values use hook-only
+                              waiting. Positive values enable Helm status waiting during
+                              install and upgrade operations up to the configured timeout;
+                              uninstall and rollback operations keep hook-only waiting.
                             type: integer
                           values:
                             description: 'Values passed to Helm. It is possible to

--- a/charts/fleet-crd/templates/crds.yaml
+++ b/charts/fleet-crd/templates/crds.yaml
@@ -505,8 +505,10 @@ spec:
                           nullable: true
                           type: object
                         timeoutSeconds:
-                          description: TimeoutSeconds is the time to wait for Helm
-                            operations.
+                          description: TimeoutSeconds is the number of seconds Fleet
+                            passes to Helm operations. Omitted or zero values disable
+                            Helm status waiting; positive values enable Helm status
+                            waiting up to the configured timeout.
                           type: integer
                         values:
                           description: 'Values passed to Helm. It is possible to specify
@@ -971,8 +973,10 @@ spec:
                           nullable: true
                           type: object
                         timeoutSeconds:
-                          description: TimeoutSeconds is the time to wait for Helm
-                            operations.
+                          description: TimeoutSeconds is the number of seconds Fleet
+                            passes to Helm operations. Omitted or zero values disable
+                            Helm status waiting; positive values enable Helm status
+                            waiting up to the configured timeout.
                           type: integer
                         values:
                           description: 'Values passed to Helm. It is possible to specify
@@ -2010,7 +2014,10 @@ spec:
                       nullable: true
                       type: object
                     timeoutSeconds:
-                      description: TimeoutSeconds is the time to wait for Helm operations.
+                      description: TimeoutSeconds is the number of seconds Fleet
+                        passes to Helm operations. Omitted or zero values disable
+                        Helm status waiting; positive values enable Helm status waiting
+                        up to the configured timeout.
                       type: integer
                     values:
                       description: 'Values passed to Helm. It is possible to specify
@@ -3036,8 +3043,10 @@ spec:
                             nullable: true
                             type: object
                           timeoutSeconds:
-                            description: TimeoutSeconds is the time to wait for Helm
-                              operations.
+                            description: TimeoutSeconds is the number of seconds Fleet
+                              passes to Helm operations. Omitted or zero values disable
+                              Helm status waiting; positive values enable Helm status
+                              waiting up to the configured timeout.
                             type: integer
                           values:
                             description: 'Values passed to Helm. It is possible to
@@ -8233,7 +8242,10 @@ spec:
                       nullable: true
                       type: object
                     timeoutSeconds:
-                      description: TimeoutSeconds is the time to wait for Helm operations.
+                      description: TimeoutSeconds is the number of seconds Fleet
+                        passes to Helm operations. Omitted or zero values disable
+                        Helm status waiting; positive values enable Helm status waiting
+                        up to the configured timeout.
                       type: integer
                     values:
                       description: 'Values passed to Helm. It is possible to specify
@@ -9283,8 +9295,10 @@ spec:
                             nullable: true
                             type: object
                           timeoutSeconds:
-                            description: TimeoutSeconds is the time to wait for Helm
-                              operations.
+                            description: TimeoutSeconds is the number of seconds Fleet
+                              passes to Helm operations. Omitted or zero values disable
+                              Helm status waiting; positive values enable Helm status
+                              waiting up to the configured timeout.
                             type: integer
                           values:
                             description: 'Values passed to Helm. It is possible to

--- a/pkg/apis/fleet.cattle.io/v1alpha1/bundledeployment_types.go
+++ b/pkg/apis/fleet.cattle.io/v1alpha1/bundledeployment_types.go
@@ -234,7 +234,9 @@ type HelmOptions struct {
 	// Version of the chart to download
 	Version string `json:"version,omitempty"`
 
-	// TimeoutSeconds is the time to wait for Helm operations.
+	// TimeoutSeconds is the number of seconds Fleet passes to Helm operations.
+	// Omitted or zero values disable Helm status waiting; positive values enable
+	// Helm status waiting up to the configured timeout.
 	TimeoutSeconds int `json:"timeoutSeconds,omitempty"`
 
 	// Values passed to Helm. It is possible to specify the keys and values

--- a/pkg/apis/fleet.cattle.io/v1alpha1/bundledeployment_types.go
+++ b/pkg/apis/fleet.cattle.io/v1alpha1/bundledeployment_types.go
@@ -235,8 +235,9 @@ type HelmOptions struct {
 	Version string `json:"version,omitempty"`
 
 	// TimeoutSeconds is the number of seconds Fleet passes to Helm operations.
-	// Omitted or zero values disable Helm status waiting; positive values enable
-	// Helm status waiting up to the configured timeout.
+	// Omitted or zero values use hook-only waiting. Positive values enable Helm
+	// status waiting during install and upgrade operations up to the configured
+	// timeout; uninstall and rollback operations keep hook-only waiting.
 	TimeoutSeconds int `json:"timeoutSeconds,omitempty"`
 
 	// Values passed to Helm. It is possible to specify the keys and values


### PR DESCRIPTION
**What this PR does**:

Clarifies the `helm.timeoutSeconds` description in the Fleet API comment and generated CRD template.

The current Helm deployer behavior is:

- omitted or `0` `timeoutSeconds` leaves Helm status waiting disabled
- positive `timeoutSeconds` enables Helm status waiting up to the configured timeout

This matches `internal/helmdeployer` behavior and the existing `TestWaitStrategyConfiguration` expectations.

**Which issue(s) this PR fixes**:
Refers #801

**Checklist**
- [ ] Tests updated
- [x] Documentation added
- [ ] `CHANGELOG.md` updated - no user-facing code change
- [ ] `docs/configuration/v1-guarantees.md` updated if this PR introduces experimental flags

**Validation performed**:

```console
ruby -e 'require "yaml"; YAML.load_file("charts/fleet-crd/templates/crds.yaml"); puts "yaml ok"'
# yaml ok

git diff --check -- pkg/apis/fleet.cattle.io/v1alpha1/bundledeployment_types.go charts/fleet-crd/templates/crds.yaml
# exit 0

rg -n "TimeoutSeconds is the time to wait for Helm operations|TimeoutSeconds is the time to wait for Helm\\s*$" pkg/apis/fleet.cattle.io/v1alpha1/bundledeployment_types.go charts/fleet-crd/templates/crds.yaml
# no matches

go test ./internal/helmdeployer -run TestWaitStrategyConfiguration -count=1
# ok github.com/rancher/fleet/internal/helmdeployer 1.628s
```

**AI assistance disclosure**:

Prepared with OpenAI GPT-5 assistance. AI was used to inspect the issue, trace the current timeout behavior, update the documentation text, and run the validation commands above. The commit includes the required `Assisted-by: OpenAI GPT-5` trailer.

