### PR TITLE
[v0.12] Validate kubeConfig Namespaces against known Fleet namespaces

### DIFF
--- a/internal/cmd/controller/agentmanagement/controllers/cluster/import.go
+++ b/internal/cmd/controller/agentmanagement/controllers/cluster/import.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"strings"
 
 	"github.com/sirupsen/logrus"
 
@@ -222,9 +223,9 @@ func (i *importHandler) importCluster(cluster *fleet.Cluster, status fleet.Clust
 		return status, nil
 	}
 
-	kubeConfigSecretNamespace := cluster.Namespace
-	if cluster.Spec.KubeConfigSecretNamespace != "" {
-		kubeConfigSecretNamespace = cluster.Spec.KubeConfigSecretNamespace
+	kubeConfigSecretNamespace, err := allowedKubeConfigSecretNamespace(cluster)
+	if err != nil {
+		return status, err
 	}
 	logrus.Debugf("Cluster import for '%s/%s'. Getting kubeconfig from secret in namespace %s", cluster.Namespace, cluster.Name, kubeConfigSecretNamespace)
 
@@ -405,6 +406,27 @@ func isLegacyAgentNamespaceSelectedByUser() bool {
 
 	return os.Getenv("NAMESPACE") == config.LegacyDefaultNamespace ||
 		cfg.Bootstrap.AgentNamespace == config.LegacyDefaultNamespace
+}
+
+// allowedKubeConfigSecretNamespace returns the namespace from which the
+// kubeconfig secret may be read. Only Fleet-managed namespaces are permitted.
+func allowedKubeConfigSecretNamespace(cluster *fleet.Cluster) (string, error) {
+	if cluster.Spec.KubeConfigSecretNamespace == "" || cluster.Spec.KubeConfigSecretNamespace == cluster.Namespace {
+		return cluster.Namespace, nil
+	}
+
+	ns := cluster.Spec.KubeConfigSecretNamespace
+	if ns == "fleet-local" ||
+		ns == "fleet-default" ||
+		ns == config.DefaultNamespace ||
+		ns == config.LegacyDefaultNamespace ||
+		ns == fleetns.SystemRegistrationNamespace(config.DefaultNamespace) ||
+		ns == fleetns.SystemRegistrationNamespace(config.LegacyDefaultNamespace) ||
+		strings.HasPrefix(ns, "cluster-") {
+		return ns, nil
+	}
+
+	return "", fmt.Errorf("kubeConfigSecretNamespace %q is not an allowed Fleet namespace", ns)
 }
 
 // restConfigFromKubeConfig checks kubeconfig data and tries to connect to server. If server is behind public CA, remove

--- a/internal/cmd/controller/agentmanagement/controllers/cluster/import_test.go
+++ b/internal/cmd/controller/agentmanagement/controllers/cluster/import_test.go
@@ -1,0 +1,148 @@
+package cluster
+
+import (
+	"strings"
+	"testing"
+
+	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/rancher/fleet/internal/config"
+)
+
+func TestAllowedKubeConfigSecretNamespace(t *testing.T) {
+	tests := map[string]struct {
+		clusterNamespace string
+		fieldValue       string
+		wantNamespace    string
+		wantErrContains  string
+	}{
+		"empty field returns cluster namespace": {
+			clusterNamespace: "fleet-default",
+			wantNamespace:    "fleet-default",
+		},
+		"custom workspace cluster referencing own namespace is allowed": {
+			clusterNamespace: "my-workspace",
+			fieldValue:       "my-workspace",
+			wantNamespace:    "my-workspace",
+		},
+		"cattle-system cluster can reference own namespace": {
+			clusterNamespace: "cattle-system",
+			fieldValue:       "cattle-system",
+			wantNamespace:    "cattle-system",
+		},
+		"fleet-default is allowed": {
+			clusterNamespace: "fleet-local",
+			fieldValue:       "fleet-default",
+			wantNamespace:    "fleet-default",
+		},
+		"fleet-local is allowed": {
+			clusterNamespace: "fleet-default",
+			fieldValue:       "fleet-local",
+			wantNamespace:    "fleet-local",
+		},
+		"cattle-fleet-system is allowed": {
+			clusterNamespace: "fleet-default",
+			fieldValue:       config.DefaultNamespace,
+			wantNamespace:    config.DefaultNamespace,
+		},
+		"fleet-system is allowed": {
+			clusterNamespace: "fleet-default",
+			fieldValue:       config.LegacyDefaultNamespace,
+			wantNamespace:    config.LegacyDefaultNamespace,
+		},
+		"cattle-fleet-clusters-system is allowed": {
+			clusterNamespace: "fleet-default",
+			fieldValue:       "cattle-fleet-clusters-system",
+			wantNamespace:    "cattle-fleet-clusters-system",
+		},
+		"fleet-clusters-system is allowed": {
+			clusterNamespace: "fleet-default",
+			fieldValue:       "fleet-clusters-system",
+			wantNamespace:    "fleet-clusters-system",
+		},
+		"cluster prefix is allowed": {
+			clusterNamespace: "fleet-default",
+			fieldValue:       "cluster-fleet-default-my-cluster-abc123",
+			wantNamespace:    "cluster-fleet-default-my-cluster-abc123",
+		},
+		"kube-system is rejected": {
+			clusterNamespace: "fleet-default",
+			fieldValue:       "kube-system",
+			wantErrContains:  "not an allowed Fleet namespace",
+		},
+		"cattle-system is rejected": {
+			clusterNamespace: "fleet-default",
+			fieldValue:       "cattle-system",
+			wantErrContains:  "not an allowed Fleet namespace",
+		},
+		"arbitrary namespace is rejected": {
+			clusterNamespace: "fleet-default",
+			fieldValue:       "tenant-a-secrets",
+			wantErrContains:  "not an allowed Fleet namespace",
+		},
+		"default is rejected": {
+			clusterNamespace: "fleet-default",
+			fieldValue:       "default",
+			wantErrContains:  "not an allowed Fleet namespace",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			cluster := &fleet.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: test.clusterNamespace,
+				},
+				Spec: fleet.ClusterSpec{
+					KubeConfigSecretNamespace: test.fieldValue,
+				},
+			}
+
+			got, err := allowedKubeConfigSecretNamespace(cluster)
+			if test.wantErrContains != "" {
+				if err == nil {
+					t.Fatalf("expected error for namespace %q", test.fieldValue)
+				}
+				if !strings.Contains(err.Error(), test.wantErrContains) {
+					t.Fatalf("expected error containing %q, got %q", test.wantErrContains, err.Error())
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error for namespace %q: %v", test.fieldValue, err)
+			}
+			if got != test.wantNamespace {
+				t.Fatalf("expected namespace %q, got %q", test.wantNamespace, got)
+			}
+		})
+	}
+}
+
+func TestImportClusterRejectsDisallowedKubeconfigNamespace(t *testing.T) {
+	h := &importHandler{}
+	config.Set(&config.Config{})
+	cluster := &fleet.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "bad-cluster",
+			Namespace: "fleet-default",
+			UID:       types.UID("test-uid"),
+		},
+		Spec: fleet.ClusterSpec{
+			ClientID:                  "client-id",
+			KubeConfigSecret:          "some-secret",
+			KubeConfigSecretNamespace: "kube-system",
+		},
+	}
+
+	_, err := h.importCluster(cluster, fleet.ClusterStatus{})
+	if err == nil {
+		t.Fatal("expected importCluster to reject disallowed kubeConfigSecretNamespace")
+	}
+	if !strings.Contains(err.Error(), "not an allowed Fleet namespace") {
+		t.Fatalf("expected Fleet namespace validation error, got %v", err)
+	}
+}


### PR DESCRIPTION
Validates kubeConfig secret namespaces so only allowed Fleet-managed namespaces are accepted.
Adds kubeconfig secret indexer and secret-watcher handling to detect config changes and trigger cluster reimports.

Backports #5224