### PR TITLE
Validate GitRepo defaults from GitRepoRestriction and Policy against allow-lists

### DIFF
--- a/internal/cmd/controller/gitops/reconciler/restrictions.go
+++ b/internal/cmd/controller/gitops/reconciler/restrictions.go
@@ -60,24 +60,26 @@ func AuthorizeAndAssignDefaults(ctx context.Context, c client.Client, gitrepo *f
 		return errors.New("empty targetNamespace denied, because allowedTargetNamespaceSelector restriction is present")
 	}
 
-	targetNamespace, err := isAllowed(gitrepo.Spec.TargetNamespace, "", allowedTargetNS)
-	if err != nil {
+	// Apply defaults before validation, so a default that is not in the allow-list
+	// is rejected rather than silently accepted. This keeps the GitRepo path
+	// consistent with the HelmOp and Bundle paths.
+	serviceAccount := firstNonEmpty(gitrepo.Spec.ServiceAccount, defaultSA)
+	clientSecretName := firstNonEmpty(gitrepo.Spec.ClientSecretName, defaultClientSecret)
+
+	if _, err := isAllowed(gitrepo.Spec.TargetNamespace, "", allowedTargetNS); err != nil {
 		return fmt.Errorf("disallowed targetNamespace %s: %w", gitrepo.Spec.TargetNamespace, err)
 	}
 
-	serviceAccount, err := isAllowed(gitrepo.Spec.ServiceAccount, defaultSA, allowedSAs)
-	if err != nil {
-		return fmt.Errorf("disallowed serviceAccount %s: %w", gitrepo.Spec.ServiceAccount, err)
+	if _, err := isAllowed(serviceAccount, "", allowedSAs); err != nil {
+		return fmt.Errorf("disallowed serviceAccount %s: %w", serviceAccount, err)
 	}
 
-	repo, err := isAllowedByRepo(gitrepo.Spec.Repo, grr.AllowedRepoPatterns, pol.GitAllowedRepoPatterns)
-	if err != nil {
+	if _, err := isAllowedByRepo(gitrepo.Spec.Repo, grr.AllowedRepoPatterns, pol.GitAllowedRepoPatterns); err != nil {
 		return fmt.Errorf("disallowed repo %s: %w", gitrepo.Spec.Repo, err)
 	}
 
-	clientSecretName, err := isAllowed(gitrepo.Spec.ClientSecretName, defaultClientSecret, allowedClientSecrets)
-	if err != nil {
-		return fmt.Errorf("disallowed clientSecretName %s: %w", gitrepo.Spec.ClientSecretName, err)
+	if _, err := isAllowed(clientSecretName, "", allowedClientSecrets); err != nil {
+		return fmt.Errorf("disallowed clientSecretName %s: %w", clientSecretName, err)
 	}
 
 	// Policy: RequireServiceAccount is checked after all defaulting.
@@ -86,9 +88,7 @@ func AuthorizeAndAssignDefaults(ctx context.Context, c client.Client, gitrepo *f
 	}
 
 	// Write resolved values back to the GitRepo.
-	gitrepo.Spec.TargetNamespace = targetNamespace
 	gitrepo.Spec.ServiceAccount = serviceAccount
-	gitrepo.Spec.Repo = repo
 	gitrepo.Spec.ClientSecretName = clientSecretName
 
 	return nil

--- a/internal/cmd/controller/gitops/reconciler/restrictions.go
+++ b/internal/cmd/controller/gitops/reconciler/restrictions.go
@@ -66,11 +66,11 @@ func AuthorizeAndAssignDefaults(ctx context.Context, c client.Client, gitrepo *f
 	serviceAccount := firstNonEmpty(gitrepo.Spec.ServiceAccount, defaultSA)
 	clientSecretName := firstNonEmpty(gitrepo.Spec.ClientSecretName, defaultClientSecret)
 
-	if _, err := isAllowed(gitrepo.Spec.TargetNamespace, "", allowedTargetNS); err != nil {
+	if err := isAllowed(gitrepo.Spec.TargetNamespace, allowedTargetNS); err != nil {
 		return fmt.Errorf("disallowed targetNamespace %s: %w", gitrepo.Spec.TargetNamespace, err)
 	}
 
-	if _, err := isAllowed(serviceAccount, "", allowedSAs); err != nil {
+	if err := isAllowed(serviceAccount, allowedSAs); err != nil {
 		return fmt.Errorf("disallowed serviceAccount %s: %w", serviceAccount, err)
 	}
 
@@ -78,7 +78,7 @@ func AuthorizeAndAssignDefaults(ctx context.Context, c client.Client, gitrepo *f
 		return fmt.Errorf("disallowed repo %s: %w", gitrepo.Spec.Repo, err)
 	}
 
-	if _, err := isAllowed(clientSecretName, "", allowedClientSecrets); err != nil {
+	if err := isAllowed(clientSecretName, allowedClientSecrets); err != nil {
 		return fmt.Errorf("disallowed clientSecretName %s: %w", clientSecretName, err)
 	}
 
@@ -123,18 +123,15 @@ func aggregate(restrictions []fleet.GitRepoRestriction) (result fleet.GitRepoRes
 	return result
 }
 
-func isAllowed(currentValue, defaultValue string, allowedValues []string) (string, error) {
-	if currentValue == "" {
-		return defaultValue, nil
-	}
-	if len(allowedValues) == 0 {
-		return currentValue, nil
+func isAllowed(currentValue string, allowedValues []string) error {
+	if currentValue == "" || len(allowedValues) == 0 {
+		return nil
 	}
 	if slices.Contains(allowedValues, currentValue) {
-		return currentValue, nil
+		return nil
 	}
 
-	return currentValue, fmt.Errorf("%s not in allowed set %v", currentValue, allowedValues)
+	return fmt.Errorf("%s not in allowed set %v", currentValue, allowedValues)
 }
 
 func isAllowedByRegex(currentValue, defaultValue string, patterns []string) (string, error) {

--- a/internal/cmd/controller/gitops/reconciler/restrictions.go
+++ b/internal/cmd/controller/gitops/reconciler/restrictions.go
@@ -74,7 +74,7 @@ func AuthorizeAndAssignDefaults(ctx context.Context, c client.Client, gitrepo *f
 		return fmt.Errorf("disallowed serviceAccount %s: %w", serviceAccount, err)
 	}
 
-	if _, err := isAllowedByRepo(gitrepo.Spec.Repo, grr.AllowedRepoPatterns, pol.GitAllowedRepoPatterns); err != nil {
+	if err := isAllowedByRepo(gitrepo.Spec.Repo, grr.AllowedRepoPatterns, pol.GitAllowedRepoPatterns); err != nil {
 		return fmt.Errorf("disallowed repo %s: %w", gitrepo.Spec.Repo, err)
 	}
 
@@ -164,27 +164,27 @@ func isAllowedByRegex(currentValue, defaultValue string, patterns []string) (str
 // compatible). Policy patterns are evaluated anchored via policyrestrictions.IsAllowedByRegex.
 // An empty combined allow-list means no restriction. The repo passes if either non-empty
 // list accepts it.
-func isAllowedByRepo(repo string, grrPatterns, policyPatterns []string) (string, error) {
+func isAllowedByRepo(repo string, grrPatterns, policyPatterns []string) error {
 	if len(grrPatterns) == 0 && len(policyPatterns) == 0 {
-		return repo, nil
+		return nil
 	}
 	var grrErr, polErr error
 	if len(grrPatterns) > 0 {
 		_, grrErr = isAllowedByRegex(repo, "", grrPatterns)
 		if grrErr == nil {
-			return repo, nil
+			return nil
 		}
 	}
 	if len(policyPatterns) > 0 {
 		_, polErr = policyrestrictions.IsAllowedByRegex(repo, "", policyPatterns)
 		if polErr == nil {
-			return repo, nil
+			return nil
 		}
 	}
 	// Both lists were non-empty and both rejected — report the Policy error if
 	// only Policy patterns were present, otherwise report the GRR error.
 	if grrErr != nil {
-		return repo, grrErr
+		return grrErr
 	}
-	return repo, polErr
+	return polErr
 }

--- a/internal/cmd/controller/gitops/reconciler/restrictions_test.go
+++ b/internal/cmd/controller/gitops/reconciler/restrictions_test.go
@@ -192,9 +192,9 @@ func TestAuthorizeAndAssignDefaults(t *testing.T) {
 			restrictions: &fleet.GitRepoRestrictionList{
 				Items: []fleet.GitRepoRestriction{
 					{
-						AllowedClientSecretNames: []string{"csn"},
+						AllowedClientSecretNames: []string{"dcsn"},
 						AllowedRepoPatterns:      []string{".*foo.bar.*"},
-						AllowedServiceAccounts:   []string{"sacc"},
+						AllowedServiceAccounts:   []string{"dsacc"},
 						AllowedTargetNamespaces:  []string{"tns"},
 						DefaultClientSecretName:  "dcsn",
 						DefaultServiceAccount:    "dsacc",
@@ -209,6 +209,57 @@ func TestAuthorizeAndAssignDefaults(t *testing.T) {
 					TargetNamespace:  "tns",
 				},
 			},
+		},
+		{
+			// A default that is not in the allow-list must be rejected, not
+			// silently applied. This mirrors the HelmOp and Bundle behavior.
+			name: "deny defaultServiceAccount that is not in allowedServiceAccounts",
+			inputGr: fleet.GitRepo{
+				Spec: fleet.GitRepoSpec{
+					Repo: "http://foo.bar/baz",
+				},
+			},
+			restrictions: &fleet.GitRepoRestrictionList{
+				Items: []fleet.GitRepoRestriction{
+					{
+						AllowedRepoPatterns:    []string{".*foo.bar.*"},
+						AllowedServiceAccounts: []string{"sacc"},
+						DefaultServiceAccount:  "dsacc",
+					},
+				},
+			},
+			// The GitRepo is left unmutated: validation fails before the
+			// resolved defaults are written back.
+			expectedGr: fleet.GitRepo{
+				Spec: fleet.GitRepoSpec{
+					Repo: "http://foo.bar/baz",
+				},
+			},
+			expectedErr: "disallowed serviceAccount.*",
+		},
+		{
+			// Same for a defaultClientSecretName outside the allow-list.
+			name: "deny defaultClientSecretName that is not in allowedClientSecretNames",
+			inputGr: fleet.GitRepo{
+				Spec: fleet.GitRepoSpec{
+					Repo: "http://foo.bar/baz",
+				},
+			},
+			restrictions: &fleet.GitRepoRestrictionList{
+				Items: []fleet.GitRepoRestriction{
+					{
+						AllowedRepoPatterns:      []string{".*foo.bar.*"},
+						AllowedClientSecretNames: []string{"csn"},
+						DefaultClientSecretName:  "dcsn",
+					},
+				},
+			},
+			expectedGr: fleet.GitRepo{
+				Spec: fleet.GitRepoSpec{
+					Repo: "http://foo.bar/baz",
+				},
+			},
+			expectedErr: "disallowed clientSecretName.*",
 		},
 		{
 			// Policy patterns are anchored: a pattern without .* must match the full URL.

--- a/internal/cmd/controller/gitops/reconciler/restrictions_test.go
+++ b/internal/cmd/controller/gitops/reconciler/restrictions_test.go
@@ -262,6 +262,56 @@ func TestAuthorizeAndAssignDefaults(t *testing.T) {
 			expectedErr: "disallowed clientSecretName.*",
 		},
 		{
+			// Same rule via a Policy rather than a GitRepoRestriction. This is a
+			// standalone case (not relying on the GRR cases above) so the Policy
+			// path stays covered once GitRepoRestriction is eventually removed.
+			name: "deny Policy defaultServiceAccount that is not in allowedServiceAccounts",
+			inputGr: fleet.GitRepo{
+				Spec: fleet.GitRepoSpec{
+					Repo: "http://foo.bar/baz",
+				},
+			},
+			restrictions: &fleet.GitRepoRestrictionList{},
+			policies: &fleet.PolicyList{Items: []fleet.Policy{
+				{
+					AllowedServiceAccounts: []string{"sacc"},
+					GitRepo: &fleet.GitRepoPolicySpec{
+						DefaultServiceAccount: "dsacc",
+					},
+				},
+			}},
+			expectedGr: fleet.GitRepo{
+				Spec: fleet.GitRepoSpec{
+					Repo: "http://foo.bar/baz",
+				},
+			},
+			expectedErr: "disallowed serviceAccount.*",
+		},
+		{
+			// Same for a Policy defaultClientSecretName outside the allow-list.
+			name: "deny Policy defaultClientSecretName that is not in allowedClientSecretNames",
+			inputGr: fleet.GitRepo{
+				Spec: fleet.GitRepoSpec{
+					Repo: "http://foo.bar/baz",
+				},
+			},
+			restrictions: &fleet.GitRepoRestrictionList{},
+			policies: &fleet.PolicyList{Items: []fleet.Policy{
+				{
+					GitRepo: &fleet.GitRepoPolicySpec{
+						AllowedClientSecretNames: []string{"csn"},
+						DefaultClientSecretName:  "dcsn",
+					},
+				},
+			}},
+			expectedGr: fleet.GitRepo{
+				Spec: fleet.GitRepoSpec{
+					Repo: "http://foo.bar/baz",
+				},
+			},
+			expectedErr: "disallowed clientSecretName.*",
+		},
+		{
 			// Policy patterns are anchored: a pattern without .* must match the full URL.
 			name: "Policy repo pattern: reject URL that matches only as substring",
 			inputGr: fleet.GitRepo{


### PR DESCRIPTION
When a `GitRepoRestriction` (or `Policy`) defines a `defaultServiceAccount` that is not contained in a non-empty `allowedServiceAccounts` (and likewise `defaultClientSecretName` vs `allowedClientSecretNames`), the GitRepo reconciler applies the default to `gitrepo.spec` and persists it before that value is validated against the allow-list. The disallowed value is validated only on the following reconcile, once it is an explicit spec field, and the GitRepo is rejected then.

This is inconsistent with the HelmOp and Bundle paths, which validate defaults before applying them.

## Steps to reproduce

```yaml
# GitRepoRestriction in fleet-local
apiVersion: fleet.cattle.io/v1alpha1
kind: GitRepoRestriction
metadata: { name: repro, namespace: fleet-local }
defaultServiceAccount: some-default-sa
allowedServiceAccounts: [some-other-sa]   # non-empty, does NOT contain the default
```

```yaml
# GitRepo in fleet-local with no serviceAccount set
apiVersion: fleet.cattle.io/v1alpha1
kind: GitRepo
metadata: { name: repro, namespace: fleet-local }
spec:
  repo: https://github.com/rancher/fleet-examples
```

Apply the restriction, then the GitRepo, and inspect it.

## Expected

The GitRepo is rejected without `spec.serviceAccount` being modified; `metadata.generation` stays `1`.

## Actual

`spec.serviceAccount` is set to `some-default-sa`, `metadata.generation` becomes `2`, and only then is the GitRepo rejected (`Accepted=False`, `PolicyViolation` event).


Refers to #5422
<!-- Make sure that the referenced issue provides steps to reproduce it -->

<!-- Describe the changes introduced by this pull request -->

<!--
  Please provide a unit, integration (`./integrationtests/`) or e2e (`./e2e/`) test if possible.
-->

## Additional Information

### Checklist

- [ ] <!-- If applicable,--> I have updated the documentation via a pull request in the [fleet-product-docs](https://github.com/rancher/fleet-product-docs) repository.
