### PR TITLE
[v0.15] Remove experimental guard from downstream resource copy

### DIFF
--- a/.github/scripts/deploy-fleet.sh
+++ b/.github/scripts/deploy-fleet.sh
@@ -71,8 +71,6 @@ eventually helm upgrade --install fleet charts/fleet \
   --set imagescan.enabled=true \
   --set-string extraEnv[0].name=EXPERIMENTAL_SCHEDULES \
   --set-string extraEnv[0].value=true \
-  --set-string extraEnv[1].name=EXPERIMENTAL_COPY_RESOURCES_DOWNSTREAM \
-  --set-string extraEnv[1].value=true \
   --set debug=true --set debugLevel=1
 
 # wait for controller and agent rollout

--- a/.github/workflows/e2e-test-fleet-in-rancher.yml
+++ b/.github/workflows/e2e-test-fleet-in-rancher.yml
@@ -224,7 +224,7 @@ jobs:
             --set "extraEnv[2].name=CATTLE_FLEET_VERSION" \
             --set "extraEnv[2].value=${fleet_version}" \
             --set "extraEnv[3].name=CATTLE_SERVER_URL" \
-            --set "extraEnv[3].value=https://$ip.sslip.io" \
+            --set "extraEnv[3].value=https://$ip.sslip.io"
 
           # wait for deployment of rancher
           kubectl -n cattle-system rollout status deploy/rancher

--- a/charts/fleet/ci/debug-values.yaml
+++ b/charts/fleet/ci/debug-values.yaml
@@ -66,7 +66,5 @@ shards:
       kubernetes.io/hostname: k3d-upstream-server-2
 
 extraEnv:
-  - name: EXPERIMENTAL_COPY_RESOURCES_DOWNSTREAM
-    value: "true"
   - name: EXPERIMENTAL_SCHEDULES
     value: "true"

--- a/charts/fleet/ci/nobootstrap-values.yaml
+++ b/charts/fleet/ci/nobootstrap-values.yaml
@@ -65,7 +65,5 @@ shards:
       kubernetes.io/hostname: k3d-upstream-server-2
 
 extraEnv:
-  - name: EXPERIMENTAL_COPY_RESOURCES_DOWNSTREAM
-    value: "true"
   - name: EXPERIMENTAL_SCHEDULES
     value: "true"

--- a/charts/fleet/ci/nodebug-values.yaml
+++ b/charts/fleet/ci/nodebug-values.yaml
@@ -65,7 +65,5 @@ shards:
       kubernetes.io/hostname: k3d-upstream-server-2
 
 extraEnv:
-  - name: EXPERIMENTAL_COPY_RESOURCES_DOWNSTREAM
-    value: "true"
   - name: EXPERIMENTAL_SCHEDULES
     value: "true"

--- a/charts/fleet/ci/nogitops-values.yaml
+++ b/charts/fleet/ci/nogitops-values.yaml
@@ -65,7 +65,5 @@ shards:
       kubernetes.io/hostname: k3d-upstream-server-2
 
 extraEnv:
-  - name: EXPERIMENTAL_COPY_RESOURCES_DOWNSTREAM
-    value: "true"
   - name: EXPERIMENTAL_SCHEDULES
     value: "true"

--- a/charts/fleet/values.yaml
+++ b/charts/fleet/values.yaml
@@ -186,8 +186,6 @@ agent:
 # extraEnv:
 # - name: OCI_STORAGE
 #   value: "false"
-# - name: EXPERIMENTAL_COPY_RESOURCES_DOWNSTREAM
-#   value: "false"
 
 # shards:
 #   - id: shard0

--- a/dev/setup-fleet
+++ b/dev/setup-fleet
@@ -49,8 +49,6 @@ helm -n cattle-fleet-system upgrade --install --create-namespace --wait --reset-
   --set imagescan.enabled=true \
   --set-string extraEnv[0].name=EXPERIMENTAL_SCHEDULES \
   --set-string extraEnv[0].value=true \
-  --set-string extraEnv[1].name=EXPERIMENTAL_COPY_RESOURCES_DOWNSTREAM \
-  --set-string extraEnv[1].value=true \
   --set debug=true --set debugLevel=1 fleet charts/fleet
 
 # wait for controller and agent rollout

