### PR TITLE
[v0.15] - apply HelmReleaseName truncation in releaseKey for GC comparison

### DIFF
--- a/internal/cmd/agent/deployer/cleanup/cleanup.go
+++ b/internal/cmd/agent/deployer/cleanup/cleanup.go
@@ -11,6 +11,7 @@ import (
 	"github.com/rancher/fleet/internal/cmd/agent/deployer/kv"
 	"github.com/rancher/fleet/internal/cmd/agent/deployer/merr"
 	"github.com/rancher/fleet/internal/helmdeployer"
+	"github.com/rancher/fleet/internal/names"
 	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
 	"github.com/rancher/fleet/pkg/durations"
 
@@ -166,7 +167,7 @@ func releaseKey(ns string, bd *fleet.BundleDeployment) string {
 	}
 
 	if bd.Spec.Options.Helm == nil || bd.Spec.Options.Helm.ReleaseName == "" {
-		return ns + "/" + bd.Name
+		return ns + "/" + names.HelmReleaseName(bd.Name)
 	}
 	return ns + "/" + bd.Spec.Options.Helm.ReleaseName
 }

--- a/internal/cmd/agent/deployer/cleanup/cleanup_test.go
+++ b/internal/cmd/agent/deployer/cleanup/cleanup_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/rancher/fleet/internal/helmdeployer"
 	"github.com/rancher/fleet/internal/mocks"
+	"github.com/rancher/fleet/internal/names"
 	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
 	"go.uber.org/mock/gomock"
 	"k8s.io/apimachinery/pkg/types"
@@ -78,6 +79,51 @@ func TestCleanupReleases(t *testing.T) {
 	mockHelmDeployer.EXPECT().ListDeployments(gomock.Any()).Return(deployedBundles, nil)
 	mockHelmDeployer.EXPECT().DeleteRelease(gomock.Any(), deployedBundles[1]).Return(nil)
 	mockHelmDeployer.EXPECT().DeleteRelease(gomock.Any(), deployedBundles[2]).Return(nil)
+
+	cleanup := New(mockClient, nil, nil, mockHelmDeployer, fleetNS, defaultNS, 1*time.Second)
+
+	err := cleanup.cleanup(context.Background(), log.FromContext(context.Background()).WithName("test"))
+
+	if err != nil {
+		t.Errorf("cleanup failed: %v", err)
+	}
+}
+
+// TestCleanupReleasesNoExplicitReleaseName verifies that a release whose name
+// was truncated by names.HelmReleaseName is not mistakenly deleted when no
+// explicit Helm.ReleaseName is configured on the bundle deployment.
+func TestCleanupReleasesNoExplicitReleaseName(t *testing.T) {
+	fleetNS := "foo"   // Used to get bundle deployments by bundle ID
+	defaultNS := "bar" // Used to compute the expected release key
+
+	// Bundle ID longer than 53 chars; the deployer truncates it via HelmReleaseName.
+	longBundleID := "gitrepo-abc123-some-app-bundle-with-a-name-that-exceeds-the-limit"
+
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	deployedBundles := []helmdeployer.DeployedBundle{
+		{
+			BundleID:    longBundleID,
+			ReleaseName: defaultNS + "/" + names.HelmReleaseName(longBundleID),
+		},
+	}
+
+	mockClient := mocks.NewMockK8sClient(mockCtrl)
+	bd := &fleet.BundleDeployment{}
+	mockClient.EXPECT().Get(gomock.Any(), types.NamespacedName{Namespace: fleetNS, Name: longBundleID}, bd).DoAndReturn(
+		func(_ context.Context, _ types.NamespacedName, bd *fleet.BundleDeployment, _ ...any) error {
+			bd.Name = longBundleID
+			bd.Spec.Options.DefaultNamespace = defaultNS // no explicit ReleaseName
+
+			return nil
+		},
+	)
+
+	mockHelmDeployer := mocks.NewMockHelmDeployer(mockCtrl)
+	mockHelmDeployer.EXPECT().NewListAction()
+	mockHelmDeployer.EXPECT().ListDeployments(gomock.Any()).Return(deployedBundles, nil)
+	// DeleteRelease must NOT be called: the release name matches.
 
 	cleanup := New(mockClient, nil, nil, mockHelmDeployer, fleetNS, defaultNS, 1*time.Second)
 


### PR DESCRIPTION
Backport of: https://github.com/rancher/fleet/pull/5302

Refers to https://github.com/rancher/fleet/issues/5362
