### PR TITLE
fix: propagate Accepted=False to Ready condition when GitRepo job creation fails

### DIFF
--- a/internal/cmd/controller/gitops/reconciler/gitjob_test.go
+++ b/internal/cmd/controller/gitops/reconciler/gitjob_test.go
@@ -3495,3 +3495,102 @@ func TestCreateJob_AlreadyExistsIsIgnored(t *testing.T) {
 		t.Fatal("createJob should return false when job already exists")
 	}
 }
+
+// Test_PropagateAcceptedFailureToReady_SetsReadyFalse verifies that when the
+// Accepted condition is False, propagateAcceptedFailureToReady forces Ready to
+// False with the same message and reason. This is the core fix for
+// https://github.com/rancher/fleet/issues/4865.
+func Test_PropagateAcceptedFailureToReady_SetsReadyFalse(t *testing.T) {
+	gitrepo := &fleetv1.GitRepo{}
+	gitrepo.Status.Conditions = []genericcondition.GenericCondition{
+		{
+			Type:    fleetv1.GitRepoAcceptedCondition,
+			Status:  "False",
+			Message: "failed to look up HelmSecretNameForPaths, error: secret not found",
+			Reason:  "Error",
+		},
+		{
+			Type:   "Ready",
+			Status: "True",
+		},
+	}
+
+	propagateAcceptedFailureToReady(gitrepo)
+
+	readyCond, found := getCondition(gitrepo, "Ready")
+	if !found {
+		t.Fatal("expected Ready condition to be present")
+	}
+	if readyCond.Status != "False" {
+		t.Errorf("expected Ready=False, got Ready=%s", readyCond.Status)
+	}
+	if readyCond.Message != "failed to look up HelmSecretNameForPaths, error: secret not found" {
+		t.Errorf("unexpected Ready message: %s", readyCond.Message)
+	}
+}
+
+// Test_PropagateAcceptedFailureToReady_AddsReadyWhenMissing verifies that when
+// Ready is absent and Accepted=False, a Ready=False condition is added.
+func Test_PropagateAcceptedFailureToReady_AddsReadyWhenMissing(t *testing.T) {
+	gitrepo := &fleetv1.GitRepo{}
+	gitrepo.Status.Conditions = []genericcondition.GenericCondition{
+		{
+			Type:    fleetv1.GitRepoAcceptedCondition,
+			Status:  "False",
+			Message: "missing cabundle secret",
+			Reason:  "Error",
+		},
+	}
+
+	propagateAcceptedFailureToReady(gitrepo)
+
+	readyCond, found := getCondition(gitrepo, "Ready")
+	if !found {
+		t.Fatal("expected Ready condition to be added")
+	}
+	if readyCond.Status != "False" {
+		t.Errorf("expected Ready=False, got Ready=%s", readyCond.Status)
+	}
+	if readyCond.Message != "missing cabundle secret" {
+		t.Errorf("unexpected Ready message: %s", readyCond.Message)
+	}
+}
+
+// Test_PropagateAcceptedFailureToReady_NoOpWhenAcceptedTrue verifies that when
+// Accepted=True, the Ready condition is not changed by propagateAcceptedFailureToReady.
+func Test_PropagateAcceptedFailureToReady_NoOpWhenAcceptedTrue(t *testing.T) {
+	gitrepo := &fleetv1.GitRepo{}
+	gitrepo.Status.Conditions = []genericcondition.GenericCondition{
+		{
+			Type:   fleetv1.GitRepoAcceptedCondition,
+			Status: "True",
+		},
+		{
+			Type:   "Ready",
+			Status: "True",
+		},
+	}
+
+	propagateAcceptedFailureToReady(gitrepo)
+
+	readyCond, found := getCondition(gitrepo, "Ready")
+	if !found {
+		t.Fatal("expected Ready condition to be present")
+	}
+	if readyCond.Status != "True" {
+		t.Errorf("expected Ready=True (unchanged), got Ready=%s", readyCond.Status)
+	}
+}
+
+// Test_PropagateAcceptedFailureToReady_NoOpWhenNoAccepted verifies that when
+// no Accepted condition is present, propagateAcceptedFailureToReady is a no-op.
+func Test_PropagateAcceptedFailureToReady_NoOpWhenNoAccepted(t *testing.T) {
+	gitrepo := &fleetv1.GitRepo{}
+	// No Accepted condition, no Ready condition - simulates fresh GitRepo with 0/0 bundles.
+	propagateAcceptedFailureToReady(gitrepo)
+
+	_, found := getCondition(gitrepo, "Ready")
+	if found {
+		t.Error("expected no Ready condition to be added when no Accepted condition is present")
+	}
+}

