### PR TITLE
Harden GitHub Actions workflows

### DIFF
--- a/.github/workflows/add_issue_to_project.yml
+++ b/.github/workflows/add_issue_to_project.yml
@@ -8,6 +8,8 @@ on:
       - opened
       - transferred
 
+permissions: {}
+
 jobs:
   add-to-project:
     name: Add issue to project

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -69,8 +69,10 @@ jobs:
             ${{ runner.os }}-k3d-
 
       - name: Install k3d
+        env:
+          CACHE_HIT: ${{ steps.cache-k3d.outputs.cache-hit }}
         run: |
-          if [ "${{ steps.cache-k3d.outputs.cache-hit }}" != "true" ]; then
+          if [ "$CACHE_HIT" != "true" ]; then
             ./.github/scripts/install-k3d.sh
           else
             echo "Using cached k3d"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-
+          persist-credentials: false
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:

--- a/.github/workflows/check-changes.yml
+++ b/.github/workflows/check-changes.yml
@@ -6,6 +6,9 @@ on:
     branches:
     - '*-hotfix-*'
 
+permissions:
+  contents: read
+
 env:
   MAIN_BRANCH: origin/main
   GOARCH: amd64

--- a/.github/workflows/check-changes.yml
+++ b/.github/workflows/check-changes.yml
@@ -23,6 +23,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       -
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
     branches:
     - '*-hotfix-*'
 
+permissions:
+  contents: read
+
 env:
   GOARCH: amd64
   CGO_ENABLED: 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       -
         name: Set up chart-testing
@@ -52,6 +53,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       -
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
@@ -74,6 +76,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       -
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:

--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -64,8 +64,10 @@ jobs:
             ${{ runner.os }}-crust-gather-
       -
         name: Install crust-gather CLI
+        env:
+          CACHE_HIT: ${{ steps.cache-crust.outputs.cache-hit }}
         run: |
-          if [ "${{ steps.cache-crust.outputs.cache-hit }}" != "true" ]; then
+          if [ "$CACHE_HIT" != "true" ]; then
             ./.github/scripts/install-crust-gather.sh
           else
             echo "Using cached crust-gather CLI"
@@ -98,8 +100,10 @@ jobs:
             ${{ runner.os }}-k3d-
       -
         name: Install k3d
+        env:
+          CACHE_HIT: ${{ steps.cache-k3d.outputs.cache-hit }}
         run: |
-          if [ "${{ steps.cache-k3d.outputs.cache-hit }}" != "true" ]; then
+          if [ "$CACHE_HIT" != "true" ]; then
             ./.github/scripts/install-k3d.sh
           else
             echo "Using cached k3d"

--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -7,6 +7,9 @@ on:
     branches:
     - '*-hotfix-*'
 
+permissions:
+  contents: read
+
 env:
   GOARCH: amd64
   CGO_ENABLED: 0

--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -45,6 +45,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       -
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:

--- a/.github/workflows/e2e-fleet-upgrade-ci.yml
+++ b/.github/workflows/e2e-fleet-upgrade-ci.yml
@@ -6,6 +6,9 @@ on:
     - cron: '0 8 */2 * *'
   pull_request:
 
+permissions:
+  contents: read
+
 env:
   GOARCH: amd64
   CGO_ENABLED: 0

--- a/.github/workflows/e2e-fleet-upgrade-ci.yml
+++ b/.github/workflows/e2e-fleet-upgrade-ci.yml
@@ -29,6 +29,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       -
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:

--- a/.github/workflows/e2e-fleet-upgrade-ci.yml
+++ b/.github/workflows/e2e-fleet-upgrade-ci.yml
@@ -48,8 +48,10 @@ jobs:
             ${{ runner.os }}-crust-gather-
       -
         name: Install crust-gather CLI
+        env:
+          CACHE_HIT: ${{ steps.cache-crust.outputs.cache-hit }}
         run: |
-          if [ "${{ steps.cache-crust.outputs.cache-hit }}" != "true" ]; then
+          if [ "$CACHE_HIT" != "true" ]; then
             ./.github/scripts/install-crust-gather.sh
           else
             echo "Using cached crust-gather CLI"
@@ -67,8 +69,10 @@ jobs:
             ${{ runner.os }}-k3d-
       -
         name: Install k3d
