### PR TITLE
Add Go duration validation across CRDs, Helm schemas, and config loader

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
         run: |
           helm plugin install https://github.com/helm-unittest/helm-unittest.git --version v1.0.2
           helm unittest ./charts/fleet
+          helm unittest ./charts/fleet-agent
       -
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:

--- a/charts/fleet-agent/tests/duration_schema_test.yaml
+++ b/charts/fleet-agent/tests/duration_schema_test.yaml
@@ -1,0 +1,61 @@
+suite: duration values are validated by values.schema.json
+templates:
+  - configmap.yaml
+tests:
+  - it: rejects an invalid garbageCollectionInterval (1d)
+    set:
+      garbageCollectionInterval: 1d
+    asserts:
+      - failedTemplate:
+          errorPattern: "garbageCollectionInterval.*(Does not match pattern|anyOf)"
+
+  - it: rejects an invalid nested leaderElection.leaseDuration (1w)
+    set:
+      leaderElection.leaseDuration: 1w
+    asserts:
+      - failedTemplate:
+          errorPattern: "leaderElection.leaseDuration.*(Does not match pattern|anyOf)"
+
+  - it: rejects an invalid nested leaderElection.retryPeriod (7d12h)
+    set:
+      leaderElection.retryPeriod: 7d12h
+    asserts:
+      - failedTemplate:
+          errorPattern: "leaderElection.retryPeriod.*(Does not match pattern|anyOf)"
+
+  - it: rejects an invalid nested leaderElection.renewDeadline (5x)
+    set:
+      leaderElection.renewDeadline: 5x
+    asserts:
+      - failedTemplate:
+          errorPattern: "leaderElection.renewDeadline.*(Does not match pattern|anyOf)"
+
+  - it: rejects a bare non-zero integer (only 0 is allowed without a unit)
+    set:
+      garbageCollectionInterval: 5
+    asserts:
+      - failedTemplate:
+          errorPattern: "garbageCollectionInterval.*(Must validate at least one schema|anyOf)"
+
+  - it: accepts a valid duration
+    set:
+      garbageCollectionInterval: 1h30m
+      leaderElection.leaseDuration: 30s
+      leaderElection.retryPeriod: 300ms
+    asserts:
+      - isKind:
+          of: ConfigMap
+
+  - it: accepts the integer 0 sentinel (falls back to the built-in default)
+    set:
+      garbageCollectionInterval: 0
+    asserts:
+      - isKind:
+          of: ConfigMap
+
+  - it: accepts the string "0" sentinel
+    set:
+      garbageCollectionInterval: "0"
+    asserts:
+      - isKind:
+          of: ConfigMap

--- a/charts/fleet-agent/values.schema.json
+++ b/charts/fleet-agent/values.schema.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Fleet agent chart values",
+  "type": "object",
+  "definitions": {
+    "goDuration": {
+      "anyOf": [
+        {
+          "type": "string",
+          "pattern": "^(0|([0-9]+([.][0-9]+)?(ns|us|µs|ms|s|m|h))+)$"
+        },
+        {
+          "type": "integer",
+          "enum": [0]
+        }
+      ],
+      "description": "A Go duration string. Valid units: ns, us, µs, ms, s, m, h (e.g. 15s, 5m, 2h, 1h30m). Units like d (days) or w (weeks) are NOT supported by Go's time.ParseDuration and will be dropped; use 0 to fall back to the built-in default."
+    }
+  },
+  "properties": {
+    "garbageCollectionInterval": {
+      "$ref": "#/definitions/goDuration"
+    },
+    "leaderElection": {
+      "type": "object",
+      "properties": {
+        "leaseDuration": {
+          "$ref": "#/definitions/goDuration"
+        },
+        "retryPeriod": {
+          "$ref": "#/definitions/goDuration"
+        },
+        "renewDeadline": {
+          "$ref": "#/definitions/goDuration"
+        }
+      }
+    }
+  }
+}

--- a/charts/fleet-crd/templates/crds.yaml
+++ b/charts/fleet-crd/templates/crds.yaml
@@ -4394,8 +4394,16 @@ spec:
                     to calculate the
 
                     expiration time. If the token expires, it will be deleted.'
+                  maxLength: 32
+                  minLength: 1
                   nullable: true
                   type: string
