### PR TITLE
Enable auto-merge in auto-bump dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -321,7 +321,8 @@ jobs:
             --ref "$target_branch" \
             -F chart=fleet \
             -F branch="$target_branch" \
-            -F multi-rc=true
+            -F multi-rc=true \
+            -F auto-merge=true
 
       - name: Dispatch to rancher/fleet-helm-charts
         env:


### PR DESCRIPTION
Pass `auto-merge=true` when triggering `Manual Trigger for Auto Bump` from `.github/workflows/release.yml` so auto-bump PRs can be merged automatically after CI succeeds.