+        env:
+          CACHE_HIT: ${{ steps.cache-k3d.outputs.cache-hit }}
         run: |
-          if [ "${{ steps.cache-k3d.outputs.cache-hit }}" != "true" ]; then
+          if [ "$CACHE_HIT" != "true" ]; then
             ./.github/scripts/install-k3d.sh
           else
             echo "Using cached k3d"

--- a/.github/workflows/e2e-multicluster-ci.yml
+++ b/.github/workflows/e2e-multicluster-ci.yml
@@ -9,6 +9,9 @@ on:
     branches:
     - '*-hotfix-*'
 
+permissions:
+  contents: read
+
 env:
   GOARCH: amd64
   CGO_ENABLED: 0

--- a/.github/workflows/e2e-multicluster-ci.yml
+++ b/.github/workflows/e2e-multicluster-ci.yml
@@ -25,6 +25,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       -
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:

--- a/.github/workflows/e2e-multicluster-ci.yml
+++ b/.github/workflows/e2e-multicluster-ci.yml
@@ -44,8 +44,10 @@ jobs:
             ${{ runner.os }}-crust-gather-
       -
         name: Install crust-gather CLI
+        env:
+          CACHE_HIT: ${{ steps.cache-crust.outputs.cache-hit }}
         run: |
-          if [ "${{ steps.cache-crust.outputs.cache-hit }}" != "true" ]; then
+          if [ "$CACHE_HIT" != "true" ]; then
             ./.github/scripts/install-crust-gather.sh
           else
             echo "Using cached crust-gather CLI"
@@ -71,8 +73,10 @@ jobs:
             ${{ runner.os }}-k3d-
       -
         name: Install k3d
+        env:
+          CACHE_HIT: ${{ steps.cache-k3d.outputs.cache-hit }}
         run: |
-          if [ "${{ steps.cache-k3d.outputs.cache-hit }}" != "true" ]; then
+          if [ "$CACHE_HIT" != "true" ]; then
             ./.github/scripts/install-k3d.sh
           else
             echo "Using cached k3d"

--- a/.github/workflows/e2e-nightly-ci.yml
+++ b/.github/workflows/e2e-nightly-ci.yml
@@ -21,6 +21,9 @@ on:
           - e2e-secrets
           - e2e-nosecrets
 
+permissions:
+  contents: read
+
 env:
   GOARCH: amd64
   CGO_ENABLED: 0

--- a/.github/workflows/e2e-nightly-ci.yml
+++ b/.github/workflows/e2e-nightly-ci.yml
@@ -70,8 +70,10 @@ jobs:
             ${{ runner.os }}-crust-gather-
       -
         name: Install crust-gather CLI
+        env:
+          CACHE_HIT: ${{ steps.cache-crust.outputs.cache-hit }}
         run: |
-          if [ "${{ steps.cache-crust.outputs.cache-hit }}" != "true" ]; then
+          if [ "$CACHE_HIT" != "true" ]; then
             ./.github/scripts/install-crust-gather.sh
           else
             echo "Using cached crust-gather CLI"
@@ -102,8 +104,10 @@ jobs:
             ${{ runner.os }}-k3d-
       -
         name: Install k3d
+        env:
+          CACHE_HIT: ${{ steps.cache-k3d.outputs.cache-hit }}
         run: |
-          if [ "${{ steps.cache-k3d.outputs.cache-hit }}" != "true" ]; then
+          if [ "$CACHE_HIT" != "true" ]; then
             ./.github/scripts/install-k3d.sh
           else
             echo "Using cached k3d"

--- a/.github/workflows/e2e-nightly-ci.yml
+++ b/.github/workflows/e2e-nightly-ci.yml
@@ -110,11 +110,13 @@ jobs:
           fi
       -
         name: Provision k3d Cluster
+        env:
+          K3S_VERSION: ${{ matrix.k3s_version }}
         run: |
           k3d cluster create upstream --wait \
             --agents 1 \
             --network "nw01" \
-            --image docker.io/rancher/k3s:${{matrix.k3s_version}} \
+            --image "docker.io/rancher/k3s:${K3S_VERSION}" \
             --k3s-arg "--cluster-init@server:0"
       -
         name: Import Images Into k3d

--- a/.github/workflows/e2e-nightly-ci.yml
+++ b/.github/workflows/e2e-nightly-ci.yml
@@ -51,6 +51,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       -
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:

