### PR TITLE
Generate binaries for AMD64 Mac

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -89,6 +89,7 @@ builds:
       - -X github.com/rancher/fleet/pkg/version.Version={{ .Tag }}
     targets:
     - darwin_arm64
+    - darwin_amd64
     - linux_amd64_v1
     - linux_arm64
     - windows_amd64
@@ -103,6 +104,7 @@ builds:
       - -X github.com/rancher/fleet/pkg/version.Version={{ .Tag }}
     targets:
     - darwin_arm64
+    - darwin_amd64
     - linux_amd64_v1
     - linux_arm64
     - windows_amd64


### PR DESCRIPTION
Users running Mac OS on amd64 architectures should be able to run the Fleet CLI and benchmark binaries.

## Additional Information

### Checklist

- [ ] <!-- If applicable,--> I have updated the documentation via a pull request in the [fleet-product-docs](https://github.com/rancher/fleet-product-docs) repository.