+                  x-kubernetes-validations:
+                    - message: must be a valid Go duration using units ns, us, µs,
+                        ms, s, m, h (e.g. 15s, 5m, 2h, 1h30m); units like d (days)
+                        or w (weeks) are not supported
+                      rule: self == '0' || (self.matches('^([0-9]+([.][0-9]+)?(ns|us|µs|ms|s|m|h))+$')
+                        && duration(self) <= duration('2562047h'))
               type: object
             status:
               properties:
@@ -7166,7 +7174,15 @@ spec:
                 imageScanInterval:
                   description: ImageScanInterval is the interval of syncing scanned
                     images and writing back to git repo.
+                  maxLength: 32
+                  minLength: 1
                   type: string
+                  x-kubernetes-validations:
+                    - message: must be a valid Go duration using units ns, us, µs,
+                        ms, s, m, h (e.g. 15s, 5m, 2h, 1h30m); units like d (days)
+                        or w (weeks) are not supported
+                      rule: self == '0' || (self.matches('^([0-9]+([.][0-9]+)?(ns|us|µs|ms|s|m|h))+$')
+                        && duration(self) <= duration('2562047h'))
                 insecureSkipTLSVerify:
                   description: InsecureSkipTLSverify will use insecure HTTPS to clone
                     the repo.
@@ -7199,8 +7215,16 @@ spec:
                   type: boolean
                 pollingInterval:
                   description: PollingInterval is how often to check git for new updates.
+                  maxLength: 32
+                  minLength: 1
                   nullable: true
                   type: string
+                  x-kubernetes-validations:
+                    - message: must be a valid Go duration using units ns, us, µs,
+                        ms, s, m, h (e.g. 15s, 5m, 2h, 1h30m); units like d (days)
+                        or w (weeks) are not supported
+                      rule: self == '0' || (self.matches('^([0-9]+([.][0-9]+)?(ns|us|µs|ms|s|m|h))+$')
+                        && duration(self) <= duration('2562047h'))
                 repo:
                   description: Repo is a URL to a git repo to clone and index.
                   minLength: 1
@@ -8491,8 +8515,16 @@ spec:
                 pollingInterval:
                   description: PollingInterval is how often to check the Helm repository
                     for new updates.
+                  maxLength: 32
+                  minLength: 1
                   nullable: true
                   type: string
+                  x-kubernetes-validations:
+                    - message: must be a valid Go duration using units ns, us, µs,
+                        ms, s, m, h (e.g. 15s, 5m, 2h, 1h30m); units like d (days)
+                        or w (weeks) are not supported
+                      rule: self == '0' || (self.matches('^([0-9]+([.][0-9]+)?(ns|us|µs|ms|s|m|h))+$')
+                        && duration(self) <= duration('2562047h'))
                 resources:
                   description: 'Resources contains the resources that were read from
                     the bundle''s
@@ -10100,8 +10132,16 @@ spec:
                   description: 'Interval is the length of time to wait between
 
                     scans of the image repository.'
+                  maxLength: 32
+                  minLength: 1
                   nullable: true
                   type: string
+                  x-kubernetes-validations:
+                    - message: must be a valid Go duration using units ns, us, µs,
+                        ms, s, m, h (e.g. 15s, 5m, 2h, 1h30m); units like d (days)
+                        or w (weeks) are not supported
+                      rule: self == '0' || (self.matches('^([0-9]+([.][0-9]+)?(ns|us|µs|ms|s|m|h))+$')
+                        && duration(self) <= duration('2562047h'))
                 policy:
                   description: 'Policy gives the particulars of the policy to be followed
                     in
@@ -10473,7 +10513,15 @@ spec:
             spec:
               properties:
                 duration:
+                  maxLength: 32
+                  minLength: 1
                   type: string
+                  x-kubernetes-validations:
+                    - message: must be a valid Go duration using units ns, us, µs,
+                        ms, s, m, h (e.g. 15s, 5m, 2h, 1h30m); units like d (days)
+                        or w (weeks) are not supported
+                      rule: self == '0' || (self.matches('^([0-9]+([.][0-9]+)?(ns|us|µs|ms|s|m|h))+$')
+                        && duration(self) <= duration('2562047h'))
                 location:
                   type: string
                 schedule:

