### PR TITLE
Add option to disable management cluster's agent

### DIFF
--- a/charts/fleet/templates/configmap.yaml
+++ b/charts/fleet/templates/configmap.yaml
@@ -30,7 +30,8 @@ data:
         "clusterLabels": {{toJson .Values.bootstrap.clusterLabels}},
         "branch":  "{{.Values.bootstrap.branch}}",
         "namespace": "{{.Values.bootstrap.namespace}}",
-        "agentNamespace": "{{.Values.bootstrap.agentNamespace}}"
+        "agentNamespace": "{{.Values.bootstrap.agentNamespace}}",
+        "agentDisabled": {{.Values.bootstrap.agentDisabled}}
       },
       "webhookReceiverURL": "{{.Values.webhookReceiverURL}}",
       "githubURLPrefix": "{{.Values.githubURLPrefix}}",

--- a/charts/fleet/templates/configmap.yaml
+++ b/charts/fleet/templates/configmap.yaml
@@ -31,7 +31,7 @@ data:
         "branch":  "{{.Values.bootstrap.branch}}",
         "namespace": "{{.Values.bootstrap.namespace}}",
         "agentNamespace": "{{.Values.bootstrap.agentNamespace}}",
-        "agentDisabled": {{.Values.bootstrap.agentDisabled}}
+        "localAgentDisabled": {{.Values.bootstrap.localAgentDisabled}}
       },
       "webhookReceiverURL": "{{.Values.webhookReceiverURL}}",
       "githubURLPrefix": "{{.Values.githubURLPrefix}}",

--- a/charts/fleet/tests/agent_disabled_test.yaml
+++ b/charts/fleet/tests/agent_disabled_test.yaml
@@ -1,0 +1,71 @@
+suite: bootstrap.agentDisabled is rendered into the fleet-controller configmap
+# These tests guard the chart side of the "disable the local fleet-agent" feature.
+templates:
+  - configmap.yaml
+tests:
+  - it: defaults agentDisabled to false
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data.config
+          pattern: '"agentDisabled":\s*false'
+
+  - it: emits agentDisabled true when set
+    set:
+      bootstrap.agentDisabled: true
+    asserts:
+      - matchRegex:
+          path: data.config
+          pattern: '"agentDisabled":\s*true'
+      # Must be the JSON boolean true, NOT the string "true": the Go
+      # Bootstrap.AgentDisabled field is bool and json.Unmarshal would reject
+      # the quoted form.
+      - notMatchRegex:
+          path: data.config
+          pattern: '"agentDisabled":\s*"true"'
+
+  - it: keeps the other bootstrap keys intact alongside agentDisabled
+    # Regression guard for the trailing-comma change on the agentNamespace line:
+    # if a future edit drops a comma or removes a field, this test fails before
+    # the broken configmap reaches a cluster.
+    set:
+      bootstrap.agentDisabled: true
+      bootstrap.namespace: fleet-local
+      bootstrap.agentNamespace: cattle-fleet-local-system
+      bootstrap.repo: https://example.com/repo
+      bootstrap.branch: main
+      bootstrap.paths: deploy
+      bootstrap.secret: my-secret
+    asserts:
+      - matchRegex:
+          path: data.config
+          pattern: '"namespace":\s*"fleet-local"'
+      - matchRegex:
+          path: data.config
+          pattern: '"agentNamespace":\s*"cattle-fleet-local-system"'
+      - matchRegex:
+          path: data.config
+          pattern: '"repo":\s*"https://example.com/repo"'
+      - matchRegex:
+          path: data.config
+          pattern: '"branch":\s*"main"'
+      - matchRegex:
+          path: data.config
+          pattern: '"paths":\s*"deploy"'
+      - matchRegex:
+          path: data.config
+          pattern: '"secret":\s*"my-secret"'
+      - matchRegex:
+          path: data.config
+          pattern: '"agentDisabled":\s*true'
+
+  - it: still emits agentDisabled when explicitly set to false
+    set:
+      bootstrap.agentDisabled: false
+    asserts:
+      - matchRegex:
+          path: data.config
+          pattern: '"agentDisabled":\s*false'

--- a/charts/fleet/tests/agent_disabled_test.yaml
+++ b/charts/fleet/tests/agent_disabled_test.yaml
@@ -1,9 +1,9 @@
-suite: bootstrap.agentDisabled is rendered into the fleet-controller configmap
+suite: bootstrap.localAgentDisabled is rendered into the fleet-controller configmap
 # These tests guard the chart side of the "disable the local fleet-agent" feature.
 templates:
   - configmap.yaml
 tests:
-  - it: defaults agentDisabled to false
+  - it: defaults localAgentDisabled to false
     asserts:
       - hasDocuments:
           count: 1
@@ -11,28 +11,28 @@ tests:
           of: ConfigMap
       - matchRegex:
           path: data.config
-          pattern: '"agentDisabled":\s*false'
+          pattern: '"localAgentDisabled":\s*false'
 
-  - it: emits agentDisabled true when set
+  - it: emits localAgentDisabled true when set
     set:
-      bootstrap.agentDisabled: true
+      bootstrap.localAgentDisabled: true
     asserts:
       - matchRegex:
           path: data.config
-          pattern: '"agentDisabled":\s*true'
+          pattern: '"localAgentDisabled":\s*true'
       # Must be the JSON boolean true, NOT the string "true": the Go
-      # Bootstrap.AgentDisabled field is bool and json.Unmarshal would reject
+      # Bootstrap.LocalAgentDisabled field is bool and json.Unmarshal would reject
       # the quoted form.
       - notMatchRegex:
           path: data.config
-          pattern: '"agentDisabled":\s*"true"'
+          pattern: '"localAgentDisabled":\s*"true"'
 
-  - it: keeps the other bootstrap keys intact alongside agentDisabled
+  - it: keeps the other bootstrap keys intact alongside localAgentDisabled
     # Regression guard for the trailing-comma change on the agentNamespace line:
     # if a future edit drops a comma or removes a field, this test fails before
     # the broken configmap reaches a cluster.
     set:
-      bootstrap.agentDisabled: true
+      bootstrap.localAgentDisabled: true
       bootstrap.namespace: fleet-local
       bootstrap.agentNamespace: cattle-fleet-local-system
       bootstrap.repo: https://example.com/repo
@@ -60,12 +60,12 @@ tests:
           pattern: '"secret":\s*"my-secret"'
       - matchRegex:
           path: data.config
-          pattern: '"agentDisabled":\s*true'
+          pattern: '"localAgentDisabled":\s*true'
 
-  - it: still emits agentDisabled when explicitly set to false
+  - it: still emits localAgentDisabled when explicitly set to false
     set:
-      bootstrap.agentDisabled: false
+      bootstrap.localAgentDisabled: false
     asserts:
       - matchRegex:
           path: data.config
-          pattern: '"agentDisabled":\s*false'
+          pattern: '"localAgentDisabled":\s*false'

--- a/charts/fleet/values.yaml
+++ b/charts/fleet/values.yaml
@@ -63,7 +63,7 @@ bootstrap:
   # If true, the local cluster stays registered (Cluster + ClusterGroup) but the
   # fleet-agent is NOT deployed into it. An already-running local agent will be removed.
   # The local cluster will not receive deployments.
-  agentDisabled: false
+  localAgentDisabled: false
   # Apply extra clusterLabels to the local cluster bootstrapped by fleet-controller
   clusterLabels: {}
   # A repo to add at install time that will deploy to the local cluster. This allows

--- a/charts/fleet/values.yaml
+++ b/charts/fleet/values.yaml
@@ -60,6 +60,10 @@ bootstrap:
   # The namespace where the fleet agent for the local cluster will be ran, if empty
   # this will default to cattle-fleet-system
   agentNamespace: ""
+  # If true, the local cluster stays registered (Cluster + ClusterGroup) but the
+  # fleet-agent is NOT deployed into it. An already-running local agent will be removed.
+  # The local cluster will not receive deployments.
+  agentDisabled: false
   # Apply extra clusterLabels to the local cluster bootstrapped by fleet-controller
   clusterLabels: {}
   # A repo to add at install time that will deploy to the local cluster. This allows