--- a/internal/cmd/controller/gitops/reconciler/status_controller.go
+++ b/internal/cmd/controller/gitops/reconciler/status_controller.go
@@ -145,6 +145,12 @@ func (r *StatusReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		return ctrl.Result{}, err
 	}
 
+	// If the Accepted condition is False (e.g. missing secret, cabundle failure,
+	// restriction violation), propagate that failure to the Ready condition.
+	// Without this, a GitRepo with no bundles (because the job never ran) would
+	// report Ready=True because the empty bundle summary satisfies 0/0 == ready.
+	propagateAcceptedFailureToReady(gitrepo)
+
 	if err := r.updateStatus(ctx, orig, gitrepo); err != nil {
 		logger.Error(err, "Reconcile failed update to git repo status", "status", gitrepo.Status)
 		return ctrl.Result{RequeueAfter: durations.GitRepoStatusDelay}, nil
@@ -245,6 +251,49 @@ bundles:
 	gitrepo.Status.Conditions = newConditions
 
 	return nil
+}
+
+// propagateAcceptedFailureToReady ensures the Ready condition reflects an
+// Accepted=False error. When a pre-job error (missing secret, cabundle failure,
+// restriction violation) prevents any bundle from being created, the bundle
+// summary is 0/0, which would normally resolve to Ready=True. By copying the
+// Accepted condition's message onto Ready we surface the real error.
+func propagateAcceptedFailureToReady(gitrepo *fleet.GitRepo) {
+	var acceptedMsg string
+	var acceptedReason string
+	acceptedFalse := false
+	for _, c := range gitrepo.Status.Conditions {
+		if c.Type == fleet.GitRepoAcceptedCondition && c.Status == v1.ConditionFalse {
+			acceptedFalse = true
+			acceptedMsg = c.Message
+			acceptedReason = c.Reason
+			break
+		}
+	}
+	if !acceptedFalse {
+		return
+	}
+
+	found := false
+	newConditions := make([]genericcondition.GenericCondition, 0, len(gitrepo.Status.Conditions))
+	for _, c := range gitrepo.Status.Conditions {
+		if c.Type == string(fleet.Ready) {
+			c.Status = v1.ConditionFalse
+			c.Message = acceptedMsg
+			c.Reason = acceptedReason
+			found = true
+		}
+		newConditions = append(newConditions, c)
+	}
+	if !found {
+		newConditions = append(newConditions, genericcondition.GenericCondition{
+			Type:    string(fleet.Ready),
+			Status:  v1.ConditionFalse,
+			Message: acceptedMsg,
+			Reason:  acceptedReason,
+		})
+	}
+	gitrepo.Status.Conditions = newConditions
 }
 
 type forcedDelayingSource[R comparable] struct {


### PR DESCRIPTION
Refers to #4865

## Summary

When a GitRepo fails before any bundles are created (e.g. a missing or invalid secret referenced by `HelmSecretNameForPaths` or `ClientSecretName`), the `gitjob_controller` sets `Accepted=False` via `updateErrorStatus`. However the `StatusReconciler` computes `Ready` independently from the bundle summary. With no bundles present the summary is 0/0, which satisfies `IsReady()`, so the GitRepo is reported as `Ready=True` even though nothing is deploying.

This PR adds `propagateAcceptedFailureToReady` in `status_controller.go`. After `setReadyStatusFromBundle` runs, the function checks whether the `Accepted` condition is `False`. If so it forces `Ready=False`, copying the `Accepted` message and reason onto the `Ready` condition. The check is additive: bundle-driven errors are still handled as before, and the propagation only fires when `Accepted` is explicitly `False`.

## Why this matters

Users who hit pre-job errors (missing secret, cabundle failure, restriction violation) see a healthy green `GitRepo` while their workload is silently not deploying. This change makes the error visible exactly where operators look first.

## Testing

Four unit tests added to `gitjob_test.go` (same package):

- `Test_PropagateAcceptedFailureToReady_SetsReadyFalse` - overwrites existing `Ready=True` when `Accepted=False`
- `Test_PropagateAcceptedFailureToReady_AddsReadyWhenMissing` - adds `Ready=False` when no Ready condition exists yet (the 0/0 empty-bundle case)
- `Test_PropagateAcceptedFailureToReady_NoOpWhenAcceptedTrue` - verifies no change when `Accepted=True`
- `Test_PropagateAcceptedFailureToReady_NoOpWhenNoAccepted` - verifies no change when no Accepted condition present

All 115 tests in the reconciler package pass (`go test ./internal/cmd/controller/gitops/reconciler/...`).

Fixes #4865

## Additional Information

### Checklist

- [ ] I have updated the documentation via a pull request in the [fleet-product-docs](https://github.com/rancher/fleet-product-docs) repository.