--- a/.github/workflows/e2e-rancher-upgrade-fleet-to-head-ci.yml
+++ b/.github/workflows/e2e-rancher-upgrade-fleet-to-head-ci.yml
@@ -53,8 +53,10 @@ jobs:
             ${{ runner.os }}-crust-gather-
       -
         name: Install crust-gather CLI
+        env:
+          CACHE_HIT: ${{ steps.cache-crust.outputs.cache-hit }}
         run: |
-          if [ "${{ steps.cache-crust.outputs.cache-hit }}" != "true" ]; then
+          if [ "$CACHE_HIT" != "true" ]; then
             ./.github/scripts/install-crust-gather.sh
           else
             echo "Using cached crust-gather CLI"
@@ -146,8 +148,10 @@ jobs:
             ${{ runner.os }}-k3d-
       -
         name: Install k3d
+        env:
+          CACHE_HIT: ${{ steps.cache-k3d.outputs.cache-hit }}
         run: |
-          if [ "${{ steps.cache-k3d.outputs.cache-hit }}" != "true" ]; then
+          if [ "$CACHE_HIT" != "true" ]; then
             ./.github/scripts/install-k3d.sh
           else
             echo "Using cached k3d"
@@ -218,9 +222,12 @@ jobs:
           until kubectl get bundles -n fleet-default test-simple-simple-chart -o=jsonpath='{.status.conditions[?(@.type=="Ready")].status}' | grep -q "True"; do sleep 3; done
       -
         name: Deploy development fleet
+        env:
+          FLEET_TAGS: ${{ steps.meta-fleet.outputs.tags }}
+          FLEET_AGENT_TAGS: ${{ steps.meta-fleet-agent.outputs.tags }}
         run: |
-          echo "${{ steps.meta-fleet.outputs.tags }} ${{ steps.meta-fleet-agent.outputs.tags }}"
-          ./.github/scripts/upgrade-rancher-fleet-to-dev-fleet.sh ${{ steps.meta-fleet.outputs.tags }} ${{ steps.meta-fleet-agent.outputs.tags }}
+          echo "$FLEET_TAGS $FLEET_AGENT_TAGS"
+          ./.github/scripts/upgrade-rancher-fleet-to-dev-fleet.sh "$FLEET_TAGS" "$FLEET_AGENT_TAGS"
       -
         name: E2E tests for examples
         env:

--- a/.github/workflows/e2e-rancher-upgrade-fleet-to-head-ci.yml
+++ b/.github/workflows/e2e-rancher-upgrade-fleet-to-head-ci.yml
@@ -33,6 +33,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
           ref: ${{ github.event.inputs.ref }}
       -
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0

--- a/.github/workflows/e2e-rancher-upgrade-fleet-to-head-ci.yml
+++ b/.github/workflows/e2e-rancher-upgrade-fleet-to-head-ci.yml
@@ -16,6 +16,9 @@ on:
     paths-ignore:
       - '*.md'
 
+permissions:
+  contents: read
+
 env:
   GOARCH: amd64
   CGO_ENABLED: 0

--- a/.github/workflows/e2e-rancher-upgrade-fleet.yml
+++ b/.github/workflows/e2e-rancher-upgrade-fleet.yml
@@ -71,8 +71,10 @@ jobs:
             ${{ runner.os }}-crust-gather-
       -
         name: Install crust-gather CLI
+        env:
+          CACHE_HIT: ${{ steps.cache-crust.outputs.cache-hit }}
         run: |
-          if [ "${{ steps.cache-crust.outputs.cache-hit }}" != "true" ]; then
+          if [ "$CACHE_HIT" != "true" ]; then
             ./.github/scripts/install-crust-gather.sh
           else
             echo "Using cached crust-gather CLI"
@@ -109,8 +111,10 @@ jobs:
             ${{ runner.os }}-k3d-
       -
         name: Install k3d
+        env:
+          CACHE_HIT: ${{ steps.cache-k3d.outputs.cache-hit }}
         run: |
-          if [ "${{ steps.cache-k3d.outputs.cache-hit }}" != "true" ]; then
+          if [ "$CACHE_HIT" != "true" ]; then
             ./.github/scripts/install-k3d.sh
           else
             echo "Using cached k3d"

