### PR TITLE
[v0.14] Validate kubeConfig Namespaces against known Fleet namespaces

### DIFF
--- a/internal/cmd/controller/agentmanagement/controllers/cluster/import.go
+++ b/internal/cmd/controller/agentmanagement/controllers/cluster/import.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"strings"
 
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/labels"
@@ -95,7 +96,12 @@ func RegisterImport(
 		if cluster == nil || len(cluster.Spec.KubeConfigSecret) == 0 {
 			return []string{}, nil
 		}
-		secretKey := getKubeConfigSecretNS(cluster) + "/" + cluster.Spec.KubeConfigSecret
+		ns, err := allowedKubeConfigSecretNamespace(cluster)
+		if err != nil {
+			logrus.Debugf("Cluster %s/%s: skipping kubeconfig secret index: %v", cluster.Namespace, cluster.Name, err)
+			return []string{}, nil
+		}
+		secretKey := ns + "/" + cluster.Spec.KubeConfigSecret
 		return []string{secretKey}, nil
 	})
 	secrets.OnChange(ctx, "kubeconfig-secrets-watch", func(key string, secret *corev1.Secret) (*corev1.Secret, error) {
@@ -136,7 +142,12 @@ func (i *importHandler) onConfig(cfg *config.Config) error {
 			continue
 		}
 
-		secret, err := i.secretsCache.Get(getKubeConfigSecretNS(cluster), cluster.Spec.KubeConfigSecret)
+		kubeConfigNS, err := allowedKubeConfigSecretNamespace(cluster)
+		if err != nil {
+			logrus.WithError(err).Warnf("cluster %s/%s: skipping config change check", cluster.Namespace, cluster.Name)
+			continue
+		}
+		secret, err := i.secretsCache.Get(kubeConfigNS, cluster.Spec.KubeConfigSecret)
 		if err != nil {
 			return fmt.Errorf("cluster %s/%s: could not check for config changes: %w", cluster.Namespace, cluster.Name, err)
 		}
@@ -299,7 +310,10 @@ func (i *importHandler) importCluster(cluster *fleet.Cluster, status fleet.Clust
 		return status, nil
 	}
 
-	kubeConfigSecretNamespace := getKubeConfigSecretNS(cluster)
+	kubeConfigSecretNamespace, err := allowedKubeConfigSecretNamespace(cluster)
+	if err != nil {
+		return status, err
+	}
 
 	logrus.Debugf("Cluster import for '%s/%s'. Getting kubeconfig from secret in namespace %s", cluster.Namespace, cluster.Name, kubeConfigSecretNamespace)
 
@@ -583,12 +597,25 @@ func (i *importHandler) checkForConfigChange(cfg *config.Config, cluster *fleet.
 	return err
 }
 
-func getKubeConfigSecretNS(cluster *fleet.Cluster) string {
-	if cluster.Spec.KubeConfigSecretNamespace == "" {
-		return cluster.Namespace
+// allowedKubeConfigSecretNamespace returns the namespace from which the
+// kubeconfig secret may be read. Only Fleet-managed namespaces are permitted.
+func allowedKubeConfigSecretNamespace(cluster *fleet.Cluster) (string, error) {
+	if cluster.Spec.KubeConfigSecretNamespace == "" || cluster.Spec.KubeConfigSecretNamespace == cluster.Namespace {
+		return cluster.Namespace, nil
 	}
 
-	return cluster.Spec.KubeConfigSecretNamespace
+	ns := cluster.Spec.KubeConfigSecretNamespace
+	if ns == "fleet-local" ||
+		ns == "fleet-default" ||
+		ns == config.DefaultNamespace ||
+		ns == config.LegacyDefaultNamespace ||
+		ns == fleetns.SystemRegistrationNamespace(config.DefaultNamespace) ||
+		ns == fleetns.SystemRegistrationNamespace(config.LegacyDefaultNamespace) ||
+		strings.HasPrefix(ns, "cluster-") {
+		return ns, nil
+	}
+
+	return "", fmt.Errorf("kubeConfigSecretNamespace %q is not an allowed Fleet namespace", ns)
 }
 
 func hasGarbageCollectionIntervalChanged(config *config.Config, cluster *fleet.Cluster) bool {

--- a/internal/cmd/controller/agentmanagement/controllers/cluster/import_test.go
+++ b/internal/cmd/controller/agentmanagement/controllers/cluster/import_test.go
@@ -1,6 +1,7 @@
 package cluster
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -352,6 +353,150 @@ func TestOnConfig(t *testing.T) {
 				t.Errorf("unexpected error: expected nil, got %v", err)
 			}
 
+		})
+	}
+}
+
+func TestOnConfig_DisallowedNamespace(t *testing.T) {
+	// A cluster with kubeConfigSecretNamespace set to a disallowed namespace
+	// must be silently skipped during onConfig — the controller must not read
+	// any secret from that namespace.
+	cfg := config.Config{
+		APIServerCA:  []byte("foo"),
+		APIServerURL: "https://hello.world",
+		AgentTLSMode: "system-store",
+	}
+
+	ctrl := gomock.NewController(t)
+	secretsCache := fake.NewMockCacheInterface[*corev1.Secret](ctrl)
+	// secretsCache.Get must never be called for the disallowed namespace.
+
+	clustersCache := fake.NewMockCacheInterface[*fleet.Cluster](ctrl)
+	clustersCache.EXPECT().List("", gomock.Eq(labels.Everything())).Return([]*fleet.Cluster{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "bad-cluster", Namespace: "fleet-default"},
+			Spec: fleet.ClusterSpec{
+				KubeConfigSecret:          "some-secret",
+				KubeConfigSecretNamespace: "kube-system",
+			},
+		},
+	}, nil)
+
+	ih := importHandler{clustersCache: clustersCache, secretsCache: secretsCache}
+	// onConfig silently skips clusters with disallowed namespaces (logs a warning
+	// and continues); it does not propagate the error to the caller.
+	if err := ih.onConfig(&cfg); err != nil {
+		t.Errorf("unexpected error: expected nil, got %v", err)
+	}
+}
+
+func TestAllowedKubeConfigSecretNamespace(t *testing.T) {
+	cases := map[string]struct {
+		clusterNamespace string
+		fieldValue       string
+		wantNS           string
+		wantErrContains  string
+	}{
+		"empty field returns cluster namespace": {
+			clusterNamespace: "fleet-default",
+			fieldValue:       "",
+			wantNS:           "fleet-default",
+		},
+		"fleet-default is allowed": {
+			clusterNamespace: "fleet-local",
+			fieldValue:       "fleet-default",
+			wantNS:           "fleet-default",
+		},
+		"fleet-local is allowed": {
+			clusterNamespace: "fleet-default",
+			fieldValue:       "fleet-local",
+			wantNS:           "fleet-local",
+		},
+		"cattle-fleet-system is allowed": {
+			clusterNamespace: "fleet-default",
+			fieldValue:       config.DefaultNamespace,
+			wantNS:           config.DefaultNamespace,
+		},
+		"fleet-system (legacy) is allowed": {
+			clusterNamespace: "fleet-default",
+			fieldValue:       config.LegacyDefaultNamespace,
+			wantNS:           config.LegacyDefaultNamespace,
+		},
+		"cattle-fleet-clusters-system is allowed": {
+			clusterNamespace: "fleet-default",
+			fieldValue:       "cattle-fleet-clusters-system",
+			wantNS:           "cattle-fleet-clusters-system",
+		},
+		"fleet-clusters-system (legacy) is allowed": {
+			clusterNamespace: "fleet-default",
+			fieldValue:       "fleet-clusters-system",
+			wantNS:           "fleet-clusters-system",
+		},
+		"cluster-* prefix is allowed": {
+			clusterNamespace: "fleet-default",
+			fieldValue:       "cluster-fleet-default-my-cluster-abc123",
+			wantNS:           "cluster-fleet-default-my-cluster-abc123",
+		},
+		"custom workspace cluster referencing own namespace is allowed": {
+			clusterNamespace: "my-workspace",
+			fieldValue:       "my-workspace",
+			wantNS:           "my-workspace",
+		},
+		"cattle-system cluster can reference own namespace": {
+			clusterNamespace: "cattle-system",
+			fieldValue:       "cattle-system",
+			wantNS:           "cattle-system",
+		},
+		"kube-system is rejected": {
+			clusterNamespace: "fleet-default",
+			fieldValue:       "kube-system",
+			wantErrContains:  "not an allowed Fleet namespace",
+		},
+		"cattle-system is rejected": {
+			clusterNamespace: "fleet-default",
+			fieldValue:       "cattle-system",
+			wantErrContains:  "not an allowed Fleet namespace",
+		},
+		"arbitrary namespace is rejected": {
+			clusterNamespace: "fleet-default",
+			fieldValue:       "tenant-a-secrets",
+			wantErrContains:  "not an allowed Fleet namespace",
+		},
+		"default namespace is rejected": {
+			clusterNamespace: "fleet-default",
+			fieldValue:       "default",
+			wantErrContains:  "not an allowed Fleet namespace",
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			cluster := &fleet.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: c.clusterNamespace,
+				},
+				Spec: fleet.ClusterSpec{
+					KubeConfigSecretNamespace: c.fieldValue,
+				},
+			}
+
+			got, err := allowedKubeConfigSecretNamespace(cluster)
+			if c.wantErrContains != "" {
+				if err == nil {
+					t.Errorf("expected error for namespace %q, got nil", c.fieldValue)
+				} else if !strings.Contains(err.Error(), c.wantErrContains) {
+					t.Errorf("expected error containing %q, got %q", c.wantErrContains, err.Error())
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("unexpected error for namespace %q: %v", c.fieldValue, err)
+				return
+			}
+			if got != c.wantNS {
+				t.Errorf("expected namespace %q, got %q", c.wantNS, got)
+			}
 		})
 	}
 }


### PR DESCRIPTION
Validates kubeConfig secret namespaces so only allowed Fleet-managed namespaces are accepted.
Adds kubeconfig secret indexer and secret-watcher handling to detect config changes and trigger cluster reimports.

Backports #5224