### PR TITLE
Update branch references for updatecli workflow

### DIFF
--- a/updatecli/values.d/scm.yaml
+++ b/updatecli/values.d/scm.yaml
@@ -6,6 +6,9 @@ scms:
     owner: rancher
     repository: fleet
     branch: main
+  v15:
+    <<: *main
+    branch: 'release/v0.15'
   v14:
     <<: *main
     branch: 'release/v0.14'
@@ -15,6 +18,3 @@ scms:
   v12:
     <<: *main
     branch: 'release/v0.12'
-  v11:
-    <<: *main
-    branch: 'release/v0.11'


### PR DESCRIPTION
The v0.11 release branch no longer exists, which led to failures of the known hosts update workflow.
On the other hand, the v0.15 release branch needs to be handled.

This should fix failures such as [this one](https://github.com/rancher/fleet/actions/runs/27389094209/job/80942521555).

## Additional Information

### Checklist

~- [ ] <!-- If applicable,--> I have updated the documentation via a pull request in the [fleet-product-docs](https://github.com/rancher/fleet-product-docs) repository.~
