### PR TITLE
Improve go-getter replacement

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -13,6 +13,7 @@ extend-exclude = [
 "ANDed" = "ANDed"
 "HoTWPQxTJ5dIY31" = "HoTWPQxTJ5dIY31"
 "wre" = "wre"                         # warning regular expression, not 'were'
+"ue" = "ue"                           # allow short var name for *url.Error
 
 [default]
 extend-ignore-re = [

--- a/internal/bundlereader/gitclone.go
+++ b/internal/bundlereader/gitclone.go
@@ -35,7 +35,7 @@ import (
 func gitDownload(ctx context.Context, dst, rawURL string, auth Auth) error {
 	u, err := url.Parse(rawURL)
 	if err != nil {
-		return fmt.Errorf("parsing git URL %q: %w", rawURL, err)
+		return fmt.Errorf("parsing git URL %q: %w", redactURL(rawURL), redactParseError(err))
 	}
 
 	ref, sshKeyPEM, depth, err := extractQueryParams(u)

--- a/internal/bundlereader/gitclone_test.go
+++ b/internal/bundlereader/gitclone_test.go
@@ -271,7 +271,7 @@ func TestGitDownloadMalformedURLRedaction(t *testing.T) {
 	)
 	rawURL := "ssh://user:" + password + "@example.com:notaport/repo?sshkey=" + privateKey
 
-	err := gitDownload(context.Background(), t.TempDir(), rawURL, Auth{})
+	err := gitDownload(t.Context(), t.TempDir(), rawURL, Auth{})
 	require.Error(t, err)
 	assert.NotContains(t, err.Error(), password, "password must not leak in error")
 	assert.NotContains(t, err.Error(), privateKey, "sshkey must not leak in error")

--- a/internal/bundlereader/gitclone_test.go
+++ b/internal/bundlereader/gitclone_test.go
@@ -257,3 +257,22 @@ func TestSetGitAuth(t *testing.T) {
 		assert.NotNil(t, opts.Auth)
 	})
 }
+
+// TestGitDownloadMalformedURLRedaction verifies that a malformed git URL
+// containing an embedded password and ?sshkey= private key does not leak those
+// secrets through the returned error (which is logged). url.Parse fails on the
+// invalid port, and its error otherwise echoes the full URL verbatim.
+func TestGitDownloadMalformedURLRedaction(t *testing.T) {
+	t.Parallel()
+
+	const (
+		password   = "s3cr3tpassword"
+		privateKey = "PRIVATE_KEY_CONTENT"
+	)
+	rawURL := "ssh://user:" + password + "@example.com:notaport/repo?sshkey=" + privateKey
+
+	err := gitDownload(context.Background(), t.TempDir(), rawURL, Auth{})
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), password, "password must not leak in error")
+	assert.NotContains(t, err.Error(), privateKey, "sshkey must not leak in error")
+}

--- a/internal/bundlereader/httpdownload.go
+++ b/internal/bundlereader/httpdownload.go
@@ -89,29 +89,41 @@ func httpDownload(ctx context.Context, dst, src string, auth Auth) error {
 		return err
 	}
 