--- a/charts/fleet/tests/duration_schema_test.yaml
+++ b/charts/fleet/tests/duration_schema_test.yaml
@@ -1,0 +1,77 @@
+suite: duration values are validated by values.schema.json
+templates:
+  - configmap.yaml
+tests:
+  - it: rejects an invalid top-level duration (garbageCollectionInterval=1d)
+    set:
+      garbageCollectionInterval: 1d
+    asserts:
+      - failedTemplate:
+          errorPattern: "garbageCollectionInterval.*(Does not match pattern|anyOf)"
+
+  - it: rejects an invalid agentCheckinInterval
+    set:
+      agentCheckinInterval: 1w
+    asserts:
+      - failedTemplate:
+          errorPattern: "agentCheckinInterval.*(Does not match pattern|anyOf)"
+
+  - it: rejects an invalid gitClientTimeout
+    set:
+      gitClientTimeout: 7d12h
+    asserts:
+      - failedTemplate:
+          errorPattern: "gitClientTimeout.*(Does not match pattern|anyOf)"
+
+  - it: rejects an invalid nested leaderElection.leaseDuration
+    set:
+      leaderElection.leaseDuration: 1w
+    asserts:
+      - failedTemplate:
+          errorPattern: "leaderElection.leaseDuration.*(Does not match pattern|anyOf)"
+
+  - it: rejects an invalid nested gitops.syncPeriod
+    set:
+      gitops.syncPeriod: 1d
+    asserts:
+      - failedTemplate:
+          errorPattern: "gitops.syncPeriod.*(Does not match pattern|anyOf)"
+
+  - it: rejects an invalid nested agent.leaderElection.renewDeadline
+    set:
+      agent.leaderElection.renewDeadline: 5x
+    asserts:
+      - failedTemplate:
+          errorPattern: "agent.leaderElection.renewDeadline.*(Does not match pattern|anyOf)"
+
+  - it: rejects a bare non-zero integer (only 0 is allowed without a unit)
+    set:
+      garbageCollectionInterval: 5
+    asserts:
+      - failedTemplate:
+          errorPattern: "garbageCollectionInterval.*(Must validate at least one schema|anyOf)"
+
+  - it: accepts a valid duration
+    set:
+      garbageCollectionInterval: 1h30m
+      agentCheckinInterval: 300ms
+      gitClientTimeout: 2h
+      leaderElection.leaseDuration: 30s
+      gitops.syncPeriod: 2h
+    asserts:
+      - isKind:
+          of: ConfigMap
+
+  - it: accepts the integer 0 sentinel (falls back to the built-in default)
+    set:
+      garbageCollectionInterval: 0
+    asserts:
+      - isKind:
+          of: ConfigMap
+
+  - it: accepts the string "0" sentinel
+    set:
+      garbageCollectionInterval: "0"
+    asserts:
+      - isKind:
+          of: ConfigMap