--- a/internal/cmd/controller/agentmanagement/controllers/bootstrap/bootstrap.go
+++ b/internal/cmd/controller/agentmanagement/controllers/bootstrap/bootstrap.go
@@ -71,13 +71,13 @@ func (h *handler) OnConfig(config *fleetconfig.Config) error {
 	logrus.Debugf("Bootstrap config set, building namespace '%s', secret, local cluster, cluster group, ...", config.Bootstrap.Namespace)
 
 	var objs []runtime.Object
-	localClusterLabels := map[string]string{"name": "local"}
+	localClusterLabels := map[string]string{"name": fleet.LocalClusterName}
 
 	if config.Bootstrap.ClusterLabels != nil {
 		maps.Copy(localClusterLabels, config.Bootstrap.ClusterLabels)
 	}
 
-	if config.Bootstrap.AgentDisabled {
+	if config.Bootstrap.LocalAgentDisabled {
 		localClusterLabels[fleet.LocalAgentDisabledLabel] = "true"
 	}
 
@@ -100,7 +100,7 @@ func (h *handler) OnConfig(config *fleetconfig.Config) error {
 		},
 	}, secret, &fleet.Cluster{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "local",
+			Name:      fleet.LocalClusterName,
 			Namespace: config.Bootstrap.Namespace,
 			Labels:    localClusterLabels,
 		},
@@ -118,7 +118,7 @@ func (h *handler) OnConfig(config *fleetconfig.Config) error {
 		Spec: fleet.ClusterGroupSpec{
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
-					"name": "local",
+					"name": fleet.LocalClusterName,
 				},
 			},
 		},

--- a/internal/cmd/controller/agentmanagement/controllers/bootstrap/bootstrap.go
+++ b/internal/cmd/controller/agentmanagement/controllers/bootstrap/bootstrap.go
@@ -77,6 +77,10 @@ func (h *handler) OnConfig(config *fleetconfig.Config) error {
 		maps.Copy(localClusterLabels, config.Bootstrap.ClusterLabels)
 	}
 
+	if config.Bootstrap.AgentDisabled {
+		localClusterLabels[fleet.LocalAgentDisabledLabel] = "true"
+	}
+
 	if config.Bootstrap.Namespace == "" || config.Bootstrap.Namespace == "-" {
 		return nil
 	}

