### PR TITLE
Surface HelmRepoURLRegex hint in bundle errors

### DIFF
--- a/internal/bundlereader/loaddirectory.go
+++ b/internal/bundlereader/loaddirectory.go
@@ -3,6 +3,7 @@ package bundlereader
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -22,6 +23,8 @@ import (
 	"github.com/rancher/fleet/internal/helmupdater"
 	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
 )
+
+const helmRepoURLRegexUIHint = "helmRepoURLRegex is empty, so Helm credentials were not forwarded; set spec.helmRepoURLRegex to allow credential forwarding"
 
 // ignoreTree represents a tree of ignored paths (read from .fleetignore files), each node being a directory.
 // It provides a means for ignored paths to be propagated down the tree, but not between subdirectories of a same
@@ -166,7 +169,7 @@ func loadDirectory(ctx context.Context, opts loadOpts, dir directory) ([]fleet.B
 
 	files, err := GetContent(ctx, dir.base, dir.source, dir.version, dir.auth, opts.disableDepsUpdate, opts.ignoreApplyConfigs)
 	if err != nil {
-		return nil, err
+		return nil, maybeAddHelmRepoURLRegexHint(err, dir)
 	}
 
 	for name, data := range files {
@@ -188,6 +191,19 @@ func loadDirectory(ctx context.Context, opts loadOpts, dir directory) ([]fleet.B
 	}
 
 	return resources, nil
+}
+
+func maybeAddHelmRepoURLRegexHint(err error, dir directory) error {
+	if err == nil {
+		return nil
+	}
+	if !dir.strippedCredentialsForEmptyHelmRepoURLRegex {
+		return err
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return err
+	}
+	return fmt.Errorf("%w: %s", err, helmRepoURLRegexUIHint)
 }
 
 // GetContent uses fetchToDir (and Helm for OCI) to read the files from directories and servers.

--- a/internal/bundlereader/loaddirectory.go
+++ b/internal/bundlereader/loaddirectory.go
@@ -197,7 +197,7 @@ func maybeAddHelmRepoURLRegexHint(err error, dir directory) error {
 	if err == nil {
 		return nil
 	}
-	if !dir.strippedCredentialsForEmptyHelmRepoURLRegex {
+	if !dir.strippedCreds {
 		return err
 	}
 	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {

--- a/internal/bundlereader/loaddirectory_internal_test.go
+++ b/internal/bundlereader/loaddirectory_internal_test.go
@@ -14,25 +14,30 @@ import (
 func TestMaybeAddHelmRepoURLRegexHint(t *testing.T) {
 	t.Run("adds hint when credentials were stripped for empty regex", func(t *testing.T) {
 		err := errors.New("unauthorized")
-		got := maybeAddHelmRepoURLRegexHint(err, directory{strippedCredentialsForEmptyHelmRepoURLRegex: true})
+		got := maybeAddHelmRepoURLRegexHint(err, directory{strippedCreds: true})
 		require.Error(t, got)
 		require.ErrorIs(t, got, err)
 		assert.Contains(t, got.Error(), helmRepoURLRegexUIHint)
 	})
 
+	t.Run("returns nil for nil error", func(t *testing.T) {
+		got := maybeAddHelmRepoURLRegexHint(nil, directory{strippedCreds: true})
+		assert.NoError(t, got)
+	})
+
 	t.Run("keeps original error when marker is not set", func(t *testing.T) {
 		err := errors.New("unauthorized")
-		got := maybeAddHelmRepoURLRegexHint(err, directory{strippedCredentialsForEmptyHelmRepoURLRegex: false})
+		got := maybeAddHelmRepoURLRegexHint(err, directory{strippedCreds: false})
 		assert.Equal(t, err, got)
 	})
 
 	t.Run("keeps context cancellation errors unchanged", func(t *testing.T) {
-		got := maybeAddHelmRepoURLRegexHint(context.Canceled, directory{strippedCredentialsForEmptyHelmRepoURLRegex: true})
+		got := maybeAddHelmRepoURLRegexHint(context.Canceled, directory{strippedCreds: true})
 		assert.Equal(t, context.Canceled, got)
 	})
 
 	t.Run("keeps context deadline errors unchanged", func(t *testing.T) {
-		got := maybeAddHelmRepoURLRegexHint(context.DeadlineExceeded, directory{strippedCredentialsForEmptyHelmRepoURLRegex: true})
+		got := maybeAddHelmRepoURLRegexHint(context.DeadlineExceeded, directory{strippedCreds: true})
 		assert.Equal(t, context.DeadlineExceeded, got)
 	})
 }

--- a/internal/bundlereader/loaddirectory_internal_test.go
+++ b/internal/bundlereader/loaddirectory_internal_test.go
@@ -1,13 +1,41 @@
 package bundlereader
 
 import (
+	"context"
 	"encoding/base64"
+	"errors"
 	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestMaybeAddHelmRepoURLRegexHint(t *testing.T) {
+	t.Run("adds hint when credentials were stripped for empty regex", func(t *testing.T) {
+		err := errors.New("unauthorized")
+		got := maybeAddHelmRepoURLRegexHint(err, directory{strippedCredentialsForEmptyHelmRepoURLRegex: true})
+		require.Error(t, got)
+		require.ErrorIs(t, got, err)
+		assert.Contains(t, got.Error(), helmRepoURLRegexUIHint)
+	})
+
+	t.Run("keeps original error when marker is not set", func(t *testing.T) {
+		err := errors.New("unauthorized")
+		got := maybeAddHelmRepoURLRegexHint(err, directory{strippedCredentialsForEmptyHelmRepoURLRegex: false})
+		assert.Equal(t, err, got)
+	})
+
+	t.Run("keeps context cancellation errors unchanged", func(t *testing.T) {
+		got := maybeAddHelmRepoURLRegexHint(context.Canceled, directory{strippedCredentialsForEmptyHelmRepoURLRegex: true})
+		assert.Equal(t, context.Canceled, got)
+	})
+
+	t.Run("keeps context deadline errors unchanged", func(t *testing.T) {
+		got := maybeAddHelmRepoURLRegexHint(context.DeadlineExceeded, directory{strippedCredentialsForEmptyHelmRepoURLRegex: true})
+		assert.Equal(t, context.DeadlineExceeded, got)
+	})
+}
 
 func TestSplitForcedScheme(t *testing.T) {
 	tests := []struct {

--- a/internal/bundlereader/resources.go
+++ b/internal/bundlereader/resources.go
@@ -149,7 +149,7 @@ type directory struct {
 	// auth is the auth to use for the chart URL
 	auth Auth
 	// indicates auth was stripped because helmRepoURLRegex was empty
-	strippedCredentialsForEmptyHelmRepoURLRegex bool
+	strippedCreds bool
 }
 
 func addDirectory(base, customDir, defaultDir string) ([]directory, error) {
@@ -245,12 +245,12 @@ func addRemoteCharts(ctx context.Context, directories []directory, base string, 
 			}
 
 			directories = append(directories, directory{
-				prefix:  checksum(chart),
-				base:    base,
-				source:  chartURL,
-				auth:    auth,
-				version: chart.Version,
-				strippedCredentialsForEmptyHelmRepoURLRegex: strippedCredentialsForEmptyRegex,
+				prefix:        checksum(chart),
+				base:          base,
+				source:        chartURL,
+				auth:          auth,
+				version:       chart.Version,
+				strippedCreds: strippedCredentialsForEmptyRegex,
 			})
 		}
 	}

--- a/internal/bundlereader/resources.go
+++ b/internal/bundlereader/resources.go
@@ -148,6 +148,8 @@ type directory struct {
 	version string
 	// auth is the auth to use for the chart URL
 	auth Auth
+	// indicates auth was stripped because helmRepoURLRegex was empty
+	strippedCredentialsForEmptyHelmRepoURLRegex bool
 }
 
 func addDirectory(base, customDir, defaultDir string) ([]directory, error) {
@@ -222,8 +224,12 @@ func addRemoteCharts(ctx context.Context, directories []directory, base string, 
 				return nil, fmt.Errorf("failed to add auth to request for %s: %w", downloadChartError(*chart), err)
 			}
 			auth := auth // loop-scoped variable
+			strippedCredentialsForEmptyRegex := false
 			if !shouldAddAuthToRequest {
-				if !warnedOnce && helmRepoURLRegex == "" && (auth.Username != "" || auth.Password != "" || len(auth.SSHPrivateKey) > 0) {
+				if helmRepoURLRegex == "" && (auth.Username != "" || auth.Password != "" || len(auth.SSHPrivateKey) > 0) {
+					strippedCredentialsForEmptyRegex = true
+				}
+				if !warnedOnce && strippedCredentialsForEmptyRegex {
 					logrus.Warn("helmRepoURLRegex is empty: Helm credentials will not be forwarded to any repository; set spec.helmRepoURLRegex to enable credential forwarding")
 					warnedOnce = true
 				}
@@ -244,6 +250,7 @@ func addRemoteCharts(ctx context.Context, directories []directory, base string, 
 				source:  chartURL,
 				auth:    auth,
 				version: chart.Version,
+				strippedCredentialsForEmptyHelmRepoURLRegex: strippedCredentialsForEmptyRegex,
 			})
 		}
 	}

--- a/internal/bundlereader/resources_test.go
+++ b/internal/bundlereader/resources_test.go
@@ -208,7 +208,7 @@ func TestAddRemoteChartsStripsCredentials(t *testing.T) {
 	assert.Nil(t, got.SSHPrivateKey, "SSHPrivateKey must be stripped when helmRepoURLRegex is empty")
 	assert.True(t, got.BasicHTTP, "BasicHTTP must be preserved when stripping credentials")
 	assert.True(t, got.InsecureSkipVerify, "InsecureSkipVerify must be preserved when stripping credentials")
-	assert.True(t, dirs[0].strippedCredentialsForEmptyHelmRepoURLRegex, "directory should be marked when credentials are stripped due to empty helmRepoURLRegex")
+	assert.True(t, dirs[0].strippedCreds, "directory should be marked when credentials are stripped due to empty helmRepoURLRegex")
 }
 
 func TestAddRemoteChartsWarnsMissingRegex(t *testing.T) {

--- a/internal/bundlereader/resources_test.go
+++ b/internal/bundlereader/resources_test.go
@@ -208,6 +208,7 @@ func TestAddRemoteChartsStripsCredentials(t *testing.T) {
 	assert.Nil(t, got.SSHPrivateKey, "SSHPrivateKey must be stripped when helmRepoURLRegex is empty")
 	assert.True(t, got.BasicHTTP, "BasicHTTP must be preserved when stripping credentials")
 	assert.True(t, got.InsecureSkipVerify, "InsecureSkipVerify must be preserved when stripping credentials")
+	assert.True(t, dirs[0].strippedCredentialsForEmptyHelmRepoURLRegex, "directory should be marked when credentials are stripped due to empty helmRepoURLRegex")
 }
 
 func TestAddRemoteChartsWarnsMissingRegex(t *testing.T) {


### PR DESCRIPTION
Track when Helm credentials are stripped because `helmRepoURLRegex` is empty and carry that marker on the chart directory metadata.

Append an explicit guidance hint to content-loading errors for those directories so the status message shown in Rancher UI explains how to fix the configuration.

Follow up to #5316