### PR TITLE
feat(controller): prevent hot-reload of cross-version config during upgrade

### DIFF
--- a/charts/fleet/templates/configmap.yaml
+++ b/charts/fleet/templates/configmap.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: fleet-controller
+  annotations:
+    fleet.cattle.io/version: {{ .Values.image.tag | quote }}
 data:
   config: |
     {

--- a/integrationtests/agentmanagement/helpers_test.go
+++ b/integrationtests/agentmanagement/helpers_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/rancher/fleet/internal/config"
 	"github.com/rancher/fleet/internal/names"
 	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
+	"github.com/rancher/fleet/pkg/version"
 
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -81,6 +82,7 @@ func deleteNamespace(name string) {
 func newConfigMap(namespace, name string, cfg *config.Config) *corev1.ConfigMap {
 	cm, err := config.ToConfigMap(namespace, name, cfg)
 	Expect(err).NotTo(HaveOccurred())
+	cm.Annotations = map[string]string{config.VersionAnnotation: version.Version}
 	return cm
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -25,6 +25,11 @@ const (
 	AgentTLSModeStrict       = "strict"
 	AgentTLSModeSystemStore  = "system-store"
 	Key                      = "config"
+	// VersionAnnotation on the fleet-controller configmap records the Fleet
+	// version the config was rendered for, so a controller only adopts config
+	// written for its own version. The agent configmap is intentionally not
+	// annotated.
+	VersionAnnotation = "fleet.cattle.io/version"
 	// DefaultNamespace is the default for the system namespace, which
 	// contains the controller and agent
 	DefaultNamespace       = "cattle-fleet-system"
@@ -264,6 +269,15 @@ var durationConfigKeys = []string{
 }
 
 func ReadConfig(cm *v1.ConfigMap) (*Config, error) {
+	// A running controller (config != nil) ignores a ConfigMap whose version
+	// annotation is absent or differs from its own, adopting only config it can
+	// positively confirm was rendered for its version; at startup there is no
+	// config to protect, so load it regardless of version.
+	if config != nil && cm.Annotations[VersionAnnotation] != version.Version {
+		logger := log.Log.WithName("fleet-config")
+		logger.Info("skipping hot-reload because version annotation of the ConfigMap is missing or is not matched.")
+		return config, nil
+	}
 	cfg := DefaultConfig()
 	data := cm.Data[Key]
 	if len(data) == 0 {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -7,11 +7,87 @@ import (
 	. "github.com/onsi/gomega"
 
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/rancher/fleet/internal/config"
+	"github.com/rancher/fleet/pkg/version"
 )
 
 var _ = Describe("Config", func() {
+	When("the configmap on startup has no version annotation", func() {
+		It("loads config anyway", func() {
+			cfg, err := config.ReadConfig(&v1.ConfigMap{
+				Data: map[string]string{"config": `{"gitClientTimeout": "20s"}`},
+			})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(cfg.GitClientTimeout.Duration).To(Equal(20 * time.Second))
+		})
+	})
+
+	When("the fleet-controller starts up for the first time", func() {
+		It("ignores the version and loads config nevertheless", func() {
+			cfg, err := config.ReadConfig(&v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{config.VersionAnnotation: "v9.9.9"},
+				},
+				Data: map[string]string{"config": `{"gitClientTimeout": "20s"}`},
+			})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(cfg.GitClientTimeout.Duration).To(Equal(20 * time.Second))
+		})
+	})
+
+	When("a configmap is already loaded and a different-version configmap arrives", func() {
+		AfterEach(func() {
+			config.Set(nil)
+		})
+
+		It("keeps the running config and does not reload on mismatched version", func() {
+			running := config.DefaultConfig()
+			running.GitClientTimeout = metav1.Duration{Duration: 20 * time.Second}
+			config.Set(running)
+
+			cfg, err := config.ReadConfig(&v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{config.VersionAnnotation: "v9.9.9"},
+				},
+				Data: map[string]string{"config": `{"gitClientTimeout": "999s"}`},
+			})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(cfg).To(BeIdenticalTo(running))
+			Expect(cfg.GitClientTimeout.Duration).To(Equal(20 * time.Second))
+		})
+
+		It("loads new config on matched version", func() {
+			running := config.DefaultConfig()
+			running.GitClientTimeout = metav1.Duration{Duration: 20 * time.Second}
+			config.Set(running)
+
+			cfg, err := config.ReadConfig(&v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{config.VersionAnnotation: version.Version},
+				},
+				Data: map[string]string{"config": `{"gitClientTimeout": "999s"}`},
+			})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(cfg).ToNot(BeIdenticalTo(running))
+			Expect(cfg.GitClientTimeout.Duration).To(Equal(999 * time.Second))
+		})
+
+		It("keeps the running config and does not reload a configmap without a version annotation", func() {
+			running := config.DefaultConfig()
+			running.GitClientTimeout = metav1.Duration{Duration: 20 * time.Second}
+			config.Set(running)
+
+			cfg, err := config.ReadConfig(&v1.ConfigMap{
+				Data: map[string]string{"config": `{"gitClientTimeout": "999s"}`},
+			})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(cfg).To(BeIdenticalTo(running))
+			Expect(cfg.GitClientTimeout.Duration).To(Equal(20 * time.Second))
+		})
+	})
+
 	When("not having set a value for gitClientTimeout", func() {
 		It("should return the default value", func() {
 			cfg, err := config.ReadConfig(&v1.ConfigMap{Data: map[string]string{}})
@@ -23,12 +99,18 @@ var _ = Describe("Config", func() {
 		It("should return the set value", func() {
 			jsonConfig := `{"gitClientTimeout": "20s"}`
 			cfg, err := config.ReadConfig(&v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						config.VersionAnnotation: version.Version,
+					},
+				},
 				Data: map[string]string{
 					"config": jsonConfig,
 				},
 			})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(cfg.GitClientTimeout.Duration).To(Equal(20 * time.Second))
+			Expect(cfg).ToNot(Equal(config.DefaultConfig()))
 		})
 	})
 
@@ -51,9 +133,16 @@ var _ = Describe("Config", func() {
 		})
 
 		It("keeps valid keys and only defaults the invalid one", func() {
-			cfg, err := config.ReadConfig(&v1.ConfigMap{Data: map[string]string{
-				"config": `{"gitClientTimeout": "20s", "garbageCollectionInterval": "1d"}`,
-			}})
+			cfg, err := config.ReadConfig(&v1.ConfigMap{
+				Data: map[string]string{
+					"config": `{"gitClientTimeout": "20s", "garbageCollectionInterval": "1d"}`,
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						config.VersionAnnotation: version.Version,
+					},
+				},
+			})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(cfg.GitClientTimeout.Duration).To(Equal(20 * time.Second))
 			Expect(cfg.GarbageCollectionInterval.Duration).To(Equal(time.Duration(0)))
@@ -68,7 +157,14 @@ var _ = Describe("Config", func() {
 					"agentCheckinInterval": "bad",
 					"gitClientTimeout": "45s"
 				}`,
-			}})
+			},
+
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						config.VersionAnnotation: version.Version,
+					},
+				},
+			})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(cfg.AgentImage).To(Equal("my-registry/fleet-agent:v1.2.3"))
 			Expect(cfg.APIServerURL).To(Equal("https://kube.example.com:6443"))
@@ -100,7 +196,13 @@ var _ = Describe("Config", func() {
 		It("still surfaces the unmarshal error", func() {
 			cfg, err := config.ReadConfig(&v1.ConfigMap{Data: map[string]string{
 				"config": "- a\n- b\n",
-			}})
+			},
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						config.VersionAnnotation: version.Version,
+					},
+				},
+			})
 			Expect(err).To(HaveOccurred())
 			Expect(cfg).To(Equal(config.DefaultConfig()))
 		})


### PR DESCRIPTION
Refers to #3547

This PR prevents cross-version config hot-reload by:

- **Annotating the ConfigMap** with `fleet.cattle.io/version` (sourced from `.Values.image.tag` which equals the binary's `version.Version` at release). Both `fleet-controller` and `fleet-agent` ConfigMaps receive the annotation.
- **Implement version guard in `ReadConfig`**: A **running** controller (config already loaded) ignores a ConfigMap whose version annotation differs from its own `version.Version`. The result: it keeps the current config. At **startup** it loads the ConfigMap regardless of version, since there is no config to protect yet. This also means the fleet-agent (which only reads its ConfigMap at startup) is never affected by the gate.

The comparison is an exact string match. Maybe it is too strict but it can be addressed later

## Additional Information

### Testing

Unit tests in `internal/config/config_test.go` cover:

- Startup with no annotation → config loads
- Startup with mismatched version → config loads anyway
- Running controller + mismatched version → no reload, keeps current config
- Running controller + matched version → reloads new config

Manual QA:
TBD

### Checklist

- [ ] I have updated the documentation via a pull request in the [fleet-product-docs](https://github.com/rancher/fleet-product-docs) repository.