### PR TITLE
Sensible agent check in defaults

### DIFF
--- a/e2e/multi-cluster/installation/agent_test.go
+++ b/e2e/multi-cluster/installation/agent_test.go
@@ -37,7 +37,7 @@ var _ = Describe("Fleet installation with TLS agent modes", func() {
 			"--type=merge",
 			"-p",
 			fmt.Sprintf(
-				`{"data":{"config":"{\"apiServerURL\": \"https://google.com\", \"apiServerCA\": \"\", \"agentTLSMode\": \"%s\"}"}}`,
+				`{"data":{"config":"{\"apiServerURL\": \"https://google.com\", \"apiServerCA\": \"\", \"agentTLSMode\": \"%s\", \"agentCheckinInterval\": \"15m\"}"}}`, // agent check-in interval must be non-zero
 				agentMode,
 			),
 		)

--- a/internal/cmd/controller/agentmanagement/controllers/cluster/import.go
+++ b/internal/cmd/controller/agentmanagement/controllers/cluster/import.go
@@ -361,6 +361,10 @@ func (i *importHandler) importCluster(cluster *fleet.Cluster, status fleet.Clust
 		apiServerCA  = secret.Data[config.APIServerCAKey]
 	)
 
+	if cfg.AgentCheckinInterval.Seconds() == 0 {
+		return status, errors.New("agent check-in interval cannot be 0")
+	}
+
 	if apiServerURL == "" {
 		if len(cfg.APIServerURL) == 0 {
 			// Current config cannot be deployed, so remove the "config changed" mark

--- a/internal/cmd/controller/agentmanagement/controllers/cluster/import.go
+++ b/internal/cmd/controller/agentmanagement/controllers/cluster/import.go
@@ -495,6 +495,7 @@ func (i *importHandler) importCluster(cluster *fleet.Cluster, status fleet.Clust
 				AgentResources:       cluster.Spec.AgentResources,
 				HostNetwork:          *cmp.Or(cluster.Spec.HostNetwork, new(false)),
 				AgentReplicas:        agentReplicas,
+				CheckinInterval:      cfg.AgentCheckinInterval.Duration.String(),
 				PriorityClassName:    priorityClassName,
 				ImagePullSecrets:     pullSecrets,
 				PropagatePullSecrets: propagate,

--- a/internal/cmd/controller/agentmanagement/controllers/cluster/import.go
+++ b/internal/cmd/controller/agentmanagement/controllers/cluster/import.go
@@ -361,8 +361,8 @@ func (i *importHandler) importCluster(cluster *fleet.Cluster, status fleet.Clust
 		apiServerCA  = secret.Data[config.APIServerCAKey]
 	)
 
-	if cfg.AgentCheckinInterval.Seconds() == 0 {
-		return status, errors.New("agent check-in interval cannot be 0")
+	if cfg.AgentCheckinInterval.Seconds() <= 0 {
+		return status, errors.New("agent check-in interval cannot be 0 or less")
 	}
 
 	if apiServerURL == "" {

--- a/internal/cmd/controller/agentmanagement/controllers/cluster/import.go
+++ b/internal/cmd/controller/agentmanagement/controllers/cluster/import.go
@@ -359,8 +359,8 @@ func (i *importHandler) importCluster(cluster *fleet.Cluster, status fleet.Clust
 		apiServerCA  = secret.Data[config.APIServerCAKey]
 	)
 
-	if cfg.AgentCheckinInterval.Seconds() == 0 {
-		return status, errors.New("agent check-in interval cannot be 0")
+	if cfg.AgentCheckinInterval.Seconds() <= 0 {
+		return status, errors.New("agent check-in interval cannot be 0 or less")
 	}
 
 	if apiServerURL == "" {

--- a/internal/cmd/controller/agentmanagement/controllers/cluster/import.go
+++ b/internal/cmd/controller/agentmanagement/controllers/cluster/import.go
@@ -359,6 +359,10 @@ func (i *importHandler) importCluster(cluster *fleet.Cluster, status fleet.Clust
 		apiServerCA  = secret.Data[config.APIServerCAKey]
 	)
 
+	if cfg.AgentCheckinInterval.Seconds() == 0 {
+		return status, errors.New("agent check-in interval cannot be 0")
+	}
+
 	if apiServerURL == "" {
 		if len(cfg.APIServerURL) == 0 {
 			// Current config cannot be deployed, so remove the "config changed" mark

--- a/internal/cmd/controller/agentmanagement/controllers/cluster/import.go
+++ b/internal/cmd/controller/agentmanagement/controllers/cluster/import.go
@@ -493,6 +493,7 @@ func (i *importHandler) importCluster(cluster *fleet.Cluster, status fleet.Clust
 				AgentResources:       cluster.Spec.AgentResources,
 				HostNetwork:          *cmp.Or(cluster.Spec.HostNetwork, new(false)),
 				AgentReplicas:        agentReplicas,
+				CheckinInterval:      cfg.AgentCheckinInterval.Duration.String(),
 				PriorityClassName:    priorityClassName,
 				ImagePullSecrets:     pullSecrets,
 				PropagatePullSecrets: propagate,

--- a/internal/cmd/controller/agentmanagement/controllers/manageagent/manageagent.go
+++ b/internal/cmd/controller/agentmanagement/controllers/manageagent/manageagent.go
@@ -336,8 +336,8 @@ func (h *handler) newAgentBundle(ns string, cluster *fleet.Cluster) ([]runtime.O
 		priorityClassName = scheduling.FleetAgentPriorityClassName
 	}
 
-	if cfg.AgentCheckinInterval.Seconds() == 0 {
-		return nil, errors.New("agent check-in interval cannot be 0")
+	if cfg.AgentCheckinInterval.Seconds() <= 0 {
+		return nil, errors.New("agent check-in interval cannot be 0 or less")
 	}
 
 	if cluster.Spec.AgentTolerations != nil {

--- a/internal/cmd/controller/agentmanagement/controllers/manageagent/manageagent.go
+++ b/internal/cmd/controller/agentmanagement/controllers/manageagent/manageagent.go
@@ -11,6 +11,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sort"
 
@@ -333,6 +334,10 @@ func (h *handler) newAgentBundle(ns string, cluster *fleet.Cluster) ([]runtime.O
 	priorityClassName := ""
 	if cluster.Spec.AgentSchedulingCustomization != nil && cluster.Spec.AgentSchedulingCustomization.PriorityClass != nil {
 		priorityClassName = scheduling.FleetAgentPriorityClassName
+	}
+
+	if cfg.AgentCheckinInterval.Seconds() == 0 {
+		return nil, errors.New("agent check-in interval cannot be 0")
 	}
 
 	if cluster.Spec.AgentTolerations != nil {

--- a/internal/cmd/controller/agentmanagement/controllers/manageagent/manageagent.go
+++ b/internal/cmd/controller/agentmanagement/controllers/manageagent/manageagent.go
@@ -334,8 +334,8 @@ func (h *handler) newAgentBundle(ns string, cluster *fleet.Cluster) ([]runtime.O
 		priorityClassName = scheduling.FleetAgentPriorityClassName
 	}
 
-	if cfg.AgentCheckinInterval.Seconds() == 0 {
-		return nil, errors.New("agent check-in interval cannot be 0")
+	if cfg.AgentCheckinInterval.Seconds() <= 0 {
+		return nil, errors.New("agent check-in interval cannot be 0 or less")
 	}
 
 	if cluster.Spec.AgentTolerations != nil {

--- a/internal/cmd/controller/agentmanagement/controllers/manageagent/manageagent.go
+++ b/internal/cmd/controller/agentmanagement/controllers/manageagent/manageagent.go
@@ -11,6 +11,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sort"
 
@@ -331,6 +332,10 @@ func (h *handler) newAgentBundle(ns string, cluster *fleet.Cluster) ([]runtime.O
 	priorityClassName := ""
 	if cluster.Spec.AgentSchedulingCustomization != nil && cluster.Spec.AgentSchedulingCustomization.PriorityClass != nil {
 		priorityClassName = scheduling.FleetAgentPriorityClassName
+	}
+
+	if cfg.AgentCheckinInterval.Seconds() == 0 {
+		return nil, errors.New("agent check-in interval cannot be 0")
 	}
 
 	if cluster.Spec.AgentTolerations != nil {

--- a/internal/cmd/controller/agentmanagement/controllers/manageagent/manageagent_test.go
+++ b/internal/cmd/controller/agentmanagement/controllers/manageagent/manageagent_test.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/rancher/wrangler/v3/pkg/generic/fake"
 	"github.com/rancher/wrangler/v3/pkg/schemes"
@@ -14,13 +15,33 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
+	"github.com/rancher/fleet/internal/config"
 	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	networkv1 "k8s.io/api/networking/v1"
 	"sigs.k8s.io/yaml"
-
-	"github.com/rancher/fleet/internal/config"
 )
+
+func TestNewAgentBundle(t *testing.T) {
+	config.Set(&config.Config{AgentCheckinInterval: metav1.Duration{Duration: 0 * time.Second}})
+
+	// ensure leader election env is set so NewLeaderElectionOptionsWithPrefix doesn't error
+	t.Setenv("FLEET_AGENT_ELECTION_LEASE_DURATION", "15s")
+	t.Setenv("FLEET_AGENT_ELECTION_RENEW_DEADLINE", "10s")
+	t.Setenv("FLEET_AGENT_ELECTION_RETRY_PERIOD", "2s")
+
+	h := handler{systemNamespace: "blah"}
+	obj, err := h.newAgentBundle("foo", &fleet.Cluster{Spec: fleet.ClusterSpec{AgentNamespace: "bar"}})
+
+	if obj != nil {
+		t.Fatalf("expected obj returned by newAgentBundle to be nil")
+	}
+
+	expectedStr := "interval cannot be 0"
+	if !strings.Contains(err.Error(), expectedStr) {
+		t.Fatalf("expected error %q returned by newAgentBundle to contain %q", err, expectedStr)
+	}
+}
 
 func TestOnClusterChangeAffinity(t *testing.T) {
 	ctrl := gomock.NewController(t)
@@ -119,7 +140,9 @@ func TestOnClusterChangeAffinity(t *testing.T) {
 
 func TestNewAgentBundle_SortsAgentTolerations(t *testing.T) {
 	// make sure config is set for newAgentBundle
-	config.Set(config.DefaultConfig())
+	cfg := config.DefaultConfig()
+	cfg.AgentCheckinInterval = metav1.Duration{Duration: 1 * time.Second} // non-zero to prevent errors covered elsewhere.
+	config.Set(cfg)
 
 	checkRegisterAddToScheme(t, appsv1.AddToScheme)
 	checkRegisterAddToScheme(t, networkv1.AddToScheme)

--- a/internal/cmd/controller/agentmanagement/controllers/manageagent/manageagent_test.go
+++ b/internal/cmd/controller/agentmanagement/controllers/manageagent/manageagent_test.go
@@ -1,6 +1,7 @@
 package manageagent
 
 import (
+	"fmt"
 	"maps"
 	"reflect"
 	"strings"
@@ -23,23 +24,40 @@ import (
 )
 
 func TestNewAgentBundle(t *testing.T) {
-	config.Set(&config.Config{AgentCheckinInterval: metav1.Duration{Duration: 0 * time.Second}})
-
-	// ensure leader election env is set so NewLeaderElectionOptionsWithPrefix doesn't error
-	t.Setenv("FLEET_AGENT_ELECTION_LEASE_DURATION", "15s")
-	t.Setenv("FLEET_AGENT_ELECTION_RENEW_DEADLINE", "10s")
-	t.Setenv("FLEET_AGENT_ELECTION_RETRY_PERIOD", "2s")
-
-	h := handler{systemNamespace: "blah"}
-	obj, err := h.newAgentBundle("foo", &fleet.Cluster{Spec: fleet.ClusterSpec{AgentNamespace: "bar"}})
-
-	if obj != nil {
-		t.Fatalf("expected obj returned by newAgentBundle to be nil")
+	testCases := []struct {
+		agentCheckInInterval time.Duration
+	}{
+		{
+			0 * time.Second,
+		},
+		{
+			-5 * time.Second,
+		},
 	}
 
-	expectedStr := "interval cannot be 0"
-	if !strings.Contains(err.Error(), expectedStr) {
-		t.Fatalf("expected error %q returned by newAgentBundle to contain %q", err, expectedStr)
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("agent check-in interval of %s", tc.agentCheckInInterval), func(t *testing.T) {
+			config.Set(&config.Config{
+				AgentCheckinInterval: metav1.Duration{Duration: tc.agentCheckInInterval},
+			})
+
+			// ensure leader election env is set so NewLeaderElectionOptionsWithPrefix doesn't error
+			t.Setenv("FLEET_AGENT_ELECTION_LEASE_DURATION", "15s")
+			t.Setenv("FLEET_AGENT_ELECTION_RENEW_DEADLINE", "10s")
+			t.Setenv("FLEET_AGENT_ELECTION_RETRY_PERIOD", "2s")
+
+			h := handler{systemNamespace: "blah"}
+			obj, err := h.newAgentBundle("foo", &fleet.Cluster{Spec: fleet.ClusterSpec{AgentNamespace: "bar"}})
+
+			if obj != nil {
+				t.Fatalf("expected obj returned by newAgentBundle to be nil")
+			}
+
+			expectedStr := "interval cannot be 0 or less"
+			if err == nil || !strings.Contains(err.Error(), expectedStr) {
+				t.Fatalf("expected error %v returned by newAgentBundle to contain %q", err, expectedStr)
+			}
+		})
 	}
 }
 

--- a/internal/cmd/controller/agentmanagement/controllers/manageagent/manageagent_test.go
+++ b/internal/cmd/controller/agentmanagement/controllers/manageagent/manageagent_test.go
@@ -292,6 +292,8 @@ func TestNewAgentBundle_PropagatesAgentImagePullSecrets(t *testing.T) {
 			if tc.configPullSecrets != nil {
 				cfg.ImagePullSecrets = *tc.configPullSecrets
 			}
+
+			cfg.AgentCheckinInterval = metav1.Duration{Duration: 1 * time.Second} // non-zero to prevent errors covered elsewhere.
 			config.Set(cfg)
 
 			checkRegisterAddToScheme(t, appsv1.AddToScheme)


### PR DESCRIPTION
This ensures that an agent check-in interval cannot be set to a zero duration.

## Additional Information

### Checklist

~- [ ] <!-- If applicable,--> I have updated the documentation via a pull request in the [fleet-product-docs](https://github.com/rancher/fleet-product-docs) repository.~