--- a/.github/workflows/e2e-rancher-upgrade-fleet.yml
+++ b/.github/workflows/e2e-rancher-upgrade-fleet.yml
@@ -51,6 +51,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
           ref: ${{ github.event.inputs.ref }}
       -
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0

--- a/.github/workflows/e2e-rancher-upgrade-fleet.yml
+++ b/.github/workflows/e2e-rancher-upgrade-fleet.yml
@@ -35,6 +35,9 @@ on:
         required: true
         default: "v0.13.1"
 
+permissions:
+  contents: read
+
 env:
   GOARCH: amd64
   CGO_ENABLED: 0

--- a/.github/workflows/e2e-test-fleet-in-rancher.yml
+++ b/.github/workflows/e2e-test-fleet-in-rancher.yml
@@ -22,6 +22,9 @@ on:
     paths-ignore:
       - '*.md'
 
+permissions:
+  contents: read
+
 env:
   GOARCH: amd64
   CGO_ENABLED: 0

--- a/.github/workflows/e2e-test-fleet-in-rancher.yml
+++ b/.github/workflows/e2e-test-fleet-in-rancher.yml
@@ -81,8 +81,10 @@ jobs:
             ${{ runner.os }}-crust-gather-
       -
         name: Install crust-gather CLI
+        env:
+          CACHE_HIT: ${{ steps.cache-crust.outputs.cache-hit }}
         run: |
-          if [ "${{ steps.cache-crust.outputs.cache-hit }}" != "true" ]; then
+          if [ "$CACHE_HIT" != "true" ]; then
             ./fleet/.github/scripts/install-crust-gather.sh
           else
             echo "Using cached crust-gather CLI"
@@ -109,9 +111,11 @@ jobs:
 
       -
         name: Install Dependencies
+        env:
+          DEPS_CACHE_HIT: ${{ steps.deps-cache.outputs.cache-hit }}
         run: |
           mkdir -p ~/.local/bin
-          if [ "${{ steps.deps-cache.outputs.cache-hit }}" != "true" ]; then
+          if [ "$DEPS_CACHE_HIT" != "true" ]; then
             KUBECTL_VERSION="v1.36.0"
             KUBECTL_SUM_amd64="123d8c8844f46b1244c547fffb3c17180c0c26dac9890589fe7e67763298748e"
             curl -sSfL "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" -o kubectl
@@ -152,8 +156,10 @@ jobs:
             ${{ runner.os }}-k3d-
       -
         name: Install k3d
+        env:
+          CACHE_HIT: ${{ steps.cache-k3d.outputs.cache-hit }}
         run: |
-          if [ "${{ steps.cache-k3d.outputs.cache-hit }}" != "true" ]; then
+          if [ "$CACHE_HIT" != "true" ]; then
             ./fleet/.github/scripts/install-k3d.sh
           else
             echo "Using cached k3d"
@@ -190,11 +196,14 @@ jobs:
 
       -
         name: Set up latest Rancher
+        env:
+          CHARTS_REPO: ${{ needs.release-against-test-charts.outputs.charts_repo }}
+          CHARTS_BRANCH: ${{ needs.release-against-test-charts.outputs.target_branch }}
         run: |
           set -x
 
-          charts_repo=${{ needs.release-against-test-charts.outputs.charts_repo }}
-          charts_branch=${{ needs.release-against-test-charts.outputs.target_branch }}
+          charts_repo="$CHARTS_REPO"
+          charts_branch="$CHARTS_BRANCH"
           fleet_version=999.9.9+up9.9.9
 
           kubectl config use-context k3d-upstream
@@ -264,9 +273,11 @@ jobs:
 
       -
         name: Rancher Provisioning Tests
+        env:
+          K8S_VERSION: ${{ env.SETUP_K3S_VERSION }}
         run: |
           cd rancher
-          k8s_version=${{ env.SETUP_K3S_VERSION }}
+          k8s_version="$K8S_VERSION"
           export SOME_K8S_VERSION=${k8s_version/-/+}
           go test -v -count=1 ./tests/v2prov/tests/fleet
 

--- a/.github/workflows/e2e-test-fleet-in-rancher.yml
+++ b/.github/workflows/e2e-test-fleet-in-rancher.yml
@@ -55,6 +55,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
           path: fleet
 
       -
@@ -256,6 +257,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
           repository: rancher/rancher
           ref: main
           path: rancher

