### PR TITLE
feat(gitrepo): announce GitRepoRestriction deprecation

### DIFF
--- a/internal/cmd/controller/gitops/reconciler/restrictions.go
+++ b/internal/cmd/controller/gitops/reconciler/restrictions.go
@@ -15,6 +15,7 @@ import (
 	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 // AuthorizeAndAssignDefaults applies restrictions from both GitRepoRestriction and
@@ -35,6 +36,12 @@ func AuthorizeAndAssignDefaults(ctx context.Context, c client.Client, gitrepo *f
 
 	if len(restrictions.Items) == 0 && len(policies.Items) == 0 {
 		return nil
+	}
+
+	if len(restrictions.Items) > 0 {
+		log.FromContext(ctx).Info(
+			"GitRepoRestriction will be removed in the next minor release (Fleet v0.18.0 / Rancher v2.17.0); All restrictions must migrate to Policy. " +
+				"See https://fleet.rancher.io/next/how-tos-for-operators/tenant-setup#_migration_from_gitreporestriction")
 	}
 
 	grr := aggregate(restrictions.Items)


### PR DESCRIPTION
GitRepoRestriction is being deprecated in favor of Policy. Seems already the case for `helmops`. With this commit we start deprecation on the next version (v2.16.0) pointing to the migration guide and announce removal from v2.17.0.

The log is gated on at least one restriction being present, so users who already moved to Policy are not warned.

Refers to #5306
