### PR TITLE
[v0.12] Warn when Helm credentials are set but helmRepoURLRegex is empty

### DIFF
--- a/internal/bundlereader/resources.go
+++ b/internal/bundlereader/resources.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/rancher/fleet/internal/bundlereader/progress"
 	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
+	"github.com/sirupsen/logrus"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/sync/semaphore"
 
@@ -206,6 +207,7 @@ func mergeGenericMap(first, second *fleet.GenericMap) *fleet.GenericMap {
 // addRemoteCharts gets the chart url from a helm repo server and returns a `directory` struct.
 // For every chart that is not on disk, create a directory struct that contains the charts URL as path.
 func addRemoteCharts(directories []directory, base string, charts []*fleet.HelmOptions, auth Auth, helmRepoURLRegex string) ([]directory, error) {
+	warnedOnce := false
 	for _, chart := range charts {
 		if _, err := os.Stat(filepath.Join(base, chart.Chart)); os.IsNotExist(err) || chart.Repo != "" {
 			shouldAddAuthToRequest, err := shouldAddAuthToRequest(helmRepoURLRegex, chart.Repo, chart.Chart)
@@ -213,6 +215,10 @@ func addRemoteCharts(directories []directory, base string, charts []*fleet.HelmO
 				return nil, fmt.Errorf("failed to add auth to request for %s: %w", downloadChartError(*chart), err)
 			}
 			if !shouldAddAuthToRequest {
+				if !warnedOnce && helmRepoURLRegex == "" && (auth.Username != "" || auth.Password != "" || len(auth.SSHPrivateKey) > 0) {
+					logrus.Warn("helmRepoURLRegex is empty: Helm credentials will not be forwarded to any repository; set spec.helmRepoURLRegex to enable credential forwarding")
+					warnedOnce = true
+				}
 				// Only clear credentials; preserve transport settings (BasicHTTP, CABundle, InsecureSkipVerify)
 				auth.Username = ""
 				auth.Password = ""

--- a/internal/bundlereader/resources_test.go
+++ b/internal/bundlereader/resources_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/sirupsen/logrus"
+
 	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
 
 	"github.com/stretchr/testify/assert"
@@ -205,4 +207,75 @@ func TestAddRemoteChartsStripsCredentials(t *testing.T) {
 	assert.Nil(t, got.SSHPrivateKey, "SSHPrivateKey must be stripped when helmRepoURLRegex is empty")
 	assert.True(t, got.BasicHTTP, "BasicHTTP must be preserved when stripping credentials")
 	assert.True(t, got.InsecureSkipVerify, "InsecureSkipVerify must be preserved when stripping credentials")
+}
+
+func TestAddRemoteChartsWarnsMissingRegex(t *testing.T) {
+	remoteChart := []*fleet.HelmOptions{{Chart: "/nonexistent/chart"}}
+
+	tests := []struct {
+		name        string
+		charts      []*fleet.HelmOptions
+		auth        Auth
+		regex       string
+		wantWarning bool
+	}{
+		{
+			name:        "credentials set, regex empty — warn",
+			charts:      remoteChart,
+			auth:        Auth{Username: "user", Password: "secret"},
+			regex:       "",
+			wantWarning: true,
+		},
+		{
+			name:        "SSH key set, regex empty — warn",
+			charts:      remoteChart,
+			auth:        Auth{SSHPrivateKey: []byte("key")},
+			regex:       "",
+			wantWarning: true,
+		},
+		{
+			name:        "no credentials, regex empty — no warn",
+			charts:      remoteChart,
+			auth:        Auth{BasicHTTP: true},
+			regex:       "",
+			wantWarning: false,
+		},
+		{
+			name:        "credentials set, regex provided — no warn",
+			charts:      remoteChart,
+			auth:        Auth{Username: "user", Password: "secret"},
+			regex:       "https://charts\\.example\\.com.*",
+			wantWarning: false,
+		},
+		{
+			name:        "credentials set, regex empty, no charts — no warn",
+			charts:      nil,
+			auth:        Auth{Username: "user", Password: "secret"},
+			regex:       "",
+			wantWarning: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			oldOut := logrus.StandardLogger().Out
+			oldLevel := logrus.GetLevel()
+			logrus.SetOutput(&buf)
+			logrus.SetLevel(logrus.WarnLevel)
+			t.Cleanup(func() {
+				logrus.SetOutput(oldOut)
+				logrus.SetLevel(oldLevel)
+			})
+
+			_, err := addRemoteCharts(nil, t.TempDir(), tt.charts, tt.auth, tt.regex)
+			require.NoError(t, err)
+
+			if tt.wantWarning {
+				assert.Contains(t, buf.String(), "helmRepoURLRegex")
+			} else {
+				assert.NotContains(t, buf.String(), "helmRepoURLRegex")
+			}
+		})
+	}
 }


### PR DESCRIPTION
When Helm credentials are configured in an Auth object but helmRepoURLRegex is empty, addRemoteCharts silently drops the credentials. Log a Warn-level message so operators know credentials are not forwarded and how to fix it by setting spec.helmRepoURLRegex.

Backports #5316