--- a/.github/workflows/e2e-test-fleet-in-rancher.yml
+++ b/.github/workflows/e2e-test-fleet-in-rancher.yml
@@ -36,7 +36,8 @@ jobs:
     with:
       charts_repo: ${{ github.event.inputs.charts_repo }}
       charts_base_branch: ${{ github.event.inputs.charts_branch }}
-    secrets: inherit # needed to enable access to repo secrets from the called workflow
+    secrets:
+      CI_PUSH_TO_FLEETREPOCI: ${{ secrets.CI_PUSH_TO_FLEETREPOCI }}
 
   rancher-integration:
     runs-on: ubuntu-latest

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
 
     # The FOSSA token is shared between all repos in Rancher's GH org. It can be
     # used directly and there is no need to request specific access to EIO.

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -5,6 +5,9 @@ on:
     - cron:  '0 5 * * *'
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   golangci:
     name: golangci-lint

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -18,6 +18,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: recursive
+          persist-credentials: false
 
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0

--- a/.github/workflows/port-issue.yml
+++ b/.github/workflows/port-issue.yml
@@ -6,6 +6,9 @@ on:
     types:
       - created
 
+permissions:
+  contents: read
+
 jobs:
   port-issue:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-against-rancher.yml
+++ b/.github/workflows/release-against-rancher.yml
@@ -103,18 +103,24 @@ jobs:
         run: go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.17.2
 
       - name: Run release script
+        env:
+          NEW_FLEET: ${{ steps.versions.outputs.new_fleet }}
+          NEW_CHART: ${{ steps.versions.outputs.new_chart }}
         run: |
           ./fleet/.github/scripts/release-against-rancher.sh \
-            "${{ steps.versions.outputs.new_fleet }}" \
-            "${{ steps.versions.outputs.new_chart }}"
+            "$NEW_FLEET" \
+            "$NEW_CHART"
 
       - name: Create Pull Request
         env:
           GITHUB_TOKEN: ${{ secrets.PUSH_TO_FORKS_SUBMIT_PRS }}
+          RANCHER_REF: ${{ steps.versions.outputs.rancher_ref }}
+          NEW_FLEET: ${{ steps.versions.outputs.new_fleet }}
+          NEW_CHART: ${{ steps.versions.outputs.new_chart }}
         working-directory: ./rancher/
         run: |
           ../fleet/.github/scripts/create-pr.sh \
-            "${{ steps.versions.outputs.rancher_ref }}" \
-            "${{ steps.versions.outputs.new_fleet }}" \
-            "${{ steps.versions.outputs.new_chart }}" \
+            "$RANCHER_REF" \
+            "$NEW_FLEET" \
+            "$NEW_CHART" \
             rancher

--- a/.github/workflows/release-against-test-charts.yml
+++ b/.github/workflows/release-against-test-charts.yml
@@ -31,6 +31,9 @@ on:
       charts_target_branch:
         description: "Use the following branch as a destination when pushing to the charts repo"
         type: string
+    secrets:
+      CI_PUSH_TO_FLEETREPOCI:
+        required: true
     outputs:
       target_branch:
         value: ${{ jobs.push-test-rancher-charts.outputs.target_branch }}

--- a/.github/workflows/release-against-test-charts.yml
+++ b/.github/workflows/release-against-test-charts.yml
@@ -157,6 +157,9 @@ jobs:
           echo "target_branch=$target_branch_name" >> "$GITHUB_OUTPUT"
 
       - name: Set up test charts repo with latest upstream state
+        env:
+          TARGET_BRANCH: ${{steps.compute_target_branch.outputs.target_branch}}
+          BASE_BRANCH: ${{steps.compute_env.outputs.charts_base_branch}}
         run: |
           cd charts
           # Add upstream remote and fetch from it
@@ -164,13 +167,13 @@ jobs:
           git remote rename origin fleetoci
           git remote add -f origin https://github.com/rancher/charts
 
-          target_branch=${{steps.compute_target_branch.outputs.target_branch}}
-          base_branch=${{steps.compute_env.outputs.charts_base_branch}}
+          target_branch="$TARGET_BRANCH"
+          base_branch="$BASE_BRANCH"
 
-          git checkout -b $target_branch origin/$base_branch
+          git checkout -b "$target_branch" "origin/$base_branch"
           if [ $? -eq 128 ]; then # branch already exists