-	body := io.Reader(resp.Body)
-	if checksum != nil {
-		checksum.hash.Reset()
-		body = io.TeeReader(resp.Body, checksum.hash)
-	}
-	// Limit the total compressed bytes read from the server before extracting.
-	// This covers all archive formats uniformly; without it a streaming format
-	// like tar.gz could pipe an unbounded compressed stream through the
-	// decompressor until MaxDecompressedBytes fires, consuming CPU and I/O
-	// with no bound on how much compressed data is transferred.
-	lr := &downloadLimitReader{r: body, limit: MaxCompressedBytes}
-	if err := extractResponse(dst, u.Path, archiveOverride, lr); err != nil {
-		return err
-	}
+	// Limit the total compressed bytes read from the server before any
+	// decompression begins. This covers all archive formats uniformly and
+	// prevents an arbitrarily large server response from consuming CPU and
+	// disk I/O before the per-archive MaxDecompressedBytes limit fires.
+	lr := &downloadLimitReader{r: resp.Body, limit: MaxCompressedBytes}
 
 	if checksum != nil {
-		actual := checksum.hash.Sum(nil)
-		if !bytes.Equal(actual, checksum.expected) {
+		// Spool the response to a temp file while computing the hash: verify
+		// the checksum over the raw compressed bytes before any archive content
+		// is written to the destination. A tampered archive must not write files
+		// even temporarily. Spooling to disk avoids buffering up to MaxCompressedBytes
+		// in memory when ?checksum= is present on a large archive.
+		checksum.hash.Reset()
+		tmpFile, err := os.CreateTemp("", "fleet-download-*")
+		if err != nil {
+			return fmt.Errorf("creating temp file for checksum verification: %w", err)
+		}
+		tmpPath := tmpFile.Name()
+		defer os.Remove(tmpPath)
+		defer tmpFile.Close()
+
+		if _, err := io.Copy(tmpFile, io.TeeReader(lr, checksum.hash)); err != nil {
+			return fmt.Errorf("downloading %q: %w", u.Redacted(), err)
+		}
+		if actual := checksum.hash.Sum(nil); !bytes.Equal(actual, checksum.expected) {
 			return fmt.Errorf("checksum mismatch for %q: expected %s:%x, got %x",
 				u.Redacted(), checksum.hashType, checksum.expected, actual)
 		}
+		if _, err := tmpFile.Seek(0, io.SeekStart); err != nil {
+			return fmt.Errorf("seeking temp file for extraction: %w", err)
+		}
+		return extractResponse(dst, u.Path, archiveOverride, tmpFile)
 	}
-	return nil
+
+	return extractResponse(dst, u.Path, archiveOverride, lr)
 }
 
 // MaxCompressedBytes caps the total number of compressed bytes accepted from

