### PR TITLE
Fix fleet-agent bundles not deleted when cluster is deleted

### DIFF
--- a/internal/cmd/controller/agentmanagement/controllers/manageagent/manageagent.go
+++ b/internal/cmd/controller/agentmanagement/controllers/manageagent/manageagent.go
@@ -405,6 +405,9 @@ func SkipCluster(cluster *fleet.Cluster) bool {
 	if cluster == nil {
 		return true
 	}
+	if !cluster.DeletionTimestamp.IsZero() {
+		return true
+	}
 	if cluster.Labels == nil {
 		return false
 	}

--- a/internal/cmd/controller/agentmanagement/controllers/manageagent/manageagent_test.go
+++ b/internal/cmd/controller/agentmanagement/controllers/manageagent/manageagent_test.go
@@ -517,6 +517,58 @@ func TestSortTolerations(t *testing.T) {
 	}
 }
 
+func TestSkipCluster(t *testing.T) {
+	now := metav1.Now()
+
+	for _, tt := range []struct {
+		name    string
+		cluster *fleet.Cluster
+		want    bool
+	}{
+		{
+			name:    "nil cluster",
+			cluster: nil,
+			want:    true,
+		},
+		{
+			name:    "active cluster without labels",
+			cluster: &fleet.Cluster{},
+			want:    false,
+		},
+		{
+			name: "cluster being deleted",
+			cluster: &fleet.Cluster{
+				ObjectMeta: metav1.ObjectMeta{DeletionTimestamp: &now},
+			},
+			want: true,
+		},
+		{
+			name: "cluster with management label",
+			cluster: &fleet.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{fleet.ClusterManagementLabel: "custom"},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "cluster with empty management label",
+			cluster: &fleet.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{fleet.ClusterManagementLabel: ""},
+				},
+			},
+			want: false,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := SkipCluster(tt.cluster); got != tt.want {
+				t.Fatalf("SkipCluster() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func checkRegisterAddToScheme(t *testing.T, f func(*runtime.Scheme) error) {
 	t.Helper()
 	err := schemes.Register(f)

--- a/internal/cmd/controller/reconciler/cluster_controller.go
+++ b/internal/cmd/controller/reconciler/cluster_controller.go
@@ -13,6 +13,7 @@ import (
 	"github.com/rancher/fleet/internal/cmd/controller/finalize"
 	"github.com/rancher/fleet/internal/cmd/controller/summary"
 	"github.com/rancher/fleet/internal/metrics"
+	"github.com/rancher/fleet/internal/names"
 	"github.com/rancher/fleet/internal/resourcestatus"
 	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
 	"github.com/rancher/fleet/pkg/durations"
@@ -371,12 +372,34 @@ func (r *ClusterReconciler) mapBundleDeploymentToCluster(ctx context.Context, a 
 	}}
 }
 
-// handleDelete runs cleanup the namespace associated to a Cluster,
+// handleDelete cleans up the namespace and fleet-agent bundle associated with a Cluster,
 // finally removing the finalizer to unblock the deletion of the object from kubernetes.
 func (r *ClusterReconciler) handleDelete(ctx context.Context, cluster *fleet.Cluster) (ctrl.Result, error) {
+	logger := log.FromContext(ctx).WithName("cluster")
+
 	if !controllerutil.ContainsFinalizer(cluster, finalize.ClusterFinalizer) {
 
 		return ctrl.Result{}, nil
+	}
+
+	// Delete the fleet-agent bundle for this cluster. The bundle lives
+	// in the cluster's management namespace (e.g. fleet-default), not
+	// in cluster.Status.Namespace, so it would not be cleaned up by
+	// the namespace deletion below.
+	bundleName := names.SafeConcatName("fleet-agent", cluster.Name)
+	bundle := &fleet.Bundle{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      bundleName,
+			Namespace: cluster.Namespace,
+		},
+	}
+	if err := r.Delete(ctx, bundle); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return ctrl.Result{}, err
+		}
+		logger.V(1).Info("Fleet-agent bundle not found, skipping deletion", "bundle", bundleName)
+	} else {
+		logger.V(1).Info("Deleted fleet-agent bundle for cluster", "bundle", bundleName)
 	}
 
 	if cluster.Status.Namespace != "" {

--- a/internal/cmd/controller/reconciler/cluster_controller_test.go
+++ b/internal/cmd/controller/reconciler/cluster_controller_test.go
@@ -95,6 +95,7 @@ var _ = Describe("ClusterReconciler", func() {
 
 	Context("Reconcile deletion", func() {
 		var clusterNamespace *corev1.Namespace
+		var agentBundle *fleet.Bundle
 
 		BeforeEach(func() {
 			cluster.Finalizers = []string{finalize.ClusterFinalizer}
@@ -106,19 +107,26 @@ var _ = Describe("ClusterReconciler", func() {
 					Name: cluster.Status.Namespace,
 				},
 			}
+
+			agentBundle = &fleet.Bundle{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "fleet-agent-test-cluster",
+					Namespace: cluster.Namespace,
+				},
+			}
 		})
 
 		JustBeforeEach(func() {
 			k8sclient = fake.NewClientBuilder().
 				WithScheme(sch).
-				WithObjects(cluster, clusterNamespace).
+				WithObjects(cluster, clusterNamespace, agentBundle).
 				WithStatusSubresource(&fleet.Cluster{}).
 				Build()
 
 			reconciler.Client = k8sclient
 		})
 
-		It("should delete the cluster namespace and remove the finalizer", func() {
+		It("should delete the cluster namespace, fleet-agent bundle, and remove the finalizer", func() {
 			_, err := reconciler.Reconcile(ctx, req)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -132,6 +140,12 @@ var _ = Describe("ClusterReconciler", func() {
 			err = k8sclient.Get(ctx, client.ObjectKey{Name: clusterNamespace.Name}, ns)
 			Expect(err).To(HaveOccurred())
 			Expect(errors.IsNotFound(err)).To(BeTrue(), "cluster namespace should be deleted")
+
+			// Check fleet-agent bundle is deleted
+			b := &fleet.Bundle{}
+			err = k8sclient.Get(ctx, client.ObjectKey{Name: agentBundle.Name, Namespace: agentBundle.Namespace}, b)
+			Expect(err).To(HaveOccurred())
+			Expect(errors.IsNotFound(err)).To(BeTrue(), "fleet-agent bundle should be deleted")
 		})
 
 		It("should remove the finalizer when cluster namespace is not set", func() {
@@ -139,7 +153,7 @@ var _ = Describe("ClusterReconciler", func() {
 			cluster.Status.Namespace = ""
 			k8sclient = fake.NewClientBuilder().
 				WithScheme(sch).
-				WithObjects(cluster).
+				WithObjects(cluster, agentBundle).
 				WithStatusSubresource(&fleet.Cluster{}).
 				Build()
 			reconciler.Client = k8sclient
@@ -151,11 +165,18 @@ var _ = Describe("ClusterReconciler", func() {
 			err = k8sclient.Get(ctx, req.NamespacedName, cluster)
 			Expect(err).To(HaveOccurred())
 			Expect(errors.IsNotFound(err)).To(BeTrue(), "cluster should be gone as finalizer is removed")
+
+			// Check fleet-agent bundle is deleted
+			b := &fleet.Bundle{}
+			err = k8sclient.Get(ctx, client.ObjectKey{Name: agentBundle.Name, Namespace: agentBundle.Namespace}, b)
+			Expect(err).To(HaveOccurred())
+			Expect(errors.IsNotFound(err)).To(BeTrue(), "fleet-agent bundle should be deleted")
 		})
 
-		It("should remove the finalizer even if the namespace is already gone", func() {
-			// Delete the namespace before the test
+		It("should remove the finalizer even if the namespace and bundle are already gone", func() {
+			// Delete the namespace and bundle before the test
 			Expect(k8sclient.Delete(ctx, clusterNamespace)).To(Succeed())
+			Expect(k8sclient.Delete(ctx, agentBundle)).To(Succeed())
 
 			_, err := reconciler.Reconcile(ctx, req)
 			Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
When a cluster is deleted, its fleet-agent bundle (fleet-agent-<clusterName>) in the management namespace was not cleaned up because:
- No owner references exist from Cluster to Bundle
- The cluster controller only deleted cluster.Status.Namespace (the registration namespace), not the bundle in cluster.Namespace

This commit:
- Adds explicit deletion of the fleet-agent bundle in the cluster controller's handleDelete, before removing the finalizer
- Updates SkipCluster in manageagent to skip clusters with DeletionTimestamp set, preventing the manageagent controller from re-creating bundles for dying clusters (race condition defense)
- Updates unit tests to verify bundle cleanup on cluster deletion

Refers to #3588

<!-- Describe the changes introduced by this pull request -->

<!--
  Please provide a unit, integration (`./integrationtests/`) or e2e (`./e2e/`) test if possible.
-->

## Additional Information

### Checklist

- [ ] <!-- If applicable,--> I have updated the documentation via a pull request in the [fleet-product-docs](https://github.com/rancher/fleet-product-docs) repository.
