### PR TITLE
[v0.12] Validate resolved paths stay within the clone directory

### DIFF
--- a/internal/cmd/controller/imagescan/gitcommit_job.go
+++ b/internal/cmd/controller/imagescan/gitcommit_job.go
@@ -197,8 +197,13 @@ func (j *GitCommitJob) cloneAndReplace(ctx context.Context) {
 		paths = []string{"/"}
 	}
 
-	for _, path := range paths {
-		updatePath := filepath.Join(tmp, path)
+	for _, p := range paths {
+		updatePath := filepath.Clean(filepath.Join(tmp, p))
+		if pathEscapesBase(tmp, p) {
+			err = j.updateErrorStatus(ctx, gitrepo, fmt.Errorf("path %q resolves outside the repository root", p))
+			logger.V(1).Info("Skipping path outside repository root", "path", p, "error", err)
+			return
+		}
 		if err := update.WithSetters(updatePath, updatePath, scans); err != nil {
 			err = j.updateErrorStatus(ctx, gitrepo, err)
 			logger.V(1).Info("Cannot update image tags in repo", "error", err)
@@ -257,6 +262,13 @@ func (j *GitCommitJob) updateErrorStatus(ctx context.Context, gitrepo *fleet.Git
 		merr = append(merr, err)
 	}
 	return errutil.NewAggregate(merr)
+}
+
+// pathEscapesBase reports whether relPath, when resolved relative to base, points outside base.
+func pathEscapesBase(base, relPath string) bool {
+	resolved := filepath.Clean(filepath.Join(base, relPath))
+	clean := filepath.Clean(base)
+	return !strings.HasPrefix(resolved, clean+string(os.PathSeparator)) && resolved != clean
 }
 
 func shouldSync(gitrepo *fleet.GitRepo) bool {

--- a/internal/cmd/controller/imagescan/gitcommit_job_test.go
+++ b/internal/cmd/controller/imagescan/gitcommit_job_test.go
@@ -1,0 +1,31 @@
+package imagescan
+
+import (
+	"testing"
+)
+
+func TestPathResolutionStaysInsideBase(t *testing.T) {
+	const base = "/tmp/repo"
+	tests := []struct {
+		name    string
+		relPath string
+		escapes bool
+	}{
+		{"plain subdirectory", "manifests", false},
+		{"nested subdirectory", "charts/my-chart", false},
+		{"current directory", ".", false},
+		{"root slash", "/", false},
+		{"parent traversal", "../etc", true},
+		{"deep traversal", "../../etc", true},
+		{"nested then traversal", "sub/../../etc", true},
+		{"leading-slash traversal", "/../etc", true},
+		{"absolute path stays inside", "/etc/passwd", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := pathEscapesBase(base, tt.relPath); got != tt.escapes {
+				t.Errorf("pathEscapesBase(%q, %q) = %v, want %v", base, tt.relPath, got, tt.escapes)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fleet's image scan git commit job now validates that each path in `gitrepo.spec.paths` resolves within the temporary clone directory.

Backports #5276 
Refers GHSA-c45g-6c2c-rj3p