### PR TITLE
Fix lookup detection for helper templates and define blocks

### DIFF
--- a/internal/helmdeployer/lookup.go
+++ b/internal/helmdeployer/lookup.go
@@ -31,8 +31,12 @@ func hasLookupFunction(ch *chartv2.Chart) bool {
 		}
 
 		// Walk all parse trees in this template and look for lookup invocations.
-		if t.Tree != nil && t.Root != nil {
-			if containsLookup(t.Root) {
+		for _, parsedTpl := range t.Templates() {
+			if parsedTpl == nil || parsedTpl.Tree == nil || parsedTpl.Root == nil {
+				continue
+			}
+
+			if containsLookup(parsedTpl.Root) {
 				return true
 			}
 		}

--- a/internal/helmdeployer/lookup_test.go
+++ b/internal/helmdeployer/lookup_test.go
@@ -112,6 +112,75 @@ func TestHasLookupFunction(t *testing.T) {
 			},
 			expectedResult: true,
 		},
+		{
+			name: "Lookup inside helper template definition",
+			templates: []*common.File{
+				{
+					Name: "templates/_helpers.tpl",
+					Data: []byte(`
+{{- define "mychart.lookupHelper" -}}
+{{ lookup "v1" "Service" "default" "kubernetes" }}
+{{- end -}}
+`),
+				},
+			},
+			expectedResult: true,
+		},
+		{
+			name: "Lookup inside helper referenced by include",
+			templates: []*common.File{
+				{
+					Name: "templates/_helpers.tpl",
+					Data: []byte(`
+{{- define "mychart.lookupHelper" -}}
+{{ lookup "v1" "Deployment" "default" "mydep" }}
+{{- end -}}
+`),
+				},
+				{
+					Name: "templates/configmap.yaml",
+					Data: []byte(`
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test
+data:
+  value: {{ include "mychart.lookupHelper" . }}
+`),
+				},
+			},
+			expectedResult: true,
+		},
+		{
+			name: "Lookup inside helper with chained expression",
+			templates: []*common.File{
+				{
+					Name: "templates/_helpers.tpl",
+					Data: []byte(`
+{{- define "mychart.lookupHelper" -}}
+{{- range $index, $pod := (lookup "v1" "Pod" "kube-system" "").items }}
+{{ $pod.metadata.name }}
+{{- end }}
+{{- end }}
+`),
+				},
+			},
+			expectedResult: true,
+		},
+		{
+			name: "Helper template without lookup",
+			templates: []*common.File{
+				{
+					Name: "templates/_helpers.tpl",
+					Data: []byte(`
+{{- define "mychart.noLookup" -}}
+hello world
+{{- end -}}
+`),
+				},
+			},
+			expectedResult: false,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
<!-- Specify the issue ID that this pull request is solving -->
Refers to https://github.com/rancher/fleet/issues/5198
Fix `hasLookupFunction()` failing to detect Helm lookup usage inside helper templates (define blocks), such as templates located in `_helpers.tpl`.
Previously Fleet only inspected` t.Tree.Root,` which represents the root parse tree for a template file. However, Go template define blocks are internally stored as separate named templates and exposed through` t.Templates()`.
As a result, lookup calls inside helper templates were ignored, causing Fleet to incorrectly conclude that a chart did not use lookup.

### Changes
Iterate over all parsed templates returned by `t.Templates()`. Detect lookup usage inside:
- helper templates
- define blocks
- _helpers.tpl

