### PR TITLE
Prevent cluster updates triggered by cluster status updates

### DIFF
--- a/internal/cmd/controller/reconciler/cluster_controller.go
+++ b/internal/cmd/controller/reconciler/cluster_controller.go
@@ -62,7 +62,18 @@ type ClusterReconciler struct {
 // SetupWithManager sets up the controller with the Manager.
 func (r *ClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&fleet.Cluster{}).
+		For(&fleet.Cluster{},
+			builder.WithPredicates(
+				// do not trigger for cluster status changes (except for cache sync)
+				predicate.Or(
+					TypedResourceVersionUnchangedPredicate[client.Object]{},
+					predicate.GenerationChangedPredicate{},
+					predicate.AnnotationChangedPredicate{},
+					predicate.LabelChangedPredicate{},
+				),
+				sharding.FilterByShardID(r.ShardID),
+			),
+		).
 		// Watch bundledeployments so we can update the status fields
 		Watches(
 			&fleet.BundleDeployment{},


### PR DESCRIPTION
Similarly to how a bundle should not be reconciled based on its own status updates, neither should a cluster.

## Additional Information

### Checklist

~- [ ] <!-- If applicable,--> I have updated the documentation via a pull request in the [fleet-product-docs](https://github.com/rancher/fleet-product-docs) repository.~