--- a/charts/fleet/values.schema.json
+++ b/charts/fleet/values.schema.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Fleet controller chart values",
+  "type": "object",
+  "definitions": {
+    "goDuration": {
+      "anyOf": [
+        {
+          "type": "string",
+          "pattern": "^(0|([0-9]+([.][0-9]+)?(ns|us|µs|ms|s|m|h))+)$"
+        },
+        {
+          "type": "integer",
+          "enum": [0]
+        }
+      ],
+      "description": "A Go duration string. Valid units: ns, us, µs, ms, s, m, h (e.g. 15s, 5m, 2h, 1h30m). Units like d (days) or w (weeks) are NOT supported by Go's time.ParseDuration and will be dropped; use 0 to fall back to the built-in default."
+    }
+  },
+  "properties": {
+    "agentCheckinInterval": {
+      "$ref": "#/definitions/goDuration"
+    },
+    "garbageCollectionInterval": {
+      "$ref": "#/definitions/goDuration"
+    },
+    "gitClientTimeout": {
+      "$ref": "#/definitions/goDuration"
+    },
+    "clusterEnqueueDelay": {
+      "$ref": "#/definitions/goDuration"
+    },
+    "gitops": {
+      "type": "object",
+      "properties": {
+        "syncPeriod": {
+          "$ref": "#/definitions/goDuration"
+        }
+      }
+    },
+    "leaderElection": {
+      "type": "object",
+      "properties": {
+        "leaseDuration": {
+          "$ref": "#/definitions/goDuration"
+        },
+        "retryPeriod": {
+          "$ref": "#/definitions/goDuration"
+        },
+        "renewDeadline": {
+          "$ref": "#/definitions/goDuration"
+        }
+      }
+    },
+    "agent": {
+      "type": "object",
+      "properties": {
+        "leaderElection": {
+          "type": "object",
+          "properties": {
+            "leaseDuration": {
+              "$ref": "#/definitions/goDuration"
+            },
+            "retryPeriod": {
+              "$ref": "#/definitions/goDuration"
+            },
+            "renewDeadline": {
+              "$ref": "#/definitions/goDuration"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/integrationtests/controller/durationvalidation/duration_validation_test.go
+++ b/integrationtests/controller/durationvalidation/duration_validation_test.go
@@ -1,0 +1,77 @@
+package durationvalidation
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+const durationMsg = "must be a valid Go duration"
+
+type durationCase struct {
+	kind      string
+	specField string
+	baseSpec  map[string]interface{}
+}
+
+var durationCases = []durationCase{
+	{"GitRepo", "pollingInterval", map[string]interface{}{"repo": "https://github.com/rancher/fleet-test-data"}},
+	{"GitRepo", "imageScanInterval", map[string]interface{}{"repo": "https://github.com/rancher/fleet-test-data"}},
+	{"HelmOp", "pollingInterval", map[string]interface{}{}},
+	{"ClusterRegistrationToken", "ttl", map[string]interface{}{}},
+	{"ImageScan", "interval", map[string]interface{}{"image": "nginx"}},
+	{"Schedule", "duration", map[string]interface{}{}},
+}
+
+var validDurations = []string{"15s", "5m", "2h", "1h30m", "300ms", "1.5h", "100µs", "0", "0s"}
+var invalidDurations = []string{"1d", "1w", "1y", "7d12h", "abc", "5x", "-1h",
+	// "5000000h" matches the unit regex but overflows Go's int64-ns duration
+	// (~570y > ~292y max); guarded by the duration(self) <= duration('2562047h')
+	// bound in the CEL rule, which rejects it with the same friendly message.
+	"5000000h"}
+
+func newObj(c durationCase, value string) *unstructured.Unstructured {
+	spec := map[string]interface{}{}
+	for k, v := range c.baseSpec {
+		spec[k] = v
+	}
+	spec[c.specField] = value
+
+	u := &unstructured.Unstructured{}
+	u.SetAPIVersion("fleet.cattle.io/v1alpha1")
+	u.SetKind(c.kind)
+	u.SetNamespace(namespace)
+	u.SetGenerateName("dv-")
+	u.Object["spec"] = spec
+	return u
+}
+
+var _ = Describe("CRD metav1.Duration field validation", func() {
+	for _, c := range durationCases {
+		Context(fmt.Sprintf("%s spec.%s", c.kind, c.specField), func() {
+			for _, v := range invalidDurations {
+				It(fmt.Sprintf("rejects %q", v), func() {
+					err := k8sClient.Create(ctx, newObj(c, v))
+					Expect(err).To(HaveOccurred(),
+						"the API server must reject an invalid duration")
+					Expect(err.Error()).To(ContainSubstring(durationMsg),
+						"rejection must come from the duration CEL rule, got: %s", err.Error())
+				})
+			}
+
+			for _, v := range validDurations {
+				It(fmt.Sprintf("accepts %q", v), func() {
+					obj := newObj(c, v)
+					Expect(k8sClient.Create(ctx, obj)).To(Succeed(),
+						"a valid duration must be accepted")
+					DeferCleanup(func() {
+						_ = k8sClient.Delete(ctx, obj)
+					})
+				})
+			}
+		})
+	}
+})

--- a/integrationtests/controller/durationvalidation/suite_test.go
+++ b/integrationtests/controller/durationvalidation/suite_test.go
@@ -1,0 +1,54 @@
+package durationvalidation
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/rancher/fleet/integrationtests/utils"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+)
+
+var (
+	cancel    context.CancelFunc
+	ctx       context.Context
+	cfg       *rest.Config
+	k8sClient client.Client
+	testenv   *envtest.Environment
+
+	namespace = "duration-validation"
+)
+
+func TestDurationValidation(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Fleet CRD Duration Validation Suite")
+}
+
+var _ = BeforeSuite(func() {
+	ctx, cancel = context.WithCancel(context.TODO())
+	testenv = utils.NewEnvTest("../../..")
+
+	var err error
+	cfg, err = utils.StartTestEnv(testenv)
+	Expect(err).NotTo(HaveOccurred())
+
+	k8sClient, err = utils.NewClient(cfg)
+	Expect(err).NotTo(HaveOccurred())
+
+	Expect(k8sClient.Create(ctx, &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: namespace},
+	})).To(Succeed())
+})
+
+var _ = AfterSuite(func() {
+	cancel()
+	Expect(testenv.Stop()).ToNot(HaveOccurred())
+})

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,6 +12,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/yaml"
 
 	"github.com/rancher/fleet/pkg/version"
@@ -256,6 +257,12 @@ func DefaultConfig() *Config {
 	}
 }
 
+var durationConfigKeys = []string{
+	"agentCheckinInterval",
+	"gitClientTimeout",
+	"garbageCollectionInterval",
+}
+
 func ReadConfig(cm *v1.ConfigMap) (*Config, error) {
 	cfg := DefaultConfig()
 	data := cm.Data[Key]
@@ -263,8 +270,77 @@ func ReadConfig(cm *v1.ConfigMap) (*Config, error) {
 		return cfg, nil
 	}
 
-	err := yaml.Unmarshal([]byte(data), &cfg)
+	data, err := sanitizeDurations(data)
+	if err != nil {
+		return cfg, err
+	}
+
+	err = yaml.Unmarshal([]byte(data), &cfg)
 	return cfg, err
+}
+
+// sanitizeDurations strips duration config keys
+// whose value Go's time.ParseDuration cannot parse before the typed unmarshal,
+// logging a warning for each, so the built-in default applies instead of
+// crash-looping the process.
+func sanitizeDurations(data string) (string, error) {
+	var raw map[string]any
+	if err := yaml.Unmarshal([]byte(data), &raw); err != nil {
+		return "", err
+	}
+	if raw == nil {
+		return data, nil
+	}
+
+	logger := log.Log.WithName("fleet-config")
+	changed := false
+	for _, key := range durationConfigKeys {
+		v, ok := raw[key]
+		if !ok {
+			continue
+		}
+
+		if s, isStr := v.(string); isStr {
+			if _, err := time.ParseDuration(s); err == nil {
+				continue // valid Go duration, keep it
+			}
+			logger.Info("ignoring invalid duration in fleet config; using built-in default",
+				"key", key, "value", s,
+				"hint", "must be a Go duration like 15s, 5m, 2h, 1h30m; units d/w/y are not supported")
+		} else if isZeroNumber(v) {
+			// 0 is the documented "fall back to the default" sentinel; so drop it
+			// silently and let the default apply.
+		} else {
+			logger.Info("ignoring invalid duration in fleet config; using built-in default",
+				"key", key, "value", v,
+				"hint", `must be a Go duration string like "15s", "5m", "2h"`)
+		}
+
+		delete(raw, key)
+		changed = true
+	}
+
+	if !changed {
+		return data, nil
+	}
+
+	out, err := yaml.Marshal(raw)
+	if err != nil {
+		return data, err
+	}
+	return string(out), nil
+}
+
+func isZeroNumber(v any) bool {
+	switch n := v.(type) {
+	case float64:
+		return n == 0
+	case int:
+		return n == 0
+	case int64:
+		return n == 0
+	}
+	return false
 }
 
 func ToConfigMap(namespace, name string, cfg *Config) (*v1.ConfigMap, error) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -31,4 +31,78 @@ var _ = Describe("Config", func() {
 			Expect(cfg.GitClientTimeout.Duration).To(Equal(20 * time.Second))
 		})
 	})
+
+	When("a duration value is not a valid Go duration", func() {
+		It("does not error and falls back to the default for that key", func() {
+			cfg, err := config.ReadConfig(&v1.ConfigMap{Data: map[string]string{
+				"config": `{"gitClientTimeout": "1d"}`,
+			}})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(cfg.GitClientTimeout.Duration).To(Equal(30 * time.Second))
+		})
+
+		It("handles every duration key (agentCheckinInterval, garbageCollectionInterval)", func() {
+			cfg, err := config.ReadConfig(&v1.ConfigMap{Data: map[string]string{
+				"config": `{"agentCheckinInterval": "1w", "garbageCollectionInterval": "7d12h"}`,
+			}})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(cfg.AgentCheckinInterval.Duration).To(Equal(time.Duration(0)))
+			Expect(cfg.GarbageCollectionInterval.Duration).To(Equal(time.Duration(0)))
+		})
+
+		It("keeps valid keys and only defaults the invalid one", func() {
+			cfg, err := config.ReadConfig(&v1.ConfigMap{Data: map[string]string{
+				"config": `{"gitClientTimeout": "20s", "garbageCollectionInterval": "1d"}`,
+			}})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(cfg.GitClientTimeout.Duration).To(Equal(20 * time.Second))
+			Expect(cfg.GarbageCollectionInterval.Duration).To(Equal(time.Duration(0)))
+		})
+
+		It("preserves non-duration fields unaltered", func() {
+			cfg, err := config.ReadConfig(&v1.ConfigMap{Data: map[string]string{
+				"config": `{
+					"agentImage": "my-registry/fleet-agent:v1.2.3",
+					"apiServerURL": "https://kube.example.com:6443",
+					"labels": {"env": "prod", "team": "platform"},
+					"agentCheckinInterval": "bad",
+					"gitClientTimeout": "45s"
+				}`,
+			}})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(cfg.AgentImage).To(Equal("my-registry/fleet-agent:v1.2.3"))
+			Expect(cfg.APIServerURL).To(Equal("https://kube.example.com:6443"))
+			Expect(cfg.Labels).To(Equal(map[string]string{"env": "prod", "team": "platform"}))
+			Expect(cfg.AgentCheckinInterval.Duration).To(Equal(time.Duration(0)))
+			Expect(cfg.GitClientTimeout.Duration).To(Equal(45 * time.Second))
+		})
+	})
+
+	When("a duration value is a bare number", func() {
+		It("treats 0 as the default sentinel without erroring", func() {
+			cfg, err := config.ReadConfig(&v1.ConfigMap{Data: map[string]string{
+				"config": `{"garbageCollectionInterval": 0}`,
+			}})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(cfg.GarbageCollectionInterval.Duration).To(Equal(time.Duration(0)))
+		})
+
+		It("falls back to the default for a non-zero number", func() {
+			cfg, err := config.ReadConfig(&v1.ConfigMap{Data: map[string]string{
+				"config": `{"gitClientTimeout": 5}`,
+			}})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(cfg.GitClientTimeout.Duration).To(Equal(30 * time.Second))
+		})
+	})
+
+	When("the config is not a valid mapping at all", func() {
+		It("still surfaces the unmarshal error", func() {
+			cfg, err := config.ReadConfig(&v1.ConfigMap{Data: map[string]string{
+				"config": "- a\n- b\n",
+			}})
+			Expect(err).To(HaveOccurred())
+			Expect(cfg).To(Equal(config.DefaultConfig()))
+		})
+	})
 })

