### PR TITLE
Remove Renovate support for Fleet v0.11

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,8 +8,7 @@
     "release/v0.15",
     "release/v0.14",
     "release/v0.13",
-    "release/v0.12",
-    "release/v0.11"
+    "release/v0.12"
   ],
   "ignorePaths": [
     "**/assets/**"
@@ -59,14 +58,6 @@
       ],
       "extends": [
         "github>rancher/renovate-config//rancher-2.11#release"
-      ]
-    },
-    {
-      "matchBaseBranches": [
-        "release/v0.11"
-      ],
-      "extends": [
-        "github>rancher/renovate-config//rancher-2.10#release"
       ]
     }
   ]

--- a/.github/workflows/release-against-rancher.yml
+++ b/.github/workflows/release-against-rancher.yml
@@ -22,7 +22,6 @@ on:
           - release/v0.14
           - release/v0.13
           - release/v0.12
-          - release/v0.11
 
 env:
   GOARCH: amd64


### PR DESCRIPTION
and also remove the Fleet v0.11 entry from the release against rancher action.

Fleet v0.11 is EOL in mid June and there won't be any new releases anymore.