### PR TITLE
ci(updatecli): remove depreacated automerge resolving CI warnings

### DIFF
--- a/updatecli/updatecli.d/installation.yaml
+++ b/updatecli/updatecli.d/installation.yaml
@@ -58,7 +58,6 @@ actions:
     kind: github/pullrequest
     scmid: fleet
     spec:
-      automerge: false
       mergemethod: squash
       labels:
         - dependencies

--- a/updatecli/updatecli.d/known-hosts.yaml
+++ b/updatecli/updatecli.d/known-hosts.yaml
@@ -39,7 +39,6 @@ actions:
     kind: github/pullrequest
     scmid: fleet
     spec:
-      automerge: false
       mergemethod: squash
       labels:
         - kind/known-hosts # /!\ label must exist in the repo!


### PR DESCRIPTION
According to https://www.updatecli.io/docs/plugins/actions/github/ the `automerge` use the _false_ by default and is marked as deprecated in favor of `merge.strategy`.

## Additional Information

See CI warnings in https://github.com/rancher/fleet/actions/runs/27318305612/job/80703624831#logs
updatecli docs: 
https://www.updatecli.io/docs/plugins/actions/github/
 https://www.updatecli.io/docs/plugins/actions/github/