--- a/internal/cmd/agent/controller/bundledeployment_controller.go
+++ b/internal/cmd/agent/controller/bundledeployment_controller.go
@@ -12,7 +12,6 @@ import (
 	"github.com/rancher/fleet/internal/cmd/agent/deployer/cleanup"
 	"github.com/rancher/fleet/internal/cmd/agent/deployer/driftdetect"
 	"github.com/rancher/fleet/internal/cmd/agent/deployer/monitor"
-	"github.com/rancher/fleet/internal/experimental"
 	"github.com/rancher/fleet/internal/helmvalues"
 	"github.com/rancher/fleet/internal/namespaces"
 	fleetv1 "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
@@ -347,10 +346,6 @@ func (r *BundleDeploymentReconciler) copyResourcesFromUpstream(
 	bd *fleetv1.BundleDeployment,
 	logger logr.Logger,
 ) (bool, error) {
-	if !experimental.CopyResourcesDownstreamEnabled() {
-		return false, nil
-	}
-
 	if len(bd.Spec.Options.DownstreamResources) == 0 {
 		return false, nil
 	}

--- a/internal/cmd/controller/agentmanagement/agent/manifest.go
+++ b/internal/cmd/controller/agentmanagement/agent/manifest.go
@@ -1,7 +1,6 @@
 package agent
 
 import (
-	"fmt"
 	"os"
 	"path"
 	"strconv"
@@ -11,7 +10,6 @@ import (
 
 	"github.com/rancher/fleet/internal/cmd"
 	"github.com/rancher/fleet/internal/config"
-	"github.com/rancher/fleet/internal/experimental"
 	"github.com/rancher/fleet/internal/names"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -198,7 +196,6 @@ func agentApp(namespace string, agentScope string, opts ManifestOptions) *appsv1
 								{Name: "CATTLE_ELECTION_LEASE_DURATION", Value: opts.LeaseDuration.String()},
 								{Name: "CATTLE_ELECTION_RETRY_PERIOD", Value: opts.RetryPeriod.String()},
 								{Name: "CATTLE_ELECTION_RENEW_DEADLINE", Value: opts.RenewDeadline.String()},
-								{Name: "EXPERIMENTAL_COPY_RESOURCES_DOWNSTREAM", Value: fmt.Sprintf("%t", experimental.CopyResourcesDownstreamEnabled())},
 							},
 							Command: []string{
 								"fleetagent",

--- a/internal/cmd/controller/agentmanagement/controllers/resources/data.go
+++ b/internal/cmd/controller/agentmanagement/controllers/resources/data.go
@@ -1,7 +1,6 @@
 package resources
 
 import (
-	"github.com/rancher/fleet/internal/experimental"
 	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
 
 	"github.com/rancher/wrangler/v3/pkg/apply"
@@ -32,16 +31,8 @@ func ApplyBootstrapResources(systemNamespace, systemRegistrationNamespace string
 		{
 			Verbs:     []string{"get"},
 			APIGroups: []string{""},
-			Resources: []string{"secrets"},
+			Resources: []string{"secrets", "configmaps"},
 		},
-	}
-
-	if experimental.CopyResourcesDownstreamEnabled() {
-		rules = append(rules, rbacv1.PolicyRule{
-			Verbs:     []string{"get"},
-			APIGroups: []string{""},
-			Resources: []string{"configmaps"},
-		})
 	}
 
 	return apply.ApplyObjects(

--- a/internal/cmd/controller/reconciler/bundle_controller.go
+++ b/internal/cmd/controller/reconciler/bundle_controller.go
@@ -20,7 +20,6 @@ import (
 	"github.com/rancher/fleet/internal/cmd/controller/summary"
 	"github.com/rancher/fleet/internal/cmd/controller/target"
 	"github.com/rancher/fleet/internal/config"
-	"github.com/rancher/fleet/internal/experimental"
 	"github.com/rancher/fleet/internal/helmvalues"
 	"github.com/rancher/fleet/internal/manifest"
 	"github.com/rancher/fleet/internal/metrics"
@@ -815,10 +814,6 @@ func (r *BundleReconciler) updateErrorStatus(
 }
 
 func (r *BundleReconciler) handleDownstreamObjects(ctx context.Context, bundle *fleet.Bundle, bd *fleet.BundleDeployment) error {
-	if !experimental.CopyResourcesDownstreamEnabled() {
-		return nil
-	}
-
 	// Track if any resources were created or updated
 	resourcesUpdated := false
 

--- a/internal/cmd/controller/reconciler/bundle_controller_test.go
+++ b/internal/cmd/controller/reconciler/bundle_controller_test.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"os"
 	"strings"
 	"testing"
 
@@ -61,7 +60,7 @@ func TestReconcile_FinalizerUpdateError(t *testing.T) {
 	mockClient := mocks.NewMockK8sClient(mockCtrl)
 
 	mockClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.AssignableToTypeOf(&fleetv1.Bundle{}), gomock.Any()).DoAndReturn(
-		func(ctx context.Context, req types.NamespacedName, b *fleetv1.Bundle, opts ...interface{}) error {
+		func(ctx context.Context, req types.NamespacedName, b *fleetv1.Bundle, opts ...any) error {
 			b.Name = bundle.Name
 			b.Namespace = bundle.Namespace
 			// no finalizer
@@ -477,7 +476,7 @@ func TestReconcile_OptionsSecretCreateUpdateError(t *testing.T) {
 							Options: fleetv1.BundleDeploymentOptions{
 								Helm: &fleetv1.HelmOptions{
 									Values: &fleetv1.GenericMap{
-										Data: map[string]interface{}{"foo": "bar"}, // non-empty, to generate a non-empty hash and force secret creation/update
+										Data: map[string]any{"foo": "bar"}, // non-empty, to generate a non-empty hash and force secret creation/update
 									},
 								},
 							},
@@ -587,13 +586,13 @@ func TestReconcile_OptionsSecretDeletionError(t *testing.T) {
 func TestReconcile_OCIReferenceSecretResolutionError(t *testing.T) {
 	cases := []struct {
 		name               string
-		secretGet          func(ctx context.Context, req types.NamespacedName, s *corev1.Secret, opts ...interface{}) error
+		secretGet          func(ctx context.Context, req types.NamespacedName, s *corev1.Secret, opts ...any) error
 		expectStatusUpdate bool
 		expectedErrMsg     string
 	}{
 		{
 			name: "non-retryable error",
-			secretGet: func(ctx context.Context, req types.NamespacedName, s *corev1.Secret, opts ...interface{}) error {
+			secretGet: func(ctx context.Context, req types.NamespacedName, s *corev1.Secret, opts ...any) error {
 				// Necessary reference field is missing → non-retryable
 				return nil
 			},
@@ -602,7 +601,7 @@ func TestReconcile_OCIReferenceSecretResolutionError(t *testing.T) {
 		},
 		{
 			name: "retryable error",
-			secretGet: func(ctx context.Context, req types.NamespacedName, s *corev1.Secret, opts ...interface{}) error {
+			secretGet: func(ctx context.Context, req types.NamespacedName, s *corev1.Secret, opts ...any) error {
 				return errors.New("something went wrong")
 			},
 			// no expected reconcile error (requeue set instead)
@@ -689,14 +688,6 @@ func TestReconcile_OCIReferenceSecretResolutionError(t *testing.T) {
 }
 
 func TestReconcile_DownstreamObjectsHandlingError(t *testing.T) {
-	envVar := "EXPERIMENTAL_COPY_RESOURCES_DOWNSTREAM"
-	bkp := os.Getenv(envVar)
-	defer func() {
-		os.Setenv(envVar, bkp)
-	}()
-
-	os.Setenv(envVar, "true")
-
 	cases := []struct {
 		name                        string
 		downstreamResources         []fleetv1.DownstreamResource
@@ -825,6 +816,9 @@ func TestReconcile_DownstreamObjectsHandlingError(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{
 							Namespace: "my-bd", // non-empty
 						},
+					},
+					Options: fleetv1.BundleDeploymentOptions{
+						DownstreamResources: c.downstreamResources,
 					},
 					DeploymentID: "foo",
 				},
@@ -1029,7 +1023,7 @@ func TestReconcile_AccessSecretsHandlingError(t *testing.T) {
 	// OCI contents secret
 	mockClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.AssignableToTypeOf(&corev1.Secret{}), gomock.Any()).
 		DoAndReturn(
-			func(ctx context.Context, req types.NamespacedName, s *corev1.Secret, opts ...interface{}) error {
+			func(ctx context.Context, req types.NamespacedName, s *corev1.Secret, opts ...any) error {
 				s.Data = map[string][]byte{
 					"reference": []byte("foo"), // key exists
 				}
@@ -1088,7 +1082,7 @@ func TestReconcile_AccessSecretsHandlingError(t *testing.T) {
 func expectStatusPatch(t *testing.T, sClient *mocks.MockStatusWriter, errMsg string) {
 	t.Helper()
 	sClient.EXPECT().Patch(gomock.Any(), gomock.AssignableToTypeOf(&fleetv1.Bundle{}), gomock.Any()).Do(
-		func(ctx context.Context, b *fleetv1.Bundle, p client.Patch, opts ...interface{}) {
+		func(ctx context.Context, b *fleetv1.Bundle, p client.Patch, opts ...any) {
 			cond, found := getBundleReadyCondition(b)
 			if !found {
 				t.Errorf("expecting Condition %s to be found", fleetv1.BundleConditionReady)
@@ -1232,7 +1226,7 @@ func TestBundleDeploymentMapFunc(t *testing.T) {
 
 func expectGetWithFinalizer(mockCli *mocks.MockK8sClient, bundle fleetv1.Bundle) {
 	mockCli.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.AssignableToTypeOf(&fleetv1.Bundle{}), gomock.Any()).DoAndReturn(
-		func(ctx context.Context, req types.NamespacedName, b *fleetv1.Bundle, opts ...interface{}) error {
+		func(ctx context.Context, req types.NamespacedName, b *fleetv1.Bundle, opts ...any) error {
 			b.Name = bundle.Name
 			b.Namespace = bundle.Namespace
 			controllerutil.AddFinalizer(b, finalize.BundleFinalizer)
@@ -1243,18 +1237,10 @@ func expectGetWithFinalizer(mockCli *mocks.MockK8sClient, bundle fleetv1.Bundle)
 		},
 	)
 	// AuthorizeBundle lists Policies in the namespace; return empty list so no policy is enforced.
-	mockCli.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&fleetv1.PolicyList{}), gomock.Any()).Return(nil)
+	mockCli.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&fleetv1.PolicyList{}), gomock.Any()).Return(nil).AnyTimes()
 }
 
 func TestReconcile_DownstreamResourcesGeneration_Increment(t *testing.T) {
-	envVar := "EXPERIMENTAL_COPY_RESOURCES_DOWNSTREAM"
-	bkp := os.Getenv(envVar)
-	defer func() {
-		os.Setenv(envVar, bkp)
-	}()
-
-	os.Setenv(envVar, "true")
-
 	testCases := []struct {
 		name                     string
 		downstreamResources      []fleetv1.DownstreamResource
@@ -1282,7 +1268,7 @@ func TestReconcile_DownstreamResourcesGeneration_Increment(t *testing.T) {
 			setupResourceMocks: func(ctrl *gomock.Controller, mc *mocks.MockK8sClient) {
 				// Source secret get
 				mc.EXPECT().Get(gomock.Any(), types.NamespacedName{Namespace: "default", Name: "my-secret"}, gomock.AssignableToTypeOf(&corev1.Secret{}), gomock.Any()).
-					DoAndReturn(func(ctx context.Context, key types.NamespacedName, s *corev1.Secret, opts ...interface{}) error {
+					DoAndReturn(func(ctx context.Context, key types.NamespacedName, s *corev1.Secret, opts ...any) error {
 						s.Name = "my-secret"
 						s.Namespace = "default"
 						s.Data = map[string][]byte{"key": []byte("value")}
@@ -1297,7 +1283,7 @@ func TestReconcile_DownstreamResourcesGeneration_Increment(t *testing.T) {
 
 				// Patch to increment generation
 				mc.EXPECT().Patch(gomock.Any(), gomock.AssignableToTypeOf(&fleetv1.BundleDeployment{}), gomock.Any()).
-					DoAndReturn(func(ctx context.Context, bd *fleetv1.BundleDeployment, patch client.Patch, opts ...interface{}) error {
+					DoAndReturn(func(ctx context.Context, bd *fleetv1.BundleDeployment, patch client.Patch, opts ...any) error {
 						if bd.Spec.DownstreamResourcesGeneration != 1 {
 							t.Errorf("Expected generation 1, got %d", bd.Spec.DownstreamResourcesGeneration)
 						}
@@ -1325,7 +1311,7 @@ func TestReconcile_DownstreamResourcesGeneration_Increment(t *testing.T) {
 			setupResourceMocks: func(ctrl *gomock.Controller, mc *mocks.MockK8sClient) {
 				// Source configmap get
 				mc.EXPECT().Get(gomock.Any(), types.NamespacedName{Namespace: "default", Name: "my-config"}, gomock.AssignableToTypeOf(&corev1.ConfigMap{}), gomock.Any()).
-					DoAndReturn(func(ctx context.Context, key types.NamespacedName, cm *corev1.ConfigMap, opts ...interface{}) error {
+					DoAndReturn(func(ctx context.Context, key types.NamespacedName, cm *corev1.ConfigMap, opts ...any) error {
 						cm.Name = "my-config"
 						cm.Namespace = "default"
 						cm.Data = map[string]string{"key": "new-value"}
@@ -1334,7 +1320,7 @@ func TestReconcile_DownstreamResourcesGeneration_Increment(t *testing.T) {
 
 				// Target configmap get (exists) + update
 				mc.EXPECT().Get(gomock.Any(), types.NamespacedName{Namespace: "cluster-ns", Name: "my-config"}, gomock.AssignableToTypeOf(&corev1.ConfigMap{}), gomock.Any()).
-					DoAndReturn(func(ctx context.Context, key types.NamespacedName, cm *corev1.ConfigMap, opts ...interface{}) error {
+					DoAndReturn(func(ctx context.Context, key types.NamespacedName, cm *corev1.ConfigMap, opts ...any) error {
 						cm.Name = "my-config"
 						cm.Namespace = "cluster-ns"
 						cm.Data = map[string]string{"key": "old-value"}
@@ -1345,7 +1331,7 @@ func TestReconcile_DownstreamResourcesGeneration_Increment(t *testing.T) {
 
 				// Patch to increment generation
 				mc.EXPECT().Patch(gomock.Any(), gomock.AssignableToTypeOf(&fleetv1.BundleDeployment{}), gomock.Any()).
-					DoAndReturn(func(ctx context.Context, bd *fleetv1.BundleDeployment, patch client.Patch, opts ...interface{}) error {
+					DoAndReturn(func(ctx context.Context, bd *fleetv1.BundleDeployment, patch client.Patch, opts ...any) error {
 						if bd.Spec.DownstreamResourcesGeneration != 6 {
 							t.Errorf("Expected generation 6, got %d", bd.Spec.DownstreamResourcesGeneration)
 						}
@@ -1374,7 +1360,7 @@ func TestReconcile_DownstreamResourcesGeneration_Increment(t *testing.T) {
 			setupResourceMocks: func(ctrl *gomock.Controller, mc *mocks.MockK8sClient) {
 				// Source secret get
 				mc.EXPECT().Get(gomock.Any(), types.NamespacedName{Namespace: "default", Name: "my-secret"}, gomock.AssignableToTypeOf(&corev1.Secret{}), gomock.Any()).
-					DoAndReturn(func(ctx context.Context, key types.NamespacedName, s *corev1.Secret, opts ...interface{}) error {
+					DoAndReturn(func(ctx context.Context, key types.NamespacedName, s *corev1.Secret, opts ...any) error {
 						s.Name = "my-secret"
 						s.Namespace = "default"
 						s.Data = map[string][]byte{"key": []byte("value")}
@@ -1389,7 +1375,7 @@ func TestReconcile_DownstreamResourcesGeneration_Increment(t *testing.T) {
 
 				// Source configmap get
 				mc.EXPECT().Get(gomock.Any(), types.NamespacedName{Namespace: "default", Name: "my-config"}, gomock.AssignableToTypeOf(&corev1.ConfigMap{}), gomock.Any()).
-					DoAndReturn(func(ctx context.Context, key types.NamespacedName, cm *corev1.ConfigMap, opts ...interface{}) error {
+					DoAndReturn(func(ctx context.Context, key types.NamespacedName, cm *corev1.ConfigMap, opts ...any) error {
 						cm.Name = "my-config"
 						cm.Namespace = "default"
 						cm.Data = map[string]string{"key": "value"}
@@ -1398,7 +1384,7 @@ func TestReconcile_DownstreamResourcesGeneration_Increment(t *testing.T) {
 
 				// Target configmap get (exists) + update
 				mc.EXPECT().Get(gomock.Any(), types.NamespacedName{Namespace: "cluster-ns", Name: "my-config"}, gomock.AssignableToTypeOf(&corev1.ConfigMap{}), gomock.Any()).
-					DoAndReturn(func(ctx context.Context, key types.NamespacedName, cm *corev1.ConfigMap, opts ...interface{}) error {
+					DoAndReturn(func(ctx context.Context, key types.NamespacedName, cm *corev1.ConfigMap, opts ...any) error {
 						cm.Name = "my-config"
 						cm.Namespace = "cluster-ns"
 						cm.Data = map[string]string{"key": "old-value"}
@@ -1409,7 +1395,7 @@ func TestReconcile_DownstreamResourcesGeneration_Increment(t *testing.T) {
 
 				// Patch to increment generation (only once for both resources)
 				mc.EXPECT().Patch(gomock.Any(), gomock.AssignableToTypeOf(&fleetv1.BundleDeployment{}), gomock.Any()).
-					DoAndReturn(func(ctx context.Context, bd *fleetv1.BundleDeployment, patch client.Patch, opts ...interface{}) error {
+					DoAndReturn(func(ctx context.Context, bd *fleetv1.BundleDeployment, patch client.Patch, opts ...any) error {
 						if bd.Spec.DownstreamResourcesGeneration != 11 {
 							t.Errorf("Expected generation 11, got %d", bd.Spec.DownstreamResourcesGeneration)
 						}
@@ -1437,7 +1423,7 @@ func TestReconcile_DownstreamResourcesGeneration_Increment(t *testing.T) {
 			setupResourceMocks: func(ctrl *gomock.Controller, mc *mocks.MockK8sClient) {
 				// Source secret get
 				mc.EXPECT().Get(gomock.Any(), types.NamespacedName{Namespace: "default", Name: "my-secret"}, gomock.AssignableToTypeOf(&corev1.Secret{}), gomock.Any()).
-					DoAndReturn(func(ctx context.Context, key types.NamespacedName, s *corev1.Secret, opts ...interface{}) error {
+					DoAndReturn(func(ctx context.Context, key types.NamespacedName, s *corev1.Secret, opts ...any) error {
 						s.Name = "my-secret"
 						s.Namespace = "default"
 						s.Data = map[string][]byte{"key": []byte("value")}
@@ -1446,7 +1432,7 @@ func TestReconcile_DownstreamResourcesGeneration_Increment(t *testing.T) {
 
 				// Target secret get (exists with same data) - no update needed
 				mc.EXPECT().Get(gomock.Any(), types.NamespacedName{Namespace: "cluster-ns", Name: "my-secret"}, gomock.AssignableToTypeOf(&corev1.Secret{}), gomock.Any()).
-					DoAndReturn(func(ctx context.Context, key types.NamespacedName, s *corev1.Secret, opts ...interface{}) error {
+					DoAndReturn(func(ctx context.Context, key types.NamespacedName, s *corev1.Secret, opts ...any) error {
 						s.Name = "my-secret"
 						s.Namespace = "cluster-ns"
 						s.Data = map[string][]byte{"key": []byte("value")}
@@ -1489,7 +1475,10 @@ func TestReconcile_DownstreamResourcesGeneration_Increment(t *testing.T) {
 			mockClient.EXPECT().Delete(gomock.Any(), gomock.AssignableToTypeOf(&corev1.Secret{}), gomock.Any()).
 				Return(&k8serrors.StatusError{ErrStatus: metav1.Status{Code: http.StatusNotFound}})
 
-			// Target builder returns our test bundle deployment
+			// Target builder returns our test bundle deployment. Set Options as the
+			// real target builder would after options.Merge: DownstreamResources end
+			// up in bd.Spec.Options. The builder is mocked here, so we set it directly.
+			tc.existingBundleDeployment.Spec.Options.DownstreamResources = tc.downstreamResources
 			matchedTargets := []*target.Target{
 				{
 					Bundle: &bundle,
@@ -1515,14 +1504,14 @@ func TestReconcile_DownstreamResourcesGeneration_Increment(t *testing.T) {
 
 			// List BundleDeployments for cleanup
 			mockClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&fleetv1.BundleDeploymentList{}), gomock.Any()).
-				DoAndReturn(func(ctx context.Context, list *fleetv1.BundleDeploymentList, opts ...interface{}) error {
+				DoAndReturn(func(ctx context.Context, list *fleetv1.BundleDeploymentList, opts ...any) error {
 					list.Items = []fleetv1.BundleDeployment{*tc.existingBundleDeployment}
 					return nil
 				})
 
 			// BundleDeployment get (for CreateOrUpdate)
 			mockClient.EXPECT().Get(gomock.Any(), types.NamespacedName{Namespace: "cluster-ns", Name: "test-bd"}, gomock.AssignableToTypeOf(&fleetv1.BundleDeployment{}), gomock.Any()).
-				DoAndReturn(func(ctx context.Context, key types.NamespacedName, bd *fleetv1.BundleDeployment, opts ...interface{}) error {
+				DoAndReturn(func(ctx context.Context, key types.NamespacedName, bd *fleetv1.BundleDeployment, opts ...any) error {
 					*bd = *tc.existingBundleDeployment
 					return nil
 				})
@@ -1560,135 +1549,6 @@ func TestReconcile_DownstreamResourcesGeneration_Increment(t *testing.T) {
 	}
 }
 
-func TestReconcile_DownstreamResources_FeatureDisabled(t *testing.T) {
-	envVar := "EXPERIMENTAL_COPY_RESOURCES_DOWNSTREAM"
-	bkp := os.Getenv(envVar)
-	defer func() {
-		os.Setenv(envVar, bkp)
-	}()
-
-	// Explicitly disable the feature
-	os.Setenv(envVar, "false")
-
-	mockCtrl := gomock.NewController(t)
-	defer mockCtrl.Finish()
-
-	scheme := runtime.NewScheme()
-	utilruntime.Must(corev1.AddToScheme(scheme))
-	utilruntime.Must(fleetv1.AddToScheme(scheme))
-
-	bundle := fleetv1.Bundle{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-bundle",
-			Namespace: "default",
-		},
-		Spec: fleetv1.BundleSpec{
-			BundleDeploymentOptions: fleetv1.BundleDeploymentOptions{
-				DownstreamResources: []fleetv1.DownstreamResource{
-					{Kind: "Secret", Name: "my-secret"},
-					{Kind: "ConfigMap", Name: "my-config"},
-				},
-			},
-		},
-	}
-
-	existingBundleDeployment := &fleetv1.BundleDeployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-bd",
-			Namespace: "cluster-ns",
-			UID:       "test-uid",
-		},
-		Spec: fleetv1.BundleDeploymentSpec{
-			DeploymentID:                  "test-deployment",
-			DownstreamResourcesGeneration: 5, // Has a non-zero value
-		},
-	}
-
-	namespacedName := types.NamespacedName{Name: bundle.Name, Namespace: bundle.Namespace}
-
-	mockClient := mocks.NewMockK8sClient(mockCtrl)
-	expectGetWithFinalizer(mockClient, bundle)
-
-	// Options secret deletion
-	mockClient.EXPECT().Delete(gomock.Any(), gomock.AssignableToTypeOf(&corev1.Secret{}), gomock.Any()).
-		Return(&k8serrors.StatusError{ErrStatus: metav1.Status{Code: http.StatusNotFound}})
-
-	matchedTargets := []*target.Target{
-		{
-			Bundle: &bundle,
-			Cluster: &fleetv1.Cluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "fleet-default",
-					Name:      "test-cluster",
-				},
-				Status: fleetv1.ClusterStatus{
-					Namespace: "cluster-ns",
-				},
-			},
-			Deployment:   existingBundleDeployment,
-			DeploymentID: "test-deployment",
-		},
-	}
-
-	targetBuilderMock := mocks.NewMockTargetBuilder(mockCtrl)
-	targetBuilderMock.EXPECT().Targets(gomock.Any(), gomock.Any(), gomock.Any()).Return(matchedTargets, false, nil)
-
-	storeMock := mocks.NewMockStore(mockCtrl)
-	storeMock.EXPECT().Store(gomock.Any(), gomock.Any()).Return(nil)
-
-	// List BundleDeployments for cleanup
-	mockClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&fleetv1.BundleDeploymentList{}), gomock.Any()).
-		DoAndReturn(func(ctx context.Context, list *fleetv1.BundleDeploymentList, opts ...interface{}) error {
-			list.Items = []fleetv1.BundleDeployment{*existingBundleDeployment}
-			return nil
-		})
-
-	// BundleDeployment get (for CreateOrUpdate)
-	mockClient.EXPECT().Get(gomock.Any(), types.NamespacedName{Namespace: "cluster-ns", Name: "test-bd"}, gomock.AssignableToTypeOf(&fleetv1.BundleDeployment{}), gomock.Any()).
-		DoAndReturn(func(ctx context.Context, key types.NamespacedName, bd *fleetv1.BundleDeployment, opts ...interface{}) error {
-			*bd = *existingBundleDeployment
-			return nil
-		})
-
-	// BundleDeployment update - when feature is disabled, generation stays unchanged
-	// because handleDownstreamObjects modifies BD in memory but doesn't persist it
-	mockClient.EXPECT().Update(gomock.Any(), gomock.AssignableToTypeOf(&fleetv1.BundleDeployment{}), gomock.Any()).
-		DoAndReturn(func(ctx context.Context, obj client.Object, opts ...interface{}) error {
-			bd := obj.(*fleetv1.BundleDeployment)
-			// Feature is disabled, so resources are not cloned and generation stays as-is (5)
-			// The handleDownstreamObjects sets it to 0 in memory but doesn't persist that change
-			if bd.Spec.DownstreamResourcesGeneration != 5 {
-				t.Errorf("Expected generation to remain unchanged at 5 when feature is disabled, got %d", bd.Spec.DownstreamResourcesGeneration)
-			}
-			return nil
-		})
-
-	// No resource cloning calls expected since feature is disabled
-
-	// Status update
-	statusClient := mocks.NewMockStatusWriter(mockCtrl)
-	mockClient.EXPECT().Status().Return(statusClient).Times(1)
-	statusClient.EXPECT().Patch(gomock.Any(), gomock.AssignableToTypeOf(&fleetv1.Bundle{}), gomock.Any()).
-		Return(nil)
-
-	recorderMock := mocks.NewMockEventRecorder(mockCtrl)
-
-	r := reconciler.BundleReconciler{
-		Client:   mockClient,
-		Scheme:   scheme,
-		Recorder: recorderMock,
-		Builder:  targetBuilderMock,
-		Store:    storeMock,
-	}
-
-	ctx := context.TODO()
-	_, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: namespacedName})
-
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-}
-
 // secretNotFoundReader wraps a client.Reader and returns NotFound for a
 // specific secret name/namespace, simulating transient etcd/API-server
 // pressure where the options secret cannot be read inside Targets().
@@ -1709,7 +1569,7 @@ func (r *secretNotFoundReader) Get(ctx context.Context, key client.ObjectKey, ob
 // reconciler skeleton used by both race-condition tests. The caller provides
 // the client.Reader that the real Targets() manager will use; this is the
 // single injection point that distinguishes the bug scenario from the control.
-func setupBundleRaceTest(t *testing.T, reader client.Reader, helmValues map[string]interface{}) (
+func setupBundleRaceTest(t *testing.T, reader client.Reader, helmValues map[string]any) (
 	fakeClient client.Client,
 	r *reconciler.BundleReconciler,
 	req ctrl.Request,
@@ -1815,7 +1675,7 @@ func TestReconcile_OptionsSecretNotFound_ValuesPreserved(t *testing.T) {
 		namespace: clusterNS,
 	}
 
-	helmValues := map[string]interface{}{
+	helmValues := map[string]any{
 		"replicas": float64(3),
 		"image":    "nginx:latest",
 	}
@@ -1888,7 +1748,7 @@ func TestReconcile_OptionsSecretNotFound_ValuesPreserved(t *testing.T) {
 	}
 	// Also verify that the values match the original Helm values we set up in the test,
 	// to confirm the secret is intact.
-	var valuesFromSecret map[string]interface{}
+	var valuesFromSecret map[string]any
 	if err := json.Unmarshal(valuesData, &valuesFromSecret); err != nil {
 		t.Fatalf("Failed to unmarshal values from secret: %v", err)
 	}
@@ -1935,7 +1795,7 @@ func TestReconcile_WithOptionsSecret_ValuesPreserved(t *testing.T) {
 		clusterNS  = "cluster-one-ns"
 	)
 
-	helmValues := map[string]interface{}{
+	helmValues := map[string]any{
 		"replicas": float64(3),
 		"image":    "nginx:latest",
 	}
@@ -1981,7 +1841,7 @@ func TestReconcile_WithOptionsSecret_ValuesPreserved(t *testing.T) {
 
 	// Also verify that the values match the original Helm values we set up in the test,
 	// to confirm the secret is intact.
-	var valuesFromSecret map[string]interface{}
+	var valuesFromSecret map[string]any
 	if err := json.Unmarshal(valuesData, &valuesFromSecret); err != nil {
 		t.Fatalf("Failed to unmarshal values from secret: %v", err)
 	}

--- a/internal/experimental/experimental.go
+++ b/internal/experimental/experimental.go
@@ -6,16 +6,8 @@ import (
 )
 
 const (
-	CopyResourcesDownstreamFlag = "EXPERIMENTAL_COPY_RESOURCES_DOWNSTREAM"
-	SchedulesFlag               = "EXPERIMENTAL_SCHEDULES"
+	SchedulesFlag = "EXPERIMENTAL_SCHEDULES"
 )
-
-// CopyResourcesDownstreamEnabled returns true if the EXPERIMENTAL_COPY_RESOURCES_DOWNSTREAM env variable
-// is set to true; returns false otherwise.
-func CopyResourcesDownstreamEnabled() bool {
-	value, err := strconv.ParseBool(os.Getenv(CopyResourcesDownstreamFlag))
-	return err == nil && value
-}
 
 // SchedulesEnabled returns true if the EXPERIMENTAL_SCHEDULES env variable is set to true
 // returns false otherwise

--- a/internal/helmdeployer/delete.go
+++ b/internal/helmdeployer/delete.go
@@ -13,7 +13,6 @@ import (
 	"helm.sh/helm/v4/pkg/storage/driver"
 
 	"github.com/rancher/fleet/internal/cmd/agent/deployer/kv"
-	"github.com/rancher/fleet/internal/experimental"
 	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
 
 	corev1 "k8s.io/api/core/v1"
@@ -180,10 +179,6 @@ func deleteHistory(cfg *action.Configuration, logger logr.Logger, bundleID strin
 // deleteResourcesCopiedFromUpstream deletes resources referenced through a bundle's `DownstreamResources`
 // field, and copied from downstream.
 func deleteResourcesCopiedFromUpstream(ctx context.Context, c client.Client, bdName string) error {
-	if !experimental.CopyResourcesDownstreamEnabled() {
-		return nil
-	}
-
 	var merr []error
 
 	// No information is available about a deleted bundle deployment beside its name and namespace;

--- a/internal/helmdeployer/install.go
+++ b/internal/helmdeployer/install.go
@@ -17,7 +17,6 @@ import (
 	releasev1 "helm.sh/helm/v4/pkg/release/v1"
 	"helm.sh/helm/v4/pkg/storage/driver"
 
-	"github.com/rancher/fleet/internal/experimental"
 	"github.com/rancher/fleet/internal/helmdeployer/render"
 	"github.com/rancher/fleet/internal/manifest"
 	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
@@ -661,9 +660,6 @@ func getDryRunConfig(chart *chartv2.Chart, dryRun bool) dryRunConfig {
 // If not found, returns false.
 func isInDownstreamResources(resourceName, kind string, options fleet.BundleDeploymentOptions) bool {
 	kind = strings.ToLower(kind)
-	if !experimental.CopyResourcesDownstreamEnabled() {
-		return false
-	}
 
 	for _, dr := range options.DownstreamResources {
 		if dr.Name == resourceName && strings.ToLower(dr.Kind) == kind {

--- a/internal/helmdeployer/install_test.go
+++ b/internal/helmdeployer/install_test.go
@@ -13,11 +13,7 @@ import (
 	"helm.sh/helm/v4/pkg/action"
 	"helm.sh/helm/v4/pkg/kube"
 
-	"os"
-
-	"github.com/rancher/fleet/internal/experimental"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubernetesfake "k8s.io/client-go/kubernetes/fake"
 )
@@ -33,8 +29,8 @@ func TestValuesFrom(t *testing.T) {
 
 	configMapPayload := fmt.Sprintf("replication: \"true\"%sreplicas: \"2\"%sserviceType: NodePort", newline, newline)
 	secretPayload := fmt.Sprintf("replication: \"false\"%sreplicas: \"3\"%sserviceType: NodePort%sfoo: bar", newline, newline, newline)
-	totalValues := map[string]interface{}{"beforeMerge": "value"}
-	expected := map[string]interface{}{
+	totalValues := map[string]any{"beforeMerge": "value"}
+	expected := map[string]any{
 		"beforeMerge": "value",
 		"replicas":    "2",
 		"replication": "true",
@@ -469,9 +465,6 @@ func TestIsInDownstreamResources(t *testing.T) {
 	}
 
 	// function returns only a boolean indicating membership for a kind
-	// enable experimental feature for this test
-	os.Setenv(experimental.CopyResourcesDownstreamFlag, "true")
-	defer os.Unsetenv(experimental.CopyResourcesDownstreamFlag)
 
 	found := isInDownstreamResources("my-config", "ConfigMap", opts)
 	a.True(found, "expected to find my-config in DownstreamResources")
@@ -586,10 +579,6 @@ func TestValuesFromUsesDefaultNamespaceWhenResourceCopiedDownstream(t *testing.T
 		DownstreamResources: []fleet.DownstreamResource{{Kind: "ConfigMap", Name: "cm-down"}, {Kind: "Secret", Name: "sec-down"}},
 	}
 
-	// enable experimental copy behavior for this test
-	os.Setenv(experimental.CopyResourcesDownstreamFlag, "true")
-	defer os.Unsetenv(experimental.CopyResourcesDownstreamFlag)
-
 	vals, err := h.getValues(context.TODO(), opts, defaultNS, kubeClient)
 	r.NoError(err)
 
@@ -623,39 +612,9 @@ func TestValuesFromUsesProvidedNamespaceWhenNotCopiedDownstream(t *testing.T) {
 		DownstreamResources: []fleet.DownstreamResource{{Kind: "ConfigMap", Name: "some-other"}},
 	}
 
-	// enable experimental copy behavior for this test
-	os.Setenv(experimental.CopyResourcesDownstreamFlag, "true")
-	defer os.Unsetenv(experimental.CopyResourcesDownstreamFlag)
-
 	vals, err := h.getValues(context.TODO(), opts, defaultNS, kubeClient)
 	r.NoError(err)
 	a.Equal("cmProvided", vals["cmVal"])
-}
-
-func TestValuesFromErrorWhenCopiedDownstreamButExperimentalDisabled(t *testing.T) {
-	a := assert.New(t)
-	r := require.New(t)
-
-	kubeClient := kubernetesfake.NewSimpleClientset()
-	h := &Helm{template: false}
-
-	opts := fleet.BundleDeploymentOptions{
-		Helm: &fleet.HelmOptions{
-			ValuesFrom: []fleet.ValuesFrom{
-				{ConfigMapKeyRef: &fleet.ConfigMapKeySelector{LocalObjectReference: fleet.LocalObjectReference{Name: "cm-down"}, Namespace: "provided-ns"}},
-				{SecretKeyRef: &fleet.SecretKeySelector{LocalObjectReference: fleet.LocalObjectReference{Name: "sec-down"}, Namespace: "provided-ns"}},
-			},
-		},
-		DownstreamResources: []fleet.DownstreamResource{{Kind: "ConfigMap", Name: "cm-down"}, {Kind: "Secret", Name: "sec-down"}},
-	}
-
-	// ensure experimental feature is disabled
-	os.Unsetenv(experimental.CopyResourcesDownstreamFlag)
-
-	_, err := h.getValues(context.TODO(), opts, "default-ns", kubeClient)
-	r.Error(err)
-	// get will fail trying to read from provided-ns and should report not found
-	a.True(apierrors.IsNotFound(err), "expected a NotFound error when valuesFrom references resources and experimental feature is disabled")
 }
 
 func TestInstallActionCorrectDriftForce(t *testing.T) {


### PR DESCRIPTION
Promotes the downstream resource copy feature from experimental to stable by removing `EXPERIMENTAL_COPY_RESOURCES_DOWNSTREAM` and unconditionally enabling all related code paths. The env var is removed from agent pod manifests, RBAC bootstrap, CI scripts, chart values, and dev setup scripts. Tests no longer need to set the flag.

Backports #5207

Refers #5036