--- a/internal/bundlereader/httpdownload.go
+++ b/internal/bundlereader/httpdownload.go
@@ -39,7 +39,7 @@ import (
 func httpDownload(ctx context.Context, dst, src string, auth Auth) error {
 	u, err := url.Parse(src)
 	if err != nil {
-		return fmt.Errorf("parsing URL %q: %w", redactURL(src), err)
+		return fmt.Errorf("parsing URL %q: %w", redactURL(src), redactParseError(err))
 	}
 
 	q := u.Query()

--- a/internal/bundlereader/httpdownload_internal_test.go
+++ b/internal/bundlereader/httpdownload_internal_test.go
@@ -230,7 +230,8 @@ func TestHttpDownload_ChecksumVerification(t *testing.T) {
 }
 
 // TestHttpDownload_ChecksumMismatch verifies that a wrong ?checksum= value
-// causes httpDownload to return a "checksum mismatch" error.
+// causes httpDownload to return a "checksum mismatch" error and does NOT write
+// any files to disk.
 func TestHttpDownload_ChecksumMismatch(t *testing.T) {
 	body := []byte("hello world")
 	wrongHash := "0000000000000000000000000000000000000000000000000000000000000000"
@@ -244,6 +245,10 @@ func TestHttpDownload_ChecksumMismatch(t *testing.T) {
 	err := httpDownload(t.Context(), dst, srv.URL+"/file.txt?checksum=sha256:"+wrongHash, Auth{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "checksum mismatch")
+
+	entries, readErr := os.ReadDir(dst)
+	require.NoError(t, readErr)
+	assert.Empty(t, entries, "no files must be written to disk when the checksum fails")
 }
 
 // TestHttpDownload_ArchiveOverride verifies that ?archive= forces format
@@ -280,6 +285,45 @@ func TestHttpDownload_ArchiveOverride(t *testing.T) {
 	data, err := os.ReadFile(filepath.Join(dst, "inner.txt"))
 	require.NoError(t, err)
 	assert.Equal(t, content, data)
+}
+
+// TestHttpDownload_ChecksumBeforeExtraction verifies that when a ?checksum=
+// parameter is provided and does not match, no archive content is written to
+// disk. Extraction must not occur before the checksum is verified.
+func TestHttpDownload_ChecksumBeforeExtraction(t *testing.T) {
+	// Build a valid tar.gz containing a recognisable file.
+	innerContent := []byte("must not appear on disk")
+	var archiveBuf bytes.Buffer
+	gw := gzip.NewWriter(&archiveBuf)
+	tw := tar.NewWriter(gw)
+	require.NoError(t, tw.WriteHeader(&tar.Header{
+		Typeflag: tar.TypeReg,
+		Name:     "secret.txt",
+		Size:     int64(len(innerContent)),
+		Mode:     0600,
+	}))
+	_, err := tw.Write(innerContent)
+	require.NoError(t, err)
+	require.NoError(t, tw.Close())
+	require.NoError(t, gw.Close())
+	archiveBytes := archiveBuf.Bytes()
+
+	wrongHash := "0000000000000000000000000000000000000000000000000000000000000000"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(archiveBytes)
+	}))
+	defer srv.Close()
+
+	dst := t.TempDir()
+	err = httpDownload(t.Context(), dst, srv.URL+"/bundle.tar.gz?checksum=sha256:"+wrongHash, Auth{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "checksum mismatch")
+
+	// The archive contains "secret.txt"; it must not have been written to disk.
+	entries, readErr := os.ReadDir(dst)
+	require.NoError(t, readErr)
+	assert.Empty(t, entries, "archive must not be extracted before the checksum is verified")
 }
 
 // -- extractResponse round-trip tests ----------------------------------------

--- a/internal/bundlereader/loaddirectory.go
+++ b/internal/bundlereader/loaddirectory.go
@@ -273,7 +273,27 @@ func GetContent(ctx context.Context, base, source, version string, auth Auth, di
 			return nil
 		}
 
-		content, err := os.ReadFile(path) //nolint:gosec // G122: path is from WalkDir over a go-getter controlled temp directory
+		// Symlinks are allowed as long as their fully-resolved target stays
+		// within the bundle root. This permits legitimate intra-bundle symlinks
+		// (e.g. a chart with values.yaml -> defaults.yaml, or symlinks created
+		// by extractTar from a tar archive) while rejecting symlinks that point
+		// outside (e.g. to /etc/passwd or ../../secret). filepath.EvalSymlinks
+		// resolves the full chain, so chained escapes are also caught.
+		if info.Type()&os.ModeSymlink != 0 {
+			resolved, err := filepath.EvalSymlinks(path)
+			if err != nil {
+				return fmt.Errorf("GetContent: resolving symlink %q: %w", name, err)
+			}
+			cleanRoot := filepath.Clean(temp)
+			rel, relErr := filepath.Rel(cleanRoot, resolved)
+			if relErr != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+				return fmt.Errorf("GetContent: symlink %q: target escapes bundle directory", name)
+			}
+			// Target is within bundle; fall through to os.ReadFile which follows the link.
+		}
+
+		//nolint:gosec // G304: path is from WalkDir over a downloaded temp directory
+		content, err := os.ReadFile(path)
 		if err != nil {
 			return err
 		}

--- a/internal/bundlereader/loaddirectory_test.go
+++ b/internal/bundlereader/loaddirectory_test.go
@@ -733,7 +733,7 @@ func TestGetContent_EscapingSymlinkRejected(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(bundleDir, "legit.txt"), []byte("ok"), 0644))
 	require.NoError(t, os.Symlink(secretFile, filepath.Join(bundleDir, "evil-link.txt")))
 
-	_, err := bundlereader.GetContent(context.Background(), bundleDir, bundleDir, "", bundlereader.Auth{}, false, nil)
+	_, err := bundlereader.GetContent(t.Context(), bundleDir, bundleDir, "", bundlereader.Auth{}, false, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "escapes bundle directory")
 

