### PR TITLE
Disable WatchListClient in Fleet pods

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
         run: |
           helm plugin install https://github.com/helm-unittest/helm-unittest.git --version v1.0.2
           helm unittest ./charts/fleet
+          helm unittest ./charts/fleet-agent
       -
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:

--- a/charts/fleet-agent/templates/deployment.yaml
+++ b/charts/fleet-agent/templates/deployment.yaml
@@ -18,6 +18,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: KUBE_FEATURE_WatchListClient
+          value: "false"
         {{- if $.Values.agent.reconciler.workers.bundledeployment }}
         - name: BUNDLEDEPLOYMENT_RECONCILER_WORKERS
           value: {{ quote $.Values.agent.reconciler.workers.bundledeployment }}

--- a/charts/fleet-agent/tests/watchlistclient_test.yaml
+++ b/charts/fleet-agent/tests/watchlistclient_test.yaml
@@ -1,0 +1,11 @@
+suite: WatchListClient feature gate env var tests
+templates:
+  - deployment.yaml
+tests:
+  - it: should set KUBE_FEATURE_WatchListClient to false in the fleet-agent container
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name == 'fleet-agent')].env
+          content:
+            name: KUBE_FEATURE_WatchListClient
+            value: "false"

--- a/charts/fleet/templates/deployment.yaml
+++ b/charts/fleet/templates/deployment.yaml
@@ -41,6 +41,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: KUBE_FEATURE_WatchListClient
+          value: "false"
         {{- if $.Values.clusterEnqueueDelay }}
         - name: FLEET_CLUSTER_ENQUEUE_DELAY
           value: {{ $.Values.clusterEnqueueDelay }}
@@ -191,6 +193,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: KUBE_FEATURE_WatchListClient
+          value: "false"
         - name: FLEET_PROPAGATE_DEBUG_SETTINGS_TO_AGENTS
           value: {{ quote $.Values.propagateDebugSettingsToAgents }}
         - name: FLEET_DEBUG_DISABLE_SECURITY_CONTEXT

--- a/charts/fleet/templates/deployment_gitjob.yaml
+++ b/charts/fleet/templates/deployment_gitjob.yaml
@@ -74,6 +74,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: KUBE_FEATURE_WatchListClient
+              value: "false"
           {{- if $.Values.leaderElection.leaseDuration }}
             - name: CATTLE_ELECTION_LEASE_DURATION
               value: {{$.Values.leaderElection.leaseDuration}}

--- a/charts/fleet/templates/deployment_helmops.yaml
+++ b/charts/fleet/templates/deployment_helmops.yaml
@@ -65,6 +65,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: KUBE_FEATURE_WatchListClient
+              value: "false"
           {{- if $.Values.leaderElection.leaseDuration }}
             - name: CATTLE_ELECTION_LEASE_DURATION
               value: {{$.Values.leaderElection.leaseDuration}}

--- a/charts/fleet/tests/watchlistclient_test.yaml
+++ b/charts/fleet/tests/watchlistclient_test.yaml
@@ -1,8 +1,11 @@
 suite: WatchListClient feature gate env var tests
 templates:
   - deployment.yaml
+  - deployment_gitjob.yaml
+  - deployment_helmops.yaml
 tests:
   - it: should set KUBE_FEATURE_WatchListClient to false in the fleet-controller container
+    template: deployment.yaml
     asserts:
       - contains:
           path: spec.template.spec.containers[?(@.name == 'fleet-controller')].env
@@ -11,9 +14,28 @@ tests:
             value: "false"
 
   - it: should set KUBE_FEATURE_WatchListClient to false in the fleet-agentmanagement container
+    template: deployment.yaml
     asserts:
       - contains:
           path: spec.template.spec.containers[?(@.name == 'fleet-agentmanagement')].env
+          content:
+            name: KUBE_FEATURE_WatchListClient
+            value: "false"
+
+  - it: should set KUBE_FEATURE_WatchListClient to false in the gitjob container
+    template: deployment_gitjob.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name == 'gitjob')].env
+          content:
+            name: KUBE_FEATURE_WatchListClient
+            value: "false"
+
+  - it: should set KUBE_FEATURE_WatchListClient to false in the helmops container
+    template: deployment_helmops.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name == 'helmops')].env
           content:
             name: KUBE_FEATURE_WatchListClient
             value: "false"

--- a/charts/fleet/tests/watchlistclient_test.yaml
+++ b/charts/fleet/tests/watchlistclient_test.yaml
@@ -1,0 +1,19 @@
+suite: WatchListClient feature gate env var tests
+templates:
+  - deployment.yaml
+tests:
+  - it: should set KUBE_FEATURE_WatchListClient to false in the fleet-controller container
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name == 'fleet-controller')].env
+          content:
+            name: KUBE_FEATURE_WatchListClient
+            value: "false"
+
+  - it: should set KUBE_FEATURE_WatchListClient to false in the fleet-agentmanagement container
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name == 'fleet-agentmanagement')].env
+          content:
+            name: KUBE_FEATURE_WatchListClient
+            value: "false"

--- a/internal/cmd/controller/agentmanagement/agent/manifest.go
+++ b/internal/cmd/controller/agentmanagement/agent/manifest.go
@@ -191,6 +191,7 @@ func agentApp(namespace string, agentScope string, opts ManifestOptions) *appsv1
 										},
 									},
 								},
+								{Name: "KUBE_FEATURE_WatchListClient", Value: "false"},
 								{Name: "AGENT_SCOPE", Value: agentScope},
 								{Name: "CHECKIN_INTERVAL", Value: opts.CheckinInterval},
 								{Name: "CATTLE_ELECTION_LEASE_DURATION", Value: opts.LeaseDuration.String()},

--- a/internal/cmd/controller/agentmanagement/agent/manifest_test.go
+++ b/internal/cmd/controller/agentmanagement/agent/manifest_test.go
@@ -416,3 +416,20 @@ func TestManifestCheckGVKErrorMappingEnvVar(t *testing.T) {
 		})
 	}
 }
+
+func TestManifestWatchListClientDisabled(t *testing.T) {
+	d := getAgentFromManifests("test-scope", agent.ManifestOptions{
+		LeaderElectionOptions: leaderOpts,
+	})
+	if d == nil {
+		t.Fatal("no deployment returned from manifests")
+	}
+
+	envVar, found := findEnvVar(d.Spec.Template.Spec.Containers, "KUBE_FEATURE_WatchListClient")
+	if !found {
+		t.Fatal("env var KUBE_FEATURE_WatchListClient not found in agent container")
+	}
+	if envVar.Value != "false" {
+		t.Fatalf("expected KUBE_FEATURE_WatchListClient=false, got %q", envVar.Value)
+	}
+}


### PR DESCRIPTION
Set `KUBE_FEATURE_WatchListClient=false` on Fleet controller and agent pods rendered by the `fleet` and `fleet-agent` charts so informer cache startup does not depend on WatchList bookmark behavior.

This returns to the old behavior after k8s client-go 0.35 changed the [default to true](https://github.com/kubernetes/client-go/blob/v0.35.1/features/known_features.go#L101-L104).

Refers #5059