### PR TITLE
[v0.13] Surface HelmRepoURLRegex hint in bundle errors

### DIFF
--- a/internal/bundlereader/loaddirectory.go
+++ b/internal/bundlereader/loaddirectory.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"io/fs"
 	"net/http"
@@ -23,6 +24,8 @@ import (
 	helmgetter "helm.sh/helm/v3/pkg/getter"
 	"helm.sh/helm/v3/pkg/registry"
 )
+
+const helmRepoURLRegexUIHint = "helmRepoURLRegex is empty, so Helm credentials were not forwarded; set spec.helmRepoURLRegex to allow credential forwarding"
 
 // ignoreTree represents a tree of ignored paths (read from .fleetignore files), each node being a directory.
 // It provides a means for ignored paths to be propagated down the tree, but not between subdirectories of a same
@@ -169,7 +172,7 @@ func loadDirectory(ctx context.Context, opts loadOpts, dir directory) ([]fleet.B
 
 	files, err := GetContent(ctx, dir.base, dir.source, dir.version, dir.auth, opts.disableDepsUpdate, opts.ignoreApplyConfigs)
 	if err != nil {
-		return nil, err
+		return nil, maybeAddHelmRepoURLRegexHint(err, dir)
 	}
 
 	for name, data := range files {
@@ -191,6 +194,19 @@ func loadDirectory(ctx context.Context, opts loadOpts, dir directory) ([]fleet.B
 	}
 
 	return resources, nil
+}
+
+func maybeAddHelmRepoURLRegexHint(err error, dir directory) error {
+	if err == nil {
+		return nil
+	}
+	if !dir.strippedCreds {
+		return err
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return err
+	}
+	return fmt.Errorf("%w: %s", err, helmRepoURLRegexUIHint)
 }
 
 // GetContent uses go-getter (and Helm for OCI) to read the files from directories and servers.

--- a/internal/bundlereader/loaddirectory_internal_test.go
+++ b/internal/bundlereader/loaddirectory_internal_test.go
@@ -1,0 +1,41 @@
+package bundlereader
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMaybeAddHelmRepoURLRegexHint(t *testing.T) {
+	t.Run("returns nil for nil error", func(t *testing.T) {
+		got := maybeAddHelmRepoURLRegexHint(nil, directory{})
+		require.NoError(t, got)
+	})
+
+	t.Run("adds hint when credentials were stripped for empty regex", func(t *testing.T) {
+		err := errors.New("unauthorized")
+		got := maybeAddHelmRepoURLRegexHint(err, directory{strippedCreds: true})
+		require.Error(t, got)
+		require.ErrorIs(t, got, err)
+		assert.Contains(t, got.Error(), helmRepoURLRegexUIHint)
+	})
+
+	t.Run("keeps original error when marker is not set", func(t *testing.T) {
+		err := errors.New("unauthorized")
+		got := maybeAddHelmRepoURLRegexHint(err, directory{strippedCreds: false})
+		assert.Equal(t, err, got)
+	})
+
+	t.Run("keeps context cancellation errors unchanged", func(t *testing.T) {
+		got := maybeAddHelmRepoURLRegexHint(context.Canceled, directory{strippedCreds: true})
+		assert.Equal(t, context.Canceled, got)
+	})
+
+	t.Run("keeps context deadline errors unchanged", func(t *testing.T) {
+		got := maybeAddHelmRepoURLRegexHint(context.DeadlineExceeded, directory{strippedCreds: true})
+		assert.Equal(t, context.DeadlineExceeded, got)
+	})
+}

--- a/internal/bundlereader/resources.go
+++ b/internal/bundlereader/resources.go
@@ -141,6 +141,8 @@ type directory struct {
 	version string
 	// auth is the auth to use for the chart URL
 	auth Auth
+	// indicates auth was stripped because helmRepoURLRegex was empty
+	strippedCreds bool
 }
 
 func addDirectory(base, customDir, defaultDir string) ([]directory, error) {
@@ -214,8 +216,12 @@ func addRemoteCharts(directories []directory, base string, charts []*fleet.HelmO
 			if err != nil {
 				return nil, fmt.Errorf("failed to add auth to request for %s: %w", downloadChartError(*chart), err)
 			}
+			strippedCredentialsForEmptyRegex := false
 			if !shouldAddAuthToRequest {
-				if !warnedOnce && helmRepoURLRegex == "" && (auth.Username != "" || auth.Password != "" || len(auth.SSHPrivateKey) > 0) {
+				if helmRepoURLRegex == "" && (auth.Username != "" || auth.Password != "" || len(auth.SSHPrivateKey) > 0) {
+					strippedCredentialsForEmptyRegex = true
+				}
+				if !warnedOnce && strippedCredentialsForEmptyRegex {
 					logrus.Warn("helmRepoURLRegex is empty: Helm credentials will not be forwarded to any repository; set spec.helmRepoURLRegex to enable credential forwarding")
 					warnedOnce = true
 				}
@@ -236,6 +242,7 @@ func addRemoteCharts(directories []directory, base string, charts []*fleet.HelmO
 				source:  chartURL,
 				auth:    auth,
 				version: chart.Version,
+					strippedCreds: strippedCredentialsForEmptyRegex,
 			})
 		}
 	}

--- a/internal/bundlereader/resources_test.go
+++ b/internal/bundlereader/resources_test.go
@@ -200,6 +200,7 @@ func TestAddRemoteChartsStripsCredentials(t *testing.T) {
 	dirs, err := addRemoteCharts(nil, t.TempDir(), charts, auth, "")
 	require.NoError(t, err)
 	require.Len(t, dirs, 1)
+	require.True(t, dirs[0].strippedCreds)
 
 	got := dirs[0].auth
 	assert.Empty(t, got.Username, "Username must be stripped when helmRepoURLRegex is empty")


### PR DESCRIPTION
Track when Helm credentials are stripped because `helmRepoURLRegex` is empty and carry that marker on the chart directory metadata.

Append an explicit guidance hint to content-loading errors for those directories so the status message shown in Rancher UI explains how to fix the configuration.

Refine the implementation by shortening the marker field name to `strippedCreds` while preserving its intent via comment, and add test coverage for the nil error path.

Backports #5367 