--- a/internal/bundlereader/loaddirectory_test.go
+++ b/internal/bundlereader/loaddirectory_test.go
@@ -752,7 +752,7 @@ func TestGetContent_InternalSymlinkAllowed(t *testing.T) {
 	// Symlink within the bundle pointing to the sibling real.yaml.
 	require.NoError(t, os.Symlink(filepath.Join(bundleDir, "real.yaml"), filepath.Join(bundleDir, "link.yaml")))
 
-	files, err := bundlereader.GetContent(context.Background(), bundleDir, bundleDir, "", bundlereader.Auth{}, false, nil)
+	files, err := bundlereader.GetContent(t.Context(), bundleDir, bundleDir, "", bundlereader.Auth{}, false, nil)
 	require.NoError(t, err)
 	assert.Equal(t, realContent, files["real.yaml"])
 	assert.Equal(t, realContent, files["link.yaml"], "symlink within bundle must be followed")

--- a/internal/bundlereader/loaddirectory_test.go
+++ b/internal/bundlereader/loaddirectory_test.go
@@ -716,3 +716,44 @@ func createDirStruct(t *testing.T, basePath string, node fsNode) string {
 
 	return path
 }
+
+// TestGetContent_EscapingSymlinkRejected verifies that GetContent returns an
+// error when the bundle directory contains a symlink whose target resolves
+// outside the bundle root. Following such a symlink could allow a malicious
+// repository to exfiltrate files from outside the cloned directory.
+func TestGetContent_EscapingSymlinkRejected(t *testing.T) {
+	// Create a file outside the bundle directory to serve as the link target.
+	outsideDir := t.TempDir()
+	secretFile := filepath.Join(outsideDir, "secret.txt")
+	require.NoError(t, os.WriteFile(secretFile, []byte("sensitive content"), 0600))
+
+	// Build a bundle directory that contains one legitimate file and one
+	// symlink pointing to the secret file outside the bundle.
+	bundleDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(bundleDir, "legit.txt"), []byte("ok"), 0644))
+	require.NoError(t, os.Symlink(secretFile, filepath.Join(bundleDir, "evil-link.txt")))
+
+	_, err := bundlereader.GetContent(context.Background(), bundleDir, bundleDir, "", bundlereader.Auth{}, false, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "escapes bundle directory")
+
+	// The secret contents must not appear in the error message.
+	assert.NotContains(t, err.Error(), "sensitive content")
+}
+
+// TestGetContent_InternalSymlinkAllowed verifies that GetContent includes the
+// content of files pointed to by symlinks that stay within the bundle root.
+// Intra-bundle symlinks are valid in both git repositories and tar archives
+// (e.g. values.yaml -> defaults.yaml) and must not be rejected.
+func TestGetContent_InternalSymlinkAllowed(t *testing.T) {
+	bundleDir := t.TempDir()
+	realContent := []byte("real content")
+	require.NoError(t, os.WriteFile(filepath.Join(bundleDir, "real.yaml"), realContent, 0644))
+	// Symlink within the bundle pointing to the sibling real.yaml.
+	require.NoError(t, os.Symlink(filepath.Join(bundleDir, "real.yaml"), filepath.Join(bundleDir, "link.yaml")))
+
+	files, err := bundlereader.GetContent(context.Background(), bundleDir, bundleDir, "", bundlereader.Auth{}, false, nil)
+	require.NoError(t, err)
+	assert.Equal(t, realContent, files["real.yaml"])
+	assert.Equal(t, realContent, files["link.yaml"], "symlink within bundle must be followed")
+}

--- a/internal/bundlereader/source.go
+++ b/internal/bundlereader/source.go
@@ -1,9 +1,11 @@
 package bundlereader
 
 import (
+	"errors"
 	"fmt"
 	"net/url"
 	"path/filepath"
+	"regexp"
 	"strings"
 )
 
