### PR TITLE
fix(ci): restrict permissions to read in workflows

### DIFF
--- a/.github/workflows/release-against-test-charts.yml
+++ b/.github/workflows/release-against-test-charts.yml
@@ -44,7 +44,7 @@ env:
   GOARCH: amd64
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   push-test-rancher-charts:

--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -11,8 +11,8 @@ on:
     - cron: '0 1 * * *'
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
+  pull-requests: read
 
 jobs:
   updatecli:


### PR DESCRIPTION
Both workflows do not use GITHUB_TOKEN, so the write permissions give overgranted access. In additional `release-against-test-charts.yml` is used as reusable workflow while the caller has excplicit `read` and as such it prevents `Test Fleet in Rancher` to run.

