### PR TITLE
webhooks handling update

### DIFF
--- a/charts/fleet-crd/templates/crds.yaml
+++ b/charts/fleet-crd/templates/crds.yaml
@@ -7403,6 +7403,11 @@ spec:
                     scan.
                   format: date-time
                   type: string
+                lastWebhookTime:
+                  description: LastWebhookTime is the time of the last received webhook
+                    notification
+                  format: date-time
+                  type: string
                 observedGeneration:
                   description: 'ObservedGeneration is the current generation of the
                     resource in the cluster. It is copied from k8s

--- a/integrationtests/gitjob/controller/controller_test.go
+++ b/integrationtests/gitjob/controller/controller_test.go
@@ -960,6 +960,9 @@ var _ = Describe("GitJob controller", func() {
 			}).Should(BeTrue())
 
 			By("Setting WebhookCommit to simulate a webhook event")
+			// Make the mock fetcher return the webhook commit so LatestCommit
+			// resolves HEAD to the new tip rather than stableCommit.
+			expectedCommit = webhookCommit
 			Expect(setGitRepoWebhookCommit(gitRepo, webhookCommit)).To(Succeed())
 		})
 
@@ -971,6 +974,100 @@ var _ = Describe("GitJob controller", func() {
 			Eventually(func() error {
 				jobName := names.SafeConcatName(gitRepoName, names.Hex(repo+webhookCommit, 5))
 				return k8sClient.Get(ctx, types.NamespacedName{Name: jobName, Namespace: gitRepoNamespace}, &job)
+			}, testenv.MediumTimeout, testenv.ShortTimeout).Should(Not(HaveOccurred()))
+		})
+	})
+
+	// Regression test for the webhook-vs-head race condition: the reconciler must
+	// not create a job for a commit that the webhook announced but that HEAD has
+	// not yet propagated to the remote.  It must wait (up to webhookMaxWait) and
+	// only create the job once LatestCommit returns the expected commit.
+	When("a webhook arrives before HEAD is visible in the remote", func() {
+		var (
+			gitRepo     v1alpha1.GitRepo
+			gitRepoName string
+			job         batchv1.Job
+		)
+		const webhookCommit = "deaf1234cafe5678beef9012dead3456cafe7890"
+
+		BeforeEach(func() {
+			gitRepoName = "webhook-propagation-wait"
+			expectedCommit = stableCommit
+		})
+
+		JustBeforeEach(func() {
+			gitRepo = v1alpha1.GitRepo{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      gitRepoName,
+					Namespace: gitRepoNamespace,
+				},
+				Spec: v1alpha1.GitRepoSpec{
+					Repo:            webhookTestRepo,
+					PollingInterval: &metav1.Duration{Duration: 24 * time.Hour},
+				},
+			}
+			Expect(k8sClient.Create(ctx, &gitRepo)).To(Succeed())
+
+			By("Waiting for the initial job")
+			Eventually(func() error {
+				jobName := names.SafeConcatName(gitRepoName, names.Hex(webhookTestRepo+stableCommit, 5))
+				return k8sClient.Get(ctx, types.NamespacedName{Name: jobName, Namespace: gitRepoNamespace}, &job)
+			}, testenv.MediumTimeout, testenv.ShortTimeout).Should(Not(HaveOccurred()))
+
+			By("Marking the initial job succeeded and waiting for its deletion")
+			Eventually(func() error {
+				jobName := names.SafeConcatName(gitRepoName, names.Hex(webhookTestRepo+stableCommit, 5))
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: jobName, Namespace: gitRepoNamespace}, &job)
+				if client.IgnoreNotFound(err) != nil {
+					return err
+				}
+				job.Status = succeeded(job.Status)
+				return k8sClient.Status().Update(ctx, &job)
+			}).Should(Not(HaveOccurred()))
+
+			Eventually(func() bool {
+				jobName := names.SafeConcatName(gitRepoName, names.Hex(webhookTestRepo+stableCommit, 5))
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: jobName, Namespace: gitRepoNamespace}, &job)
+				return errors.IsNotFound(err)
+			}).Should(BeTrue())
+
+			By("Firing the webhook while HEAD is still stableCommit (propagation lag)")
+			// expectedCommit remains stableCommit — LatestCommit will keep returning the old
+			// HEAD, simulating a git host that hasn't replicated the push yet.
+			// sendGitHubPush sets both WebhookCommit and LastWebhookTime, which enables
+			// the propagation-wait path in the reconciler.
+			sendGitHubPush(webhookCommit)
+
+			// Confirm the webhook was applied before proceeding.
+			Eventually(func(g Gomega) {
+				var gr v1alpha1.GitRepo
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name: gitRepoName, Namespace: gitRepoNamespace,
+				}, &gr)).To(Succeed())
+				g.Expect(gr.Status.WebhookCommit).To(Equal(webhookCommit))
+			}).Should(Succeed())
+		})
+
+		AfterEach(func() {
+			waitDeleteGitrepo(gitRepo)
+		})
+
+		It("does not create a job until HEAD advances, then creates one", func() {
+			newJobName := names.SafeConcatName(gitRepoName, names.Hex(webhookTestRepo+webhookCommit, 5))
+
+			By("Confirming no job for the webhook commit while HEAD lags")
+			Consistently(func(g Gomega) {
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: newJobName, Namespace: gitRepoNamespace}, &job)
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(errors.IsNotFound(err)).To(BeTrue(), err)
+			}, 5*time.Second, time.Second).Should(Succeed())
+
+			By("Advancing HEAD to match the webhook commit")
+			expectedCommit = webhookCommit
+
+			By("Expecting the job to be created now that HEAD has caught up")
+			Eventually(func() error {
+				return k8sClient.Get(ctx, types.NamespacedName{Name: newJobName, Namespace: gitRepoNamespace}, &job)
 			}, testenv.MediumTimeout, testenv.ShortTimeout).Should(Not(HaveOccurred()))
 		})
 	})