@@ -259,7 +261,10 @@ func redactURL(src string) string {
 
 	u, err := url.Parse(cleanSrc)
 	if err != nil {
-		return src
+		// cleanSrc is not parseable as a URL (e.g. a malformed source string).
+		// url.Parse cannot help here, so fall back to a best-effort textual
+		// redaction so that an embedded sshkey or password is never returned.
+		return redactSensitiveText(src)
 	}
 
 	// Remove sshkey query param; it can carry a private key.
@@ -282,4 +287,38 @@ func redactURL(src string) string {
 		return forcedScheme + "::" + redacted
 	}
 	return redacted
+}
+
+var (
+	// sshkeyValueRe matches an "sshkey=<value>" query parameter, capturing the
+	// "sshkey=" prefix so the value (which can carry a private key) can be
+	// replaced.
+	sshkeyValueRe = regexp.MustCompile(`([?&]sshkey=)[^&]*`)
+	// userinfoPasswordRe matches the password portion of URL userinfo
+	// ("scheme://user:<password>@"), capturing everything up to and including
+	// the ":" so the password can be replaced.
+	userinfoPasswordRe = regexp.MustCompile(`(://[^/?#@]*:)[^/?#@]*@`)
+)
+
+// redactSensitiveText performs a best-effort textual redaction of credentials
+// for source strings that url.Parse cannot handle (e.g. a malformed URL that
+// still embeds an sshkey or password). It removes the value of any sshkey query
+// parameter and any password in the URL userinfo.
+func redactSensitiveText(src string) string {
+	src = sshkeyValueRe.ReplaceAllString(src, "${1}REDACTED")
+	src = userinfoPasswordRe.ReplaceAllString(src, "${1}REDACTED@")
+	return src
+}
+
+// redactParseError returns the underlying reason of a *url.Error without the
+// embedded raw URL. url.Error.Error() prints the offending URL verbatim, which
+// would leak any credentials it contains (basic-auth password, ?sshkey=) when
+// the error is wrapped into a message and logged. Other errors are returned
+// unchanged.
+func redactParseError(err error) error {
+	var ue *url.Error
+	if errors.As(err, &ue) {
+		return ue.Err
+	}
+	return err
 }

--- a/internal/bundlereader/source_test.go
+++ b/internal/bundlereader/source_test.go
@@ -73,6 +73,21 @@ func TestRedactURL(t *testing.T) {
 			input:    "git::https://example.com/repo?sshkey=PRIVATE_KEY_CONTENT",
 			expected: "git::https://example.com/repo",
 		},
+		{
+			name:     "malformed URL (invalid port) still redacts password and sshkey",
+			input:    "ssh://user:s3cr3t@example.com:notaport/repo?sshkey=PRIVATE_KEY_CONTENT",
+			expected: "ssh://user:REDACTED@example.com:notaport/repo?sshkey=REDACTED",
+		},
+		{
+			name:     "malformed URL (control char) still redacts sshkey",
+			input:    "https://example.com/re\x7fpo?sshkey=PRIVATE_KEY_CONTENT",
+			expected: "https://example.com/re\x7fpo?sshkey=REDACTED",
+		},
+		{
+			name:     "malformed forced-scheme URL still redacts password",
+			input:    "git::https://user:s3cr3t@example.com:notaport/repo",
+			expected: "git::https://user:REDACTED@example.com:notaport/repo",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Three potential issues were identified in the unreleased go-getter replacement code from #4841 and #4891.

- `httpDownload` extracted archive content to disk before verifying `?checksum=`, so a tampered server response could write files even when the hash would not match. The response is now written to a temporary file, the hash verified, and only then extracted. Streaming is preserved for the common case (no checksum).
- `GetContent`'s `WalkDir` callback passed every non-directory entry to `os.ReadFile`, which follows symlinks. A git repository or HTTP archive containing a symlink to `/etc/something` would include the target's content in the bundle. A `filepath.EvalSymlinks` check now rejects symlinks whose resolved target escapes the bundle root, while allowing legitimate intra-bundle symlinks (consistent with what `extractTar` does for tar archives).
- `redactURL` returned its input unchanged when `url.Parse` failed, and the wrapped `*url.Error` echoed the full URL verbatim — leaking an embedded password or `?sshkey=` private key into logs. `redactURL` now redacts textually on parse failure, and a new `redactParseError` strips the raw URL from the wrapped error.

Refers #4877