--- a/pkg/apis/fleet.cattle.io/v1alpha1/clusterregistrationtoken_types.go
+++ b/pkg/apis/fleet.cattle.io/v1alpha1/clusterregistrationtoken_types.go
@@ -36,6 +36,10 @@ type ClusterRegistrationTokenSpec struct {
 	// TTL is the time to live for the token. It is used to calculate the
 	// expiration time. If the token expires, it will be deleted.
 	// +nullable
+	// +kubebuilder:validation:Type=string
+	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=32
+	// +kubebuilder:validation:XValidation:rule="self == '0' || (self.matches('^([0-9]+([.][0-9]+)?(ns|us|µs|ms|s|m|h))+$') && duration(self) <= duration('2562047h'))",message="must be a valid Go duration using units ns, us, µs, ms, s, m, h (e.g. 15s, 5m, 2h, 1h30m); units like d (days) or w (weeks) are not supported"
 	TTL *metav1.Duration `json:"ttl,omitempty"`
 }
 

--- a/pkg/apis/fleet.cattle.io/v1alpha1/gitrepo_types.go
+++ b/pkg/apis/fleet.cattle.io/v1alpha1/gitrepo_types.go
@@ -112,12 +112,20 @@ type GitRepoSpec struct {
 
 	// PollingInterval is how often to check git for new updates.
 	// +nullable
+	// +kubebuilder:validation:Type=string
+	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=32
+	// +kubebuilder:validation:XValidation:rule="self == '0' || (self.matches('^([0-9]+([.][0-9]+)?(ns|us|µs|ms|s|m|h))+$') && duration(self) <= duration('2562047h'))",message="must be a valid Go duration using units ns, us, µs, ms, s, m, h (e.g. 15s, 5m, 2h, 1h30m); units like d (days) or w (weeks) are not supported"
 	PollingInterval *metav1.Duration `json:"pollingInterval,omitempty"`
 
 	// Increment this number to force a redeployment of contents from Git.
 	ForceSyncGeneration int64 `json:"forceSyncGeneration,omitempty"`
 
 	// ImageScanInterval is the interval of syncing scanned images and writing back to git repo.
+	// +kubebuilder:validation:Type=string
+	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=32
+	// +kubebuilder:validation:XValidation:rule="self == '0' || (self.matches('^([0-9]+([.][0-9]+)?(ns|us|µs|ms|s|m|h))+$') && duration(self) <= duration('2562047h'))",message="must be a valid Go duration using units ns, us, µs, ms, s, m, h (e.g. 15s, 5m, 2h, 1h30m); units like d (days) or w (weeks) are not supported"
 	ImageSyncInterval *metav1.Duration `json:"imageScanInterval,omitempty"`
 
 	// Commit specifies how to commit to the git repo when a new image is scanned and written back to git repo.

--- a/pkg/apis/fleet.cattle.io/v1alpha1/helmop_types.go
+++ b/pkg/apis/fleet.cattle.io/v1alpha1/helmop_types.go
@@ -59,6 +59,10 @@ type HelmOpSpec struct {
 
 	// PollingInterval is how often to check the Helm repository for new updates.
 	// +nullable
+	// +kubebuilder:validation:Type=string
+	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=32
+	// +kubebuilder:validation:XValidation:rule="self == '0' || (self.matches('^([0-9]+([.][0-9]+)?(ns|us|µs|ms|s|m|h))+$') && duration(self) <= duration('2562047h'))",message="must be a valid Go duration using units ns, us, µs, ms, s, m, h (e.g. 15s, 5m, 2h, 1h30m); units like d (days) or w (weeks) are not supported"
 	PollingInterval *metav1.Duration `json:"pollingInterval,omitempty"`
 
 	// HelmSecretName contains the auth secret with the credentials to access

--- a/pkg/apis/fleet.cattle.io/v1alpha1/imagescan_types.go
+++ b/pkg/apis/fleet.cattle.io/v1alpha1/imagescan_types.go
@@ -53,6 +53,10 @@ type ImageScanSpec struct {
 	// scans of the image repository.
 	// +nullable
 	// +required
+	// +kubebuilder:validation:Type=string
+	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=32
+	// +kubebuilder:validation:XValidation:rule="self == '0' || (self.matches('^([0-9]+([.][0-9]+)?(ns|us|µs|ms|s|m|h))+$') && duration(self) <= duration('2562047h'))",message="must be a valid Go duration using units ns, us, µs, ms, s, m, h (e.g. 15s, 5m, 2h, 1h30m); units like d (days) or w (weeks) are not supported"
 	Interval metav1.Duration `json:"interval,omitempty"`
 
 	// SecretRef can be given the name of a secret containing

--- a/pkg/apis/fleet.cattle.io/v1alpha1/schedule_types.go
+++ b/pkg/apis/fleet.cattle.io/v1alpha1/schedule_types.go
@@ -37,7 +37,11 @@ type ScheduleList struct {
 }
 
 type ScheduleSpec struct {
-	Schedule string          `json:"schedule,omitempty"`
+	Schedule string `json:"schedule,omitempty"`
+	// +kubebuilder:validation:Type=string
+	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=32
+	// +kubebuilder:validation:XValidation:rule="self == '0' || (self.matches('^([0-9]+([.][0-9]+)?(ns|us|µs|ms|s|m|h))+$') && duration(self) <= duration('2562047h'))",message="must be a valid Go duration using units ns, us, µs, ms, s, m, h (e.g. 15s, 5m, 2h, 1h30m); units like d (days) or w (weeks) are not supported"
 	Duration metav1.Duration `json:"duration,omitempty"`
 	Location string          `json:"location,omitempty"`
 	// Targets is a list of resources affected by this schedule


### PR DESCRIPTION
Prevent invalid duration strings (e.g. "1d", "1w").

## Additional Information

### Checklist

~- [ ] <!-- If applicable,--> I have updated the documentation via a pull request in the [fleet-product-docs](https://github.com/rancher/fleet-product-docs) repository.~
