### PR TITLE
Deduplicate appended slices in options.Merge

### DIFF
--- a/internal/cmd/cli/bundlediff.go
+++ b/internal/cmd/cli/bundlediff.go
@@ -19,6 +19,7 @@ import (
 	"sigs.k8s.io/yaml"
 
 	command "github.com/rancher/fleet/internal/cmd"
+	"github.com/rancher/fleet/internal/merge"
 	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
 )
 
@@ -249,54 +250,57 @@ func convertMergePatchToRemoveOps(patch map[string]any, basePath string) []patch
 	return ops
 }
 
-// mergeComparePatches merges new comparePatches with existing ones, avoiding duplicates.
-// This preserves any user-configured comparePatches while adding new ones from drift detection.
-func mergeComparePatches(existing, new []fleet.ComparePatch) []fleet.ComparePatch {
-	patchMap := make(map[string]fleet.ComparePatch)
+// patchIdentityKey returns the key that identifies a ComparePatch resource.
+func patchIdentityKey(p fleet.ComparePatch) string {
+	return p.APIVersion + "|" + p.Kind + "|" + p.Namespace + "|" + p.Name
+}
 
-	// Key function for resource identity
-	resourceKey := func(p fleet.ComparePatch) string {
-		return fmt.Sprintf("%s|%s|%s|%s", p.APIVersion, p.Kind, p.Namespace, p.Name)
+// unionComparePatchOps merges two ComparePatch entries for the same resource by
+// unioning their operations: base operations are kept and custom operations not
+// already present in base are appended.
+func unionComparePatchOps(base, custom fleet.ComparePatch) fleet.ComparePatch {
+	opSet := make(map[string]struct{}, len(base.Operations))
+	for _, op := range base.Operations {
+		opSet[op.Op+"|"+op.Path+"|"+op.Value] = struct{}{}
 	}
-
-	for _, patch := range existing {
-		key := resourceKey(patch)
-		patchMap[key] = patch
-	}
-
-	// Merge new patches, combining operations for same resource
-	for _, newPatch := range new {
-		key := resourceKey(newPatch)
-		if existingPatch, found := patchMap[key]; found {
-			merged := existingPatch
-			opSet := make(map[string]bool)
-			for _, op := range existingPatch.Operations {
-				opKey := fmt.Sprintf("%s|%s|%s", op.Op, op.Path, op.Value)
-				opSet[opKey] = true
-			}
-			for _, op := range newPatch.Operations {
-				opKey := fmt.Sprintf("%s|%s|%s", op.Op, op.Path, op.Value)
-				if !opSet[opKey] {
-					merged.Operations = append(merged.Operations, op)
-				}
-			}
-			patchMap[key] = merged
-		} else {
-			patchMap[key] = newPatch
+	result := base
+	for _, op := range custom.Operations {
+		if _, exists := opSet[op.Op+"|"+op.Path+"|"+op.Value]; !exists {
+			result.Operations = append(result.Operations, op)
 		}
 	}
+	return result
+}
 
-	// Convert map back to slice, sorted for deterministic output
-	var result []fleet.ComparePatch
-	keys := make([]string, 0, len(patchMap))
-	for k := range patchMap {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-	for _, k := range keys {
-		result = append(result, patchMap[k])
-	}
+// mergeComparePatches merges new comparePatches with existing ones.
+// For the same resource identity, operations are unioned — existing operations
+// are kept and new operations not already present are appended. The result is
+// sorted by resource identity for deterministic output.
+func mergeComparePatches(existing, new []fleet.ComparePatch) []fleet.ComparePatch {
+	// Consolidate duplicate resource identities within new by unioning their
+	// operations before merging with existing, so no operations are dropped.
+	consolidated := consolidatePatches(new)
+	merged := merge.ByKey(existing, consolidated, patchIdentityKey, unionComparePatchOps)
+	sort.Slice(merged, func(i, j int) bool {
+		return patchIdentityKey(merged[i]) < patchIdentityKey(merged[j])
+	})
+	return merged
+}
 
+// consolidatePatches folds entries with the same resource identity by unioning
+// their operations, preserving the order of first occurrence.
+func consolidatePatches(patches []fleet.ComparePatch) []fleet.ComparePatch {
+	seen := make(map[string]int, len(patches))
+	result := make([]fleet.ComparePatch, 0, len(patches))
+	for _, p := range patches {
+		k := patchIdentityKey(p)
+		if idx, ok := seen[k]; ok {
+			result[idx] = unionComparePatchOps(result[idx], p)
+		} else {
+			seen[k] = len(result)
+			result = append(result, p)
+		}
+	}
 	return result
 }
 

--- a/internal/cmd/cli/bundlediff_test.go
+++ b/internal/cmd/cli/bundlediff_test.go
@@ -63,6 +63,46 @@ func TestMergeComparePatches(t *testing.T) {
 	}
 }
 
+func TestMergeComparePatches_DuplicateNewEntries(t *testing.T) {
+	// Two new entries for the same resource identity must have their operations
+	// unioned, not dropped.
+	newPatches := []fleet.ComparePatch{
+		{
+			APIVersion: "v1",
+			Kind:       "ConfigMap",
+			Name:       "app-config",
+			Namespace:  "default",
+			Operations: []fleet.Operation{{Op: "remove", Path: "/data/a"}},
+		},
+		{
+			APIVersion: "v1",
+			Kind:       "ConfigMap",
+			Name:       "app-config",
+			Namespace:  "default",
+			Operations: []fleet.Operation{{Op: "remove", Path: "/data/b"}},
+		},
+	}
+
+	expected := []fleet.ComparePatch{
+		{
+			APIVersion: "v1",
+			Kind:       "ConfigMap",
+			Name:       "app-config",
+			Namespace:  "default",
+			Operations: []fleet.Operation{
+				{Op: "remove", Path: "/data/a"},
+				{Op: "remove", Path: "/data/b"},
+			},
+		},
+	}
+
+	merged := mergeComparePatches(nil, newPatches)
+
+	if diff := cmp.Diff(expected, merged); diff != "" {
+		t.Errorf("mergeComparePatches() mismatch (-want +got):\n%s", diff)
+	}
+}
+
 func TestConvertMergePatchToRemoveOps(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/cmd/controller/options/calculate.go
+++ b/internal/cmd/controller/options/calculate.go
@@ -6,10 +6,36 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"maps"
+	"strings"
 
+	"github.com/rancher/fleet/internal/merge"
 	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
 	"github.com/rancher/wrangler/v3/pkg/data"
 )
+
+// mergeUnique merges two slices by key, with custom entries taking precedence
+// over base entries for the same key. See merge.ByKey for full semantics.
+func mergeUnique[T any](base, custom []T, keyFn func(T) string) []T {
+	return merge.ByKey(base, custom, keyFn, func(_ T, c T) T { return c })
+}
+
+func downstreamResourceKey(r fleet.DownstreamResource) string {
+	return strings.ToLower(r.Kind) + "|" + r.Name
+}
+
+func valuesFromKey(v fleet.ValuesFrom) string {
+	if v.ConfigMapKeyRef != nil {
+		return "configmap|" + v.ConfigMapKeyRef.Namespace + "|" + v.ConfigMapKeyRef.Name + "|" + v.ConfigMapKeyRef.Key
+	}
+	if v.SecretKeyRef != nil {
+		return "secret|" + v.SecretKeyRef.Namespace + "|" + v.SecretKeyRef.Name + "|" + v.SecretKeyRef.Key
+	}
+	return "" // no stable identity; always append
+}
+
+func comparePatchKey(p fleet.ComparePatch) string {
+	return p.APIVersion + "|" + p.Kind + "|" + p.Namespace + "|" + p.Name
+}
 
 // DeploymentID hashes the options to a string
 func DeploymentID(manifestID string, opts fleet.BundleDeploymentOptions) (string, error) {
@@ -64,8 +90,8 @@ func Merge(base, custom fleet.BundleDeploymentOptions) fleet.BundleDeploymentOpt
 		} else if custom.Helm.TemplateValues != nil {
 			maps.Copy(result.Helm.TemplateValues, custom.Helm.TemplateValues)
 		}
-		if custom.Helm.ValuesFrom != nil {
-			result.Helm.ValuesFrom = append(result.Helm.ValuesFrom, custom.Helm.ValuesFrom...)
+		if len(custom.Helm.ValuesFrom) > 0 {
+			result.Helm.ValuesFrom = mergeUnique(result.Helm.ValuesFrom, custom.Helm.ValuesFrom, valuesFromKey)
 		}
 		if custom.Helm.Repo != "" {
 			result.Helm.Repo = custom.Helm.Repo
@@ -98,7 +124,7 @@ func Merge(base, custom fleet.BundleDeploymentOptions) fleet.BundleDeploymentOpt
 		if result.Diff == nil {
 			result.Diff = &fleet.DiffOptions{}
 		}
-		result.Diff.ComparePatches = append(result.Diff.ComparePatches, custom.Diff.ComparePatches...)
+		result.Diff.ComparePatches = mergeUnique(result.Diff.ComparePatches, custom.Diff.ComparePatches, comparePatchKey)
 	}
 	if custom.YAML != nil {
 		if result.YAML == nil {
@@ -114,7 +140,7 @@ func Merge(base, custom fleet.BundleDeploymentOptions) fleet.BundleDeploymentOpt
 		result.CorrectDrift = custom.CorrectDrift
 	}
 	if len(custom.DownstreamResources) > 0 {
-		result.DownstreamResources = append(result.DownstreamResources, custom.DownstreamResources...)
+		result.DownstreamResources = mergeUnique(result.DownstreamResources, custom.DownstreamResources, downstreamResourceKey)
 	}
 
 	return result

--- a/internal/cmd/controller/options/calculate_test.go
+++ b/internal/cmd/controller/options/calculate_test.go
@@ -9,7 +9,9 @@ import (
 	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
 )
 
-func TestMerge_DownstreamResources(t *testing.T) {
+// ---------- DownstreamResources ----------
+
+func TestMerge_DownstreamResources_Appends(t *testing.T) {
 	a := assert.New(t)
 
 	base := fleet.BundleDeploymentOptions{
@@ -28,9 +30,46 @@ func TestMerge_DownstreamResources(t *testing.T) {
 	a.Equal(fleet.DownstreamResource{Kind: "Secret", Name: "base-secret"}, result.DownstreamResources[0])
 	a.Equal(fleet.DownstreamResource{Kind: "ConfigMap", Name: "target-cm"}, result.DownstreamResources[1])
 
-	// base and custom must remain unchanged (pure function)
+	// Pure function: inputs must not be modified.
 	a.Len(base.DownstreamResources, 1)
 	a.Len(custom.DownstreamResources, 1)
+}
+
+func TestMerge_DownstreamResources_DeduplicatesExact(t *testing.T) {
+	a := assert.New(t)
+
+	base := fleet.BundleDeploymentOptions{
+		DownstreamResources: []fleet.DownstreamResource{
+			{Kind: "Secret", Name: "shared"},
+		},
+	}
+	custom := fleet.BundleDeploymentOptions{
+		DownstreamResources: []fleet.DownstreamResource{
+			{Kind: "Secret", Name: "shared"},
+		},
+	}
+
+	result := options.Merge(base, custom)
+	a.Len(result.DownstreamResources, 1, "duplicate should be dropped")
+	a.Equal(fleet.DownstreamResource{Kind: "Secret", Name: "shared"}, result.DownstreamResources[0])
+}
+
+func TestMerge_DownstreamResources_DeduplicatesCaseInsensitiveKind(t *testing.T) {
+	a := assert.New(t)
+
+	base := fleet.BundleDeploymentOptions{
+		DownstreamResources: []fleet.DownstreamResource{
+			{Kind: "Secret", Name: "sec"},
+		},
+	}
+	custom := fleet.BundleDeploymentOptions{
+		DownstreamResources: []fleet.DownstreamResource{
+			{Kind: "secret", Name: "sec"},
+		},
+	}
+
+	result := options.Merge(base, custom)
+	a.Len(result.DownstreamResources, 1, "kind comparison must be case-insensitive")
 }
 
 func TestMerge_DownstreamResources_EmptyCustom(t *testing.T) {
@@ -57,4 +96,166 @@ func TestMerge_DownstreamResources_EmptyBase(t *testing.T) {
 
 	result := options.Merge(fleet.BundleDeploymentOptions{}, custom)
 	a.Equal(custom.DownstreamResources, result.DownstreamResources)
+}
+
+// ---------- ValuesFrom ----------
+
+func TestMerge_ValuesFrom_Appends(t *testing.T) {
+	a := assert.New(t)
+
+	base := fleet.BundleDeploymentOptions{
+		Helm: &fleet.HelmOptions{
+			ValuesFrom: []fleet.ValuesFrom{
+				{ConfigMapKeyRef: &fleet.ConfigMapKeySelector{
+					LocalObjectReference: fleet.LocalObjectReference{Name: "base-cm"},
+					Namespace:            "ns",
+					Key:                  "values.yaml",
+				}},
+			},
+		},
+	}
+	custom := fleet.BundleDeploymentOptions{
+		Helm: &fleet.HelmOptions{
+			ValuesFrom: []fleet.ValuesFrom{
+				{SecretKeyRef: &fleet.SecretKeySelector{
+					LocalObjectReference: fleet.LocalObjectReference{Name: "custom-sec"},
+					Namespace:            "ns",
+					Key:                  "values.yaml",
+				}},
+			},
+		},
+	}
+
+	result := options.Merge(base, custom)
+	a.Len(result.Helm.ValuesFrom, 2)
+}
+
+func TestMerge_ValuesFrom_DeduplicatesConfigMap(t *testing.T) {
+	a := assert.New(t)
+
+	vf := fleet.ValuesFrom{ConfigMapKeyRef: &fleet.ConfigMapKeySelector{
+		LocalObjectReference: fleet.LocalObjectReference{Name: "cm"},
+		Namespace:            "ns",
+		Key:                  "values.yaml",
+	}}
+	base := fleet.BundleDeploymentOptions{Helm: &fleet.HelmOptions{ValuesFrom: []fleet.ValuesFrom{vf}}}
+	custom := fleet.BundleDeploymentOptions{Helm: &fleet.HelmOptions{ValuesFrom: []fleet.ValuesFrom{vf}}}
+
+	result := options.Merge(base, custom)
+	a.Len(result.Helm.ValuesFrom, 1, "identical ValuesFrom entry should be deduplicated")
+}
+
+func TestMerge_ValuesFrom_DeduplicatesSecret(t *testing.T) {
+	a := assert.New(t)
+
+	vf := fleet.ValuesFrom{SecretKeyRef: &fleet.SecretKeySelector{
+		LocalObjectReference: fleet.LocalObjectReference{Name: "sec"},
+		Namespace:            "ns",
+		Key:                  "values.yaml",
+	}}
+	base := fleet.BundleDeploymentOptions{Helm: &fleet.HelmOptions{ValuesFrom: []fleet.ValuesFrom{vf}}}
+	custom := fleet.BundleDeploymentOptions{Helm: &fleet.HelmOptions{ValuesFrom: []fleet.ValuesFrom{vf}}}
+
+	result := options.Merge(base, custom)
+	a.Len(result.Helm.ValuesFrom, 1, "identical ValuesFrom entry should be deduplicated")
+}
+
+func TestMerge_ValuesFrom_SameNameDifferentKey(t *testing.T) {
+	a := assert.New(t)
+
+	// Same configmap, different key — these are distinct sources and must both be kept.
+	base := fleet.BundleDeploymentOptions{
+		Helm: &fleet.HelmOptions{
+			ValuesFrom: []fleet.ValuesFrom{
+				{ConfigMapKeyRef: &fleet.ConfigMapKeySelector{
+					LocalObjectReference: fleet.LocalObjectReference{Name: "cm"},
+					Namespace:            "ns",
+					Key:                  "key1",
+				}},
+			},
+		},
+	}
+	custom := fleet.BundleDeploymentOptions{
+		Helm: &fleet.HelmOptions{
+			ValuesFrom: []fleet.ValuesFrom{
+				{ConfigMapKeyRef: &fleet.ConfigMapKeySelector{
+					LocalObjectReference: fleet.LocalObjectReference{Name: "cm"},
+					Namespace:            "ns",
+					Key:                  "key2",
+				}},
+			},
+		},
+	}
+
+	result := options.Merge(base, custom)
+	a.Len(result.Helm.ValuesFrom, 2, "same name but different key should be treated as distinct sources")
+}
+
+// ---------- ComparePatches ----------
+
+func TestMerge_ComparePatches_Appends(t *testing.T) {
+	a := assert.New(t)
+
+	base := fleet.BundleDeploymentOptions{
+		Diff: &fleet.DiffOptions{
+			ComparePatches: []fleet.ComparePatch{
+				{APIVersion: "v1", Kind: "Secret", Namespace: "ns", Name: "sec"},
+			},
+		},
+	}
+	custom := fleet.BundleDeploymentOptions{
+		Diff: &fleet.DiffOptions{
+			ComparePatches: []fleet.ComparePatch{
+				{APIVersion: "v1", Kind: "ConfigMap", Namespace: "ns", Name: "cm"},
+			},
+		},
+	}
+
+	result := options.Merge(base, custom)
+	a.Len(result.Diff.ComparePatches, 2)
+}
+
+func TestMerge_ComparePatches_CustomTakesPrecedence(t *testing.T) {
+	a := assert.New(t)
+
+	baseOp := fleet.Operation{Op: "remove", Path: "/metadata/labels/base"}
+	customOp := fleet.Operation{Op: "remove", Path: "/metadata/labels/custom"}
+	resource := fleet.ComparePatch{APIVersion: "v1", Kind: "Secret", Namespace: "ns", Name: "shared"}
+
+	base := fleet.BundleDeploymentOptions{
+		Diff: &fleet.DiffOptions{
+			ComparePatches: []fleet.ComparePatch{
+				{APIVersion: resource.APIVersion, Kind: resource.Kind, Namespace: resource.Namespace, Name: resource.Name,
+					Operations: []fleet.Operation{baseOp}},
+			},
+		},
+	}
+	custom := fleet.BundleDeploymentOptions{
+		Diff: &fleet.DiffOptions{
+			ComparePatches: []fleet.ComparePatch{
+				{APIVersion: resource.APIVersion, Kind: resource.Kind, Namespace: resource.Namespace, Name: resource.Name,
+					Operations: []fleet.Operation{customOp}},
+			},
+		},
+	}
+
+	result := options.Merge(base, custom)
+	a.Len(result.Diff.ComparePatches, 1, "overlapping patch should not be duplicated")
+	a.Equal([]fleet.Operation{customOp}, result.Diff.ComparePatches[0].Operations,
+		"custom operations should take precedence over base")
+}
+
+func TestMerge_ComparePatches_EmptyCustom(t *testing.T) {
+	a := assert.New(t)
+
+	base := fleet.BundleDeploymentOptions{
+		Diff: &fleet.DiffOptions{
+			ComparePatches: []fleet.ComparePatch{
+				{APIVersion: "v1", Kind: "Secret", Namespace: "ns", Name: "sec"},
+			},
+		},
+	}
+
+	result := options.Merge(base, fleet.BundleDeploymentOptions{})
+	a.Equal(base.Diff.ComparePatches, result.Diff.ComparePatches)
 }

--- a/internal/merge/merge.go
+++ b/internal/merge/merge.go
@@ -1,0 +1,38 @@
+// Package merge provides generic helpers for merging slices by identity key.
+package merge
+
+// ByKey merges two slices by identity key. For entries with a non-empty key
+// (returned by keyFn), a custom entry that shares a key with a base entry
+// triggers onCollide(base, custom); the return value replaces the base entry.
+// Custom entries with no matching base key are appended. Non-keyed entries
+// (empty key) are always appended. Duplicate keys within custom are collapsed;
+// the first occurrence takes effect.
+func ByKey[T any](base, custom []T, keyFn func(T) string, onCollide func(base, custom T) T) []T {
+	if len(custom) == 0 {
+		return base
+	}
+	baseIndex := make(map[string]int, len(base))
+	for i, v := range base {
+		if k := keyFn(v); k != "" {
+			baseIndex[k] = i
+		}
+	}
+	result := make([]T, len(base), len(base)+len(custom))
+	copy(result, base)
+	seen := make(map[string]struct{}, len(custom))
+	for _, v := range custom {
+		k := keyFn(v)
+		if k != "" {
+			if _, done := seen[k]; done {
+				continue
+			}
+			seen[k] = struct{}{}
+			if idx, exists := baseIndex[k]; exists {
+				result[idx] = onCollide(result[idx], v)
+				continue
+			}
+		}
+		result = append(result, v)
+	}
+	return result
+}

--- a/internal/merge/merge_test.go
+++ b/internal/merge/merge_test.go
@@ -1,0 +1,84 @@
+package merge
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+// identity is a trivial onCollide that returns the custom value.
+func identity(_ int, c int) int { return c }
+
+// sum is an onCollide that adds base and custom together.
+func sum(b, c int) int { return b + c }
+
+func key(v int) string { return strconv.Itoa(v) }
+
+func TestByKey_EmptyCustomReturnsBase(t *testing.T) {
+	base := []int{1, 2, 3}
+	got := ByKey(base, nil, key, identity)
+	if diff := cmp.Diff(base, got); diff != "" {
+		t.Fatalf("mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestByKey_EmptyBaseAppendsCustom(t *testing.T) {
+	got := ByKey([]int{}, []int{4, 5}, key, identity)
+	want := []int{4, 5}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestByKey_NoCollisionAppendsCustom(t *testing.T) {
+	got := ByKey([]int{1, 2}, []int{3, 4}, key, identity)
+	want := []int{1, 2, 3, 4}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestByKey_CollisionCallsOnCollide(t *testing.T) {
+	// base={1,2}, custom={2,3}: key "2" collides, sum → 4; "3" is new → append
+	got := ByKey([]int{1, 2}, []int{2, 3}, key, sum)
+	want := []int{1, 4, 3}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestByKey_CollisionPreservesBaseOrder(t *testing.T) {
+	// Custom arrives in reverse base-order; verify both collisions are applied
+	// in-place at the base positions and the uncollided entry (20) is preserved.
+	got := ByKey([]int{1, 20, 300}, []int{300, 1}, key, sum)
+	want := []int{2, 20, 600} // sum(1,1)=2 at idx 0; 20 untouched; sum(300,300)=600 at idx 2
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestByKey_DuplicateCustomKeyFirstWins(t *testing.T) {
+	// Two custom entries with key "9": only the first one should take effect.
+	keyOf9 := func(v int) string {
+		if v == 9 || v == 99 {
+			return "9"
+		}
+		return strconv.Itoa(v)
+	}
+	got := ByKey([]int{1}, []int{9, 99}, keyOf9, identity)
+	want := []int{1, 9} // 99 is a duplicate of key "9" and must be skipped
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestByKey_EmptyKeyAlwaysAppended(t *testing.T) {
+	noKey := func(_ int) string { return "" }
+	got := ByKey([]int{1}, []int{2, 2}, noKey, identity)
+	// Both custom entries have empty key → always appended, including the duplicate
+	want := []int{1, 2, 2}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("mismatch (-want +got):\n%s", diff)
+	}
+}


### PR DESCRIPTION
`options.Merge` appended `DownstreamResources`, `Helm.ValuesFrom`, and `Diff.ComparePatches` without checking for duplicates. When both the base and a per-target customization reference the same entry, the merged slice contained it twice and the downstream operation was applied twice.

Extract a generic `merge.ByKey[T any]` helper to `internal/merge`. It iterates base and custom once each (O(n)), replaces a base entry in-place when a custom entry shares its key, and appends otherwise. Collision behaviour is caller-defined via an `onCollide` function, which allows the two different use cases to share the same infrastructure:

- `options.mergeUnique` wraps `merge.ByKey` with a replace-with-custom collision handler, consistent with how the rest of `options.Merge` treats per-target customizations.
- `bundlediff.mergeComparePatches` (which pre-existed with its own map-based dedup logic) is simplified to use `merge.ByKey` with a union-operations collision handler: existing operations are kept and new ones not already present are appended. The result is then sorted for deterministic output.

Refers #5195