--- a/integrationtests/gitjob/controller/webhook_handler_test.go
+++ b/integrationtests/gitjob/controller/webhook_handler_test.go
@@ -101,4 +101,23 @@ var _ = Describe("Webhook handler", func() {
 			Expect(updated.Spec.PollingInterval.Duration).To(Equal(existingInterval))
 		})
 	})
+
+	When("a push webhook arrives", func() {
+		const pushCommit = "cccc3333dddd4444eeee5555ffff6666aaaa1111"
+
+		It("sets LastWebhookTime to a recent timestamp", func() {
+			// metav1.Time stores at second granularity, so truncate before comparing.
+			before := metav1.Now().Truncate(time.Second)
+			sendGitHubPush(pushCommit)
+
+			Eventually(func(g Gomega) {
+				var updated v1alpha1.GitRepo
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name: gitRepo.Name, Namespace: gitRepo.Namespace,
+				}, &updated)).To(Succeed())
+				g.Expect(updated.Status.LastWebhookTime.IsZero()).To(BeFalse())
+				g.Expect(updated.Status.LastWebhookTime.Time).To(BeTemporally(">=", before))
+			}).Should(Succeed())
+		})
+	})
 })

--- a/internal/cmd/controller/gitops/reconciler/gitjob.go
+++ b/internal/cmd/controller/gitops/reconciler/gitjob.go
@@ -179,7 +179,22 @@ func (r *GitJobReconciler) createJob(ctx context.Context, gitRepo *v1alpha1.GitR
 	if err := controllerutil.SetControllerReference(gitRepo, job, r.Scheme); err != nil {
 		return err
 	}
-	return r.Create(ctx, job)
+	// Job names are deterministic from (gitrepo, commit). An AlreadyExists here
+	// means a concurrent / cache-lagged reconcile already created the job for the
+	// same commit — treat it as a no-op rather than surfacing a reconcile
+	// error. The owning GitRepo and commit are encoded in the name, so we are not
+	// adopting a foreign job.
+	if err := r.Create(ctx, job); err != nil {
+		if apierrors.IsAlreadyExists(err) {
+			log.FromContext(ctx).V(1).Info(
+				"Git job already exists for this commit, skipping create",
+				"job", job.Name,
+			)
+			return nil
+		}
+		return err
+	}
+	return nil
 }
 
 func (r *GitJobReconciler) newGitJob(ctx context.Context, obj *v1alpha1.GitRepo) (*batchv1.Job, error) {

--- a/internal/cmd/controller/gitops/reconciler/gitjob.go
+++ b/internal/cmd/controller/gitops/reconciler/gitjob.go
@@ -67,18 +67,21 @@ func (r *GitJobReconciler) createJobAndResources(ctx context.Context, gitrepo *v
 	if _, err := r.createCABundleSecret(ctx, gitrepo, caBundleName(gitrepo)); err != nil {
 		return fmt.Errorf("failed to create cabundle secret for git job: %w", err)
 	}
-	if err := r.createJob(ctx, gitrepo); err != nil {
+	created, err := r.createJob(ctx, gitrepo)
+	if err != nil {
 		return fmt.Errorf("error creating git job: %w", err)
 	}
 
-	r.Recorder.Eventf(
-		gitrepo,
-		nil,
-		corev1.EventTypeNormal,
-		"Created",
-		"CreateGitJob",
-		"GitJob was created",
-	)
+	if created {
+		r.Recorder.Eventf(
+			gitrepo,
+			nil,
+			corev1.EventTypeNormal,
+			"Created",
+			"CreateGitJob",
+			"GitJob was created",
+		)
+	}
 	return nil
 }
 
@@ -171,13 +174,13 @@ func (r *GitJobReconciler) createCABundleSecret(ctx context.Context, gitrepo *v1
 	return true, nil
 }
 
-func (r *GitJobReconciler) createJob(ctx context.Context, gitRepo *v1alpha1.GitRepo) error {
+func (r *GitJobReconciler) createJob(ctx context.Context, gitRepo *v1alpha1.GitRepo) (bool, error) {
 	job, err := r.newGitJob(ctx, gitRepo)
 	if err != nil {
-		return err
+		return false, err
 	}
 	if err := controllerutil.SetControllerReference(gitRepo, job, r.Scheme); err != nil {
-		return err
+		return false, err
 	}
 	// Job names are deterministic from (gitrepo, commit). An AlreadyExists here
 	// means a concurrent / cache-lagged reconcile already created the job for the
@@ -190,11 +193,11 @@ func (r *GitJobReconciler) createJob(ctx context.Context, gitRepo *v1alpha1.GitR
 				"Git job already exists for this commit, skipping create",
 				"job", job.Name,
 			)
-			return nil
+			return false, nil
 		}
-		return err
+		return false, err
 	}
-	return nil
+	return true, nil
 }
 
 func (r *GitJobReconciler) newGitJob(ctx context.Context, obj *v1alpha1.GitRepo) (*batchv1.Job, error) {

--- a/internal/cmd/controller/gitops/reconciler/gitjob_controller.go
+++ b/internal/cmd/controller/gitops/reconciler/gitjob_controller.go
@@ -325,6 +325,9 @@ func (r *GitJobReconciler) fetchLatestCommit(ctx context.Context, gitrepo *v1alp
 	condition.Cond(gitPollingCondition).SetError(&gitrepo.Status, "", fetchErr)
 	if fetchErr == nil && commit != "" {
 		gitrepo.Status.Commit = commit
+		// Keep PollingCommit aligned with the resolved HEAD.
+		// Consider it as the "last seen commit from polling".
+		gitrepo.Status.PollingCommit = commit
 	}
 	if fetchErr != nil {
 		r.Recorder.Eventf(

--- a/internal/cmd/controller/gitops/reconciler/gitjob_controller.go
+++ b/internal/cmd/controller/gitops/reconciler/gitjob_controller.go
@@ -70,6 +70,11 @@ const (
 	// in order to wait for the dependent resources cleanup to finish
 	requeueAfterResourceCleanup = 2 * time.Second
 
+	// max time to wait for a git host to propagate a pushed commit before giving up
+	webhookMaxWait = 30 * time.Second
+	// requeue delay while waiting for webhook commit propagation
+	webhookPropagationDelay = 2 * time.Second
+
 	// Annotation keys for tracking secret data hashes
 	clientSecretHashAnnotation       = "fleet.cattle.io/client-secret-hash"         //nolint:gosec // not a credential
 	helmSecretHashAnnotation         = "fleet.cattle.io/helm-secret-hash"           //nolint:gosec // not a credential
@@ -310,6 +315,40 @@ func (r *GitJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	return ctrl.Result{}, nil
 }
 
+// fetchLatestCommit resolves the remote HEAD via ls-remote, updates
+// gitrepo.Status.Commit and the polling condition, and emits the matching
+// events.
+func (r *GitJobReconciler) fetchLatestCommit(ctx context.Context, gitrepo *v1alpha1.GitRepo, oldCommit string) error {
+	commit, fetchErr := monitorLatestCommit(gitrepo, func() (string, error) {
+		return r.GitFetcher.LatestCommit(ctx, gitrepo, r.Client)
+	})
+	condition.Cond(gitPollingCondition).SetError(&gitrepo.Status, "", fetchErr)
+	if fetchErr == nil && commit != "" {
+		gitrepo.Status.Commit = commit
+	}
+	if fetchErr != nil {
+		r.Recorder.Eventf(
+			gitrepo,
+			nil,
+			corev1.EventTypeWarning,
+			"Failed",
+			"MonitorLatestCommit",
+			"%v",
+			fetchErr,
+		)
+	} else if oldCommit != gitrepo.Status.Commit {
+		r.Recorder.Eventf(
+			gitrepo,
+			nil,
+			corev1.EventTypeNormal,
+			"GotNewCommit",
+			"GetNewCommit",
+			gitrepo.Status.Commit,
+		)
+	}
+	return fetchErr
+}
+
 func monitorLatestCommit(obj metav1.Object, fetch func() (string, error)) (string, error) {
 	start := time.Now()
 	commit, err := fetch()
@@ -324,6 +363,76 @@ func monitorLatestCommit(obj metav1.Object, fetch func() (string, error)) (strin
 
 // manageGitJob is responsible for creating, updating and deleting the GitJob and setting the GitRepo's status accordingly
 func (r *GitJobReconciler) manageGitJob(ctx context.Context, logger logr.Logger, gitrepo *v1alpha1.GitRepo, oldCommit string) (ctrl.Result, error) {
+	// Validate referenced secrets up front. The result (clientSecretChanged,
+	// helmSecretChanged) is reused by both the job-create and job-delete paths
+	// below, avoiding a second hasReferencedSecretChanged call.
+	clientSecretChanged, helmSecretChanged, err := r.hasReferencedSecretChanged(ctx, gitrepo)
+	if err != nil {
+		r.Recorder.Eventf(
+			gitrepo,
+			nil,
+			corev1.EventTypeWarning,
+			"FailedValidatingSecret",
+			"ValidateSecret",
+			"%v",
+			err,
+		)
+		return ctrl.Result{}, fmt.Errorf("error validating external secrets: %w", err)
+	}
+
+	// A pending webhook means a commit was announced that we have not yet
+	// observed at the remote HEAD. Resolve HEAD up front, before we delete or
+	// create any job, so we never act on the stale commit and so a webhook
+	// arriving mid-job can advance Status.Commit and supersede the running job.
+	webhookPending := gitrepo.Status.WebhookCommit != "" && gitrepo.Status.WebhookCommit != oldCommit
+	if webhookPending {
+		fetchErr := r.fetchLatestCommit(ctx, gitrepo, oldCommit)
+
+		// Propagation wait: HEAD hasn't moved yet after a recent webhook.
+		// The git host may still be replicating the pushed commit. Requeue
+		// with a short delay instead of deploying a stale HEAD. Give up after
+		// webhookMaxWait so a miss-delivered webhook never blocks indefinitely.
+		if fetchErr == nil && gitrepo.Status.Commit == oldCommit {
+			if !gitrepo.Status.LastWebhookTime.IsZero() &&
+				r.Clock.Since(gitrepo.Status.LastWebhookTime.Time) < webhookMaxWait {
+				logger.V(1).Info("Webhook announced commit not yet visible in remote HEAD, requeuing",
+					"webhookCommit", gitrepo.Status.WebhookCommit,
+					"headCommit", gitrepo.Status.Commit)
+				return ctrl.Result{RequeueAfter: webhookPropagationDelay}, nil
+			}
+			logger.V(1).Info("Webhook announced commit did not appear in remote HEAD within timeout",
+				"webhookCommit", gitrepo.Status.WebhookCommit,
+				"headCommit", gitrepo.Status.Commit)
+
+			// Surface the give-up so it is not a silent no-op.
+			r.Recorder.Eventf(
+				gitrepo,
+				nil,
+				corev1.EventTypeWarning,
+				"WebhookCommitNotVisible",
+				"MonitorLatestCommit",
+				"webhook commit %s not visible at remote HEAD after %s; clearing pending webhook",
+				gitrepo.Status.WebhookCommit,
+				webhookMaxWait,
+			)
+
+			// Clear the pending webhook by realigning WebhookCommit to the current
+			// HEAD. Without this, webhookPending stays true forever and every
+			// subsequent reconcile fires another ls-remote.
+			ref := gitrepo.Status.LastWebhookTime
+			if err := r.realignWebhookCommit(
+				ctx,
+				types.NamespacedName{Namespace: gitrepo.Namespace, Name: gitrepo.Name},
+				oldCommit,
+				&ref,
+			); err != nil {
+				logger.V(1).Error(err, "failed to clear timed-out webhook commit")
+			}
+		}
+	}
+
+	// With Status.Commit now reflecting the real HEAD (or unchanged when no
+	// fetch was required), delete the previous Job if the commit advanced.
 	deleted, err := r.deletePreviousJob(ctx, logger, *gitrepo, oldCommit)
 	if err != nil {
 		return ctrl.Result{}, err
@@ -356,54 +465,8 @@ func (r *GitJobReconciler) manageGitJob(ctx context.Context, logger logr.Logger,
 	}
 
 	if apierrors.IsNotFound(err) {
-		clientSecretChanged, helmSecretChanged, err := r.hasReferencedSecretChanged(ctx, gitrepo)
-		if err != nil {
-			r.Recorder.Eventf(
-				gitrepo,
-				nil,
-				corev1.EventTypeWarning,
-				"FailedValidatingSecret",
-				"ValidateSecret",
-				"%v",
-				err,
-			)
-			return ctrl.Result{}, fmt.Errorf("error validating external secrets: %w", err)
-		}
-
-		// In cases where we have a very large polling interval and the first commit
-		// could not be retrieved because the secret was incorrect, the gitRepo does
-		// not show any commit.
-		// If the client secret has changed, we now retrieve the latest commit.
-		// If the secret is still incorrect, we will not need to create
-		// the gitJob (which is more expensive) and we will return an error earlier.
-		if gitrepo.Spec.DisablePolling || clientSecretChanged {
-			commit, err := monitorLatestCommit(gitrepo, func() (string, error) {
-				return r.GitFetcher.LatestCommit(ctx, gitrepo, r.Client)
-			})
-			condition.Cond(gitPollingCondition).SetError(&gitrepo.Status, "", err)
-			if err == nil && commit != "" {
-				gitrepo.Status.Commit = commit
-			}
-			if err != nil {
-				r.Recorder.Eventf(
-					gitrepo,
-					nil,
-					corev1.EventTypeWarning,
-					"Failed",
-					"MonitorLatestCommit",
-					"%v",
-					err,
-				)
-			} else if oldCommit != gitrepo.Status.Commit {
-				r.Recorder.Eventf(
-					gitrepo,
-					nil,
-					corev1.EventTypeNormal,
-					"GotNewCommit",
-					"GetNewCommit",
-					gitrepo.Status.Commit,
-				)
-			}
+		if !webhookPending && (gitrepo.Spec.DisablePolling || clientSecretChanged) {
+			_ = r.fetchLatestCommit(ctx, gitrepo, oldCommit)
 		}
 
 		if r.shouldCreateJob(gitrepo, oldCommit, helmSecretChanged) {
@@ -427,7 +490,7 @@ func (r *GitJobReconciler) manageGitJob(ctx context.Context, logger logr.Logger,
 			gitjobsCreatedSuccess.Inc(gitrepo)
 		}
 	} else if gitrepo.Status.Commit != "" && gitrepo.Status.Commit == oldCommit {
-		err, recreateGitJob := r.deleteJobIfNeeded(ctx, gitrepo, &job)
+		err, recreateGitJob := r.deleteJobIfNeeded(ctx, gitrepo, &job, clientSecretChanged, helmSecretChanged)
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("error deleting git job: %w", err)
 		}
@@ -442,6 +505,23 @@ func (r *GitJobReconciler) manageGitJob(ctx context.Context, logger logr.Logger,
 
 	if err = setStatusFromGitjob(ctx, r.Client, gitrepo, &job); err != nil {
 		return ctrl.Result{}, fmt.Errorf("error setting GitRepo status from git job: %w", err)
+	}
+
+	// Once the job is successful clear the pending webhook commit if it matches the deployed commit.
+	// Without this, an out-of-order older delivery (a webhook for an older SHA arriving after a newer one)
+	// would keep webhookPending=true on every subsequent reconcile
+	// and fire redundant ls-remote calls indefinitely.
+	if job.Status.Succeeded == 1 {
+		if deployedCommit := job.Annotations["commit"]; deployedCommit != "" {
+			if err := r.realignWebhookCommit(
+				ctx,
+				types.NamespacedName{Namespace: gitrepo.Namespace, Name: gitrepo.Name},
+				deployedCommit,
+				job.Status.StartTime,
+			); err != nil {
+				logger.V(1).Error(err, "best-effort WebhookCommit realignment failed")
+			}
+		}
 	}
 
 	return ctrl.Result{}, nil
@@ -615,7 +695,10 @@ func (r *GitJobReconciler) validateExternalSecretExist(ctx context.Context, gitr
 	return nil
 }
 
-func (r *GitJobReconciler) deleteJobIfNeeded(ctx context.Context, gitRepo *v1alpha1.GitRepo, job *batchv1.Job) (error, bool) {
+// deleteJobIfNeeded deletes the Job when a force-sync, generation change, success,
+// or secret rotation requires it. The secret-changed flags are precomputed by
+// the caller (manageGitJob already needs them for the LatestCommit decision).
+func (r *GitJobReconciler) deleteJobIfNeeded(ctx context.Context, gitRepo *v1alpha1.GitRepo, job *batchv1.Job, clientSecretChanged, helmSecretChanged bool) (error, bool) {
 	logger := log.FromContext(ctx)
 
 	// the following cases imply that the job is still running but we need to stop it and
@@ -678,11 +761,8 @@ func (r *GitJobReconciler) deleteJobIfNeeded(ctx context.Context, gitRepo *v1alp
 	}
 
 	// finally if there's a job and any of the secrets related to the gitrepo changed,
-	// we need to delete the job so it gets recreated
-	clientSecretChanged, helmSecretChanged, err := r.hasReferencedSecretChanged(ctx, gitRepo)
-	if err != nil {
-		return err, false
-	}
+	// we need to delete the job so it gets recreated. The flags are computed once
+	// in manageGitJob and passed in to avoid a second hasReferencedSecretChanged call.
 	if clientSecretChanged || helmSecretChanged {
 		jobDeletedMessage := "job deletion triggered because referenced secret changed"
 		logger.Info(jobDeletedMessage)
@@ -693,6 +773,41 @@ func (r *GitJobReconciler) deleteJobIfNeeded(ctx context.Context, gitRepo *v1alp
 	}
 
 	return nil, false
+}
+
+// realignWebhookCommit clears a stale WebhookCommit by setting it to the
+// just-deployed commit. Without this, an out-of-order older delivery (a
+// webhook for an older SHA arriving after a newer one) would keep
+// webhookPending=true on every subsequent reconcile and fire redundant
+// calls indefinitely.
+func (r *GitJobReconciler) realignWebhookCommit(
+	ctx context.Context,
+	nsName types.NamespacedName,
+	deployedCommit string,
+	jobStartTime *metav1.Time,
+) error {
+	return retry.OnError(retry.DefaultRetry, apierrors.IsConflict, func() error {
+		current := &v1alpha1.GitRepo{}
+		if err := r.Get(ctx, nsName, current); err != nil {
+			return client.IgnoreNotFound(err)
+		}
+		// already aligned or never received a webhook
+		if current.Status.WebhookCommit == "" || current.Status.WebhookCommit == deployedCommit {
+			return nil
+		}
+		if jobStartTime != nil &&
+			!current.Status.LastWebhookTime.IsZero() &&
+			current.Status.LastWebhookTime.After(jobStartTime.Time) {
+			return nil
+		}
+		orig := current.DeepCopy()
+		current.Status.WebhookCommit = deployedCommit
+		return r.Status().Patch(
+			ctx,
+			current,
+			client.MergeFromWithOptions(orig, client.MergeFromWithOptimisticLock{}),
+		)
+	})
 }
 
 func jobKey(g v1alpha1.GitRepo) *quartz.JobKey {
@@ -1272,19 +1387,16 @@ func getFleetCLIErrorsFromLine(l string) string {
 	return s
 }
 
-// getNextCommit returns a commit SHA coming either from the status' webhook
-// commit or, with lower precedence, from the polling commit.
+// getNextCommit returns the candidate commit to deploy, using the polling commit
+// with higher precedence than the last-deployed commit. WebhookCommit is
+// intentionally excluded: it is a trigger and freshness hint only, not a value
+// to deploy. HEAD is resolved via LatestCommit in manageGitJob when a webhook
+// is pending.
 func getNextCommit(status v1alpha1.GitRepoStatus) string {
 	commit := status.Commit
 	if status.PollingCommit != "" && status.PollingCommit != commit {
 		commit = status.PollingCommit
 	}
-	// We could be using polling but webhooks react immediately to updates.
-	// Give preference to the webhook commit.
-	if status.WebhookCommit != "" && status.WebhookCommit != commit {
-		commit = status.WebhookCommit
-	}
-
 	return commit
 }
 

--- a/internal/cmd/controller/gitops/reconciler/gitjob_test.go
+++ b/internal/cmd/controller/gitops/reconciler/gitjob_test.go
@@ -3487,7 +3487,11 @@ func TestCreateJob_AlreadyExistsIsIgnored(t *testing.T) {
 		KnownHosts:      ssh.KnownHosts{},
 	}
 
-	if err := r.createJob(context.TODO(), gitRepo); err != nil {
+	created, err := r.createJob(context.TODO(), gitRepo)
+	if err != nil {
 		t.Fatalf("createJob should return nil on AlreadyExists, got: %v", err)
+	}
+	if created {
+		t.Fatal("createJob should return false when job already exists")
 	}
 }

--- a/internal/cmd/controller/gitops/reconciler/gitjob_test.go
+++ b/internal/cmd/controller/gitops/reconciler/gitjob_test.go
@@ -289,15 +289,6 @@ func TestReconcile_Error_WhenSecretDoesNotExist(t *testing.T) {
 		},
 	)
 
-	// we need to return a NotFound error, so the code tries to create it.
-	mockClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.AssignableToTypeOf(&batchv1.Job{}), gomock.Any()).
-		Times(1).
-		DoAndReturn(
-			func(ctx context.Context, req types.NamespacedName, job *batchv1.Job, opts ...any) error {
-				return apierrors.NewNotFound(schema.GroupResource{}, "TEST ERROR")
-			},
-		).Times(2)
-
 	mockClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).DoAndReturn(
 		func(ctx context.Context, req types.NamespacedName, job *corev1.Secret, opts ...any) error {
 			return errors.New("SECRET ERROR")
@@ -451,7 +442,7 @@ func Test_CommitNotPromotedOnGitJobError(t *testing.T) {
 			gr.Spec.Repo = "repo"
 			gr.Spec.HelmSecretNameForPaths = "helm-secret"
 			gr.Status.Commit = oldCommit
-			gr.Status.WebhookCommit = newCommit // triggers shouldCreateJob via commit != oldCommit
+			gr.Status.PollingCommit = newCommit // triggers shouldCreateJob via getNextCommit
 		},
 		2,
 	)
@@ -3209,5 +3200,294 @@ func TestShouldCreateJob_NoCommitDisablePolling(t *testing.T) {
 	if !got {
 		t.Error("shouldCreateJob returned false with DisablePolling=true and generationChanged()=true; " +
 			"job should still be created when polling is disabled")
+	}
+}
+
+// TestGetNextCommit verifies that WebhookCommit is no longer promoted as a deployable
+// commit (the key change in the webhook-vs-head-race-condition fix). Only PollingCommit
+// can advance the deploy target beyond Status.Commit.
+func TestGetNextCommit(t *testing.T) {
+	tests := map[string]struct {
+		status   fleetv1.GitRepoStatus
+		expected string
+	}{
+		"returns Status.Commit when nothing else is set": {
+			status:   fleetv1.GitRepoStatus{Commit: "aaa"},
+			expected: "aaa",
+		},
+		"returns PollingCommit when it differs from Status.Commit": {
+			status:   fleetv1.GitRepoStatus{Commit: "aaa", PollingCommit: "bbb"},
+			expected: "bbb",
+		},
+		"WebhookCommit is NOT promoted as a deployable commit": {
+			status:   fleetv1.GitRepoStatus{Commit: "aaa", WebhookCommit: "ccc"},
+			expected: "aaa",
+		},
+		"PollingCommit takes precedence; WebhookCommit is ignored": {
+			status:   fleetv1.GitRepoStatus{Commit: "aaa", PollingCommit: "bbb", WebhookCommit: "ccc"},
+			expected: "bbb",
+		},
+		"PollingCommit matching Status.Commit leaves result unchanged": {
+			status:   fleetv1.GitRepoStatus{Commit: "aaa", PollingCommit: "aaa"},
+			expected: "aaa",
+		},
+		"all empty returns empty": {
+			status:   fleetv1.GitRepoStatus{},
+			expected: "",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := getNextCommit(tc.status)
+			if got != tc.expected {
+				t.Errorf("getNextCommit() = %q, want %q", got, tc.expected)
+			}
+		})
+	}
+}
+
+// TestRealignWebhookCommit_AlreadyAligned verifies that realignWebhookCommit is a
+// no-op when WebhookCommit already equals the deployed commit.
+func TestRealignWebhookCommit_AlreadyAligned(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	const deployed = "aaaa1111bbbb2222"
+	mockClient := mocks.NewMockK8sClient(mockCtrl)
+	mockClient.EXPECT().
+		Get(gomock.Any(), gomock.Any(), gomock.AssignableToTypeOf(&fleetv1.GitRepo{}), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ types.NamespacedName, obj client.Object, _ ...any) error {
+			obj.(*fleetv1.GitRepo).Status.WebhookCommit = deployed
+			return nil
+		})
+	// Status().Patch must NOT be called — no mock expectations for it.
+
+	r := &GitJobReconciler{Client: mockClient}
+	if err := r.realignWebhookCommit(context.TODO(), types.NamespacedName{}, deployed, nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// TestRealignWebhookCommit_EmptyWebhookCommit verifies that realignWebhookCommit is a
+// no-op when no webhook has ever set WebhookCommit (empty string).
+func TestRealignWebhookCommit_EmptyWebhookCommit(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	mockClient := mocks.NewMockK8sClient(mockCtrl)
+	mockClient.EXPECT().
+		Get(gomock.Any(), gomock.Any(), gomock.AssignableToTypeOf(&fleetv1.GitRepo{}), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ types.NamespacedName, obj client.Object, _ ...any) error {
+			// WebhookCommit intentionally left empty
+			return nil
+		})
+
+	r := &GitJobReconciler{Client: mockClient}
+	if err := r.realignWebhookCommit(context.TODO(), types.NamespacedName{}, "deployed", nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// TestRealignWebhookCommit_StaleWebhook verifies that realignWebhookCommit patches
+// WebhookCommit to the deployed commit when the stored value is stale and no newer
+// webhook has arrived after the job started.
+func TestRealignWebhookCommit_StaleWebhook(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	const stale = "stale1111"
+	const deployed = "deployed1"
+
+	mockClient := mocks.NewMockK8sClient(mockCtrl)
+	mockClient.EXPECT().
+		Get(gomock.Any(), gomock.Any(), gomock.AssignableToTypeOf(&fleetv1.GitRepo{}), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ types.NamespacedName, obj client.Object, _ ...any) error {
+			obj.(*fleetv1.GitRepo).Status.WebhookCommit = stale
+			// LastWebhookTime is zero — no recent webhook to preserve
+			return nil
+		})
+
+	var patchedCommit string
+	statusClient := mocks.NewMockStatusWriter(mockCtrl)
+	mockClient.EXPECT().Status().Return(statusClient)
+	statusClient.EXPECT().
+		Patch(gomock.Any(), gomock.AssignableToTypeOf(&fleetv1.GitRepo{}), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, obj client.Object, _ client.Patch, _ ...any) error {
+			patchedCommit = obj.(*fleetv1.GitRepo).Status.WebhookCommit
+			return nil
+		})
+
+	r := &GitJobReconciler{Client: mockClient}
+	if err := r.realignWebhookCommit(context.TODO(), types.NamespacedName{}, deployed, nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if patchedCommit != deployed {
+		t.Errorf("patched WebhookCommit = %q, want %q", patchedCommit, deployed)
+	}
+}
+
+// TestRealignWebhookCommit_NewerWebhookAfterJob verifies that realignWebhookCommit does
+// NOT overwrite a newer webhook that arrived after the job started. Without this guard, a
+// late-arriving webhook for a different commit would be silently clobbered.
+func TestRealignWebhookCommit_NewerWebhookAfterJob(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	jobStart := metav1.Now()
+	laterWebhook := metav1.NewTime(jobStart.Add(time.Second))
+
+	mockClient := mocks.NewMockK8sClient(mockCtrl)
+	mockClient.EXPECT().
+		Get(gomock.Any(), gomock.Any(), gomock.AssignableToTypeOf(&fleetv1.GitRepo{}), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ types.NamespacedName, obj client.Object, _ ...any) error {
+			gr := obj.(*fleetv1.GitRepo)
+			gr.Status.WebhookCommit = "newer-webhook-commit"
+			gr.Status.LastWebhookTime = laterWebhook
+			return nil
+		})
+	// No Status().Patch expected — newer webhook must be preserved.
+
+	r := &GitJobReconciler{Client: mockClient}
+	if err := r.realignWebhookCommit(context.TODO(), types.NamespacedName{}, "deployed", &jobStart); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// TestRealignWebhookCommit_TimeoutClearsToHead verifies the propagation-wait
+// give-up caller: realignWebhookCommit is invoked with the current HEAD and a
+// guard equal to the timed-out webhook's own timestamp (no newer webhook
+// arrived). The guard must NOT block, so the stale webhook commit is cleared to
+// HEAD, stopping webhookPending from firing an ls-remote on every reconcile.
+func TestRealignWebhookCommit_TimeoutClearsToHead(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	const head = "head1111head2222"
+	const pendingWebhook = "neverappeared111"
+	webhookTime := metav1.Now()
+
+	mockClient := mocks.NewMockK8sClient(mockCtrl)
+	mockClient.EXPECT().
+		Get(gomock.Any(), gomock.Any(), gomock.AssignableToTypeOf(&fleetv1.GitRepo{}), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ types.NamespacedName, obj client.Object, _ ...any) error {
+			gr := obj.(*fleetv1.GitRepo)
+			gr.Status.WebhookCommit = pendingWebhook
+			gr.Status.LastWebhookTime = webhookTime
+			return nil
+		})
+
+	var patchedCommit string
+	statusClient := mocks.NewMockStatusWriter(mockCtrl)
+	mockClient.EXPECT().Status().Return(statusClient)
+	statusClient.EXPECT().
+		Patch(gomock.Any(), gomock.AssignableToTypeOf(&fleetv1.GitRepo{}), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, obj client.Object, _ client.Patch, _ ...any) error {
+			patchedCommit = obj.(*fleetv1.GitRepo).Status.WebhookCommit
+			return nil
+		})
+
+	// Guard equals the pending webhook's own timestamp: After() is false, so the
+	// clear proceeds.
+	ref := webhookTime
+	r := &GitJobReconciler{Client: mockClient}
+	if err := r.realignWebhookCommit(context.TODO(), types.NamespacedName{}, head, &ref); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if patchedCommit != head {
+		t.Errorf("patched WebhookCommit = %q, want %q (cleared to HEAD)", patchedCommit, head)
+	}
+}
+
+// TestRealignWebhookCommit_GitRepoGone verifies that realignWebhookCommit ignores a
+// NotFound error, treating a deleted GitRepo as a benign race.
+func TestRealignWebhookCommit_GitRepoGone(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	mockClient := mocks.NewMockK8sClient(mockCtrl)
+	mockClient.EXPECT().
+		Get(gomock.Any(), gomock.Any(), gomock.AssignableToTypeOf(&fleetv1.GitRepo{}), gomock.Any()).
+		Return(apierrors.NewNotFound(schema.GroupResource{Resource: "gitrepos"}, "missing"))
+
+	r := &GitJobReconciler{Client: mockClient}
+	if err := r.realignWebhookCommit(context.TODO(), types.NamespacedName{}, "deployed", nil); err != nil {
+		t.Fatalf("expected nil for not-found, got: %v", err)
+	}
+}
+
+// TestCreateJob_AlreadyExistsIsIgnored verifies that createJob treats an AlreadyExists
+// error from the API server as a benign no-op. This handles a concurrent reconcile that
+// created the same job (same gitrepo + commit) between when
+// the current reconcile decided to create and when it actually called Create.
+func TestCreateJob_AlreadyExistsIsIgnored(t *testing.T) {
+	scheme := runtime.NewScheme()
+	utilruntime.Must(corev1.AddToScheme(scheme))
+	utilruntime.Must(appsv1.AddToScheme(scheme))
+	utilruntime.Must(batchv1.AddToScheme(scheme))
+	utilruntime.Must(fleetv1.AddToScheme(scheme))
+
+	gitRepo := &fleetv1.GitRepo{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-repo",
+			Namespace: "default",
+			UID:       "test-uid",
+		},
+		Spec:   fleetv1.GitRepoSpec{Repo: "https://example.com/org/repo.git"},
+		Status: fleetv1.GitRepoStatus{Commit: "abc1234567890"},
+	}
+
+	// Pre-create the job that createJob will try to create, so the fake client
+	// returns AlreadyExists on the Create call.
+	preExisting := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      jobName(gitRepo),
+			Namespace: gitRepo.Namespace,
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(
+			preExisting,
+			&corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "known-hosts",
+					Namespace: config.DefaultNamespace,
+				},
+				Data: map[string]string{"known_hosts": ""},
+			},
+			&appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      config.ManagerConfigName,
+					Namespace: config.DefaultNamespace,
+				},
+				Spec: appsv1.DeploymentSpec{
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"app": "fleet-controller"},
+					},
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{"app": "fleet-controller"},
+						},
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{{Name: "test", Image: "test"}},
+						},
+					},
+				},
+			},
+		).
+		Build()
+
+	r := &GitJobReconciler{
+		Client:          fakeClient,
+		Scheme:          scheme,
+		Image:           "test",
+		SystemNamespace: config.DefaultNamespace,
+		KnownHosts:      ssh.KnownHosts{},
+	}
+
+	if err := r.createJob(context.TODO(), gitRepo); err != nil {
+		t.Fatalf("createJob should return nil on AlreadyExists, got: %v", err)
 	}
 }

--- a/pkg/apis/fleet.cattle.io/v1alpha1/gitrepo_types.go
+++ b/pkg/apis/fleet.cattle.io/v1alpha1/gitrepo_types.go
@@ -187,6 +187,9 @@ type GitRepoStatus struct {
 	// WebhookCommit is the latest Git commit hash received from a webhook
 	// +optional
 	WebhookCommit string `json:"webhookCommit,omitempty"`
+	// LastWebhookTime is the time of the last received webhook notification
+	// +optional
+	LastWebhookTime metav1.Time `json:"lastWebhookTime,omitempty"`
 	// PollingCommit is the latest Git commit hash received from polling
 	// +optional
 	PollingCommit string `json:"pollingCommit,omitempty"`

--- a/pkg/apis/fleet.cattle.io/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/fleet.cattle.io/v1alpha1/zz_generated.deepcopy.go
@@ -1697,6 +1697,7 @@ func (in *GitRepoSpec) DeepCopy() *GitRepoSpec {
 func (in *GitRepoStatus) DeepCopyInto(out *GitRepoStatus) {
 	*out = *in
 	in.StatusBase.DeepCopyInto(&out.StatusBase)
+	in.LastWebhookTime.DeepCopyInto(&out.LastWebhookTime)
 	in.LastSyncedImageScanTime.DeepCopyInto(&out.LastSyncedImageScanTime)
 	in.LastPollingTime.DeepCopyInto(&out.LastPollingTime)
 }

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -166,6 +166,7 @@ func (w *Webhook) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 				}
 				orig := gitRepoFromCluster.DeepCopy()
 				gitRepoFromCluster.Status.WebhookCommit = revision
+				gitRepoFromCluster.Status.LastWebhookTime = metav1.Now()
 				if err := w.client.Status().Patch(ctx, &gitRepoFromCluster, client.MergeFrom(orig)); err != nil {
 					w.logAndReturn(rw, err)
 					return


### PR DESCRIPTION
This PR changes the way webhooks are processed by adding an extra layer to handle the following scenarios:

* A webhook arrives before the repository HEAD has been updated.
* Multiple webhooks are received in a different order than the corresponding commits in the repository.

Webhooks now act solely as triggers for the reconciler. Upon receiving a webhook, the reconciler updates the `status.webhookCommit` field as well as a new field that stores the timestamp of the most recently received webhook.

This timestamp is used to implement an active wait mechanism whenever a mismatch is detected between the commit received in the latest webhook and the repository HEAD.

The repository HEAD is always treated as the single source of truth. If, after a reasonable waiting period, the HEAD still does not match the commit reported by the webhook, the user is notified about the potential loss of a commit reference. This situation should never occur unless there is a serious issue with the Git repository. 

Refers to: https://github.com/rancher/fleet/issues/5216 
Refers to: https://github.com/rancher/fleet/issues/5077



## Additional Information

### Checklist

~- [ ] <!-- If applicable,--> I have updated the documentation via a pull request in the [fleet-product-docs](https://github.com/rancher/fleet-product-docs) repository.~