--- a/internal/cmd/controller/agentmanagement/controllers/bootstrap/bootstrap_test.go
+++ b/internal/cmd/controller/agentmanagement/controllers/bootstrap/bootstrap_test.go
@@ -77,9 +77,9 @@ func TestOnConfig_AppliesClusterLabels(t *testing.T) {
 
 			inputConfig := &fleetconfig.Config{
 				Bootstrap: fleetconfig.Bootstrap{
-					Namespace:     "bootstrap-ns", // not empty
-					ClusterLabels: c.configLabels,
-					AgentDisabled: c.agentDisabled,
+					Namespace:          "bootstrap-ns", // not empty
+					ClusterLabels:      c.configLabels,
+					LocalAgentDisabled: c.agentDisabled,
 				},
 			}
 

--- a/internal/cmd/controller/agentmanagement/controllers/bootstrap/bootstrap_test.go
+++ b/internal/cmd/controller/agentmanagement/controllers/bootstrap/bootstrap_test.go
@@ -22,6 +22,7 @@ func TestOnConfig_AppliesClusterLabels(t *testing.T) {
 	cases := []struct {
 		name           string
 		configLabels   map[string]string
+		agentDisabled  bool
 		expectedLabels map[string]string
 	}{
 		{
@@ -42,6 +43,33 @@ func TestOnConfig_AppliesClusterLabels(t *testing.T) {
 				"random-hash-12345": "enabled",
 			},
 		},
+		{
+			name:          "agentDisabled stamps the local-agent-disabled label",
+			agentDisabled: true,
+			expectedLabels: map[string]string{
+				"name":                        "local",
+				fleet.LocalAgentDisabledLabel: "true",
+			},
+		},
+		{
+			name:          "agentDisabled false leaves the label off",
+			agentDisabled: false,
+			expectedLabels: map[string]string{
+				"name": "local",
+			},
+		},
+		{
+			name:          "agentDisabled coexists with user-supplied clusterLabels",
+			agentDisabled: true,
+			configLabels: map[string]string{
+				"region": "eu-west-1",
+			},
+			expectedLabels: map[string]string{
+				"name":                        "local",
+				"region":                      "eu-west-1",
+				fleet.LocalAgentDisabledLabel: "true",
+			},
+		},
 	}
 
 	for _, c := range cases {
@@ -51,6 +79,7 @@ func TestOnConfig_AppliesClusterLabels(t *testing.T) {
 				Bootstrap: fleetconfig.Bootstrap{
 					Namespace:     "bootstrap-ns", // not empty
 					ClusterLabels: c.configLabels,
+					AgentDisabled: c.agentDisabled,
 				},
 			}
 

--- a/internal/cmd/controller/agentmanagement/controllers/cluster/import.go
+++ b/internal/cmd/controller/agentmanagement/controllers/cluster/import.go
@@ -574,32 +574,113 @@ func (i *importHandler) teardownLocalAgent(cluster *fleet.Cluster) error {
 		return err
 	}
 
+	// Agent bundle lives on the management cluster — independent of the wrangler set.
+	if err := i.bundleClient.Delete(
+		cluster.Namespace,
+		names.SafeConcatName(manageagent.AgentBundleName, cluster.Name),
+		nil,
+	); err != nil && !apierrors.IsNotFound(err) {
+		return err
+	}
+	i.namespaceController.Enqueue(cluster.Namespace)
+
 	agentNamespace := cluster.Status.Agent.Namespace
 	if agentNamespace == "" {
 		agentNamespace = i.systemNamespace
 	}
 
-	if err := i.bundleClient.Delete(cluster.Namespace, names.SafeConcatName(manageagent.AgentBundleName, cluster.Name), nil); err != nil && !apierrors.IsNotFound(err) {
-		return err
-	}
-	i.namespaceController.Enqueue(cluster.Namespace)
-
-	if err := i.deleteOldAgent(cluster, kc, agentNamespace); err != nil {
+	if err := i.deleteAgentResources(kc, agentNamespace); err != nil {
 		return err
 	}
 
+	// Mirror the deploy path: when the system namespace was customized, drop the
+	// now-orphaned legacy system-registration namespace too.
 	if i.systemNamespace != config.DefaultNamespace {
-		_, err := kc.CoreV1().Namespaces().Get(i.ctx, config.DefaultNamespace, metav1.GetOptions{})
-		if err == nil {
-			if err := i.deleteOldAgent(cluster, kc, config.DefaultNamespace); err != nil {
-				return err
-			}
-		} else if !apierrors.IsNotFound(err) {
+		if err := kc.CoreV1().Namespaces().Delete(
+			i.ctx,
+			fleetns.SystemRegistrationNamespace(config.DefaultNamespace),
+			metav1.DeleteOptions{},
+		); err != nil && !apierrors.IsNotFound(err) {
 			return err
 		}
 	}
 
 	logrus.Infof("Cluster import for '%s/%s'. Removed local agent (agentDisabled=true)", cluster.Namespace, cluster.Name)
+	return nil
+}
+
+// deleteAgentResources removes every resource the deploy path creates for a
+// fleet-agent, identified by the fixed names that agent.Manifest assigns.
+func (i *importHandler) deleteAgentResources(kc kubernetes.Interface, agentNamespace string) error {
+	ignoreNotFound := func(err error) error {
+		if err == nil || apierrors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+
+	// Cluster-scoped RBAC — names are constructed the same way as in agent.Manifest.
+	crName := names.SafeConcatName(agentNamespace, agent.DefaultName, "role")
+	crbName := names.SafeConcatName(agentNamespace, agent.DefaultName, "role", "binding")
+	if err := ignoreNotFound(kc.RbacV1().ClusterRoles().Delete(i.ctx, crName, metav1.DeleteOptions{})); err != nil {
+		return err
+	}
+	if err := ignoreNotFound(kc.RbacV1().ClusterRoleBindings().Delete(i.ctx, crbName, metav1.DeleteOptions{})); err != nil {
+		return err
+	}
+
+	// Cluster-scoped scheduling resources.
+	if err := ignoreNotFound(kc.SchedulingV1().PriorityClasses().Delete(i.ctx, scheduling.FleetAgentPriorityClassName, metav1.DeleteOptions{})); err != nil {
+		return err
+	}
+
+	// Namespaced resources.
+	if err := ignoreNotFound(kc.CoreV1().Secrets(agentNamespace).Delete(i.ctx, config.AgentConfigName, metav1.DeleteOptions{})); err != nil {
+		return err
+	}
+	if err := ignoreNotFound(kc.CoreV1().Secrets(agentNamespace).Delete(i.ctx, config.AgentBootstrapConfigName, metav1.DeleteOptions{})); err != nil {
+		return err
+	}
+	if err := ignoreNotFound(kc.CoreV1().ConfigMaps(agentNamespace).Delete(i.ctx, config.AgentConfigName, metav1.DeleteOptions{})); err != nil {
+		return err
+	}
+	if err := ignoreNotFound(kc.CoreV1().ServiceAccounts(agentNamespace).Delete(i.ctx, agent.DefaultName, metav1.DeleteOptions{})); err != nil {
+		return err
+	}
+	if err := ignoreNotFound(kc.NetworkingV1().NetworkPolicies(agentNamespace).Delete(i.ctx, "default-allow-all", metav1.DeleteOptions{})); err != nil {
+		return err
+	}
+	if err := ignoreNotFound(kc.AppsV1().Deployments(agentNamespace).Delete(i.ctx, config.AgentConfigName, metav1.DeleteOptions{})); err != nil {
+		return err
+	}
+	if err := ignoreNotFound(kc.AppsV1().StatefulSets(agentNamespace).Delete(i.ctx, config.AgentConfigName, metav1.DeleteOptions{})); err != nil {
+		return err
+	}
+	if err := ignoreNotFound(kc.PolicyV1().PodDisruptionBudgets(agentNamespace).Delete(i.ctx, scheduling.FleetAgentPodDisruptionBudgetName, metav1.DeleteOptions{})); err != nil {
+		return err
+	}
+
+	// Also clean up the default SA on older installs that left it with a modified
+	// AutomountServiceAccountToken. Candidate namespaces: agent's namespace plus
+	// the legacy default if the system namespace was customized.
+	if i.systemNamespace != config.DefaultNamespace && agentNamespace != config.DefaultNamespace {
+		if err := ignoreNotFound(kc.CoreV1().Secrets(config.DefaultNamespace).Delete(i.ctx, config.AgentConfigName, metav1.DeleteOptions{})); err != nil {
+			return err
+		}
+		if err := ignoreNotFound(kc.CoreV1().Secrets(config.DefaultNamespace).Delete(i.ctx, config.AgentBootstrapConfigName, metav1.DeleteOptions{})); err != nil {
+			return err
+		}
+		if err := ignoreNotFound(kc.CoreV1().ServiceAccounts(config.DefaultNamespace).Delete(i.ctx, agent.DefaultName, metav1.DeleteOptions{})); err != nil {
+			return err
+		}
+		if err := ignoreNotFound(kc.AppsV1().Deployments(config.DefaultNamespace).Delete(i.ctx, config.AgentConfigName, metav1.DeleteOptions{})); err != nil {
+			return err
+		}
+		if err := ignoreNotFound(kc.AppsV1().StatefulSets(config.DefaultNamespace).Delete(i.ctx, config.AgentConfigName, metav1.DeleteOptions{})); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 

--- a/internal/cmd/controller/agentmanagement/controllers/cluster/import.go
+++ b/internal/cmd/controller/agentmanagement/controllers/cluster/import.go
@@ -194,6 +194,10 @@ func hashStatusField(field any) string {
 	return hex.EncodeToString(hasher.Sum(nil))
 }
 
+func localAgentDisabled(cluster *fleet.Cluster) bool {
+	return cluster.Labels[fleet.LocalAgentDisabledLabel] == "true"
+}
+
 func agentDeployed(cluster *fleet.Cluster) bool {
 	if cluster.Status.AgentConfigChanged {
 		return false
@@ -230,7 +234,7 @@ func (i *importHandler) OnChange(key string, cluster *fleet.Cluster) (_ *fleet.C
 		return cluster, nil
 	}
 
-	if manageagent.SkipCluster(cluster) {
+	if manageagent.SkipCluster(cluster) || localAgentDisabled(cluster) {
 		return cluster, nil
 	}
 
@@ -297,6 +301,23 @@ func (i *importHandler) deleteOldAgent(cluster *fleet.Cluster, kc kubernetes.Int
 //nolint:gocyclo
 func (i *importHandler) importCluster(cluster *fleet.Cluster, status fleet.ClusterStatus) (fleet.ClusterStatus, error) {
 	if manageagent.SkipCluster(cluster) {
+		return status, nil
+	}
+
+	if localAgentDisabled(cluster) {
+		// Never deployed or already torn down: nothing to do.
+		if status.Agent.Namespace == "" && status.AgentDeployedGeneration == nil {
+			return status, nil
+		}
+		// Tear down a previously-deployed agent.
+		if cluster.Spec.KubeConfigSecret != "" {
+			if err := i.teardownLocalAgent(cluster); err != nil {
+				return status, err
+			}
+		}
+		status.Agent = fleet.AgentStatus{}
+		status.AgentDeployedGeneration = nil
+		status.AgentConfigChanged = false
 		return status, nil
 	}
 
@@ -523,6 +544,63 @@ func (i *importHandler) importCluster(cluster *fleet.Cluster, status fleet.Clust
 	status.GarbageCollectionInterval = &cfg.GarbageCollectionInterval
 
 	return status, nil
+}
+
+// teardownLocalAgent removes the fleet-agent and its associated bundle from the
+// local cluster. It is idempotent: NotFound errors from the deletes are ignored.
+func (i *importHandler) teardownLocalAgent(cluster *fleet.Cluster) error {
+	kubeConfigSecretNamespace, err := allowedKubeConfigSecretNamespace(cluster)
+	if err != nil {
+		return err
+	}
+	secret, err := i.secretsCache.Get(kubeConfigSecretNamespace, cluster.Spec.KubeConfigSecret)
+	if err != nil {
+		return err
+	}
+
+	cfg := config.Get()
+	restConfig, err := i.restConfigFromKubeConfig(secret.Data[config.KubeConfigSecretValueKey], cfg.AgentTLSMode)
+	if err != nil {
+		return err
+	}
+	restConfig.Timeout = durations.RestConfigTimeout
+
+	kc, err := kubernetes.NewForConfig(restConfig)
+	if err != nil {
+		return err
+	}
+
+	if err := connection.SmokeTestKubeClientConnection(kc); err != nil {
+		return err
+	}
+
+	agentNamespace := cluster.Status.Agent.Namespace
+	if agentNamespace == "" {
+		agentNamespace = i.systemNamespace
+	}
+
+	if err := i.bundleClient.Delete(cluster.Namespace, names.SafeConcatName(manageagent.AgentBundleName, cluster.Name), nil); err != nil && !apierrors.IsNotFound(err) {
+		return err
+	}
+	i.namespaceController.Enqueue(cluster.Namespace)
+
+	if err := i.deleteOldAgent(cluster, kc, agentNamespace); err != nil {
+		return err
+	}
+
+	if i.systemNamespace != config.DefaultNamespace {
+		_, err := kc.CoreV1().Namespaces().Get(i.ctx, config.DefaultNamespace, metav1.GetOptions{})
+		if err == nil {
+			if err := i.deleteOldAgent(cluster, kc, config.DefaultNamespace); err != nil {
+				return err
+			}
+		} else if !apierrors.IsNotFound(err) {
+			return err
+		}
+	}
+
+	logrus.Infof("Cluster import for '%s/%s'. Removed local agent (agentDisabled=true)", cluster.Namespace, cluster.Name)
+	return nil
 }
 
 func shouldMigrateFromLegacyNamespace(agentStatusNs string) bool {

--- a/internal/cmd/controller/agentmanagement/controllers/cluster/import.go
+++ b/internal/cmd/controller/agentmanagement/controllers/cluster/import.go
@@ -194,8 +194,42 @@ func hashStatusField(field any) string {
 	return hex.EncodeToString(hasher.Sum(nil))
 }
 
+// localAgentDisabled reports whether the agent must not be deployed for this
+// cluster. It only ever applies to the management (local) cluster: the
+// disabling label is honored exclusively there, so that labeling a downstream
+// cluster cannot prevent its agent from being deployed or tear it down.
 func localAgentDisabled(cluster *fleet.Cluster) bool {
-	return cluster.Labels[fleet.LocalAgentDisabledLabel] == "true"
+	return isLocalCluster(cluster) && cluster.Labels[fleet.LocalAgentDisabledLabel] == "true"
+}
+
+// isLocalCluster is a fast, metadata-only check that a Cluster object is the
+// management (local) cluster: it must carry the well-known name in the
+// configured bootstrap namespace, matching what the bootstrap controller
+// creates.
+func isLocalCluster(cluster *fleet.Cluster) bool {
+	return cluster.Name == fleet.LocalClusterName &&
+		cluster.Namespace == config.Get().Bootstrap.Namespace
+}
+
+// isManagementCluster confirms, with certainty, that the cluster reachable
+// through kc is the very cluster the controller runs on. It compares the UID of
+// the kube-system namespace as seen locally (through the controller's own
+// client) and through the downstream client: that UID is unique per cluster and
+// immutable, so a match proves both clients target the same cluster. Used to
+// guard the agent teardown so we never remove an agent from a cluster that only
+// looks local by name.
+func (i *importHandler) isManagementCluster(kc kubernetes.Interface) (bool, error) {
+	local, err := i.namespaceController.Get(metav1.NamespaceSystem, metav1.GetOptions{})
+	if err != nil {
+		return false, err
+	}
+
+	remote, err := kc.CoreV1().Namespaces().Get(i.ctx, metav1.NamespaceSystem, metav1.GetOptions{})
+	if err != nil {
+		return false, err
+	}
+
+	return local.UID != "" && local.UID == remote.UID, nil
 }
 
 func agentDeployed(cluster *fleet.Cluster) bool {
@@ -263,35 +297,6 @@ func (i *importHandler) deleteOldAgentBundle(cluster *fleet.Cluster) error {
 		return err
 	}
 	i.namespaceController.Enqueue(cluster.Namespace)
-	return nil
-}
-
-func (i *importHandler) deleteOldAgent(cluster *fleet.Cluster, kc kubernetes.Interface, namespace string) error {
-	err := kc.CoreV1().Secrets(namespace).Delete(i.ctx, config.AgentConfigName, metav1.DeleteOptions{})
-	if err != nil && !apierrors.IsNotFound(err) {
-		return err
-	}
-
-	err = kc.CoreV1().Secrets(namespace).Delete(i.ctx, config.AgentBootstrapConfigName, metav1.DeleteOptions{})
-	if err != nil && !apierrors.IsNotFound(err) {
-		return err
-	}
-
-	if err := kc.AppsV1().StatefulSets(namespace).Delete(i.ctx, config.AgentConfigName, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
-		return err
-	}
-	if err := kc.AppsV1().Deployments(namespace).Delete(i.ctx, config.AgentConfigName, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
-		return err
-	}
-	if err := kc.SchedulingV1().PriorityClasses().Delete(i.ctx, scheduling.FleetAgentPriorityClassName, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
-		return err
-	}
-	if err := kc.PolicyV1().PodDisruptionBudgets(namespace).Delete(i.ctx, scheduling.FleetAgentPodDisruptionBudgetName, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
-		return err
-	}
-
-	logrus.Infof("Deleted old agent for cluster (%s/%s) in namespace %s", cluster.Namespace, cluster.Name, namespace)
-
 	return nil
 }
 
@@ -494,13 +499,13 @@ func (i *importHandler) importCluster(cluster *fleet.Cluster, status fleet.Clust
 			return status, err
 		}
 		if cluster.Status.Agent.Namespace != "" {
-			if err := i.deleteOldAgent(cluster, kc, cluster.Status.Agent.Namespace); err != nil {
+			if err := i.deleteAgentResources(kc, cluster.Status.Agent.Namespace); err != nil {
 				return status, err
 			}
 		}
 	}
 
-	if err := i.deleteOldAgent(cluster, kc, agentNamespace); err != nil {
+	if err := i.deleteAgentResources(kc, agentNamespace); err != nil {
 		return status, err
 	}
 
@@ -510,24 +515,8 @@ func (i *importHandler) importCluster(cluster *fleet.Cluster, status fleet.Clust
 	}
 	logrus.Infof("Cluster import for '%s/%s'. Deployed new agent", cluster.Namespace, cluster.Name)
 
-	if i.systemNamespace != config.DefaultNamespace {
-		// Clean up the leftover agent if it exists.
-		_, err := kc.CoreV1().Namespaces().Get(i.ctx, config.DefaultNamespace, metav1.GetOptions{})
-		if err == nil {
-			logrus.Infof("System namespace (%s) does not equal default namespace (%s), checking for leftover objects...", i.systemNamespace, config.DefaultNamespace)
-			if err := i.deleteOldAgent(cluster, kc, config.DefaultNamespace); err != nil {
-				return status, err
-			}
-		} else if !apierrors.IsNotFound(err) {
-			return status, err
-		}
-
-		// Clean up the leftover clusters namespace if it exists.
-		// We want to keep the DefaultNamespace alive, but not the clusters namespace.
-		err = kc.CoreV1().Namespaces().Delete(i.ctx, fleetns.SystemRegistrationNamespace(config.DefaultNamespace), metav1.DeleteOptions{})
-		if err != nil && !apierrors.IsNotFound(err) {
-			return status, err
-		}
+	if err := i.cleanupLeftoverDefaultNamespace(kc); err != nil {
+		return status, err
 	}
 
 	status.AgentDeployedGeneration = &cluster.Spec.RedeployAgentGeneration
@@ -574,6 +563,22 @@ func (i *importHandler) teardownLocalAgent(cluster *fleet.Cluster) error {
 		return err
 	}
 
+	// Before deleting anything, make absolutely sure the kubeconfig points at
+	// the management cluster itself. isLocalCluster already gated us here based
+	// on metadata, but tearing down an agent is destructive, so we confirm
+	// cluster identity for real.
+	isLocal, err := i.isManagementCluster(kc)
+	if err != nil {
+		return err
+	}
+	if !isLocal {
+		logrus.Warnf(
+			"Cluster import for '%s/%s'. Refusing to remove agent: label %s=true is set but the cluster reached through its kubeconfig is not the management cluster",
+			cluster.Namespace, cluster.Name, fleet.LocalAgentDisabledLabel,
+		)
+		return nil
+	}
+
 	// Agent bundle lives on the management cluster — independent of the wrangler set.
 	if err := i.bundleClient.Delete(
 		cluster.Namespace,
@@ -593,25 +598,18 @@ func (i *importHandler) teardownLocalAgent(cluster *fleet.Cluster) error {
 		return err
 	}
 
-	// Mirror the deploy path: when the system namespace was customized, drop the
-	// now-orphaned legacy system-registration namespace too.
-	if i.systemNamespace != config.DefaultNamespace {
-		if err := kc.CoreV1().Namespaces().Delete(
-			i.ctx,
-			fleetns.SystemRegistrationNamespace(config.DefaultNamespace),
-			metav1.DeleteOptions{},
-		); err != nil && !apierrors.IsNotFound(err) {
-			return err
-		}
+	if err := i.cleanupLeftoverDefaultNamespace(kc); err != nil {
+		return err
 	}
 
 	logrus.Infof("Cluster import for '%s/%s'. Removed local agent (%s=true)", cluster.Namespace, cluster.Name, fleet.LocalAgentDisabledLabel)
 	return nil
 }
 
-// deleteAgentResources removes every resource the deploy path creates for a
-// fleet-agent, identified by the fixed names that agent.Manifest assigns.
-func (i *importHandler) deleteAgentResources(kc kubernetes.Interface, agentNamespace string) error {
+// deleteAgentResources removes every resource the
+// deploy path creates for a fleet-agent (identified by the fixed names that
+// agent.Manifest assigns). It is idempotent: NotFound errors are ignored.
+func (i *importHandler) deleteAgentResources(kc kubernetes.Interface, namespace string) error {
 	ignoreNotFound := func(err error) error {
 		if err == nil || apierrors.IsNotFound(err) {
 			return nil
@@ -620,8 +618,8 @@ func (i *importHandler) deleteAgentResources(kc kubernetes.Interface, agentNames
 	}
 
 	// Cluster-scoped RBAC — names are constructed the same way as in agent.Manifest.
-	crName := names.SafeConcatName(agentNamespace, agent.DefaultName, "role")
-	crbName := names.SafeConcatName(agentNamespace, agent.DefaultName, "role", "binding")
+	crName := names.SafeConcatName(namespace, agent.DefaultName, "role")
+	crbName := names.SafeConcatName(namespace, agent.DefaultName, "role", "binding")
 	if err := ignoreNotFound(kc.RbacV1().ClusterRoles().Delete(i.ctx, crName, metav1.DeleteOptions{})); err != nil {
 		return err
 	}
@@ -635,50 +633,58 @@ func (i *importHandler) deleteAgentResources(kc kubernetes.Interface, agentNames
 	}
 
 	// Namespaced resources.
-	if err := ignoreNotFound(kc.CoreV1().Secrets(agentNamespace).Delete(i.ctx, config.AgentConfigName, metav1.DeleteOptions{})); err != nil {
+	if err := ignoreNotFound(kc.CoreV1().Secrets(namespace).Delete(i.ctx, config.AgentConfigName, metav1.DeleteOptions{})); err != nil {
 		return err
 	}
-	if err := ignoreNotFound(kc.CoreV1().Secrets(agentNamespace).Delete(i.ctx, config.AgentBootstrapConfigName, metav1.DeleteOptions{})); err != nil {
+	if err := ignoreNotFound(kc.CoreV1().Secrets(namespace).Delete(i.ctx, config.AgentBootstrapConfigName, metav1.DeleteOptions{})); err != nil {
 		return err
 	}
-	if err := ignoreNotFound(kc.CoreV1().ConfigMaps(agentNamespace).Delete(i.ctx, config.AgentConfigName, metav1.DeleteOptions{})); err != nil {
+	if err := ignoreNotFound(kc.CoreV1().ConfigMaps(namespace).Delete(i.ctx, config.AgentConfigName, metav1.DeleteOptions{})); err != nil {
 		return err
 	}
-	if err := ignoreNotFound(kc.CoreV1().ServiceAccounts(agentNamespace).Delete(i.ctx, agent.DefaultName, metav1.DeleteOptions{})); err != nil {
+	if err := ignoreNotFound(kc.CoreV1().ServiceAccounts(namespace).Delete(i.ctx, agent.DefaultName, metav1.DeleteOptions{})); err != nil {
 		return err
 	}
-	if err := ignoreNotFound(kc.NetworkingV1().NetworkPolicies(agentNamespace).Delete(i.ctx, "default-allow-all", metav1.DeleteOptions{})); err != nil {
+	if err := ignoreNotFound(kc.NetworkingV1().NetworkPolicies(namespace).Delete(i.ctx, "default-allow-all", metav1.DeleteOptions{})); err != nil {
 		return err
 	}
-	if err := ignoreNotFound(kc.AppsV1().Deployments(agentNamespace).Delete(i.ctx, config.AgentConfigName, metav1.DeleteOptions{})); err != nil {
+	if err := ignoreNotFound(kc.AppsV1().Deployments(namespace).Delete(i.ctx, config.AgentConfigName, metav1.DeleteOptions{})); err != nil {
 		return err
 	}
-	if err := ignoreNotFound(kc.AppsV1().StatefulSets(agentNamespace).Delete(i.ctx, config.AgentConfigName, metav1.DeleteOptions{})); err != nil {
+	if err := ignoreNotFound(kc.AppsV1().StatefulSets(namespace).Delete(i.ctx, config.AgentConfigName, metav1.DeleteOptions{})); err != nil {
 		return err
 	}
-	if err := ignoreNotFound(kc.PolicyV1().PodDisruptionBudgets(agentNamespace).Delete(i.ctx, scheduling.FleetAgentPodDisruptionBudgetName, metav1.DeleteOptions{})); err != nil {
+	if err := ignoreNotFound(kc.PolicyV1().PodDisruptionBudgets(namespace).Delete(i.ctx, scheduling.FleetAgentPodDisruptionBudgetName, metav1.DeleteOptions{})); err != nil {
 		return err
 	}
 
-	// Also clean up legacy fleet-agent resources that may exist in the default system
-	// namespace on older installs (e.g. if the system namespace was later customized).
-	// Candidate namespaces: agent's namespace plus the legacy default if the system namespace was customized.
-	if i.systemNamespace != config.DefaultNamespace && agentNamespace != config.DefaultNamespace {
-		if err := ignoreNotFound(kc.CoreV1().Secrets(config.DefaultNamespace).Delete(i.ctx, config.AgentConfigName, metav1.DeleteOptions{})); err != nil {
+	return nil
+}
+
+// cleanupLeftoverDefaultNamespace removes a fleet-agent left behind in the
+// default system namespace and drops the now-orphaned default registration
+// namespace. This only matters when the system namespace was customized away
+// from the default; otherwise there is nothing to clean up. The default
+// namespace itself is kept.
+func (i *importHandler) cleanupLeftoverDefaultNamespace(kc kubernetes.Interface) error {
+	if i.systemNamespace == config.DefaultNamespace {
+		return nil
+	}
+
+	// Clean up the leftover agent if the default namespace still exists.
+	_, err := kc.CoreV1().Namespaces().Get(i.ctx, config.DefaultNamespace, metav1.GetOptions{})
+	if err == nil {
+		logrus.Infof("System namespace (%s) does not equal default namespace (%s), checking for leftover objects...", i.systemNamespace, config.DefaultNamespace)
+		if err := i.deleteAgentResources(kc, config.DefaultNamespace); err != nil {
 			return err
 		}
-		if err := ignoreNotFound(kc.CoreV1().Secrets(config.DefaultNamespace).Delete(i.ctx, config.AgentBootstrapConfigName, metav1.DeleteOptions{})); err != nil {
-			return err
-		}
-		if err := ignoreNotFound(kc.CoreV1().ServiceAccounts(config.DefaultNamespace).Delete(i.ctx, agent.DefaultName, metav1.DeleteOptions{})); err != nil {
-			return err
-		}
-		if err := ignoreNotFound(kc.AppsV1().Deployments(config.DefaultNamespace).Delete(i.ctx, config.AgentConfigName, metav1.DeleteOptions{})); err != nil {
-			return err
-		}
-		if err := ignoreNotFound(kc.AppsV1().StatefulSets(config.DefaultNamespace).Delete(i.ctx, config.AgentConfigName, metav1.DeleteOptions{})); err != nil {
-			return err
-		}
+	} else if !apierrors.IsNotFound(err) {
+		return err
+	}
+
+	// Keep the default namespace alive, but drop the orphaned registration namespace.
+	if err := kc.CoreV1().Namespaces().Delete(i.ctx, fleetns.SystemRegistrationNamespace(config.DefaultNamespace), metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+		return err
 	}
 
 	return nil

--- a/internal/cmd/controller/agentmanagement/controllers/cluster/import.go
+++ b/internal/cmd/controller/agentmanagement/controllers/cluster/import.go
@@ -605,7 +605,7 @@ func (i *importHandler) teardownLocalAgent(cluster *fleet.Cluster) error {
 		}
 	}
 
-	logrus.Infof("Cluster import for '%s/%s'. Removed local agent (agentDisabled=true)", cluster.Namespace, cluster.Name)
+	logrus.Infof("Cluster import for '%s/%s'. Removed local agent (%s=true)", cluster.Namespace, cluster.Name, fleet.LocalAgentDisabledLabel)
 	return nil
 }
 
@@ -660,9 +660,9 @@ func (i *importHandler) deleteAgentResources(kc kubernetes.Interface, agentNames
 		return err
 	}
 
-	// Also clean up the default SA on older installs that left it with a modified
-	// AutomountServiceAccountToken. Candidate namespaces: agent's namespace plus
-	// the legacy default if the system namespace was customized.
+	// Also clean up legacy fleet-agent resources that may exist in the default system
+	// namespace on older installs (e.g. if the system namespace was later customized).
+	// Candidate namespaces: agent's namespace plus the legacy default if the system namespace was customized.
 	if i.systemNamespace != config.DefaultNamespace && agentNamespace != config.DefaultNamespace {
 		if err := ignoreNotFound(kc.CoreV1().Secrets(config.DefaultNamespace).Delete(i.ctx, config.AgentConfigName, metav1.DeleteOptions{})); err != nil {
 			return err

--- a/internal/cmd/controller/agentmanagement/controllers/cluster/import_test.go
+++ b/internal/cmd/controller/agentmanagement/controllers/cluster/import_test.go
@@ -2,6 +2,7 @@ package cluster
 
 import (
 	"context"
+	"errors"
 	"reflect"
 	"strings"
 	"testing"
@@ -828,6 +829,11 @@ func TestIsManagementCluster(t *testing.T) {
 			localUID:  "",
 			remoteUID: "",
 			want:      false,
+		},
+		{
+			name:     "error fetching the local kube-system namespace propagates",
+			localErr: errors.New("boom"),
+			wantErr:  true,
 		},
 	}
 

--- a/internal/cmd/controller/agentmanagement/controllers/cluster/import_test.go
+++ b/internal/cmd/controller/agentmanagement/controllers/cluster/import_test.go
@@ -1,6 +1,7 @@
 package cluster
 
 import (
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -504,6 +505,180 @@ func TestAllowedKubeConfigSecretNamespace(t *testing.T) {
 			}
 			if got != c.wantNS {
 				t.Errorf("expected namespace %q, got %q", c.wantNS, got)
+			}
+		})
+	}
+}
+
+func TestLocalAgentDisabled(t *testing.T) {
+	cases := []struct {
+		name    string
+		cluster *fleet.Cluster
+		want    bool
+	}{
+		{
+			name:    "nil labels",
+			cluster: &fleet.Cluster{},
+			want:    false,
+		},
+		{
+			name: "label absent",
+			cluster: &fleet.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"name": "local"},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "label set to true",
+			cluster: &fleet.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"name":                        "local",
+						fleet.LocalAgentDisabledLabel: "true",
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			// Only the literal string "true" enables it: anything else (false,
+			// empty, "1", "yes") is treated as not-disabled so users can't
+			// accidentally disable the agent by toggling the label.
+			name: "label set to a non-true value is treated as not disabled",
+			cluster: &fleet.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						fleet.LocalAgentDisabledLabel: "1",
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "label set to false",
+			cluster: &fleet.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						fleet.LocalAgentDisabledLabel: "false",
+					},
+				},
+			},
+			want: false,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := localAgentDisabled(c.cluster); got != c.want {
+				t.Errorf("localAgentDisabled = %v, want %v", got, c.want)
+			}
+		})
+	}
+}
+
+func TestOnChange_LocalAgentDisabledShortCircuits(t *testing.T) {
+	// A cluster carrying the local-agent-disabled label must short-circuit
+	// out of OnChange before it touches any of the controllers/caches —
+	// no ClientID generation, no clusters.Update, nothing.
+	//
+	// We assert this by leaving every field of importHandler nil; reaching
+	// any of them would panic.
+	cluster := &fleet.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "local",
+			Namespace: "fleet-local",
+			Labels: map[string]string{
+				"name":                        "local",
+				fleet.LocalAgentDisabledLabel: "true",
+			},
+		},
+		Spec: fleet.ClusterSpec{
+			KubeConfigSecret: "local-cluster", // would normally trigger ClientID gen
+		},
+	}
+
+	ih := importHandler{}
+	got, err := ih.OnChange("fleet-local/local", cluster)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != cluster {
+		t.Errorf("OnChange returned a different cluster; want short-circuit returning the input as-is")
+	}
+}
+
+func TestImportCluster_LocalAgentDisabled(t *testing.T) {
+	cases := map[string]struct {
+		cluster    *fleet.Cluster
+		status     fleet.ClusterStatus
+		wantStatus fleet.ClusterStatus
+	}{
+		"never deployed: returns immediately with status unchanged": {
+			// status.Agent.Namespace == "" && status.AgentDeployedGeneration == nil
+			// → no teardown, no status mutation. Avoids reconnecting to the
+			// downstream every reconcile after teardown has already run.
+			cluster: &fleet.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "local",
+					Namespace: "fleet-local",
+					Labels: map[string]string{
+						fleet.LocalAgentDisabledLabel: "true",
+					},
+				},
+				Spec: fleet.ClusterSpec{
+					// non-empty would normally drive the deploy path,
+					// but the label must skip past it.
+					KubeConfigSecret: "local-cluster",
+				},
+			},
+			status:     fleet.ClusterStatus{},
+			wantStatus: fleet.ClusterStatus{},
+		},
+		"previously deployed without a kubeconfig secret: clears status, skips teardown": {
+			// Defensive branch: the teardown only runs when there's a
+			// kubeconfig to connect with. The status is still wiped so
+			// later reconciles take the early-return path above.
+			cluster: &fleet.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "local",
+					Namespace: "fleet-local",
+					Labels: map[string]string{
+						fleet.LocalAgentDisabledLabel: "true",
+					},
+				},
+				Spec: fleet.ClusterSpec{
+					KubeConfigSecret: "", // skips teardownLocalAgent
+				},
+			},
+			status: fleet.ClusterStatus{
+				Agent: fleet.AgentStatus{
+					Namespace: "cattle-fleet-local-system",
+				},
+				AgentDeployedGeneration: new(int64),
+				AgentConfigChanged:      true,
+			},
+			wantStatus: fleet.ClusterStatus{
+				Agent:                   fleet.AgentStatus{},
+				AgentDeployedGeneration: nil,
+				AgentConfigChanged:      false,
+			},
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			// All importHandler fields nil — any access would panic, proving
+			// the disabled path does not reach the kubeconfig/secrets/apply
+			// code.
+			ih := importHandler{}
+			gotStatus, err := ih.importCluster(c.cluster, c.status)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !reflect.DeepEqual(gotStatus, c.wantStatus) {
+				t.Errorf("status mismatch.\nwant: %#v\ngot:  %#v", c.wantStatus, gotStatus)
 			}
 		})
 	}

--- a/internal/cmd/controller/agentmanagement/controllers/cluster/import_test.go
+++ b/internal/cmd/controller/agentmanagement/controllers/cluster/import_test.go
@@ -1,6 +1,7 @@
 package cluster
 
 import (
+	"context"
 	"reflect"
 	"strings"
 	"testing"
@@ -8,14 +9,166 @@ import (
 
 	"github.com/rancher/wrangler/v3/pkg/generic/fake"
 	"go.uber.org/mock/gomock"
-	"k8s.io/apimachinery/pkg/labels"
 
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	policyv1 "k8s.io/api/policy/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	schedulingv1 "k8s.io/api/scheduling/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+	kubernetesfake "k8s.io/client-go/kubernetes/fake"
 
+	"github.com/rancher/fleet/internal/cmd/controller/agentmanagement/agent"
+	"github.com/rancher/fleet/internal/cmd/controller/agentmanagement/scheduling"
+	fleetns "github.com/rancher/fleet/internal/cmd/controller/namespace"
 	"github.com/rancher/fleet/internal/config"
+	"github.com/rancher/fleet/internal/names"
 	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
 )
+
+// localBootstrapNamespace is the bootstrap namespace the local cluster lives in
+// throughout these tests; it must match the cluster objects' Namespace for
+// isLocalCluster to recognize them.
+const localBootstrapNamespace = "fleet-local"
+
+// setLocalBootstrapConfig points config.Get().Bootstrap.Namespace at
+// localBootstrapNamespace so isLocalCluster can resolve the local cluster.
+func setLocalBootstrapConfig(t *testing.T) {
+	t.Helper()
+	config.Set(&config.Config{Bootstrap: config.Bootstrap{Namespace: localBootstrapNamespace}})
+}
+
+// agentResourceObjects returns one object of every kind that the deploy path
+// creates for a fleet-agent in namespace, named exactly as agent.Manifest and
+// deleteAgentResources expect.
+func agentResourceObjects(namespace string) []runtime.Object {
+	return []runtime.Object{
+		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: config.AgentConfigName}},
+		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: config.AgentBootstrapConfigName}},
+		&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: config.AgentConfigName}},
+		&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: agent.DefaultName}},
+		&networkingv1.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "default-allow-all"}},
+		&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: config.AgentConfigName}},
+		&appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: config.AgentConfigName}},
+		&policyv1.PodDisruptionBudget{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: scheduling.FleetAgentPodDisruptionBudgetName}},
+		&schedulingv1.PriorityClass{ObjectMeta: metav1.ObjectMeta{Name: scheduling.FleetAgentPriorityClassName}},
+		&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: names.SafeConcatName(namespace, agent.DefaultName, "role")}},
+		&rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: names.SafeConcatName(namespace, agent.DefaultName, "role", "binding")}},
+	}
+}
+
+// assertAgentResourcesGone fails the test if any agent resource still exists in
+// namespace (or, for the cluster-scoped ones, with names derived from it).
+func assertAgentResourcesGone(ctx context.Context, t *testing.T, kc kubernetes.Interface, namespace string) {
+	t.Helper()
+	checkGone := func(kind string, err error) {
+		if !apierrors.IsNotFound(err) {
+			t.Errorf("%s in %q: expected NotFound, got %v", kind, namespace, err)
+		}
+	}
+
+	_, err := kc.CoreV1().Secrets(namespace).Get(ctx, config.AgentConfigName, metav1.GetOptions{})
+	checkGone("agent secret", err)
+	_, err = kc.CoreV1().Secrets(namespace).Get(ctx, config.AgentBootstrapConfigName, metav1.GetOptions{})
+	checkGone("bootstrap secret", err)
+	_, err = kc.CoreV1().ConfigMaps(namespace).Get(ctx, config.AgentConfigName, metav1.GetOptions{})
+	checkGone("configmap", err)
+	_, err = kc.CoreV1().ServiceAccounts(namespace).Get(ctx, agent.DefaultName, metav1.GetOptions{})
+	checkGone("serviceaccount", err)
+	_, err = kc.NetworkingV1().NetworkPolicies(namespace).Get(ctx, "default-allow-all", metav1.GetOptions{})
+	checkGone("networkpolicy", err)
+	_, err = kc.AppsV1().Deployments(namespace).Get(ctx, config.AgentConfigName, metav1.GetOptions{})
+	checkGone("deployment", err)
+	_, err = kc.AppsV1().StatefulSets(namespace).Get(ctx, config.AgentConfigName, metav1.GetOptions{})
+	checkGone("statefulset", err)
+	_, err = kc.PolicyV1().PodDisruptionBudgets(namespace).Get(ctx, scheduling.FleetAgentPodDisruptionBudgetName, metav1.GetOptions{})
+	checkGone("poddisruptionbudget", err)
+	_, err = kc.SchedulingV1().PriorityClasses().Get(ctx, scheduling.FleetAgentPriorityClassName, metav1.GetOptions{})
+	checkGone("priorityclass", err)
+	_, err = kc.RbacV1().ClusterRoles().Get(ctx, names.SafeConcatName(namespace, agent.DefaultName, "role"), metav1.GetOptions{})
+	checkGone("clusterrole", err)
+	_, err = kc.RbacV1().ClusterRoleBindings().Get(ctx, names.SafeConcatName(namespace, agent.DefaultName, "role", "binding"), metav1.GetOptions{})
+	checkGone("clusterrolebinding", err)
+}
+
+func TestDeleteAgentResources(t *testing.T) {
+	const ns = "cattle-fleet-system"
+	kc := kubernetesfake.NewSimpleClientset(agentResourceObjects(ns)...)
+	ih := importHandler{ctx: context.Background()}
+
+	// Every agent resource kind — including the ServiceAccount, ConfigMap,
+	// NetworkPolicy and ClusterRole/Binding the old deploy-path deleter missed —
+	// must be removed.
+	if err := ih.deleteAgentResources(kc, ns); err != nil {
+		t.Fatalf("deleteAgentResources: %v", err)
+	}
+	assertAgentResourcesGone(context.Background(), t, kc, ns)
+
+	// Idempotent: a second pass over already-deleted resources must not error.
+	if err := ih.deleteAgentResources(kc, ns); err != nil {
+		t.Fatalf("deleteAgentResources (idempotent call): %v", err)
+	}
+}
+
+func TestCleanupLeftoverDefaultNamespace(t *testing.T) {
+	regNS := fleetns.SystemRegistrationNamespace(config.DefaultNamespace)
+	ctx := context.Background()
+
+	t.Run("system namespace is the default: nothing is touched", func(t *testing.T) {
+		kc := kubernetesfake.NewSimpleClientset(
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: regNS}},
+		)
+		ih := importHandler{ctx: ctx, systemNamespace: config.DefaultNamespace}
+
+		if err := ih.cleanupLeftoverDefaultNamespace(kc); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if _, err := kc.CoreV1().Namespaces().Get(ctx, regNS, metav1.GetOptions{}); err != nil {
+			t.Errorf("registration namespace should have been left untouched, got %v", err)
+		}
+	})
+
+	t.Run("customized system namespace cleans the leftover agent and registration namespace", func(t *testing.T) {
+		objs := append(agentResourceObjects(config.DefaultNamespace),
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: config.DefaultNamespace}},
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: regNS}},
+		)
+		kc := kubernetesfake.NewSimpleClientset(objs...)
+		ih := importHandler{ctx: ctx, systemNamespace: "cattle-fleet-local-system"}
+
+		if err := ih.cleanupLeftoverDefaultNamespace(kc); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		assertAgentResourcesGone(ctx, t, kc, config.DefaultNamespace)
+		if _, err := kc.CoreV1().Namespaces().Get(ctx, regNS, metav1.GetOptions{}); !apierrors.IsNotFound(err) {
+			t.Errorf("registration namespace should have been deleted, got %v", err)
+		}
+		// The default namespace itself must be preserved.
+		if _, err := kc.CoreV1().Namespaces().Get(ctx, config.DefaultNamespace, metav1.GetOptions{}); err != nil {
+			t.Errorf("default namespace should have been kept, got %v", err)
+		}
+	})
+
+	t.Run("customized system namespace with no default namespace still drops the registration namespace", func(t *testing.T) {
+		kc := kubernetesfake.NewSimpleClientset(
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: regNS}},
+		)
+		ih := importHandler{ctx: ctx, systemNamespace: "cattle-fleet-local-system"}
+
+		if err := ih.cleanupLeftoverDefaultNamespace(kc); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if _, err := kc.CoreV1().Namespaces().Get(ctx, regNS, metav1.GetOptions{}); !apierrors.IsNotFound(err) {
+			t.Errorf("registration namespace should have been deleted, got %v", err)
+		}
+	})
+}
 
 func TestOnConfig(t *testing.T) {
 	cases := map[string]struct {
@@ -510,7 +663,21 @@ func TestAllowedKubeConfigSecretNamespace(t *testing.T) {
 	}
 }
 
+// localCluster returns a Cluster object recognized as the management (local)
+// cluster by isLocalCluster, carrying the given labels.
+func localCluster(labels map[string]string) *fleet.Cluster {
+	return &fleet.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fleet.LocalClusterName,
+			Namespace: localBootstrapNamespace,
+			Labels:    labels,
+		},
+	}
+}
+
 func TestLocalAgentDisabled(t *testing.T) {
+	setLocalBootstrapConfig(t)
+
 	cases := []struct {
 		name    string
 		cluster *fleet.Cluster
@@ -518,54 +685,63 @@ func TestLocalAgentDisabled(t *testing.T) {
 	}{
 		{
 			name:    "nil labels",
-			cluster: &fleet.Cluster{},
+			cluster: localCluster(nil),
 			want:    false,
 		},
 		{
-			name: "label absent",
+			name:    "label absent",
+			cluster: localCluster(map[string]string{"name": "local"}),
+			want:    false,
+		},
+		{
+			name: "label set to true on the local cluster",
+			cluster: localCluster(map[string]string{
+				"name":                        "local",
+				fleet.LocalAgentDisabledLabel: "true",
+			}),
+			want: true,
+		},
+		{
+			// The label must only ever take effect on the management cluster:
+			// a downstream cluster carrying it (wrong namespace) must not be
+			// treated as disabled, otherwise its agent would be torn down.
+			name: "label set to true on a non-local cluster (wrong namespace)",
 			cluster: &fleet.Cluster{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{"name": "local"},
+					Name:      fleet.LocalClusterName,
+					Namespace: "some-downstream-ns",
+					Labels: map[string]string{
+						fleet.LocalAgentDisabledLabel: "true",
+					},
 				},
 			},
 			want: false,
 		},
 		{
-			name: "label set to true",
+			name: "label set to true on a non-local cluster (wrong name)",
 			cluster: &fleet.Cluster{
 				ObjectMeta: metav1.ObjectMeta{
+					Name:      "downstream",
+					Namespace: localBootstrapNamespace,
 					Labels: map[string]string{
-						"name":                        "local",
 						fleet.LocalAgentDisabledLabel: "true",
 					},
 				},
 			},
-			want: true,
+			want: false,
 		},
 		{
 			// Only the literal string "true" enables it: anything else (false,
 			// empty, "1", "yes") is treated as not-disabled so users can't
 			// accidentally disable the agent by toggling the label.
-			name: "label set to a non-true value is treated as not disabled",
-			cluster: &fleet.Cluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{
-						fleet.LocalAgentDisabledLabel: "1",
-					},
-				},
-			},
-			want: false,
+			name:    "label set to a non-true value is treated as not disabled",
+			cluster: localCluster(map[string]string{fleet.LocalAgentDisabledLabel: "1"}),
+			want:    false,
 		},
 		{
-			name: "label set to false",
-			cluster: &fleet.Cluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{
-						fleet.LocalAgentDisabledLabel: "false",
-					},
-				},
-			},
-			want: false,
+			name:    "label set to false",
+			cluster: localCluster(map[string]string{fleet.LocalAgentDisabledLabel: "false"}),
+			want:    false,
 		},
 	}
 
