### PR TITLE
Switch container base images to bci-nano and remove tini

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -130,7 +130,6 @@ dockers_v2:
       BUILD_ENV: "goreleaser"
     flags:
     - "--pull"
-    extra_files: [ "package/log.sh" ]
     platforms:
     - linux/amd64
     - linux/arm64
@@ -184,7 +183,6 @@ dockers_v2:
     - "--sbom=true"
     - "--provenance=true"
     - "--provenance=mode=max"
-    extra_files: [ "package/log.sh" ]
     platforms:
     - linux/amd64
     - linux/arm64

--- a/charts/fleet-agent/templates/deployment.yaml
+++ b/charts/fleet-agent/templates/deployment.yaml
@@ -48,7 +48,7 @@ spec:
         {{- end }}
         image: '{{ template "system_default_registry" . }}{{.Values.image.repository}}:{{.Values.image.tag}}'
         name: fleet-agent
-        command:
+        args:
         - fleetagent
         {{- if .Values.debug }}
         - --debug

--- a/charts/fleet-agent/templates/deployment.yaml
+++ b/charts/fleet-agent/templates/deployment.yaml
@@ -48,8 +48,9 @@ spec:
         {{- end }}
         image: '{{ template "system_default_registry" . }}{{.Values.image.repository}}:{{.Values.image.tag}}'
         name: fleet-agent
-        args:
+        command:
         - fleetagent
+        args:
         {{- if .Values.debug }}
         - --debug
         - --debug-level

--- a/charts/fleet/templates/deployment.yaml
+++ b/charts/fleet/templates/deployment.yaml
@@ -120,8 +120,9 @@ spec:
         - containerPort: 8080
           name: metrics
         {{- end }}
-        args:
+        command:
         - fleetcontroller
+        args:
         {{- if $shard.id }}
         - --shard-id
         - {{ quote $shard.id }}
@@ -172,8 +173,9 @@ spec:
         image: '{{ template "system_default_registry" $ }}{{ $.Values.image.repository }}:{{ $.Values.image.tag }}'
         name: fleet-cleanup
         imagePullPolicy: "{{ $.Values.image.imagePullPolicy }}"
-        args:
+        command:
         - fleetcontroller
+        args:
         - cleanup
         {{- if $.Values.debug }}
         - --debug
@@ -239,8 +241,9 @@ spec:
         image: '{{ template "system_default_registry" $ }}{{ $.Values.image.repository }}:{{ $.Values.image.tag }}'
         name: fleet-agentmanagement
         imagePullPolicy: "{{ $.Values.image.imagePullPolicy }}"
-        args:
+        command:
         - fleetcontroller
+        args:
         - agentmanagement
         {{- if not $.Values.bootstrap.enabled }}
         - --disable-bootstrap

--- a/charts/fleet/templates/deployment.yaml
+++ b/charts/fleet/templates/deployment.yaml
@@ -120,7 +120,7 @@ spec:
         - containerPort: 8080
           name: metrics
         {{- end }}
-        command:
+        args:
         - fleetcontroller
         {{- if $shard.id }}
         - --shard-id
@@ -172,7 +172,7 @@ spec:
         image: '{{ template "system_default_registry" $ }}{{ $.Values.image.repository }}:{{ $.Values.image.tag }}'
         name: fleet-cleanup
         imagePullPolicy: "{{ $.Values.image.imagePullPolicy }}"
-        command:
+        args:
         - fleetcontroller
         - cleanup
         {{- if $.Values.debug }}
@@ -239,7 +239,7 @@ spec:
         image: '{{ template "system_default_registry" $ }}{{ $.Values.image.repository }}:{{ $.Values.image.tag }}'
         name: fleet-agentmanagement
         imagePullPolicy: "{{ $.Values.image.imagePullPolicy }}"
-        command:
+        args:
         - fleetcontroller
         - agentmanagement
         {{- if not $.Values.bootstrap.enabled }}

--- a/charts/fleet/templates/deployment_gitjob.yaml
+++ b/charts/fleet/templates/deployment_gitjob.yaml
@@ -49,8 +49,9 @@ spec:
           - containerPort: 8081
             name: metrics
           {{- end }}
-          args:
+          command:
           - fleetcontroller
+          args:
           - gitjob
           - --gitjob-image
           - "{{ template "system_default_registry" $ }}{{ $.Values.image.repository }}:{{ $.Values.image.tag }}"

--- a/charts/fleet/templates/deployment_helmops.yaml
+++ b/charts/fleet/templates/deployment_helmops.yaml
@@ -49,8 +49,9 @@ spec:
           - containerPort: 8081
             name: metrics
           {{- end }}
-          args:
+          command:
           - fleetcontroller
+          args:
           - helmops
           {{- if $.Values.debug }}
           - --debug

--- a/charts/fleet/templates/job_cleanup_clusterregistrations.yaml
+++ b/charts/fleet/templates/job_cleanup_clusterregistrations.yaml
@@ -34,9 +34,8 @@ spec:
             - ALL
           readOnlyRootFilesystem: false
           privileged: false
-        command:
-        - fleet
         args:
+        - fleet
         - cleanup
         - clusterregistration
       nodeSelector: {{ include "linux-node-selector" . | nindent 8 }}

--- a/charts/fleet/templates/job_cleanup_gitrepojobs.yaml
+++ b/charts/fleet/templates/job_cleanup_gitrepojobs.yaml
@@ -37,9 +37,8 @@ spec:
                 - ALL
               readOnlyRootFilesystem: false
               privileged: false
-            command:
-            - fleet
             args:
+            - fleet
             - cleanup
             - gitjob
           nodeSelector: {{ include "linux-node-selector" . | nindent 12 }}

--- a/charts/fleet/templates/job_migrate_gitrepo_helmrepourl.yaml
+++ b/charts/fleet/templates/job_migrate_gitrepo_helmrepourl.yaml
@@ -34,9 +34,8 @@ spec:
             - ALL
           readOnlyRootFilesystem: false
           privileged: false
-        command:
-        - fleet
         args:
+        - fleet
         - migrate
         - gitrepo-helm-url-regex
         env:

--- a/e2e/single-cluster/signals_test.go
+++ b/e2e/single-cluster/signals_test.go
@@ -2,6 +2,7 @@ package singlecluster_test
 
 import (
 	"encoding/json"
+	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -17,21 +18,24 @@ type containerLastTerminatedState struct {
 // parseTerminatedState parses the JSON output from kubectl jsonpath query.
 // Returns nil if the pod hasn't terminated yet (empty or null JSON output).
 func parseTerminatedState(jsonOutput string) (*containerLastTerminatedState, error) {
-	if jsonOutput == "" || jsonOutput == "{}" {
+	trimmed := strings.TrimSpace(jsonOutput)
+	if trimmed == "" || trimmed == "{}" || trimmed == "null" || trimmed == "<no value>" {
 		return nil, nil
 	}
 
 	var state containerLastTerminatedState
-	err := json.Unmarshal([]byte(jsonOutput), &state)
+	err := json.Unmarshal([]byte(trimmed), &state)
 	if err != nil {
 		return nil, err
 	}
 	return &state, nil
 }
 
-// waitForPodReadyAndKill waits for a pod matching the given label selector to be ready,
-// then sends SIGTERM to it.
-func waitForPodReadyAndKill(k kubectl.Command, labels string) {
+// waitForPodReadyAndTerminate waits for a pod matching the given label selector to be ready,
+// then deletes it to trigger graceful pod termination (SIGTERM).
+func waitForPodReadyAndTerminate(k kubectl.Command, labels string) string {
+	var pod string
+
 	// Wait for pod to exist and be ready before sending SIGTERM
 	Eventually(func(g Gomega) {
 		pods, err := k.Get("pod", "-l", labels, "-o", "jsonpath={.items[*].status.phase}")
@@ -40,12 +44,16 @@ func waitForPodReadyAndKill(k kubectl.Command, labels string) {
 	}).Should(Succeed())
 
 	Eventually(func(g Gomega) {
-		pod, err := k.Get("pod", "-l", labels, "-o", "jsonpath={.items[0].metadata.name}")
-		g.Expect(err).ToNot(HaveOccurred(), pod)
+		name, err := k.Get("pod", "-l", labels, "-o", "jsonpath={.items[0].metadata.name}")
+		g.Expect(err).ToNot(HaveOccurred(), name)
+		pod = strings.TrimSpace(name)
+		g.Expect(pod).ToNot(BeEmpty())
 
-		out, err := k.Run("exec", pod, "--", "kill", "1")
+		out, err := k.Run("delete", "pod", pod, "--wait=false")
 		g.Expect(err).ToNot(HaveOccurred(), out)
 	}).Should(Succeed())
+
+	return pod
 }
 
 var _ = Describe("Shuts down gracefully", func() {
@@ -53,6 +61,7 @@ var _ = Describe("Shuts down gracefully", func() {
 		k      kubectl.Command
 		ns     string
 		labels string
+		pod    string
 	)
 
 	When("the agent receives SIGTERM", func() {
@@ -62,23 +71,16 @@ var _ = Describe("Shuts down gracefully", func() {
 		})
 
 		JustBeforeEach(func() {
-			// Wait for deployment to exist and be ready before sending SIGTERM
-			Eventually(func(g Gomega) {
-				out, err := k.Get("deployment", "fleet-agent", "-o", "jsonpath={.status.readyReplicas}")
-				g.Expect(err).ToNot(HaveOccurred(), "deployment should exist")
-				g.Expect(out).ToNot(BeEmpty(), "deployment should have ready replicas")
-			}).Should(Succeed())
-
-			Eventually(func(g Gomega) {
-				out, err := k.Run("exec", "deploy/fleet-agent", "--", "kill", "1")
-				g.Expect(err).ToNot(HaveOccurred(), out)
-			}).Should(Succeed())
+			pod = waitForPodReadyAndTerminate(k, "app=fleet-agent")
 		})
 
 		It("exits gracefully", func() {
 			Eventually(func(g Gomega) {
-				out, err := k.Get("pod", "-l", "app=fleet-agent", "-o", "jsonpath={.items[0].status.containerStatuses[0].lastState.terminated}")
-				g.Expect(err).ToNot(HaveOccurred())
+				out, err := k.Get("pod", pod, "-o", "jsonpath={.status.containerStatuses[0].state.terminated}")
+				if err != nil {
+					g.Expect(strings.Contains(strings.ToLower(out), "not found")).To(BeTrue(), out)
+					return
+				}
 
 				state, err := parseTerminatedState(out)
 				g.Expect(err).ToNot(HaveOccurred())
@@ -86,6 +88,12 @@ var _ = Describe("Shuts down gracefully", func() {
 
 				g.Expect(state.ExitCode).To(Equal(0))
 				g.Expect(state.Reason).To(Equal("Completed"))
+			}).Should(Succeed())
+
+			Eventually(func(g Gomega) {
+				pods, err := k.Get("pod", "-l", "app=fleet-agent", "-o", "jsonpath={.items[*].status.phase}")
+				g.Expect(err).ToNot(HaveOccurred(), pods)
+				g.Expect(pods).To(ContainSubstring("Running"), "replacement pod should be running")
 			}).Should(Succeed())
 		})
 	})
@@ -102,17 +110,20 @@ var _ = Describe("Shuts down gracefully", func() {
 		})
 
 		JustBeforeEach(func() {
-			waitForPodReadyAndKill(k, labels)
+			pod = waitForPodReadyAndTerminate(k, labels)
 		})
 
 		It("exits gracefully", func() {
 			Eventually(func(g Gomega) {
 				out, err := k.Get(
 					"pod",
-					"-l", labels,
-					"-o", `jsonpath={.items[0].status.containerStatuses[?(@.name=="fleet-controller")].lastState.terminated}`,
+					pod,
+					"-o", `jsonpath={.status.containerStatuses[?(@.name=="fleet-controller")].state.terminated}`,
 				)
-				g.Expect(err).ToNot(HaveOccurred())
+				if err != nil {
+					g.Expect(strings.Contains(strings.ToLower(out), "not found")).To(BeTrue(), out)
+					return
+				}
 
 				state, err := parseTerminatedState(out)
 				g.Expect(err).ToNot(HaveOccurred(), out)
@@ -120,6 +131,12 @@ var _ = Describe("Shuts down gracefully", func() {
 
 				g.Expect(state.ExitCode).To(Equal(0))
 				g.Expect(state.Reason).To(Equal("Completed"))
+			}).Should(Succeed())
+
+			Eventually(func(g Gomega) {
+				pods, err := k.Get("pod", "-l", labels, "-o", "jsonpath={.items[*].status.phase}")
+				g.Expect(err).ToNot(HaveOccurred(), pods)
+				g.Expect(pods).To(ContainSubstring("Running"), "replacement pod should be running")
 			}).Should(Succeed())
 		})
 	})
@@ -132,17 +149,20 @@ var _ = Describe("Shuts down gracefully", func() {
 		})
 
 		JustBeforeEach(func() {
-			waitForPodReadyAndKill(k, labels)
+			pod = waitForPodReadyAndTerminate(k, labels)
 		})
 
 		It("exits gracefully", func() {
 			Eventually(func(g Gomega) {
 				out, err := k.Get(
 					"pod",
-					"-l", labels,
-					"-o", "jsonpath={.items[0].status.containerStatuses[0].lastState.terminated}",
+					pod,
+					"-o", "jsonpath={.status.containerStatuses[0].state.terminated}",
 				)
-				g.Expect(err).ToNot(HaveOccurred())
+				if err != nil {
+					g.Expect(strings.Contains(strings.ToLower(out), "not found")).To(BeTrue(), out)
+					return
+				}
 
 				state, err := parseTerminatedState(out)
 				g.Expect(err).ToNot(HaveOccurred())
@@ -150,6 +170,12 @@ var _ = Describe("Shuts down gracefully", func() {
 
 				g.Expect(state.ExitCode).To(Equal(0))
 				g.Expect(state.Reason).To(Equal("Completed"))
+			}).Should(Succeed())
+
+			Eventually(func(g Gomega) {
+				pods, err := k.Get("pod", "-l", labels, "-o", "jsonpath={.items[*].status.phase}")
+				g.Expect(err).ToNot(HaveOccurred(), pods)
+				g.Expect(pods).To(ContainSubstring("Running"), "replacement pod should be running")
 			}).Should(Succeed())
 		})
 	})
@@ -162,17 +188,20 @@ var _ = Describe("Shuts down gracefully", func() {
 		})
 
 		JustBeforeEach(func() {
-			waitForPodReadyAndKill(k, labels)
+			pod = waitForPodReadyAndTerminate(k, labels)
 		})
 
 		It("exits gracefully", func() {
 			Eventually(func(g Gomega) {
 				out, err := k.Get(
 					"pod",
-					"-l", labels,
-					"-o", "jsonpath={.items[0].status.containerStatuses[0].lastState.terminated}",
+					pod,
+					"-o", "jsonpath={.status.containerStatuses[0].state.terminated}",
 				)
-				g.Expect(err).ToNot(HaveOccurred())
+				if err != nil {
+					g.Expect(strings.Contains(strings.ToLower(out), "not found")).To(BeTrue(), out)
+					return
+				}
 
 				state, err := parseTerminatedState(out)
 				g.Expect(err).ToNot(HaveOccurred())
@@ -180,6 +209,12 @@ var _ = Describe("Shuts down gracefully", func() {
 
 				g.Expect(state.ExitCode).To(Equal(0))
 				g.Expect(state.Reason).To(Equal("Completed"))
+			}).Should(Succeed())
+
+			Eventually(func(g Gomega) {
+				pods, err := k.Get("pod", "-l", labels, "-o", "jsonpath={.items[*].status.phase}")
+				g.Expect(err).ToNot(HaveOccurred(), pods)
+				g.Expect(pods).To(ContainSubstring("Running"), "replacement pod should be running")
 			}).Should(Succeed())
 		})
 	})

--- a/e2e/single-cluster/signals_test.go
+++ b/e2e/single-cluster/signals_test.go
@@ -44,10 +44,11 @@ func waitForPodReadyAndTerminate(k kubectl.Command, labels string) string {
 	}).Should(Succeed())
 
 	Eventually(func(g Gomega) {
-		name, err := k.Get("pod", "-l", labels, "-o", "jsonpath={.items[0].metadata.name}")
+		name, err := k.Get("pod", "-l", labels, "-o", `jsonpath={.items[?(@.status.phase=="Running")].metadata.name}`)
 		g.Expect(err).ToNot(HaveOccurred(), name)
-		pod = strings.TrimSpace(name)
-		g.Expect(pod).ToNot(BeEmpty())
+		runningPods := strings.Fields(name)
+		g.Expect(runningPods).ToNot(BeEmpty(), name)
+		pod = runningPods[0]
 
 		out, err := k.Run("delete", "pod", pod, "--wait=false")
 		g.Expect(err).ToNot(HaveOccurred(), out)
@@ -78,7 +79,7 @@ var _ = Describe("Shuts down gracefully", func() {
 			Eventually(func(g Gomega) {
 				out, err := k.Get("pod", pod, "-o", "jsonpath={.status.containerStatuses[0].state.terminated}")
 				if err != nil {
-					g.Expect(strings.Contains(strings.ToLower(out), "not found")).To(BeTrue(), out)
+					g.Expect(strings.Contains(strings.ToLower(out), "notfound")).To(BeTrue(), out)
 					return
 				}
 
@@ -121,7 +122,7 @@ var _ = Describe("Shuts down gracefully", func() {
 					"-o", `jsonpath={.status.containerStatuses[?(@.name=="fleet-controller")].state.terminated}`,
 				)
 				if err != nil {
-					g.Expect(strings.Contains(strings.ToLower(out), "not found")).To(BeTrue(), out)
+					g.Expect(strings.Contains(strings.ToLower(out), "notfound")).To(BeTrue(), out)
 					return
 				}
 
@@ -160,7 +161,7 @@ var _ = Describe("Shuts down gracefully", func() {
 					"-o", "jsonpath={.status.containerStatuses[0].state.terminated}",
 				)
 				if err != nil {
-					g.Expect(strings.Contains(strings.ToLower(out), "not found")).To(BeTrue(), out)
+					g.Expect(strings.Contains(strings.ToLower(out), "notfound")).To(BeTrue(), out)
 					return
 				}
 
@@ -199,7 +200,7 @@ var _ = Describe("Shuts down gracefully", func() {
 					"-o", "jsonpath={.status.containerStatuses[0].state.terminated}",
 				)
 				if err != nil {
-					g.Expect(strings.Contains(strings.ToLower(out), "not found")).To(BeTrue(), out)
+					g.Expect(strings.Contains(strings.ToLower(out), "notfound")).To(BeTrue(), out)
 					return
 				}
 

--- a/e2e/testenv/infra/cmd/setup.go
+++ b/e2e/testenv/infra/cmd/setup.go
@@ -188,10 +188,14 @@ var setupCmd = &cobra.Command{
 			if externalIP == "" {
 				externalIP = waitForLoadbalancer(k, "chartmuseum-service")
 			}
+			chartMuseumURL := fmt.Sprintf("https://%s:8081", externalIP)
+			if err := waitForChartMuseumReadyEventually(chartMuseumURL); err != nil {
+				fail(err)
+			}
 
 			_ = eventually(func() (string, error) {
 				c, err := chartmuseum.NewClient(
-					chartmuseum.URL(fmt.Sprintf("https://%s:8081", externalIP)),
+					chartmuseum.URL(chartMuseumURL),
 					chartmuseum.Username(os.Getenv("CI_OCI_USERNAME")),
 					chartmuseum.Password(os.Getenv("CI_OCI_PASSWORD")),
 					chartmuseum.InsecureSkipVerify(true),
@@ -365,9 +369,64 @@ func waitForPodReady(k kubectl.Command, appName string) {
 
 func waitForLoadbalancer(k kubectl.Command, name string) string {
 	ip := eventually(func() (string, error) {
-		return k.Get("service", name, "-o", "jsonpath={.status.loadBalancer.ingress[0].ip}")
+		out, err := k.Get("service", name, "-o", "jsonpath={.status.loadBalancer.ingress[0].ip}")
+		if err != nil {
+			return "", err
+		}
+
+		value := strings.TrimSpace(out)
+		if value == "" || value == "<no value>" {
+			return "", fmt.Errorf("service %s loadBalancer ingress IP is not available yet", name)
+		}
+
+		return value, nil
 	})
 	return ip
+}
+
+func waitForChartMuseumReady(baseURL string) error {
+	addr := strings.TrimRight(baseURL, "/") + "/health"
+	client := http.Client{
+		Timeout: 5 * time.Second,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		},
+	}
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, addr, nil)
+	if err != nil {
+		return fmt.Errorf("creating ChartMuseum health request: %w", err)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("waiting for ChartMuseum health endpoint: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("waiting for ChartMuseum health endpoint: status %d", resp.StatusCode)
+	}
+
+	return nil
+}
+
+func waitForChartMuseumReadyEventually(baseURL string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), timeoutDuration)
+	defer cancel()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("timed out waiting for ChartMuseum readiness: %w", ctx.Err())
+		default:
+			if err := waitForChartMuseumReady(baseURL); err != nil {
+				time.Sleep(time.Second)
+				continue
+			}
+			return nil
+		}
+	}
 }
 
 // fail prints err and exits.

--- a/integrationtests/gitjob/controller/controller_test.go
+++ b/integrationtests/gitjob/controller/controller_test.go
@@ -111,7 +111,8 @@ var _ = Describe("GitJob controller", func() {
 			}).Should(Not(HaveOccurred()))
 
 			Expect(job.Spec.Template.Spec.Containers).To(HaveLen(1))
-			Expect(job.Spec.Template.Spec.Containers[0].Args).To(ContainElements("fleet", "apply"))
+			Expect(job.Spec.Template.Spec.Containers[0].Command).To(Equal([]string{"fleet"}))
+			Expect(job.Spec.Template.Spec.Containers[0].Args).To(ContainElements("apply"))
 
 			gitRepoOwnerRef := metav1.OwnerReference{
 				Kind:       "GitRepo",

--- a/internal/cmd/controller/gitops/reconciler/gitjob.go
+++ b/internal/cmd/controller/gitops/reconciler/gitjob.go
@@ -537,13 +537,14 @@ func (r *GitJobReconciler) newJobSpec(ctx context.Context, gitrepo *v1alpha1.Git
 				RestartPolicy:      corev1.RestartPolicyNever,
 				Containers: []corev1.Container{
 					{
-						Name:         "fleet",
-						Image:        r.Image,
-						Command:      []string{"log.sh"},
-						Args:         append(args, paths...),
-						WorkingDir:   "/workspace/source",
-						VolumeMounts: volumeMounts,
-						Env:          envs,
+						Name:                     "fleet",
+						Image:                    r.Image,
+						Command:                  []string{"tini", "--"},
+						Args:                     append(args, paths...),
+						TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
+						WorkingDir:               "/workspace/source",
+						VolumeMounts:             volumeMounts,
+						Env:                      envs,
 						SecurityContext: &corev1.SecurityContext{
 							AllowPrivilegeEscalation: &[]bool{false}[0],
 							ReadOnlyRootFilesystem:   &[]bool{true}[0],
@@ -690,12 +691,13 @@ func (r *GitJobReconciler) newGitCloner(
 	}
 
 	return corev1.Container{
-		Command:      []string{"log.sh"},
-		Args:         args,
-		Image:        r.Image,
-		Name:         "gitcloner-initializer",
-		VolumeMounts: volumeMounts,
-		Env:          env,
+		Command:                  []string{"tini", "--"},
+		Args:                     args,
+		Image:                    r.Image,
+		Name:                     "gitcloner-initializer",
+		TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
+		VolumeMounts:             volumeMounts,
+		Env:                      env,
 		SecurityContext: &corev1.SecurityContext{
 			AllowPrivilegeEscalation: &[]bool{false}[0],
 			ReadOnlyRootFilesystem:   &[]bool{true}[0],

--- a/internal/cmd/controller/gitops/reconciler/gitjob.go
+++ b/internal/cmd/controller/gitops/reconciler/gitjob.go
@@ -539,8 +539,8 @@ func (r *GitJobReconciler) newJobSpec(ctx context.Context, gitrepo *v1alpha1.Git
 					{
 						Name:                     "fleet",
 						Image:                    r.Image,
-						Command:                  []string{"tini", "--"},
-						Args:                     append(args, paths...),
+						Command:                  []string{"fleet"},
+						Args:                     append(args[1:], paths...),
 						TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 						WorkingDir:               "/workspace/source",
 						VolumeMounts:             volumeMounts,
@@ -691,8 +691,8 @@ func (r *GitJobReconciler) newGitCloner(
 	}
 
 	return corev1.Container{
-		Command:                  []string{"tini", "--"},
-		Args:                     args,
+		Command:                  []string{"fleet"},
+		Args:                     args[1:],
 		Image:                    r.Image,
 		Name:                     "gitcloner-initializer",
 		TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,

--- a/internal/cmd/controller/gitops/reconciler/gitjob_test.go
+++ b/internal/cmd/controller/gitops/reconciler/gitjob_test.go
@@ -608,9 +608,7 @@ func TestNewJob(t *testing.T) {
 			},
 			expectedInitContainers: []corev1.Container{
 				{
-					Command: []string{
-						"log.sh",
-					},
+					Command: []string{"tini", "--"},
 					Args: []string{
 						"fleet",
 						"gitcloner",
@@ -619,8 +617,9 @@ func TestNewJob(t *testing.T) {
 						"--branch",
 						"master",
 					},
-					Image: "test",
-					Name:  "gitcloner-initializer",
+					Image:                    "test",
+					Name:                     "gitcloner-initializer",
+					TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 					VolumeMounts: []corev1.VolumeMount{
 						{
 							Name:      gitClonerVolumeName,
@@ -681,9 +680,7 @@ func TestNewJob(t *testing.T) {
 			},
 			expectedInitContainers: []corev1.Container{
 				{
-					Command: []string{
-						"log.sh",
-					},
+					Command: []string{"tini", "--"},
 					Args: []string{
 						"fleet",
 						"gitcloner",
@@ -692,8 +689,9 @@ func TestNewJob(t *testing.T) {
 						"--branch",
 						"foo",
 					},
-					Image: "test",
-					Name:  "gitcloner-initializer",
+					Image:                    "test",
+					Name:                     "gitcloner-initializer",
+					TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 					VolumeMounts: []corev1.VolumeMount{
 						{
 							Name:      gitClonerVolumeName,
@@ -754,9 +752,7 @@ func TestNewJob(t *testing.T) {
 			},
 			expectedInitContainers: []corev1.Container{
 				{
-					Command: []string{
-						"log.sh",
-					},
+					Command: []string{"tini", "--"},
 					Args: []string{
 						"fleet",
 						"gitcloner",
@@ -765,8 +761,9 @@ func TestNewJob(t *testing.T) {
 						"--revision",
 						"foo",
 					},
-					Image: "test",
-					Name:  "gitcloner-initializer",
+					Image:                    "test",
+					Name:                     "gitcloner-initializer",
+					TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 					VolumeMounts: []corev1.VolumeMount{
 						{
 							Name:      gitClonerVolumeName,
@@ -827,9 +824,7 @@ func TestNewJob(t *testing.T) {
 			},
 			expectedInitContainers: []corev1.Container{
 				{
-					Command: []string{
-						"log.sh",
-					},
+					Command: []string{"tini", "--"},
 					Args: []string{
 						"fleet",
 						"gitcloner",
@@ -842,8 +837,9 @@ func TestNewJob(t *testing.T) {
 						"--password-file",
 						"/gitjob/credentials/" + corev1.BasicAuthPasswordKey,
 					},
-					Image: "test",
-					Name:  "gitcloner-initializer",
+					Image:                    "test",
+					Name:                     "gitcloner-initializer",
+					TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 					VolumeMounts: []corev1.VolumeMount{
 						{
 							Name:      gitClonerVolumeName,
@@ -927,9 +923,7 @@ func TestNewJob(t *testing.T) {
 			},
 			expectedInitContainers: []corev1.Container{
 				{
-					Command: []string{
-						"log.sh",
-					},
+					Command: []string{"tini", "--"},
 					Args: []string{
 						"fleet",
 						"gitcloner",
@@ -941,8 +935,9 @@ func TestNewJob(t *testing.T) {
 						"/gitjob/ssh/" + corev1.SSHAuthPrivateKey,
 					},
 					// FLEET_KNOWN_HOSTS not expected here as strict host key checks are disabled
-					Image: "test",
-					Name:  "gitcloner-initializer",
+					Image:                    "test",
+					Name:                     "gitcloner-initializer",
+					TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 					VolumeMounts: []corev1.VolumeMount{
 						{
 							Name:      gitClonerVolumeName,
@@ -1012,9 +1007,7 @@ func TestNewJob(t *testing.T) {
 			strictHostKeyChecks: true,
 			expectedInitContainers: []corev1.Container{
 				{
-					Command: []string{
-						"log.sh",
-					},
+					Command: []string{"tini", "--"},
 					Args: []string{
 						"fleet",
 						"gitcloner",
@@ -1035,8 +1028,9 @@ func TestNewJob(t *testing.T) {
 							Value: "some known hosts",
 						},
 					},
-					Image: "test",
-					Name:  "gitcloner-initializer",
+					Image:                    "test",
+					Name:                     "gitcloner-initializer",
+					TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 					VolumeMounts: []corev1.VolumeMount{
 						{
 							Name:      gitClonerVolumeName,
@@ -1104,9 +1098,7 @@ func TestNewJob(t *testing.T) {
 			strictHostKeyChecks: true,
 			expectedInitContainers: []corev1.Container{
 				{
-					Command: []string{
-						"log.sh",
-					},
+					Command: []string{"tini", "--"},
 					Args: []string{
 						"fleet",
 						"gitcloner",
@@ -1127,8 +1119,9 @@ func TestNewJob(t *testing.T) {
 							Value: "foo",
 						},
 					},
-					Image: "test",
-					Name:  "gitcloner-initializer",
+					Image:                    "test",
+					Name:                     "gitcloner-initializer",
+					TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 					VolumeMounts: []corev1.VolumeMount{
 						{
 							Name:      gitClonerVolumeName,
@@ -1203,9 +1196,7 @@ func TestNewJob(t *testing.T) {
 			strictHostKeyChecks: true,
 			expectedInitContainers: []corev1.Container{
 				{
-					Command: []string{
-						"log.sh",
-					},
+					Command: []string{"tini", "--"},
 					Args: []string{
 						"fleet",
 						"gitcloner",
@@ -1224,8 +1215,9 @@ func TestNewJob(t *testing.T) {
 							Value: "foo",
 						},
 					},
-					Image: "test",
-					Name:  "gitcloner-initializer",
+					Image:                    "test",
+					Name:                     "gitcloner-initializer",
+					TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 					VolumeMounts: []corev1.VolumeMount{
 						{
 							Name:      gitClonerVolumeName,
@@ -1278,9 +1270,7 @@ func TestNewJob(t *testing.T) {
 			},
 			expectedInitContainers: []corev1.Container{
 				{
-					Command: []string{
-						"log.sh",
-					},
+					Command: []string{"tini", "--"},
 					Args: []string{
 						"fleet",
 						"gitcloner",
@@ -1295,8 +1285,9 @@ func TestNewJob(t *testing.T) {
 						"--github-app-key-file",
 						"/gitjob/githubapp/github_app_private_key",
 					},
-					Image: "test",
-					Name:  "gitcloner-initializer",
+					Image:                    "test",
+					Name:                     "gitcloner-initializer",
+					TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 					VolumeMounts: []corev1.VolumeMount{
 						{
 							Name:      gitClonerVolumeName,
@@ -1378,9 +1369,7 @@ func TestNewJob(t *testing.T) {
 			},
 			expectedInitContainers: []corev1.Container{
 				{
-					Command: []string{
-						"log.sh",
-					},
+					Command: []string{"tini", "--"},
 					Args: []string{
 						"fleet",
 						"gitcloner",
@@ -1391,8 +1380,9 @@ func TestNewJob(t *testing.T) {
 						"--ca-bundle-file",
 						"/gitjob/cabundle/" + bundleCAFile,
 					},
-					Image: "test",
-					Name:  "gitcloner-initializer",
+					Image:                    "test",
+					Name:                     "gitcloner-initializer",
+					TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 					VolumeMounts: []corev1.VolumeMount{
 						{
 							Name:      gitClonerVolumeName,
@@ -1474,9 +1464,7 @@ func TestNewJob(t *testing.T) {
 			},
 			expectedInitContainers: []corev1.Container{
 				{
-					Command: []string{
-						"log.sh",
-					},
+					Command: []string{"tini", "--"},
 					Args: []string{
 						"fleet",
 						"gitcloner",
@@ -1487,8 +1475,9 @@ func TestNewJob(t *testing.T) {
 						"--ca-bundle-file",
 						"/gitjob/cabundle/" + bundleCAFile,
 					},
-					Image: "test",
-					Name:  "gitcloner-initializer",
+					Image:                    "test",
+					Name:                     "gitcloner-initializer",
+					TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 					VolumeMounts: []corev1.VolumeMount{
 						{
 							Name:      gitClonerVolumeName,
@@ -1554,7 +1543,8 @@ func TestNewJob(t *testing.T) {
 						"--cacerts-file",
 						"/etc/rancher/certs/cacerts",
 					},
-					Name: "fleet",
+					Name:                     "fleet",
+					TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 					VolumeMounts: []corev1.VolumeMount{
 						{
 							Name:      "rancher-helm-secret-cert",
@@ -1608,9 +1598,7 @@ func TestNewJob(t *testing.T) {
 			},
 			expectedInitContainers: []corev1.Container{
 				{
-					Command: []string{
-						"log.sh",
-					},
+					Command: []string{"tini", "--"},
 					Args: []string{
 						"fleet",
 						"gitcloner",
@@ -1620,8 +1608,9 @@ func TestNewJob(t *testing.T) {
 						"master",
 						"--insecure-skip-tls",
 					},
-					Image: "test",
-					Name:  "gitcloner-initializer",
+					Image:                    "test",
+					Name:                     "gitcloner-initializer",
+					TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 					VolumeMounts: []corev1.VolumeMount{
 						{
 							Name:      gitClonerVolumeName,
@@ -1643,8 +1632,9 @@ func TestNewJob(t *testing.T) {
 			},
 			expectedContainers: []corev1.Container{
 				{
-					Name: "fleet",
-					Args: []string{"--helm-insecure-skip-tls"},
+					Name:                     "fleet",
+					TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
+					Args:                     []string{"--helm-insecure-skip-tls"},
 				},
 			},
 			expectedVolumes: []corev1.Volume{
@@ -1685,9 +1675,7 @@ func TestNewJob(t *testing.T) {
 			},
 			expectedInitContainers: []corev1.Container{
 				{
-					Command: []string{
-						"log.sh",
-					},
+					Command: []string{"tini", "--"},
 					Args: []string{
 						"fleet",
 						"gitcloner",
@@ -1696,8 +1684,9 @@ func TestNewJob(t *testing.T) {
 						"--branch",
 						"master",
 					},
-					Image: "test",
-					Name:  "gitcloner-initializer",
+					Image:                    "test",
+					Name:                     "gitcloner-initializer",
+					TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 					VolumeMounts: []corev1.VolumeMount{
 						{
 							Name:      gitClonerVolumeName,

--- a/internal/cmd/controller/gitops/reconciler/gitjob_test.go
+++ b/internal/cmd/controller/gitops/reconciler/gitjob_test.go
@@ -608,9 +608,8 @@ func TestNewJob(t *testing.T) {
 			},
 			expectedInitContainers: []corev1.Container{
 				{
-					Command: []string{"tini", "--"},
+					Command: []string{"fleet"},
 					Args: []string{
-						"fleet",
 						"gitcloner",
 						"repo",
 						"/workspace",
@@ -680,9 +679,8 @@ func TestNewJob(t *testing.T) {
 			},
 			expectedInitContainers: []corev1.Container{
 				{
-					Command: []string{"tini", "--"},
+					Command: []string{"fleet"},
 					Args: []string{
-						"fleet",
 						"gitcloner",
 						"repo",
 						"/workspace",
@@ -752,9 +750,8 @@ func TestNewJob(t *testing.T) {
 			},
 			expectedInitContainers: []corev1.Container{
 				{
-					Command: []string{"tini", "--"},
+					Command: []string{"fleet"},
 					Args: []string{
-						"fleet",
 						"gitcloner",
 						"repo",
 						"/workspace",
@@ -824,9 +821,8 @@ func TestNewJob(t *testing.T) {
 			},
 			expectedInitContainers: []corev1.Container{
 				{
-					Command: []string{"tini", "--"},
+					Command: []string{"fleet"},
 					Args: []string{
-						"fleet",
 						"gitcloner",
 						"repo",
 						"/workspace",
@@ -923,9 +919,8 @@ func TestNewJob(t *testing.T) {
 			},
 			expectedInitContainers: []corev1.Container{
 				{
-					Command: []string{"tini", "--"},
+					Command: []string{"fleet"},
 					Args: []string{
-						"fleet",
 						"gitcloner",
 						"repo",
 						"/workspace",
@@ -1007,9 +1002,8 @@ func TestNewJob(t *testing.T) {
 			strictHostKeyChecks: true,
 			expectedInitContainers: []corev1.Container{
 				{
-					Command: []string{"tini", "--"},
+					Command: []string{"fleet"},
 					Args: []string{
-						"fleet",
 						"gitcloner",
 						"ssh://repo",
 						"/workspace",
@@ -1098,9 +1092,8 @@ func TestNewJob(t *testing.T) {
 			strictHostKeyChecks: true,
 			expectedInitContainers: []corev1.Container{
 				{
-					Command: []string{"tini", "--"},
+					Command: []string{"fleet"},
 					Args: []string{
-						"fleet",
 						"gitcloner",
 						"ssh://repo",
 						"/workspace",
@@ -1196,9 +1189,8 @@ func TestNewJob(t *testing.T) {
 			strictHostKeyChecks: true,
 			expectedInitContainers: []corev1.Container{
 				{
-					Command: []string{"tini", "--"},
+					Command: []string{"fleet"},
 					Args: []string{
-						"fleet",
 						"gitcloner",
 						"ssh://repo",
 						"/workspace",
@@ -1270,9 +1262,8 @@ func TestNewJob(t *testing.T) {
 			},
 			expectedInitContainers: []corev1.Container{
 				{
-					Command: []string{"tini", "--"},
+					Command: []string{"fleet"},
 					Args: []string{
-						"fleet",
 						"gitcloner",
 						"repo",
 						"/workspace",
@@ -1369,9 +1360,8 @@ func TestNewJob(t *testing.T) {
 			},
 			expectedInitContainers: []corev1.Container{
 				{
-					Command: []string{"tini", "--"},
+					Command: []string{"fleet"},
 					Args: []string{
-						"fleet",
 						"gitcloner",
 						"repo",
 						"/workspace",
@@ -1464,9 +1454,8 @@ func TestNewJob(t *testing.T) {
 			},
 			expectedInitContainers: []corev1.Container{
 				{
-					Command: []string{"tini", "--"},
+					Command: []string{"fleet"},
 					Args: []string{
-						"fleet",
 						"gitcloner",
 						"repo",
 						"/workspace",
@@ -1598,9 +1587,8 @@ func TestNewJob(t *testing.T) {
 			},
 			expectedInitContainers: []corev1.Container{
 				{
-					Command: []string{"tini", "--"},
+					Command: []string{"fleet"},
 					Args: []string{
-						"fleet",
 						"gitcloner",
 						"repo",
 						"/workspace",
@@ -1675,9 +1663,8 @@ func TestNewJob(t *testing.T) {
 			},
 			expectedInitContainers: []corev1.Container{
 				{
-					Command: []string{"tini", "--"},
+					Command: []string{"fleet"},
 					Args: []string{
-						"fleet",
 						"gitcloner",
 						"repo",
 						"/workspace",
@@ -2423,7 +2410,6 @@ func TestGitClonerSSH(t *testing.T) {
 			// The error does not matter, as known hosts checks should not be called for non-SSH repos
 			knownHostsErr: errors.New("something happened"),
 			expectedContainerArgs: []string{
-				"fleet",
 				"gitcloner",
 				"foo",
 				"/workspace",
@@ -2439,7 +2425,6 @@ func TestGitClonerSSH(t *testing.T) {
 				},
 			},
 			expectedContainerArgs: []string{
-				"fleet",
 				"gitcloner",
 				"ssh://foo",
 				"/workspace",
@@ -2455,7 +2440,6 @@ func TestGitClonerSSH(t *testing.T) {
 				},
 			},
 			expectedContainerArgs: []string{
-				"fleet",
 				"gitcloner",
 				"foo",
 				"/workspace",
@@ -2472,7 +2456,6 @@ func TestGitClonerSSH(t *testing.T) {
 			},
 			knownHostsData: "foo",
 			expectedContainerArgs: []string{
-				"fleet",
 				"gitcloner",
 				"ssh://foo",
 				"/workspace",

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -22,10 +22,9 @@ RUN set -eux; \
     echo "${TINI_SUM_arm64}  /tini-arm64" | sha256sum -c -; \
     chmod 0755 /tini-amd64 /tini-arm64
 
-FROM --platform=linux/${ARCH} registry.suse.com/bci/bci-busybox:16.0 AS base
+FROM --platform=linux/${ARCH} registry.suse.com/bci/bci-nano:16.0 AS base
 ARG ARCH
 COPY --from=tini-downloader /tini-${ARCH} /usr/bin/tini
-COPY package/log.sh /usr/bin/
 
 FROM base AS copy_docker
 ONBUILD ARG ARCH

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,30 +1,10 @@
 ARG BUILD_ENV=docker
-ARG BUILDPLATFORM
 ARG TARGETPLATFORM
 ARG TARGETARCH
 ARG ARCH=${TARGETARCH}
 
-# renovate: datasource=github-release-attachments depName=krallin/tini
-ARG TINI_VERSION=v0.19.0
-# renovate: datasource=github-release-attachments depName=krallin/tini digestVersion=v0.19.0
-ARG TINI_SUM_amd64=c5b0666b4cb676901f90dfcb37106783c5fe2077b04590973b885950611b30ee
-# renovate: datasource=github-release-attachments depName=krallin/tini digestVersion=v0.19.0
-ARG TINI_SUM_arm64=eae1d3aa50c48fb23b8cbdf4e369d0910dfc538566bfd09df89a774aa84a48b9
-
-# Download both tini binaries on the native build platform to avoid QEMU networking
-# issues when cross-building for arm64.
-FROM --platform=$BUILDPLATFORM registry.suse.com/bci/bci-busybox:16.0 AS tini-downloader
-ARG TINI_VERSION TINI_SUM_amd64 TINI_SUM_arm64
-RUN set -eux; \
-    wget -qO /tini-amd64 "https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-static-amd64"; \
-    echo "${TINI_SUM_amd64}  /tini-amd64" | sha256sum -c -; \
-    wget -qO /tini-arm64 "https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-static-arm64"; \
-    echo "${TINI_SUM_arm64}  /tini-arm64" | sha256sum -c -; \
-    chmod 0755 /tini-amd64 /tini-arm64
-
 FROM --platform=linux/${ARCH} registry.suse.com/bci/bci-nano:16.0 AS base
 ARG ARCH
-COPY --from=tini-downloader /tini-${ARCH} /usr/bin/tini
 
 FROM base AS copy_docker
 ONBUILD ARG ARCH
@@ -43,5 +23,4 @@ COPY ${TARGETPLATFORM}/fleet-linux-* /usr/bin/fleet
 
 FROM copy_${BUILD_ENV}
 USER 1000
-ENTRYPOINT ["tini", "--"]
 CMD ["fleetcontroller"]

--- a/package/Dockerfile.agent
+++ b/package/Dockerfile.agent
@@ -1,29 +1,10 @@
 ARG BUILD_ENV=docker
-ARG BUILDPLATFORM
 ARG TARGETPLATFORM
 ARG TARGETARCH
 ARG ARCH=${TARGETARCH}
 
-# renovate: datasource=github-release-attachments depName=krallin/tini
-ARG TINI_VERSION=v0.19.0
-# renovate: datasource=github-release-attachments depName=krallin/tini digestVersion=v0.19.0
-ARG TINI_SUM_amd64=c5b0666b4cb676901f90dfcb37106783c5fe2077b04590973b885950611b30ee
-# renovate: datasource=github-release-attachments depName=krallin/tini digestVersion=v0.19.0
-ARG TINI_SUM_arm64=eae1d3aa50c48fb23b8cbdf4e369d0910dfc538566bfd09df89a774aa84a48b9
-
-# Download tini binaries on the native build platform to avoid cross-build networking issues.
-FROM --platform=$BUILDPLATFORM registry.suse.com/bci/bci-busybox:16.0 AS tini-downloader
-ARG TINI_VERSION TINI_SUM_amd64 TINI_SUM_arm64
-RUN set -eux; \
-	wget -qO /tini-amd64 "https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-static-amd64"; \
-	echo "${TINI_SUM_amd64}  /tini-amd64" | sha256sum -c -; \
-	wget -qO /tini-arm64 "https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-static-arm64"; \
-	echo "${TINI_SUM_arm64}  /tini-arm64" | sha256sum -c -; \
-	chmod 0755 /tini-amd64 /tini-arm64
-
 FROM --platform=linux/${ARCH} registry.suse.com/bci/bci-nano:16.0 AS base
 ARG ARCH
-COPY --from=tini-downloader /tini-${ARCH} /usr/bin/tini
 
 FROM base AS copy_docker
 ONBUILD ARG ARCH
@@ -39,5 +20,4 @@ COPY ${TARGETPLATFORM}/fleetagent-linux-* /usr/bin/fleetagent
 
 FROM copy_${BUILD_ENV}
 USER 1000
-ENTRYPOINT ["tini", "--"]
 CMD ["fleetagent"]

--- a/package/Dockerfile.agent
+++ b/package/Dockerfile.agent
@@ -1,9 +1,29 @@
 ARG BUILD_ENV=docker
+ARG BUILDPLATFORM
 ARG TARGETPLATFORM
 ARG TARGETARCH
 ARG ARCH=${TARGETARCH}
 
-FROM --platform=linux/${ARCH} registry.suse.com/bci/bci-busybox:16.0 AS base
+# renovate: datasource=github-release-attachments depName=krallin/tini
+ARG TINI_VERSION=v0.19.0
+# renovate: datasource=github-release-attachments depName=krallin/tini digestVersion=v0.19.0
+ARG TINI_SUM_amd64=c5b0666b4cb676901f90dfcb37106783c5fe2077b04590973b885950611b30ee
+# renovate: datasource=github-release-attachments depName=krallin/tini digestVersion=v0.19.0
+ARG TINI_SUM_arm64=eae1d3aa50c48fb23b8cbdf4e369d0910dfc538566bfd09df89a774aa84a48b9
+
+# Download tini binaries on the native build platform to avoid cross-build networking issues.
+FROM --platform=$BUILDPLATFORM registry.suse.com/bci/bci-busybox:16.0 AS tini-downloader
+ARG TINI_VERSION TINI_SUM_amd64 TINI_SUM_arm64
+RUN set -eux; \
+	wget -qO /tini-amd64 "https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-static-amd64"; \
+	echo "${TINI_SUM_amd64}  /tini-amd64" | sha256sum -c -; \
+	wget -qO /tini-arm64 "https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-static-arm64"; \
+	echo "${TINI_SUM_arm64}  /tini-arm64" | sha256sum -c -; \
+	chmod 0755 /tini-amd64 /tini-arm64
+
+FROM --platform=linux/${ARCH} registry.suse.com/bci/bci-nano:16.0 AS base
+ARG ARCH
+COPY --from=tini-downloader /tini-${ARCH} /usr/bin/tini
 
 FROM base AS copy_docker
 ONBUILD ARG ARCH
@@ -19,4 +39,5 @@ COPY ${TARGETPLATFORM}/fleetagent-linux-* /usr/bin/fleetagent
 
 FROM copy_${BUILD_ENV}
 USER 1000
+ENTRYPOINT ["tini", "--"]
 CMD ["fleetagent"]

--- a/package/log.sh
+++ b/package/log.sh
@@ -1,4 +1,0 @@
-#!/bin/sh
-set -o pipefail
-env
-"$@" 2>&1 | tee /dev/termination-log


### PR DESCRIPTION
Switch the `fleet-controller` and `fleet-agent` container images from `bci-busybox` to `bci-nano` to reduce image size and CVE exposure.

Both images no longer ship `tini`. The controller and agent now run the Fleet binaries directly as PID 1, which keeps signal handling correct without an init wrapper. The original controller-side `tini` usage was only needed when `log.sh` was the entrypoint; that shell wrapper has been removed, and the remaining Fleet processes do not spawn child processes that require zombie reaping.

Because `bci-nano` has no shell, `log.sh` is removed. Gitjob containers now use `TerminationMessageFallbackToLogsOnError` to preserve failure diagnostics by surfacing container logs as the termination message on non-zero exit. Their commands now invoke `fleet` directly instead of going through `tini --`.

Also wait for the ChartMuseum health endpoint before uploading charts in the E2E test environment setup to make the process more reliable.

Refers #5407 