### PR TITLE
Follow-up PR to disable local agent

### DIFF
--- a/internal/cmd/controller/agentmanagement/controllers/bootstrap/bootstrap.go
+++ b/internal/cmd/controller/agentmanagement/controllers/bootstrap/bootstrap.go
@@ -77,10 +77,6 @@ func (h *handler) OnConfig(config *fleetconfig.Config) error {
 		maps.Copy(localClusterLabels, config.Bootstrap.ClusterLabels)
 	}
 
-	if config.Bootstrap.LocalAgentDisabled {
-		localClusterLabels[fleet.LocalAgentDisabledLabel] = "true"
-	}
-
 	if config.Bootstrap.Namespace == "" || config.Bootstrap.Namespace == "-" {
 		return nil
 	}

--- a/internal/cmd/controller/agentmanagement/controllers/bootstrap/bootstrap_test.go
+++ b/internal/cmd/controller/agentmanagement/controllers/bootstrap/bootstrap_test.go
@@ -22,7 +22,6 @@ func TestOnConfig_AppliesClusterLabels(t *testing.T) {
 	cases := []struct {
 		name           string
 		configLabels   map[string]string
-		agentDisabled  bool
 		expectedLabels map[string]string
 	}{
 		{
@@ -43,33 +42,6 @@ func TestOnConfig_AppliesClusterLabels(t *testing.T) {
 				"random-hash-12345": "enabled",
 			},
 		},
-		{
-			name:          "agentDisabled stamps the local-agent-disabled label",
-			agentDisabled: true,
-			expectedLabels: map[string]string{
-				"name":                        "local",
-				fleet.LocalAgentDisabledLabel: "true",
-			},
-		},
-		{
-			name:          "agentDisabled false leaves the label off",
-			agentDisabled: false,
-			expectedLabels: map[string]string{
-				"name": "local",
-			},
-		},
-		{
-			name:          "agentDisabled coexists with user-supplied clusterLabels",
-			agentDisabled: true,
-			configLabels: map[string]string{
-				"region": "eu-west-1",
-			},
-			expectedLabels: map[string]string{
-				"name":                        "local",
-				"region":                      "eu-west-1",
-				fleet.LocalAgentDisabledLabel: "true",
-			},
-		},
 	}
 
 	for _, c := range cases {
@@ -77,9 +49,8 @@ func TestOnConfig_AppliesClusterLabels(t *testing.T) {
 
 			inputConfig := &fleetconfig.Config{
 				Bootstrap: fleetconfig.Bootstrap{
-					Namespace:          "bootstrap-ns", // not empty
-					ClusterLabels:      c.configLabels,
-					LocalAgentDisabled: c.agentDisabled,
+					Namespace:     "bootstrap-ns", // not empty
+					ClusterLabels: c.configLabels,
 				},
 			}
 

--- a/internal/cmd/controller/agentmanagement/controllers/cluster/import.go
+++ b/internal/cmd/controller/agentmanagement/controllers/cluster/import.go
@@ -89,6 +89,7 @@ func RegisterImport(
 	clusters.OnChange(ctx, "import-cluster", h.OnChange)
 	fleetcontrollers.RegisterClusterStatusHandler(ctx, clusters, "Imported", "import-cluster", h.importCluster)
 	config.OnChange(ctx, h.onConfig)
+	config.OnChange(ctx, h.enqueueLocalClusterOnConfig)
 
 	clustersCache := clusters.Cache()
 	clustersCache.AddIndexer(clusterForKubeconfigSecretIndexer, func(cluster *fleet.Cluster) ([]string, error) {
@@ -160,6 +161,18 @@ func (i *importHandler) onConfig(cfg *config.Config) error {
 	return nil
 }
 
+// enqueueLocalClusterOnConfig re-evaluates the local cluster whenever the global
+// config changes, so that flipping Bootstrap.LocalAgentDisabled triggers
+// teardown (or redeploy) of its agent through importCluster. The config is
+// the single source of truth; see manageagent.LocalAgentDisabled.
+func (i *importHandler) enqueueLocalClusterOnConfig(cfg *config.Config) error {
+	if cfg == nil {
+		return nil
+	}
+	i.clusters.Enqueue(cfg.Bootstrap.Namespace, fleet.LocalClusterName)
+	return nil
+}
+
 // hasAPIServerConfigChanged checks for changes in API server URL or CA configuration, comparing the current state of
 // the cluster with cfg. However, if the cluster references a secret through its `KubeConfigSecret` field, then API
 // server URL and CA are understood to be sourced from there, hence config changes for those fields will be skipped.
@@ -196,20 +209,11 @@ func hashStatusField(field any) string {
 }
 
 // localAgentDisabled reports whether the agent must not be deployed for this
-// cluster. It only ever applies to the management (local) cluster: the
-// disabling label is honored exclusively there, so that labeling a downstream
-// cluster cannot prevent its agent from being deployed or tear it down.
+// cluster. It only ever applies to the management (local) cluster and is driven
+// by the global config, so it is honored even when the bootstrap controller is
+// disabled (e.g. under Rancher). See manageagent.LocalAgentDisabled.
 func localAgentDisabled(cluster *fleet.Cluster) bool {
-	return isLocalCluster(cluster) && cluster.Labels[fleet.LocalAgentDisabledLabel] == "true"
-}
-
-// isLocalCluster is a fast, metadata-only check that a Cluster object is the
-// management (local) cluster: it must carry the well-known name in the
-// configured bootstrap namespace, matching what the bootstrap controller
-// creates.
-func isLocalCluster(cluster *fleet.Cluster) bool {
-	return cluster.Name == fleet.LocalClusterName &&
-		cluster.Namespace == config.Get().Bootstrap.Namespace
+	return manageagent.LocalAgentDisabled(cluster)
 }
 
 // isManagementCluster confirms, with certainty, that the cluster reachable
@@ -568,17 +572,17 @@ func (i *importHandler) teardownLocalAgent(cluster *fleet.Cluster) error {
 	}
 
 	// Before deleting anything, make absolutely sure the kubeconfig points at
-	// the management cluster itself. isLocalCluster already gated us here based
-	// on metadata, but tearing down an agent is destructive, so we confirm
-	// cluster identity for real.
+	// the management cluster itself. manageagent.IsLocalCluster already gated us
+	// here based on metadata, but tearing down an agent is destructive, so we
+	// confirm cluster identity for real.
 	isLocal, err := i.isManagementCluster(kc)
 	if err != nil {
 		return err
 	}
 	if !isLocal {
 		logrus.Warnf(
-			"Cluster import for '%s/%s'. Refusing to remove agent: label %s=true is set but the cluster reached through its kubeconfig is not the management cluster",
-			cluster.Namespace, cluster.Name, fleet.LocalAgentDisabledLabel,
+			"Cluster import for '%s/%s'. Refusing to remove agent: localAgentDisabled is set but the cluster reached through its kubeconfig is not the management cluster",
+			cluster.Namespace, cluster.Name,
 		)
 		return nil
 	}
@@ -606,7 +610,7 @@ func (i *importHandler) teardownLocalAgent(cluster *fleet.Cluster) error {
 		return err
 	}
 
-	logrus.Infof("Cluster import for '%s/%s'. Removed local agent (%s=true)", cluster.Namespace, cluster.Name, fleet.LocalAgentDisabledLabel)
+	logrus.Infof("Cluster import for '%s/%s'. Removed local agent (localAgentDisabled=true)", cluster.Namespace, cluster.Name)
 	return nil
 }
 

--- a/internal/cmd/controller/agentmanagement/controllers/cluster/import.go
+++ b/internal/cmd/controller/agentmanagement/controllers/cluster/import.go
@@ -166,7 +166,7 @@ func (i *importHandler) onConfig(cfg *config.Config) error {
 // teardown (or redeploy) of its agent through importCluster. The config is
 // the single source of truth; see manageagent.LocalAgentDisabled.
 func (i *importHandler) enqueueLocalClusterOnConfig(cfg *config.Config) error {
-	if cfg == nil {
+	if cfg == nil || cfg.Bootstrap.Namespace == "" || cfg.Bootstrap.Namespace == "-" {
 		return nil
 	}
 	i.clusters.Enqueue(cfg.Bootstrap.Namespace, fleet.LocalClusterName)

--- a/internal/cmd/controller/agentmanagement/controllers/cluster/import_test.go
+++ b/internal/cmd/controller/agentmanagement/controllers/cluster/import_test.go
@@ -38,11 +38,15 @@ import (
 // isLocalCluster to recognize them.
 const localBootstrapNamespace = "fleet-local"
 
-// setLocalBootstrapConfig points config.Get().Bootstrap.Namespace at
-// localBootstrapNamespace so isLocalCluster can resolve the local cluster.
-func setLocalBootstrapConfig(t *testing.T) {
+// setLocalAgentDisabledConfig sets the bootstrap namespace and the
+// LocalAgentDisabled flag, so manageagent.LocalAgentDisabled reports the local
+// cluster's agent as disabled without relying on any label.
+func setLocalAgentDisabledConfig(t *testing.T, disabled bool) {
 	t.Helper()
-	config.Set(&config.Config{Bootstrap: config.Bootstrap{Namespace: localBootstrapNamespace}})
+	config.Set(&config.Config{Bootstrap: config.Bootstrap{
+		Namespace:          localBootstrapNamespace,
+		LocalAgentDisabled: disabled,
+	}})
 }
 
 // agentResourceObjects returns one object of every kind that the deploy path
@@ -664,140 +668,6 @@ func TestAllowedKubeConfigSecretNamespace(t *testing.T) {
 	}
 }
 
-// localCluster returns a Cluster object recognized as the management (local)
-// cluster by isLocalCluster, carrying the given labels.
-func localCluster(labels map[string]string) *fleet.Cluster {
-	return &fleet.Cluster{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      fleet.LocalClusterName,
-			Namespace: localBootstrapNamespace,
-			Labels:    labels,
-		},
-	}
-}
-
-func TestLocalAgentDisabled(t *testing.T) {
-	setLocalBootstrapConfig(t)
-
-	cases := []struct {
-		name    string
-		cluster *fleet.Cluster
-		want    bool
-	}{
-		{
-			name:    "nil labels",
-			cluster: localCluster(nil),
-			want:    false,
-		},
-		{
-			name:    "label absent",
-			cluster: localCluster(map[string]string{"name": "local"}),
-			want:    false,
-		},
-		{
-			name: "label set to true on the local cluster",
-			cluster: localCluster(map[string]string{
-				"name":                        "local",
-				fleet.LocalAgentDisabledLabel: "true",
-			}),
-			want: true,
-		},
-		{
-			// The label must only ever take effect on the management cluster:
-			// a downstream cluster carrying it (wrong namespace) must not be
-			// treated as disabled, otherwise its agent would be torn down.
-			name: "label set to true on a non-local cluster (wrong namespace)",
-			cluster: &fleet.Cluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      fleet.LocalClusterName,
-					Namespace: "some-downstream-ns",
-					Labels: map[string]string{
-						fleet.LocalAgentDisabledLabel: "true",
-					},
-				},
-			},
-			want: false,
-		},
-		{
-			name: "label set to true on a non-local cluster (wrong name)",
-			cluster: &fleet.Cluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "downstream",
-					Namespace: localBootstrapNamespace,
-					Labels: map[string]string{
-						fleet.LocalAgentDisabledLabel: "true",
-					},
-				},
-			},
-			want: false,
-		},
-		{
-			// Only the literal string "true" enables it: anything else (false,
-			// empty, "1", "yes") is treated as not-disabled so users can't
-			// accidentally disable the agent by toggling the label.
-			name:    "label set to a non-true value is treated as not disabled",
-			cluster: localCluster(map[string]string{fleet.LocalAgentDisabledLabel: "1"}),
-			want:    false,
-		},
-		{
-			name:    "label set to false",
-			cluster: localCluster(map[string]string{fleet.LocalAgentDisabledLabel: "false"}),
-			want:    false,
-		},
-	}
-
-	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
-			if got := localAgentDisabled(c.cluster); got != c.want {
-				t.Errorf("localAgentDisabled = %v, want %v", got, c.want)
-			}
-		})
-	}
-}
-
-func TestIsLocalCluster(t *testing.T) {
-	setLocalBootstrapConfig(t)
-
-	cases := []struct {
-		name    string
-		cluster *fleet.Cluster
-		want    bool
-	}{
-		{
-			name:    "correct name and namespace",
-			cluster: localCluster(nil),
-			want:    true,
-		},
-		{
-			name: "correct name, wrong namespace",
-			cluster: &fleet.Cluster{
-				ObjectMeta: metav1.ObjectMeta{Name: fleet.LocalClusterName, Namespace: "other"},
-			},
-			want: false,
-		},
-		{
-			name: "wrong name, correct namespace",
-			cluster: &fleet.Cluster{
-				ObjectMeta: metav1.ObjectMeta{Name: "downstream", Namespace: localBootstrapNamespace},
-			},
-			want: false,
-		},
-		{
-			name:    "empty cluster",
-			cluster: &fleet.Cluster{},
-			want:    false,
-		},
-	}
-
-	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
-			if got := isLocalCluster(c.cluster); got != c.want {
-				t.Errorf("isLocalCluster = %v, want %v", got, c.want)
-			}
-		})
-	}
-}
-
 func TestIsManagementCluster(t *testing.T) {
 	const kubeSystem = "kube-system"
 
@@ -867,20 +737,19 @@ func TestIsManagementCluster(t *testing.T) {
 }
 
 func TestOnChange_LocalAgentDisabledShortCircuits(t *testing.T) {
-	// A cluster carrying the local-agent-disabled label must short-circuit
-	// out of OnChange before it touches any of the controllers/caches —
-	// no ClientID generation, no clusters.Update, nothing.
+	// The local cluster, when disabled via config, must short-circuit out of
+	// OnChange before it touches any of the controllers/caches — no ClientID
+	// generation, no clusters.Update, nothing.
 	//
 	// We assert this by leaving every field of importHandler nil; reaching
 	// any of them would panic.
-	setLocalBootstrapConfig(t)
+	setLocalAgentDisabledConfig(t, true)
 	cluster := &fleet.Cluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fleet.LocalClusterName,
 			Namespace: localBootstrapNamespace,
 			Labels: map[string]string{
-				"name":                        "local",
-				fleet.LocalAgentDisabledLabel: "true",
+				"name": "local",
 			},
 		},
 		Spec: fleet.ClusterSpec{
@@ -899,7 +768,9 @@ func TestOnChange_LocalAgentDisabledShortCircuits(t *testing.T) {
 }
 
 func TestImportCluster_LocalAgentDisabled(t *testing.T) {
-	setLocalBootstrapConfig(t)
+	// The agent-disabled intent comes from config (Bootstrap.LocalAgentDisabled),
+	// not from a label on the Cluster, so it works even with --disable-bootstrap.
+	setLocalAgentDisabledConfig(t, true)
 
 	cases := map[string]struct {
 		cluster    *fleet.Cluster
@@ -914,13 +785,10 @@ func TestImportCluster_LocalAgentDisabled(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      fleet.LocalClusterName,
 					Namespace: localBootstrapNamespace,
-					Labels: map[string]string{
-						fleet.LocalAgentDisabledLabel: "true",
-					},
 				},
 				Spec: fleet.ClusterSpec{
 					// non-empty would normally drive the deploy path,
-					// but the label must skip past it.
+					// but the disabled config must skip past it.
 					KubeConfigSecret: "local-cluster",
 				},
 			},
@@ -935,9 +803,6 @@ func TestImportCluster_LocalAgentDisabled(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      fleet.LocalClusterName,
 					Namespace: localBootstrapNamespace,
-					Labels: map[string]string{
-						fleet.LocalAgentDisabledLabel: "true",
-					},
 				},
 				Spec: fleet.ClusterSpec{
 					KubeConfigSecret: "", // skips teardownLocalAgent
@@ -956,18 +821,16 @@ func TestImportCluster_LocalAgentDisabled(t *testing.T) {
 				AgentConfigChanged:      false,
 			},
 		},
-		"non-local cluster carrying the label is not disabled: status preserved, no teardown": {
-			// The disabling label only applies to the management cluster. A
-			// downstream cluster (wrong namespace) carrying it must not take the
-			// teardown/clear path: with an empty ClientID importCluster returns
-			// the status untouched, leaving the agent in place.
+		"non-local cluster is not disabled: status preserved, no teardown": {
+			// The disable behavior only applies to the management cluster. A
+			// downstream cluster (wrong namespace) must not take the
+			// teardown/clear path even while LocalAgentDisabled is set: with an
+			// empty ClientID importCluster returns the status untouched, leaving
+			// the agent in place.
 			cluster: &fleet.Cluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      fleet.LocalClusterName,
 					Namespace: "some-downstream-ns",
-					Labels: map[string]string{
-						fleet.LocalAgentDisabledLabel: "true",
-					},
 				},
 				Spec: fleet.ClusterSpec{
 					KubeConfigSecret: "downstream-kubeconfig",
@@ -999,5 +862,31 @@ func TestImportCluster_LocalAgentDisabled(t *testing.T) {
 				t.Errorf("status mismatch.\nwant: %#v\ngot:  %#v", c.wantStatus, gotStatus)
 			}
 		})
+	}
+}
+
+func TestEnqueueLocalClusterOnConfig(t *testing.T) {
+	// A config change must enqueue the local cluster (by the configured bootstrap
+	// namespace and well-known name) so importCluster re-evaluates the
+	// agent-disabled state. This is what makes the feature work without the
+	// bootstrap controller relabeling the Cluster.
+	ctrl := gomock.NewController(t)
+	clustersController := fake.NewMockControllerInterface[*fleet.Cluster, *fleet.ClusterList](ctrl)
+	clustersController.EXPECT().Enqueue(localBootstrapNamespace, fleet.LocalClusterName)
+
+	ih := importHandler{clusters: clustersController}
+	if err := ih.enqueueLocalClusterOnConfig(&config.Config{
+		Bootstrap: config.Bootstrap{Namespace: localBootstrapNamespace},
+	}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestEnqueueLocalClusterOnConfig_NilConfig(t *testing.T) {
+	// A nil config must be a no-op: importHandler.clusters is left nil so any
+	// access would panic.
+	ih := importHandler{}
+	if err := ih.enqueueLocalClusterOnConfig(nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/internal/cmd/controller/agentmanagement/controllers/manageagent/manageagent.go
+++ b/internal/cmd/controller/agentmanagement/controllers/manageagent/manageagent.go
@@ -120,7 +120,7 @@ func Register(ctx context.Context,
 }
 
 func (h *handler) onClusterStatusChange(cluster *fleet.Cluster, status fleet.ClusterStatus) (fleet.ClusterStatus, error) {
-	if SkipCluster(cluster) || cluster.Labels[fleet.LocalAgentDisabledLabel] == "true" {
+	if SkipCluster(cluster) || LocalAgentDisabled(cluster) {
 		return status, nil
 	}
 
@@ -298,7 +298,7 @@ func (h *handler) OnNamespace(key string, namespace *corev1.Namespace) (*corev1.
 	var objs []runtime.Object
 
 	for _, cluster := range clusters {
-		if SkipCluster(cluster) || cluster.Labels[fleet.LocalAgentDisabledLabel] == "true" {
+		if SkipCluster(cluster) || LocalAgentDisabled(cluster) {
 			continue
 		}
 		logrus.Infof("Update agent bundle for cluster %s/%s", cluster.Namespace, cluster.Name)
@@ -460,4 +460,22 @@ func SkipCluster(cluster *fleet.Cluster) bool {
 		return true
 	}
 	return false
+}
+
+// LocalAgentDisabled reports whether the fleet-agent must NOT be deployed to
+// this cluster. It only ever applies to the management (local) cluster and is
+// driven by the global config value Bootstrap.LocalAgentDisabled.
+func LocalAgentDisabled(cluster *fleet.Cluster) bool {
+	return IsLocalCluster(cluster) && config.Get().Bootstrap.LocalAgentDisabled
+}
+
+// IsLocalCluster is a fast, metadata-only check that a Cluster object is the
+// management (local) cluster: the well-known name in the configured bootstrap
+// namespace, matching what the bootstrap controller creates. Restricting the
+// disable behavior to this cluster ensures a downstream cluster can never have
+// its agent skipped or torn down.
+func IsLocalCluster(cluster *fleet.Cluster) bool {
+	return cluster != nil &&
+		cluster.Name == fleet.LocalClusterName &&
+		cluster.Namespace == config.Get().Bootstrap.Namespace
 }

--- a/internal/cmd/controller/agentmanagement/controllers/manageagent/manageagent_test.go
+++ b/internal/cmd/controller/agentmanagement/controllers/manageagent/manageagent_test.go
@@ -777,3 +777,101 @@ func checkRegisterAddToScheme(t *testing.T, f func(*runtime.Scheme) error) {
 		t.Fatalf("failed to add to scheme: %v", err)
 	}
 }
+
+func TestIsLocalCluster(t *testing.T) {
+	const bootstrapNS = "fleet-local"
+	config.Set(&config.Config{Bootstrap: config.Bootstrap{Namespace: bootstrapNS}})
+
+	for _, tt := range []struct {
+		name    string
+		cluster *fleet.Cluster
+		want    bool
+	}{
+		{
+			name:    "correct name and namespace",
+			cluster: &fleet.Cluster{ObjectMeta: metav1.ObjectMeta{Name: fleet.LocalClusterName, Namespace: bootstrapNS}},
+			want:    true,
+		},
+		{
+			name:    "correct name, wrong namespace",
+			cluster: &fleet.Cluster{ObjectMeta: metav1.ObjectMeta{Name: fleet.LocalClusterName, Namespace: "other"}},
+			want:    false,
+		},
+		{
+			name:    "wrong name, correct namespace",
+			cluster: &fleet.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "downstream", Namespace: bootstrapNS}},
+			want:    false,
+		},
+		{
+			name:    "empty cluster",
+			cluster: &fleet.Cluster{},
+			want:    false,
+		},
+		{
+			name:    "nil cluster",
+			cluster: nil,
+			want:    false,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsLocalCluster(tt.cluster); got != tt.want {
+				t.Errorf("IsLocalCluster = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLocalAgentDisabled(t *testing.T) {
+	const bootstrapNS = "fleet-local"
+	localCluster := &fleet.Cluster{ObjectMeta: metav1.ObjectMeta{Name: fleet.LocalClusterName, Namespace: bootstrapNS}}
+
+	for _, tt := range []struct {
+		name     string
+		disabled bool
+		cluster  *fleet.Cluster
+		want     bool
+	}{
+		{
+			// The core of the fix: the local cluster's agent is reported disabled
+			// straight from config, with no label on the Cluster object. This is
+			// what makes it work under --disable-bootstrap (Rancher).
+			name:     "local cluster, config disabled",
+			disabled: true,
+			cluster:  localCluster,
+			want:     true,
+		},
+		{
+			name:     "local cluster, config enabled",
+			disabled: false,
+			cluster:  localCluster,
+			want:     false,
+		},
+		{
+			// The disable behavior must never leak to a downstream cluster, even
+			// while the global flag is set.
+			name:     "downstream cluster, wrong namespace",
+			disabled: true,
+			cluster:  &fleet.Cluster{ObjectMeta: metav1.ObjectMeta{Name: fleet.LocalClusterName, Namespace: "downstream-ns"}},
+			want:     false,
+		},
+		{
+			name:     "downstream cluster, wrong name",
+			disabled: true,
+			cluster:  &fleet.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "downstream", Namespace: bootstrapNS}},
+			want:     false,
+		},
+		{
+			name:     "nil cluster",
+			disabled: true,
+			cluster:  nil,
+			want:     false,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			config.Set(&config.Config{Bootstrap: config.Bootstrap{Namespace: bootstrapNS, LocalAgentDisabled: tt.disabled}})
+			if got := LocalAgentDisabled(tt.cluster); got != tt.want {
+				t.Errorf("LocalAgentDisabled = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/apis/fleet.cattle.io/v1alpha1/cluster_types.go
+++ b/pkg/apis/fleet.cattle.io/v1alpha1/cluster_types.go
@@ -51,11 +51,6 @@ var (
 	// ClusterManagementLabel can be used to specify a custom cluster manager
 	ClusterManagementLabel = "fleet.cattle.io/cluster-management"
 
-	// LocalAgentDisabledLabel, when set on a Cluster, instructs the agent
-	// management import handler to skip deploying the fleet-agent and to tear
-	// down any agent already deployed. Used for the local cluster only.
-	LocalAgentDisabledLabel = "fleet.cattle.io/local-agent-disabled"
-
 	// LocalClusterName is the name of the Cluster object that represents the
 	// management (local) cluster. It is created by the bootstrap controller in
 	// the bootstrap namespace and is also used as the value of the "name" label


### PR DESCRIPTION
There was a problem when testing the code merged in https://github.com/rancher/fleet/pull/5250 in Rancher, as the implementation was using the bootstrap controller + a label in the Cluster to disable the local agent.
Rancher does not enable the boostrap controller, so that approach is only valid for Fleet standalone.

This PR is a follow-up to that approach and tracks the value using a config-driven approach this time.

## Additional Information

### Checklist

~- [ ] <!-- If applicable,--> I have updated the documentation via a pull request in the [fleet-product-docs](https://github.com/rancher/fleet-product-docs) repository.~