@@ -578,6 +754,112 @@ func TestLocalAgentDisabled(t *testing.T) {
 	}
 }
 
+func TestIsLocalCluster(t *testing.T) {
+	setLocalBootstrapConfig(t)
+
+	cases := []struct {
+		name    string
+		cluster *fleet.Cluster
+		want    bool
+	}{
+		{
+			name:    "correct name and namespace",
+			cluster: localCluster(nil),
+			want:    true,
+		},
+		{
+			name: "correct name, wrong namespace",
+			cluster: &fleet.Cluster{
+				ObjectMeta: metav1.ObjectMeta{Name: fleet.LocalClusterName, Namespace: "other"},
+			},
+			want: false,
+		},
+		{
+			name: "wrong name, correct namespace",
+			cluster: &fleet.Cluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "downstream", Namespace: localBootstrapNamespace},
+			},
+			want: false,
+		},
+		{
+			name:    "empty cluster",
+			cluster: &fleet.Cluster{},
+			want:    false,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := isLocalCluster(c.cluster); got != c.want {
+				t.Errorf("isLocalCluster = %v, want %v", got, c.want)
+			}
+		})
+	}
+}
+
+func TestIsManagementCluster(t *testing.T) {
+	const kubeSystem = "kube-system"
+
+	cases := []struct {
+		name string
+		// localUID is the UID reported by the controller's own kube-system
+		// namespace; localErr, if set, is returned instead.
+		localUID  string
+		localErr  error
+		remoteUID string
+		want      bool
+		wantErr   bool
+	}{
+		{
+			name:      "matching UIDs: same cluster",
+			localUID:  "uid-management",
+			remoteUID: "uid-management",
+			want:      true,
+		},
+		{
+			name:      "different UIDs: different cluster",
+			localUID:  "uid-management",
+			remoteUID: "uid-downstream",
+			want:      false,
+		},
+		{
+			// Defensive: never treat an empty UID on both sides as a match.
+			name:      "empty UIDs are never considered a match",
+			localUID:  "",
+			remoteUID: "",
+			want:      false,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+
+			nsController := fake.NewMockNonNamespacedControllerInterface[*corev1.Namespace, *corev1.NamespaceList](ctrl)
+			if c.localErr != nil {
+				nsController.EXPECT().Get(kubeSystem, gomock.Any()).Return(nil, c.localErr)
+			} else {
+				nsController.EXPECT().Get(kubeSystem, gomock.Any()).Return(&corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{Name: kubeSystem, UID: types.UID(c.localUID)},
+				}, nil)
+			}
+
+			kc := kubernetesfake.NewSimpleClientset(&corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{Name: kubeSystem, UID: types.UID(c.remoteUID)},
+			})
+
+			ih := importHandler{ctx: context.Background(), namespaceController: nsController}
+			got, err := ih.isManagementCluster(kc)
+			if (err != nil) != c.wantErr {
+				t.Fatalf("isManagementCluster error = %v, wantErr %v", err, c.wantErr)
+			}
+			if got != c.want {
+				t.Errorf("isManagementCluster = %v, want %v", got, c.want)
+			}
+		})
+	}
+}
+
 func TestOnChange_LocalAgentDisabledShortCircuits(t *testing.T) {
 	// A cluster carrying the local-agent-disabled label must short-circuit
 	// out of OnChange before it touches any of the controllers/caches —
@@ -585,10 +867,11 @@ func TestOnChange_LocalAgentDisabledShortCircuits(t *testing.T) {
 	//
 	// We assert this by leaving every field of importHandler nil; reaching
 	// any of them would panic.
+	setLocalBootstrapConfig(t)
 	cluster := &fleet.Cluster{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "local",
-			Namespace: "fleet-local",
+			Name:      fleet.LocalClusterName,
+			Namespace: localBootstrapNamespace,
 			Labels: map[string]string{
 				"name":                        "local",
 				fleet.LocalAgentDisabledLabel: "true",
@@ -610,6 +893,8 @@ func TestOnChange_LocalAgentDisabledShortCircuits(t *testing.T) {
 }
 
 func TestImportCluster_LocalAgentDisabled(t *testing.T) {
+	setLocalBootstrapConfig(t)
+
 	cases := map[string]struct {
 		cluster    *fleet.Cluster
 		status     fleet.ClusterStatus
@@ -621,8 +906,8 @@ func TestImportCluster_LocalAgentDisabled(t *testing.T) {
 			// downstream every reconcile after teardown has already run.
 			cluster: &fleet.Cluster{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "local",
-					Namespace: "fleet-local",
+					Name:      fleet.LocalClusterName,
+					Namespace: localBootstrapNamespace,
 					Labels: map[string]string{
 						fleet.LocalAgentDisabledLabel: "true",
 					},
@@ -642,8 +927,8 @@ func TestImportCluster_LocalAgentDisabled(t *testing.T) {
 			// later reconciles take the early-return path above.
 			cluster: &fleet.Cluster{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "local",
-					Namespace: "fleet-local",
+					Name:      fleet.LocalClusterName,
+					Namespace: localBootstrapNamespace,
 					Labels: map[string]string{
 						fleet.LocalAgentDisabledLabel: "true",
 					},
@@ -663,6 +948,33 @@ func TestImportCluster_LocalAgentDisabled(t *testing.T) {
 				Agent:                   fleet.AgentStatus{},
 				AgentDeployedGeneration: nil,
 				AgentConfigChanged:      false,
+			},
+		},
+		"non-local cluster carrying the label is not disabled: status preserved, no teardown": {
+			// The disabling label only applies to the management cluster. A
+			// downstream cluster (wrong namespace) carrying it must not take the
+			// teardown/clear path: with an empty ClientID importCluster returns
+			// the status untouched, leaving the agent in place.
+			cluster: &fleet.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fleet.LocalClusterName,
+					Namespace: "some-downstream-ns",
+					Labels: map[string]string{
+						fleet.LocalAgentDisabledLabel: "true",
+					},
+				},
+				Spec: fleet.ClusterSpec{
+					KubeConfigSecret: "downstream-kubeconfig",
+					ClientID:         "", // makes importCluster return early, untouched
+				},
+			},
+			status: fleet.ClusterStatus{
+				Agent:                   fleet.AgentStatus{Namespace: "cattle-fleet-system"},
+				AgentDeployedGeneration: new(int64),
+			},
+			wantStatus: fleet.ClusterStatus{
+				Agent:                   fleet.AgentStatus{Namespace: "cattle-fleet-system"},
+				AgentDeployedGeneration: new(int64),
 			},
 		},
 	}

--- a/internal/cmd/controller/agentmanagement/controllers/manageagent/manageagent.go
+++ b/internal/cmd/controller/agentmanagement/controllers/manageagent/manageagent.go
@@ -115,7 +115,7 @@ func Register(ctx context.Context,
 }
 
 func (h *handler) onClusterStatusChange(cluster *fleet.Cluster, status fleet.ClusterStatus) (fleet.ClusterStatus, error) {
-	if SkipCluster(cluster) {
+	if SkipCluster(cluster) || cluster.Labels[fleet.LocalAgentDisabledLabel] == "true" {
 		return status, nil
 	}
 
@@ -293,7 +293,7 @@ func (h *handler) OnNamespace(key string, namespace *corev1.Namespace) (*corev1.
 	var objs []runtime.Object
 
 	for _, cluster := range clusters {
-		if SkipCluster(cluster) {
+		if SkipCluster(cluster) || cluster.Labels[fleet.LocalAgentDisabledLabel] == "true" {
 			continue
 		}
 		logrus.Infof("Update agent bundle for cluster %s/%s", cluster.Namespace, cluster.Name)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -170,6 +170,7 @@ type AgentWorkers struct {
 type Bootstrap struct {
 	Namespace      string            `json:"namespace,omitempty"`
 	AgentNamespace string            `json:"agentNamespace,omitempty"`
+	AgentDisabled  bool              `json:"agentDisabled,omitempty"`
 	ClusterLabels  map[string]string `json:"clusterLabels,omitempty"`
 	// Repo to add at install time that will deploy to the local cluster. This allows
 	// one to fully bootstrap fleet, its configuration and all its downstream clusters

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -168,10 +168,10 @@ type AgentWorkers struct {
 }
 
 type Bootstrap struct {
-	Namespace      string            `json:"namespace,omitempty"`
-	AgentNamespace string            `json:"agentNamespace,omitempty"`
-	AgentDisabled  bool              `json:"agentDisabled,omitempty"`
-	ClusterLabels  map[string]string `json:"clusterLabels,omitempty"`
+	Namespace          string            `json:"namespace,omitempty"`
+	AgentNamespace     string            `json:"agentNamespace,omitempty"`
+	LocalAgentDisabled bool              `json:"localAgentDisabled,omitempty"`
+	ClusterLabels      map[string]string `json:"clusterLabels,omitempty"`
 	// Repo to add at install time that will deploy to the local cluster. This allows
 	// one to fully bootstrap fleet, its configuration and all its downstream clusters
 	// in one shot.

--- a/pkg/apis/fleet.cattle.io/v1alpha1/cluster_types.go
+++ b/pkg/apis/fleet.cattle.io/v1alpha1/cluster_types.go
@@ -50,6 +50,11 @@ var (
 
 	// ClusterManagementLabel can be used to specify a custom cluster manager
 	ClusterManagementLabel = "fleet.cattle.io/cluster-management"
+
+	// LocalAgentDisabledLabel, when set on a Cluster, instructs the agent
+	// management import handler to skip deploying the fleet-agent and to tear
+	// down any agent already deployed. Used for the local cluster only.
+	LocalAgentDisabledLabel = "fleet.cattle.io/local-agent-disabled"
 )
 
 // +genclient

--- a/pkg/apis/fleet.cattle.io/v1alpha1/cluster_types.go
+++ b/pkg/apis/fleet.cattle.io/v1alpha1/cluster_types.go
@@ -55,6 +55,12 @@ var (
 	// management import handler to skip deploying the fleet-agent and to tear
 	// down any agent already deployed. Used for the local cluster only.
 	LocalAgentDisabledLabel = "fleet.cattle.io/local-agent-disabled"
+
+	// LocalClusterName is the name of the Cluster object that represents the
+	// management (local) cluster. It is created by the bootstrap controller in
+	// the bootstrap namespace and is also used as the value of the "name" label
+	// the local cluster's ClusterGroup selects on.
+	LocalClusterName = "local"
 )
 
 // +genclient


### PR DESCRIPTION
This PR adds an option in the helm chart to disable/enable the local agent. If the agent was already deployed it tears down the agent.

Refers to: https://github.com/rancher/fleet/issues/4807

- [x] <!-- If applicable,--> I have updated the documentation via a pull request in the [fleet-product-docs](https://github.com/rancher/fleet-product-docs) repository.
