### PR TITLE
Fix cloner when using tags in revision.

### DIFF
--- a/internal/cmd/cli/gitcloner/cloner.go
+++ b/internal/cmd/cli/gitcloner/cloner.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/protocol/packp/capability"
 	"github.com/go-git/go-git/v5/plumbing/transport"
@@ -23,6 +24,7 @@ const defaultBranch = "master"
 
 var (
 	plainClone                                 = git.PlainClone
+	cloneCommit                                = cloneCommitShallow
 	updateSubmodules                           = submodule.UpdateSubmodules
 	readFile                                   = os.ReadFile
 	fileStat                                   = os.Stat
@@ -80,39 +82,117 @@ func (c *Cloner) CloneRepo(opts *GitCloner) error {
 }
 
 func cloneBranch(opts *GitCloner, auth transport.AuthMethod, caBundle []byte) error {
-	r, err := plainClone(opts.Path, false, &git.CloneOptions{
+	r, err := shallowCloneRef(opts, auth, caBundle, plumbing.ReferenceName(opts.Branch))
+	if err != nil {
+		return fmt.Errorf("failed to clone main repo from branch %s: %w, skipping submodule clone", repo(opts), err)
+	}
+
+	return updateSubmodulesShallow(r, auth)
+}
+
+func cloneRevision(opts *GitCloner, auth transport.AuthMethod, caBundle []byte) error {
+	// A bare 40-hex revision resolves to the commit object (git ignores any
+	// ref with that name), so skip the tag/branch attempts and fetch the exact
+	// commit shallowly. The full-clone fallback covers the rare case where the
+	// 40-hex value is actually a ref pointing at some other commit.
+	if plumbing.IsHash(opts.Revision) {
+		if err := cloneCommit(opts, auth, caBundle); err == nil {
+			return nil
+		}
+		if err := resetDir(opts.Path); err != nil {
+			return fmt.Errorf("failed to reset clone dir for %s: %w", repo(opts), err)
+		}
+		return fullCloneRevision(opts, auth, caBundle)
+	}
+
+	if r, err := shallowCloneRef(opts, auth, caBundle, plumbing.NewTagReferenceName(opts.Revision)); err == nil {
+		return updateSubmodulesShallow(r, auth)
+	}
+	if err := resetDir(opts.Path); err != nil {
+		return fmt.Errorf("failed to reset clone dir for %s: %w", repo(opts), err)
+	}
+
+	if r, err := shallowCloneRef(opts, auth, caBundle, plumbing.NewBranchReferenceName(opts.Revision)); err == nil {
+		return updateSubmodulesShallow(r, auth)
+	}
+	if err := resetDir(opts.Path); err != nil {
+		return fmt.Errorf("failed to reset clone dir for %s: %w", repo(opts), err)
+	}
+
+	return fullCloneRevision(opts, auth, caBundle)
+}
+
+// shallowCloneRef performs a depth-1, single-branch clone pinned to ref. It
+// only owns the clone and leaves submodule handling to the caller, so the
+// revision path can fall through to the next strategy on error while the
+// branch path can wrap the error and update submodules on success.
+func shallowCloneRef(opts *GitCloner, auth transport.AuthMethod, caBundle []byte, ref plumbing.ReferenceName) (*git.Repository, error) {
+	return plainClone(opts.Path, false, &git.CloneOptions{
 		URL:               opts.Repo,
 		Depth:             1,
 		Auth:              auth,
 		InsecureSkipTLS:   opts.InsecureSkipTLS,
 		CABundle:          caBundle,
 		SingleBranch:      true,
-		ReferenceName:     plumbing.ReferenceName(opts.Branch),
+		ReferenceName:     ref,
 		RecurseSubmodules: git.NoRecurseSubmodules,
 		Tags:              git.NoTags,
 		ProxyOptions:      fleetgit.ProxyOptsFromEnvironment(opts.Repo),
 	})
-	if err != nil {
-		return fmt.Errorf("failed to clone main repo from branch %s: %w, skipping submodule clone", repo(opts), err)
-	}
-
-	return updateSubmodules(r, &git.SubmoduleUpdateOptions{
-		Init:              true,
-		RecurseSubmodules: git.DefaultSubmoduleRecursionDepth,
-		Depth:             1,
-		Auth:              auth,
-	})
 }
 
-func cloneRevision(opts *GitCloner, auth transport.AuthMethod, caBundle []byte) error {
+// cloneCommitShallow fetches a single commit by SHA with depth 1, avoiding the
+// full-history clone that resolving an arbitrary commit would otherwise need.
+// It only succeeds when the server allows fetching an exact SHA
+// (uploadpack.allowReachableSHA1InWant / allowAnySHA1InWant); callers must fall
+// back to a full clone on error.
+func cloneCommitShallow(opts *GitCloner, auth transport.AuthMethod, caBundle []byte) error {
+	r, err := git.PlainInit(opts.Path, false)
+	if err != nil {
+		return err
+	}
+	if _, err := r.CreateRemote(&config.RemoteConfig{
+		Name: git.DefaultRemoteName,
+		URLs: []string{opts.Repo},
+	}); err != nil {
+		return err
+	}
+	// Store the fetched commit under a normal local ref, matching the SHA-fetch
+	// strategies in submodule/strategy. The checkout below reads the object by
+	// hash, so the destination ref name itself is irrelevant.
+	refSpec := config.RefSpec(opts.Revision + ":refs/heads/temp")
+	if err := r.Fetch(&git.FetchOptions{
+		RemoteName:      git.DefaultRemoteName,
+		Depth:           1,
+		RefSpecs:        []config.RefSpec{refSpec},
+		Auth:            auth,
+		InsecureSkipTLS: opts.InsecureSkipTLS,
+		CABundle:        caBundle,
+		Tags:            git.NoTags,
+		ProxyOptions:    fleetgit.ProxyOptsFromEnvironment(opts.Repo),
+	}); err != nil {
+		return err
+	}
+	w, err := r.Worktree()
+	if err != nil {
+		return err
+	}
+	if err := w.Checkout(&git.CheckoutOptions{Hash: plumbing.NewHash(opts.Revision)}); err != nil {
+		return err
+	}
+	return updateSubmodulesShallow(r, auth)
+}
+
+// fullCloneRevision clones the whole repository (all history and tags) and
+// resolves opts.Revision locally. This is the slowest path and is only used
+// when no cheaper strategy can satisfy the revision.
+func fullCloneRevision(opts *GitCloner, auth transport.AuthMethod, caBundle []byte) error {
 	r, err := plainClone(opts.Path, false, &git.CloneOptions{
 		URL:               opts.Repo,
-		Depth:             1,
 		Auth:              auth,
 		InsecureSkipTLS:   opts.InsecureSkipTLS,
 		CABundle:          caBundle,
 		RecurseSubmodules: git.NoRecurseSubmodules,
-		Tags:              git.NoTags,
 		ProxyOptions:      fleetgit.ProxyOptsFromEnvironment(opts.Repo),
 	})
 	if err != nil {
@@ -129,13 +209,27 @@ func cloneRevision(opts *GitCloner, auth transport.AuthMethod, caBundle []byte) 
 	if err := w.Checkout(&git.CheckoutOptions{Hash: *h}); err != nil {
 		return fmt.Errorf("failed to checkout in worktree %s: %w", repo(opts), err)
 	}
+	return updateSubmodulesShallow(r, auth)
+}
 
+// updateSubmodulesShallow recursively initializes and shallowly updates the
+// repository's submodules. It is shared by every clone path.
+func updateSubmodulesShallow(r *git.Repository, auth transport.AuthMethod) error {
 	return updateSubmodules(r, &git.SubmoduleUpdateOptions{
 		Init:              true,
 		RecurseSubmodules: git.DefaultSubmoduleRecursionDepth,
 		Depth:             1,
 		Auth:              auth,
 	})
+}
+
+// resetDir clears the clone destination so a subsequent clone attempt starts
+// from a clean slate. go-git refuses to clone into a non-empty directory.
+func resetDir(path string) error {
+	if err := os.RemoveAll(path); err != nil {
+		return err
+	}
+	return os.MkdirAll(path, 0750)
 }
 
 func getCABundleFromFile(path string) ([]byte, error) {

--- a/internal/cmd/cli/gitcloner/cloner_test.go
+++ b/internal/cmd/cli/gitcloner/cloner_test.go
@@ -379,9 +379,11 @@ func TestCloneRepo_CloneError(t *testing.T) {
 }
 
 // initTestRepoWithCommit returns a real go-git repo containing a single
-// commit, plus the commit hash. cloneRevision uses ResolveRevision and
-// Worktree on the value returned from plainClone, so the mock must hand back
-// a populated *git.Repository rather than an empty stub.
+// commit, plus the commit hash. A populated *git.Repository is required
+// because the full-clone fallback (fullCloneRevision) calls ResolveRevision
+// and Worktree on the value returned from plainClone, and because
+// TestCloneCommitShallow_Body fetches from it as a source repository; an
+// empty stub would not satisfy either.
 func initTestRepoWithCommit(t *testing.T) (*git.Repository, plumbing.Hash) {
 	t.Helper()
 	tempDir := t.TempDir()

--- a/internal/cmd/cli/gitcloner/cloner_test.go
+++ b/internal/cmd/cli/gitcloner/cloner_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/go-git/go-git/v5/plumbing/protocol/packp/capability"
 	"github.com/go-git/go-git/v5/plumbing/transport"
@@ -377,162 +378,318 @@ func TestCloneRepo_CloneError(t *testing.T) {
 	}
 }
 
-func TestCloneRevision(t *testing.T) {
-	var (
-		cloneOptsCalled            *git.CloneOptions
-		updateSubmodulesCalled     bool
-		updateSubmodulesOptsCalled *git.SubmoduleUpdateOptions
-	)
-
-	// Create a temp directory with a real git repo for testing
+// initTestRepoWithCommit returns a real go-git repo containing a single
+// commit, plus the commit hash. cloneRevision uses ResolveRevision and
+// Worktree on the value returned from plainClone, so the mock must hand back
+// a populated *git.Repository rather than an empty stub.
+func initTestRepoWithCommit(t *testing.T) (*git.Repository, plumbing.Hash) {
+	t.Helper()
 	tempDir := t.TempDir()
-
-	// Initialize a real git repository so we can use its methods
-	testRepo, err := git.PlainInit(tempDir, false)
+	r, err := git.PlainInit(tempDir, false)
 	if err != nil {
 		t.Fatalf("failed to init test repo: %v", err)
 	}
-
-	plainClone = func(path string, isBare bool, o *git.CloneOptions) (*git.Repository, error) {
-		cloneOptsCalled = o
-		return testRepo, nil
-	}
-	updateSubmodules = func(r *git.Repository, opts *git.SubmoduleUpdateOptions) error {
-		updateSubmodulesCalled = true
-		updateSubmodulesOptsCalled = opts
-		return nil
-	}
-
-	// We need to mock the repository methods, but go-git doesn't use interfaces
-	// So we'll test via integration with a real repo that has a commit
-	// First, create a commit in the test repo
-	wt, err := testRepo.Worktree()
+	wt, err := r.Worktree()
 	if err != nil {
 		t.Fatalf("failed to get worktree: %v", err)
 	}
-
-	// Create a file and commit it
-	testFile := tempDir + "/test.txt"
-	if err := os.WriteFile(testFile, []byte("test"), 0644); err != nil {
+	if err := os.WriteFile(tempDir+"/test.txt", []byte("test"), 0644); err != nil {
 		t.Fatalf("failed to write test file: %v", err)
 	}
 	if _, err := wt.Add("test.txt"); err != nil {
 		t.Fatalf("failed to add file: %v", err)
 	}
-	commitHash, err := wt.Commit("test commit", &git.CommitOptions{
-		Author: &object.Signature{
-			Name:  "Test",
-			Email: "test@test.com",
-			When:  time.Now(),
-		},
+	h, err := wt.Commit("test commit", &git.CommitOptions{
+		Author: &object.Signature{Name: "Test", Email: "test@test.com", When: time.Now()},
 	})
 	if err != nil {
 		t.Fatalf("failed to commit: %v", err)
 	}
+	return r, h
+}
 
+// TestCloneRevision_TagShortcut covers the cheap path: cloneRevision first
+// tries refs/tags/<revision> with Depth: 1, and on success skips the
+// remaining fallbacks.
+func TestCloneRevision_TagShortcut(t *testing.T) {
+	testRepo, _ := initTestRepoWithCommit(t)
+
+	var calls []*git.CloneOptions
+	var submoduleOpts *git.SubmoduleUpdateOptions
+	plainClone = func(path string, isBare bool, o *git.CloneOptions) (*git.Repository, error) {
+		calls = append(calls, o)
+		return testRepo, nil
+	}
+	updateSubmodules = func(r *git.Repository, opts *git.SubmoduleUpdateOptions) error {
+		submoduleOpts = opts
+		return nil
+	}
 	defer func() {
 		plainClone = git.PlainClone
 		updateSubmodules = submodule.UpdateSubmodules
 	}()
 
-	tests := map[string]struct {
-		opts              *GitCloner
-		expectedCloneOpts *git.CloneOptions
-		expectedErr       error
-	}{
-		"revision clone success": {
-			opts: &GitCloner{
-				Repo:     "https://repo",
-				Path:     "path",
-				Revision: commitHash.String(),
-			},
-			expectedCloneOpts: &git.CloneOptions{
-				URL:               "https://repo",
-				Depth:             1,
-				RecurseSubmodules: git.NoRecurseSubmodules,
-				Tags:              git.NoTags,
-			},
-		},
-		"revision clone with auth": {
-			opts: &GitCloner{
-				Repo:         "https://repo",
-				Path:         "path",
-				Revision:     commitHash.String(),
-				Username:     "user",
-				PasswordFile: "passFile",
-			},
-			expectedCloneOpts: &git.CloneOptions{
-				URL:   "https://repo",
-				Depth: 1,
-				Auth: &httpgit.BasicAuth{
-					Username: "user",
-					Password: "1234",
-				},
-				RecurseSubmodules: git.NoRecurseSubmodules,
-				Tags:              git.NoTags,
-			},
-		},
+	c := Cloner{}
+	if err := c.CloneRepo(&GitCloner{
+		Repo:     "https://repo",
+		Path:     t.TempDir(),
+		Revision: "v1.2.3",
+	}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
 
+	if len(calls) != 1 {
+		t.Fatalf("expected exactly 1 clone attempt, got %d", len(calls))
+	}
+	got := calls[0]
+	if got.ReferenceName != plumbing.NewTagReferenceName("v1.2.3") {
+		t.Errorf("expected ReferenceName refs/tags/v1.2.3, got %q", got.ReferenceName)
+	}
+	if !got.SingleBranch {
+		t.Error("expected SingleBranch=true on the tag-shortcut clone")
+	}
+	if got.Depth != 1 {
+		t.Errorf("expected Depth=1, got %d", got.Depth)
+	}
+	if got.Tags != git.NoTags {
+		t.Errorf("expected Tags=NoTags, got %v", got.Tags)
+	}
+	if got.RecurseSubmodules != git.NoRecurseSubmodules {
+		t.Errorf("expected RecurseSubmodules=NoRecurseSubmodules, got %v", got.RecurseSubmodules)
+	}
+	if submoduleOpts == nil {
+		t.Fatal("expected updateSubmodules to be called")
+	}
+}
+
+// TestCloneRevision_BranchShortcut covers the case where the revision names
+// a branch — the tag attempt fails, then the branch attempt succeeds.
+func TestCloneRevision_BranchShortcut(t *testing.T) {
+	testRepo, _ := initTestRepoWithCommit(t)
+
+	var calls []*git.CloneOptions
+	plainClone = func(path string, isBare bool, o *git.CloneOptions) (*git.Repository, error) {
+		calls = append(calls, o)
+		// Fail the tag attempt, succeed the branch attempt.
+		if o.ReferenceName.IsTag() {
+			return nil, errors.New("reference not found")
+		}
+		return testRepo, nil
+	}
+	updateSubmodules = func(r *git.Repository, opts *git.SubmoduleUpdateOptions) error {
+		return nil
+	}
+	defer func() {
+		plainClone = git.PlainClone
+		updateSubmodules = submodule.UpdateSubmodules
+	}()
+
+	c := Cloner{}
+	if err := c.CloneRepo(&GitCloner{
+		Repo:     "https://repo",
+		Path:     t.TempDir(),
+		Revision: "release-1.0",
+	}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(calls) != 2 {
+		t.Fatalf("expected 2 clone attempts (tag, branch), got %d", len(calls))
+	}
+	branch := calls[1]
+	if branch.ReferenceName != plumbing.NewBranchReferenceName("release-1.0") {
+		t.Errorf("expected ReferenceName refs/heads/release-1.0, got %q", branch.ReferenceName)
+	}
+	if !branch.SingleBranch || branch.Depth != 1 || branch.Tags != git.NoTags {
+		t.Errorf("unexpected branch clone opts: %+v", branch)
+	}
+}
+
+// TestCloneRevision_CommitShallow covers the fast path for a full commit SHA:
+// cloneRevision must skip the tag/branch ref attempts entirely and resolve the
+// commit through the shallow commit fetch, never falling back to a full clone.
+func TestCloneRevision_CommitShallow(t *testing.T) {
+	_, commitHash := initTestRepoWithCommit(t)
+
+	var cloneCalls int
+	plainClone = func(path string, isBare bool, o *git.CloneOptions) (*git.Repository, error) {
+		cloneCalls++
+		return nil, errors.New("unexpected clone")
+	}
+	var commitCalled bool
+	cloneCommit = func(opts *GitCloner, auth transport.AuthMethod, caBundle []byte) error {
+		commitCalled = true
+		return nil
+	}
+	defer func() {
+		plainClone = git.PlainClone
+		cloneCommit = cloneCommitShallow
+	}()
+
+	c := Cloner{}
+	if err := c.CloneRepo(&GitCloner{
+		Repo:     "https://repo",
+		Path:     t.TempDir(),
+		Revision: commitHash.String(),
+	}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !commitCalled {
+		t.Fatal("expected the shallow commit fetch to be used for a full SHA")
+	}
+	if cloneCalls != 0 {
+		t.Fatalf("expected no plainClone calls for a full SHA, got %d", cloneCalls)
+	}
+}
+
+// TestCloneCommitShallow_Body exercises the real cloneCommitShallow body
+// (PlainInit → CreateRemote → Fetch-by-SHA → Checkout) end-to-end. It
+// complements TestCloneRevision_CommitShallow, which mocks the entire
+// cloneCommit var and never runs the function body.
+func TestCloneCommitShallow_Body(t *testing.T) {
+	srcRepo, commitHash := initTestRepoWithCommit(t)
+	srcWt, err := srcRepo.Worktree()
+	if err != nil {
+		t.Fatalf("getting source worktree: %v", err)
+	}
+	// Enable SHA-based fetching on the local source repo so go-git's local
+	// transport advertises allow-reachable-sha1-in-want.
+	srcCfg, err := srcRepo.Config()
+	if err != nil {
+		t.Fatalf("reading source repo config: %v", err)
+	}
+	srcCfg.Raw.SetOption("uploadpack", "", "allowReachableSHA1InWant", "true")
+	if err := srcRepo.Storer.SetConfig(srcCfg); err != nil {
+		t.Fatalf("setting source repo config: %v", err)
+	}
+
+	var submoduleOpts *git.SubmoduleUpdateOptions
+	updateSubmodules = func(r *git.Repository, opts *git.SubmoduleUpdateOptions) error {
+		submoduleOpts = opts
+		return nil
+	}
+	defer func() { updateSubmodules = submodule.UpdateSubmodules }()
+
+	destPath := t.TempDir()
+	if err := cloneCommitShallow(&GitCloner{
+		Repo:     srcWt.Filesystem.Root(),
+		Path:     destPath,
+		Revision: commitHash.String(),
+	}, nil, nil); err != nil {
+		t.Fatalf("cloneCommitShallow: %v", err)
+	}
+
+	cloned, err := git.PlainOpen(destPath)
+	if err != nil {
+		t.Fatalf("opening cloned repo: %v", err)
+	}
+	head, err := cloned.Head()
+	if err != nil {
+		t.Fatalf("getting HEAD: %v", err)
+	}
+	if head.Hash() != commitHash {
+		t.Errorf("expected HEAD %s, got %s", commitHash, head.Hash())
+	}
+	if _, err := os.Stat(destPath + "/test.txt"); err != nil {
+		t.Errorf("expected test.txt in cloned worktree: %v", err)
+	}
+	if submoduleOpts == nil {
+		t.Fatal("expected updateSubmodules to be called")
+	}
+	if !submoduleOpts.Init {
+		t.Error("expected submodule Init=true")
+	}
+	if submoduleOpts.Depth != 1 {
+		t.Errorf("expected Depth=1, got %d", submoduleOpts.Depth)
+	}
+}
+
+// TestCloneRevision_FullCloneFallback covers a full commit SHA on a server
+// that rejects fetch-by-SHA: the shallow commit fetch fails, so cloneRevision
+// falls back to a full clone + ResolveRevision against the real test repo.
+func TestCloneRevision_FullCloneFallback(t *testing.T) {
+	testRepo, commitHash := initTestRepoWithCommit(t)
+
+	var calls []*git.CloneOptions
+	var submoduleOpts *git.SubmoduleUpdateOptions
+	plainClone = func(path string, isBare bool, o *git.CloneOptions) (*git.Repository, error) {
+		calls = append(calls, o)
+		return testRepo, nil
+	}
+	cloneCommit = func(opts *GitCloner, auth transport.AuthMethod, caBundle []byte) error {
+		return errors.New("server does not support exact SHA1 refspec")
+	}
+	updateSubmodules = func(r *git.Repository, opts *git.SubmoduleUpdateOptions) error {
+		submoduleOpts = opts
+		return nil
+	}
 	readFile = func(name string) ([]byte, error) {
 		if name == "passFile" {
 			return []byte("1234"), nil
 		}
 		return nil, errors.New("file not found")
 	}
+	defer func() {
+		plainClone = git.PlainClone
+		cloneCommit = cloneCommitShallow
+		updateSubmodules = submodule.UpdateSubmodules
+		readFile = os.ReadFile
+	}()
 
-	for name, test := range tests {
-		cloneOptsCalled = nil
-		updateSubmodulesCalled = false
-		updateSubmodulesOptsCalled = nil
+	c := Cloner{}
+	if err := c.CloneRepo(&GitCloner{
+		Repo:         "https://repo",
+		Path:         t.TempDir(),
+		Revision:     commitHash.String(),
+		Username:     "user",
+		PasswordFile: "passFile",
+	}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
-		t.Run(name, func(t *testing.T) {
-			c := Cloner{}
-			err := c.CloneRepo(test.opts)
-
-			if test.expectedErr != nil {
-				if err == nil {
-					t.Fatalf("expected error [%v], got nil", test.expectedErr)
-				}
-				if err.Error() != test.expectedErr.Error() {
-					t.Fatalf("expected error [%s], got [%s]", test.expectedErr.Error(), err.Error())
-				}
-				return
-			}
-
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-
-			// Verify clone options (revision clone doesn't use SingleBranch/ReferenceName)
-			if !cmp.Equal(cloneOptsCalled, test.expectedCloneOpts) {
-				t.Fatalf("expected clone options %+v, got %+v", test.expectedCloneOpts, cloneOptsCalled)
-			}
-
-			// Verify updateSubmodules was called
-			if !updateSubmodulesCalled {
-				t.Fatal("expected updateSubmodules to be called")
-			}
-
-			// Verify submodule update options
-			expectedSubmoduleOpts := &git.SubmoduleUpdateOptions{
-				Init:              true,
-				RecurseSubmodules: git.DefaultSubmoduleRecursionDepth,
-				Depth:             1,
-				Auth:              test.expectedCloneOpts.Auth,
-			}
-			if !cmp.Equal(updateSubmodulesOptsCalled, expectedSubmoduleOpts) {
-				t.Fatalf("expected submodule options %+v, got %+v", expectedSubmoduleOpts, updateSubmodulesOptsCalled)
-			}
-		})
+	// Only the full clone hits plainClone; the SHA path skips the ref attempts.
+	if len(calls) != 1 {
+		t.Fatalf("expected exactly 1 clone attempt (full), got %d", len(calls))
+	}
+	full := calls[0]
+	// The full clone must NOT pin a ref or depth, and must rely on go-git's
+	// default Tags mode (AllTags) so ResolveRevision can find any ref.
+	if full.ReferenceName != "" {
+		t.Errorf("expected empty ReferenceName on full clone, got %q", full.ReferenceName)
+	}
+	if full.SingleBranch {
+		t.Error("expected SingleBranch=false on full clone")
+	}
+	if full.Depth != 0 {
+		t.Errorf("expected Depth=0 on full clone, got %d", full.Depth)
+	}
+	if full.Tags != git.InvalidTagMode {
+		// InvalidTagMode is the zero value; go-git treats it as AllTags.
+		t.Errorf("expected default Tags mode on full clone, got %v", full.Tags)
+	}
+	expectedAuth := &httpgit.BasicAuth{Username: "user", Password: "1234"}
+	if !cmp.Equal(full.Auth, expectedAuth) {
+		t.Errorf("expected auth %+v, got %+v", expectedAuth, full.Auth)
+	}
+	if submoduleOpts == nil || submoduleOpts.Auth == nil {
+		t.Fatal("expected updateSubmodules to be called with auth")
 	}
 }
 
+// TestCloneRevision_ResolveRevisionError exercises the third-attempt path:
+// the full clone succeeds, but the requested revision is not present in the
+// repo so ResolveRevision errors out.
 func TestCloneRevision_ResolveRevisionError(t *testing.T) {
 	tempDir := t.TempDir()
 	testRepo, _ := git.PlainInit(tempDir, false)
 
 	plainClone = func(path string, isBare bool, o *git.CloneOptions) (*git.Repository, error) {
+		// Fail both shortcuts to reach the full-clone path, then return the
+		// empty test repo so ResolveRevision has nothing to resolve.
+		if o.ReferenceName != "" {
+			return nil, errors.New("reference not found")
+		}
 		return testRepo, nil
 	}
 	defer func() {
@@ -542,7 +699,7 @@ func TestCloneRevision_ResolveRevisionError(t *testing.T) {
 	c := Cloner{}
 	err := c.CloneRepo(&GitCloner{
 		Repo:     "https://repo",
-		Path:     "path",
+		Path:     t.TempDir(),
 		Revision: "nonexistent-revision",
 	})
 
@@ -554,8 +711,13 @@ func TestCloneRevision_ResolveRevisionError(t *testing.T) {
 	}
 }
 
+// TestCloneRevision_CloneError ensures the final error is reported when all
+// three clone strategies fail (e.g. network/auth failure that's independent
+// of the ref).
 func TestCloneRevision_CloneError(t *testing.T) {
+	var attempts int
 	plainClone = func(path string, isBare bool, o *git.CloneOptions) (*git.Repository, error) {
+		attempts++
 		return nil, errors.New("clone failed")
 	}
 	defer func() {
@@ -565,12 +727,15 @@ func TestCloneRevision_CloneError(t *testing.T) {
 	c := Cloner{}
 	err := c.CloneRepo(&GitCloner{
 		Repo:     "https://repo",
-		Path:     "path",
+		Path:     t.TempDir(),
 		Revision: "abc123",
 	})
 
 	if err == nil {
 		t.Fatal("expected error, got nil")
+	}
+	if attempts != 3 {
+		t.Errorf("expected 3 clone attempts, got %d", attempts)
 	}
 	if !strings.Contains(err.Error(), "failed to clone repo from revision") {
 		t.Fatalf("expected 'failed to clone repo from revision' error, got: %s", err.Error())
@@ -578,29 +743,11 @@ func TestCloneRevision_CloneError(t *testing.T) {
 }
 
 func TestCloneRevision_SubmoduleUpdateError(t *testing.T) {
-	tempDir := t.TempDir()
-	testRepo, _ := git.PlainInit(tempDir, false)
-
-	// Create a commit
-	wt, _ := testRepo.Worktree()
-	testFile := tempDir + "/test.txt"
-	err := os.WriteFile(testFile, []byte("test"), 0644)
-	if err != nil {
-		t.Fatalf("failed to create the file %s: %v", testFile, err)
-	}
-	_, err = wt.Add("test.txt")
-	if err != nil {
-		t.Fatalf("failed to add the file test.txt: %v", err)
-	}
-	commitHash, _ := wt.Commit("test commit", &git.CommitOptions{
-		Author: &object.Signature{
-			Name:  "Test",
-			Email: "test@test.com",
-			When:  time.Now(),
-		},
-	})
+	testRepo, _ := initTestRepoWithCommit(t)
 
 	plainClone = func(path string, isBare bool, o *git.CloneOptions) (*git.Repository, error) {
+		// First attempt (tag) succeeds — exercises the early return that
+		// still calls updateSubmodules.
 		return testRepo, nil
 	}
 	updateSubmodules = func(r *git.Repository, opts *git.SubmoduleUpdateOptions) error {
@@ -612,10 +759,11 @@ func TestCloneRevision_SubmoduleUpdateError(t *testing.T) {
 	}()
 
 	c := Cloner{}
-	err = c.CloneRepo(&GitCloner{
-		Repo:     "https://repo",
-		Path:     "path",
-		Revision: commitHash.String(),
+	err := c.CloneRepo(&GitCloner{
+		Repo: "https://repo",
+		Path: t.TempDir(),
+		// A tag name (not a full SHA) so the tag shortcut handles it.
+		Revision: "v1.0.0",
 	})
 
 	if err == nil {


### PR DESCRIPTION
This PR fixes an issue when using tags in the revision field of `GitRepo`.

It also includes a small refactoring creating functions with names to make core more readable.

Refers to: https://github.com/rancher/fleet/issues/5181


## Additional Information

### Checklist

~- [ ] <!-- If applicable,--> I have updated the documentation via a pull request in the [fleet-product-docs](https://github.com/rancher/fleet-product-docs) repository.~