-            git checkout $target_branch
-            git rebase origin/$base_branch
+            git checkout "$target_branch"
+            git rebase "origin/$base_branch"
           fi
 
       - name: Install dependencies
@@ -180,6 +183,8 @@ jobs:
           sudo snap install yq --channel=v4/stable
 
       - name: Run release script
+        env:
+          UUID: ${{ steps.uuid.outputs.uuid }}
         run: |
           fleet_test_version=9.9.9
 
@@ -188,13 +193,15 @@ jobs:
           latest_fleet="${latest_fleet_rancher_version#*+up}"
 
           ./fleet/.github/scripts/release-against-test-charts.sh \
-            $latest_fleet \
-            $fleet_test_version \
-            $latest_chart \
-            999.9.9 \
-            ${{ steps.uuid.outputs.uuid }}
+            "$latest_fleet" \
+            "$fleet_test_version" \
+            "$latest_chart" \
+            "999.9.9" \
+            "$UUID"
 
       - name: Push to custom branch
+        env:
+          TARGET_BRANCH: ${{ steps.compute_target_branch.outputs.target_branch }}
         run: |
           cd charts
-          git push -u fleetoci ${{ steps.compute_target_branch.outputs.target_branch }}
+          git push -u fleetoci "$TARGET_BRANCH"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -225,8 +225,9 @@ jobs:
         if: ${{ env.IS_HOTFIX == 'false' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GORELEASER_METADATA: ${{ steps.goreleaser.outputs.metadata }}
         run: |
-          version=$(jq -r '.version' <<< '${{ steps.goreleaser.outputs.metadata }}')
+          version=$(jq -r '.version' <<< "$GORELEASER_METADATA")
           branch_version=v$(cut -d'.' -f1,2 <<< "$version")
           charts_branch=charts/$branch_version
 

--- a/.github/workflows/typos.yaml
+++ b/.github/workflows/typos.yaml
@@ -12,6 +12,8 @@ jobs:
     steps:
     - name: Checkout Repository
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
 
     - name: Check spelling of file.txt
       uses: crate-ci/typos@5374cbf686e897b15713110e233094e2874de7ef # v1.46.1

--- a/.github/workflows/typos.yaml
+++ b/.github/workflows/typos.yaml
@@ -1,6 +1,9 @@
 name: Test Typos
 on: [pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   run:
     name: Spell Check with Typos

--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -22,6 +22,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install Updatecli in the runner
         uses: updatecli/updatecli-action@e71be7554f3f940bc439cf720b3e4e379823c562 # v3.2.0

--- a/.zizmor.yml
+++ b/.zizmor.yml
@@ -6,3 +6,9 @@ rules:
       - e2e-rancher-upgrade-fleet-to-head-ci.yml
       - e2e-test-fleet-in-rancher.yml
       - release-against-test-charts.yml
+  artipacked:
+    ignore:
+      # These release workflows perform authenticated git operations.
+      # Forcing checkout credential removal risks breaking release publishing.
+      - release-against-test-charts.yml
+      - release.yml

--- a/.zizmor.yml
+++ b/.zizmor.yml
@@ -1,0 +1,8 @@
+rules:
+  cache-poisoning:
+    ignore:
+      # Allow caching outside of the release process to have fast CI
+      # while ensuring reliability of the release action
+      - e2e-rancher-upgrade-fleet-to-head-ci.yml
+      - e2e-test-fleet-in-rancher.yml
+      - release-against-test-charts.yml


### PR DESCRIPTION
Move GitHub Actions step outputs into environment variables, add least-privilege `permissions`, and restrict checkout/secret usage to address `zizmor` findings. No functional changes - outputs are set in `env:` and referenced safely in `run:` blocks.

- **Template-injection**: Move `steps.*.outputs.*` into env vars (e.g. `CACHE_HIT`) and reference `$CACHE_HIT` in `run` blocks.
- **Permissions & checkout**: Add explicit `permissions` and set `persist-credentials: false` for non-release `actions/checkout` steps.
- **Config**: Update [.zizmor.yml](.zizmor.yml) suppress non-actionable `cache-poisoning` because using caches should be fine outside of the release process to speed up CI and ignores warning about stored git credentials (`artipacked`) for two actions which need them during their runtime