### PR TITLE
feat(agent): report agent version and surface version mismatch

### DIFF
--- a/charts/fleet-crd/templates/crds.yaml
+++ b/charts/fleet-crd/templates/crds.yaml
@@ -6425,6 +6425,11 @@ spec:
                         e.g. "cattle-fleet-system".
                       nullable: true
                       type: string
+                    version:
+                      description: Version is the agent's version as reported by the
+                        running agent binary.
+                      nullable: true
+                      type: string
                   type: object
                 agentAffinityHash:
                   description: 'AgentAffinityHash is a hash of the agent''s affinity

--- a/charts/fleet-crd/templates/crds.yaml
+++ b/charts/fleet-crd/templates/crds.yaml
@@ -6340,6 +6340,11 @@ spec:
                         e.g. "cattle-fleet-system".
                       nullable: true
                       type: string
+                    version:
+                      description: Version is the agent's version as reported by the
+                        running agent binary.
+                      nullable: true
+                      type: string
                   type: object
                 agentAffinityHash:
                   description: 'AgentAffinityHash is a hash of the agent''s affinity

--- a/internal/cmd/agent/clusterstatus/ticker.go
+++ b/internal/cmd/agent/clusterstatus/ticker.go
@@ -3,10 +3,13 @@ package clusterstatus
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"time"
 
 	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
 	"github.com/rancher/fleet/pkg/durations"
+	"github.com/rancher/fleet/pkg/version"
 
 	"github.com/rancher/wrangler/v3/pkg/ticker"
 
@@ -60,6 +63,7 @@ func (h *handler) Update(ctx context.Context) error {
 	agentStatus := fleet.AgentStatus{
 		LastSeen:  metav1.Now(),
 		Namespace: h.agentNamespace,
+		Version:   version.Version,
 	}
 
 	if equality.Semantic.DeepEqual(h.reported, agentStatus) {
@@ -73,15 +77,16 @@ func (h *handler) Update(ctx context.Context) error {
 		},
 	}
 
+	value, err := json.Marshal(agentStatus)
+	if err != nil {
+		return err
+	}
+
 	// Create a patch with the updated status, we avoid Get as that would
 	// need additional RBAC
-	patch := `[{"op":"add","path":"/status/agent","value":{"lastSeen":"` +
-		agentStatus.LastSeen.Format(time.RFC3339) +
-		`","namespace":"` + agentStatus.Namespace +
-		`"}}]`
+	patch := fmt.Sprintf(`[{"op":"add","path":"/status/agent","value":%s}]`, value)
 
-	err := h.client.Status().Patch(ctx, cluster, client.RawPatch(types.JSONPatchType, []byte(patch)))
-	if err != nil {
+	if err := h.client.Status().Patch(ctx, cluster, client.RawPatch(types.JSONPatchType, []byte(patch))); err != nil {
 		return err
 	}
 

--- a/internal/cmd/controller/agentmanagement/controllers/manageagent/manageagent.go
+++ b/internal/cmd/controller/agentmanagement/controllers/manageagent/manageagent.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"sort"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/sirupsen/logrus"
 
 	"github.com/rancher/fleet/internal/cmd"
@@ -24,8 +25,10 @@ import (
 	"github.com/rancher/fleet/internal/names"
 	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
 	fleetcontrollers "github.com/rancher/fleet/pkg/generated/controllers/fleet.cattle.io/v1alpha1"
+	"github.com/rancher/fleet/pkg/version"
 
 	"github.com/rancher/wrangler/v3/pkg/apply"
+	"github.com/rancher/wrangler/v3/pkg/condition"
 	corecontrollers "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
 	"github.com/rancher/wrangler/v3/pkg/relatedresource"
 	"github.com/rancher/wrangler/v3/pkg/yaml"
@@ -143,7 +146,58 @@ func (h *handler) onClusterStatusChange(cluster *fleet.Cluster, status fleet.Clu
 		h.namespaces.Enqueue(cluster.Namespace)
 	}
 
+	setAgentVersionCondition(&status, version.Version)
+
 	return status, nil
+}
+
+// setAgentVersionCondition sets the AgentVersionUpToDate condition by
+// comparing the version reported by the running agent binary against
+// controllerVersion, the version of the running fleet-controller binary.
+// The controller and agent are built and released together, so the
+// controller's own version is the version agents are expected to run,
+// independent of the configured agent image (which may be a moving tag, a
+// custom image, or otherwise not reflect the actual released version).
+//
+// The condition is informational only: it is legitimately False for a short
+// window during a rolling upgrade while downstream agents catch up to the
+// controller. It must not be fed into cluster readiness (Ready is derived
+// solely from the bundle summary, see summary.SetReadyConditions) and its
+// Reason is deliberately left unset: a Reason of "Error" would make Rancher's
+// generic condition summarizer surface routine version skew as a cluster
+// error.
+func setAgentVersionCondition(status *fleet.ClusterStatus, controllerVersion string) {
+	cond := condition.Cond(fleet.ClusterConditionAgentVersionUpToDate)
+	agentVersion := status.Agent.Version
+
+	if agentVersion == "" {
+		// Either the agent has not checked in yet, or it predates version
+		// reporting. We can't compare versions, and this handler only runs on
+		// cluster writes (no timer), so we can't reliably tell "hasn't reported
+		// yet" from "stopped reporting" either. Detecting a silent agent is the
+		// job of the WaitCheckIn state in the cluster reconciler.
+		cond.Unknown(status)
+		cond.Message(status, "agent has not reported a version")
+		return
+	}
+
+	desired, errDesired := semver.NewVersion(controllerVersion)
+	reported, errReported := semver.NewVersion(agentVersion)
+	if errDesired != nil || errReported != nil {
+		// Unstamped builds report "dev"; neither side can be compared then.
+		cond.Unknown(status)
+		cond.Message(status, fmt.Sprintf("cannot compare agent version %q to controller version %q", agentVersion, controllerVersion))
+		return
+	}
+
+	if reported.Equal(desired) {
+		cond.True(status)
+		cond.Message(status, "")
+		return
+	}
+
+	cond.False(status)
+	cond.Message(status, fmt.Sprintf("agent version %s does not match controller version %s", agentVersion, controllerVersion))
 }
 
 func hashStatusField(field any) (string, error) {

--- a/internal/cmd/controller/agentmanagement/controllers/manageagent/manageagent.go
+++ b/internal/cmd/controller/agentmanagement/controllers/manageagent/manageagent.go
@@ -14,6 +14,8 @@ import (
 	"fmt"
 	"sort"
 
+	"github.com/Masterminds/semver/v3"
+
 	"github.com/rancher/fleet/internal/cmd"
 	"github.com/rancher/fleet/internal/cmd/controller/agentmanagement/agent"
 	"github.com/rancher/fleet/internal/cmd/controller/agentmanagement/scheduling"
@@ -22,9 +24,11 @@ import (
 	"github.com/rancher/fleet/internal/names"
 	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
 	fleetcontrollers "github.com/rancher/fleet/pkg/generated/controllers/fleet.cattle.io/v1alpha1"
+	"github.com/rancher/fleet/pkg/version"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/rancher/wrangler/v3/pkg/apply"
+	"github.com/rancher/wrangler/v3/pkg/condition"
 	corecontrollers "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
 	"github.com/rancher/wrangler/v3/pkg/relatedresource"
 	"github.com/rancher/wrangler/v3/pkg/yaml"
@@ -141,7 +145,73 @@ func (h *handler) onClusterStatusChange(cluster *fleet.Cluster, status fleet.Clu
 		h.namespaces.Enqueue(cluster.Namespace)
 	}
 
+	setAgentVersionCondition(&status, version.Version)
+
 	return status, nil
+}
+
+// setAgentVersionCondition sets the AgentVersionUpToDate condition by
+// comparing the version reported by the running agent binary against
+// controllerVersion, the version of the running fleet-controller binary.
+// The controller and agent are built and released together, so the
+// controller's own version is the version agents are expected to run,
+// independent of the configured agent image (which may be a moving tag, a
+// custom image, or otherwise not reflect the actual released version).
+//
+// A checked-in agent that reports no version is treated as outdated (False):
+// every version-reporting agent writes its version alongside LastSeen, so an
+// empty version can only mean the agent predates version reporting. An agent
+// that has never checked in stays Unknown, and versions that cannot be parsed
+// as semver ("dev" builds, custom tags) are Unknown as well.
+//
+// The condition is informational only: it is legitimately False for a short
+// window during a rolling upgrade while downstream agents catch up to the
+// controller, and False for outdated agents that predate version reporting. It must not be fed into cluster readiness (Ready is derived
+// solely from the bundle summary, see summary.SetReadyConditions) and its
+// Reason is deliberately left unset: a Reason of "Error" would make Rancher's
+// generic condition summarizer surface routine version skew as a cluster
+// error.
+func setAgentVersionCondition(status *fleet.ClusterStatus, controllerVersion string) {
+	cond := condition.Cond(fleet.ClusterConditionAgentVersionUpToDate)
+	agentVersion := status.Agent.Version
+
+	if agentVersion == "" {
+		if status.Agent.LastSeen.IsZero() {
+			// The agent has never checked in; there is nothing to compare yet.
+			// Detecting an agent that has checked in before but has since gone
+			// silent is the job of the WaitCheckIn state in the cluster
+			// reconciler, not this write-triggered handler.
+			cond.Unknown(status)
+			cond.Message(status, "agent has not reported a version yet")
+			return
+		}
+		// The agent has checked in but reports no version. Every version-
+		// reporting agent writes its version alongside LastSeen in the same
+		// status patch, and version.Version defaults to "dev" rather than "",
+		// so an empty version on a checked-in agent can only mean the agent
+		// predates version reporting and is therefore outdated.
+		cond.False(status)
+		cond.Message(status, "agent is checking in but does not report a version; it predates version reporting and is outdated")
+		return
+	}
+
+	desired, errDesired := semver.NewVersion(controllerVersion)
+	reported, errReported := semver.NewVersion(agentVersion)
+	if errDesired != nil || errReported != nil {
+		// Unstamped builds report "dev"; neither side can be compared then.
+		cond.Unknown(status)
+		cond.Message(status, fmt.Sprintf("cannot compare agent version %q to controller version %q", agentVersion, controllerVersion))
+		return
+	}
+
+	if reported.Equal(desired) {
+		cond.True(status)
+		cond.Message(status, "")
+		return
+	}
+
+	cond.False(status)
+	cond.Message(status, fmt.Sprintf("agent version %s does not match controller version %s", agentVersion, controllerVersion))
 }
 
 func hashStatusField(field any) (string, error) {

--- a/internal/cmd/controller/agentmanagement/controllers/manageagent/manageagent_test.go
+++ b/internal/cmd/controller/agentmanagement/controllers/manageagent/manageagent_test.go
@@ -2,10 +2,12 @@ package manageagent
 
 import (
 	"maps"
+	"os"
 	"reflect"
 	"strings"
 	"testing"
 
+	"github.com/rancher/wrangler/v3/pkg/condition"
 	"github.com/rancher/wrangler/v3/pkg/generic/fake"
 	"github.com/rancher/wrangler/v3/pkg/schemes"
 	"go.uber.org/mock/gomock"
@@ -21,6 +23,13 @@ import (
 
 	"github.com/rancher/fleet/internal/config"
 )
+
+func TestMain(m *testing.M) {
+	// onClusterStatusChange reads the config (via reconcileAgentEnvVars and
+	// updateClusterStatus), which panics if it has not been set.
+	config.Set(config.DefaultConfig())
+	os.Exit(m.Run())
+}
 
 func TestOnClusterChangeAffinity(t *testing.T) {
 	ctrl := gomock.NewController(t)
@@ -765,6 +774,74 @@ func TestSkipCluster(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := SkipCluster(tt.cluster); got != tt.want {
 				t.Fatalf("SkipCluster() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSetAgentVersionCondition(t *testing.T) {
+	for _, tt := range []struct {
+		name              string
+		agentVersion      string
+		controllerVersion string
+		expectedStatus    corev1.ConditionStatus
+		expectedMessage   string
+	}{
+		{
+			name:              "matching versions",
+			agentVersion:      "v0.14.0",
+			controllerVersion: "v0.14.0",
+			expectedStatus:    corev1.ConditionTrue,
+		},
+		{
+			name:              "matching versions without v prefix on one side",
+			agentVersion:      "0.14.0",
+			controllerVersion: "v0.14.0",
+			expectedStatus:    corev1.ConditionTrue,
+		},
+		{
+			name:              "outdated agent",
+			agentVersion:      "v0.13.2",
+			controllerVersion: "v0.14.0",
+			expectedStatus:    corev1.ConditionFalse,
+			expectedMessage:   "agent version v0.13.2 does not match controller version v0.14.0",
+		},
+		{
+			name:              "no version reported",
+			controllerVersion: "v0.14.0",
+			expectedStatus:    corev1.ConditionUnknown,
+			expectedMessage:   "agent has not reported a version",
+		},
+		{
+			name:              "unstamped agent build",
+			agentVersion:      "dev",
+			controllerVersion: "v0.14.0",
+			expectedStatus:    corev1.ConditionUnknown,
+			expectedMessage:   `cannot compare agent version "dev" to controller version "v0.14.0"`,
+		},
+		{
+			name:              "unstamped controller build",
+			agentVersion:      "v0.14.0",
+			controllerVersion: "dev",
+			expectedStatus:    corev1.ConditionUnknown,
+			expectedMessage:   `cannot compare agent version "v0.14.0" to controller version "dev"`,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			status := fleet.ClusterStatus{
+				Agent: fleet.AgentStatus{
+					Version: tt.agentVersion,
+				},
+			}
+
+			setAgentVersionCondition(&status, tt.controllerVersion)
+
+			cond := condition.Cond(fleet.ClusterConditionAgentVersionUpToDate)
+			if got := cond.GetStatus(&status); got != string(tt.expectedStatus) {
+				t.Errorf("condition status = %q, want %q", got, tt.expectedStatus)
+			}
+			if got := cond.GetMessage(&status); got != tt.expectedMessage {
+				t.Errorf("condition message = %q, want %q", got, tt.expectedMessage)
 			}
 		})
 	}

--- a/internal/cmd/controller/agentmanagement/controllers/manageagent/manageagent_test.go
+++ b/internal/cmd/controller/agentmanagement/controllers/manageagent/manageagent_test.go
@@ -2,10 +2,12 @@ package manageagent
 
 import (
 	"maps"
+	"os"
 	"reflect"
 	"strings"
 	"testing"
 
+	"github.com/rancher/wrangler/v3/pkg/condition"
 	"github.com/rancher/wrangler/v3/pkg/generic/fake"
 	"github.com/rancher/wrangler/v3/pkg/schemes"
 	"go.uber.org/mock/gomock"
@@ -21,6 +23,13 @@ import (
 
 	"github.com/rancher/fleet/internal/config"
 )
+
+func TestMain(m *testing.M) {
+	// onClusterStatusChange reads the config (via reconcileAgentEnvVars and
+	// updateClusterStatus), which panics if it has not been set.
+	config.Set(config.DefaultConfig())
+	os.Exit(m.Run())
+}
 
 func TestOnClusterChangeAffinity(t *testing.T) {
 	ctrl := gomock.NewController(t)
@@ -765,6 +774,83 @@ func TestSkipCluster(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := SkipCluster(tt.cluster); got != tt.want {
 				t.Fatalf("SkipCluster() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSetAgentVersionCondition(t *testing.T) {
+	for _, tt := range []struct {
+		name              string
+		agentVersion      string
+		lastSeen          metav1.Time
+		controllerVersion string
+		expectedStatus    corev1.ConditionStatus
+		expectedMessage   string
+	}{
+		{
+			name:              "matching versions",
+			agentVersion:      "v0.14.0",
+			controllerVersion: "v0.14.0",
+			expectedStatus:    corev1.ConditionTrue,
+		},
+		{
+			name:              "matching versions without v prefix on one side",
+			agentVersion:      "0.14.0",
+			controllerVersion: "v0.14.0",
+			expectedStatus:    corev1.ConditionTrue,
+		},
+		{
+			name:              "outdated agent",
+			agentVersion:      "v0.13.2",
+			controllerVersion: "v0.14.0",
+			expectedStatus:    corev1.ConditionFalse,
+			expectedMessage:   "agent version v0.13.2 does not match controller version v0.14.0",
+		},
+		{
+			name:              "no version reported and no check-in yet",
+			controllerVersion: "v0.14.0",
+			expectedStatus:    corev1.ConditionUnknown,
+			expectedMessage:   "agent has not reported a version yet",
+		},
+		{
+			name:              "checked in but reports no version",
+			lastSeen:          metav1.Now(),
+			controllerVersion: "v0.14.0",
+			expectedStatus:    corev1.ConditionFalse,
+			expectedMessage:   "agent is checking in but does not report a version; it predates version reporting and is outdated",
+		},
+		{
+			name:              "unstamped agent build",
+			agentVersion:      "dev",
+			controllerVersion: "v0.14.0",
+			expectedStatus:    corev1.ConditionUnknown,
+			expectedMessage:   `cannot compare agent version "dev" to controller version "v0.14.0"`,
+		},
+		{
+			name:              "unstamped controller build",
+			agentVersion:      "v0.14.0",
+			controllerVersion: "dev",
+			expectedStatus:    corev1.ConditionUnknown,
+			expectedMessage:   `cannot compare agent version "v0.14.0" to controller version "dev"`,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			status := fleet.ClusterStatus{
+				Agent: fleet.AgentStatus{
+					Version:  tt.agentVersion,
+					LastSeen: tt.lastSeen,
+				},
+			}
+
+			setAgentVersionCondition(&status, tt.controllerVersion)
+
+			cond := condition.Cond(fleet.ClusterConditionAgentVersionUpToDate)
+			if got := cond.GetStatus(&status); got != string(tt.expectedStatus) {
+				t.Errorf("condition status = %q, want %q", got, tt.expectedStatus)
+			}
+			if got := cond.GetMessage(&status); got != tt.expectedMessage {
+				t.Errorf("condition message = %q, want %q", got, tt.expectedMessage)
 			}
 		})
 	}

--- a/pkg/apis/fleet.cattle.io/v1alpha1/cluster_types.go
+++ b/pkg/apis/fleet.cattle.io/v1alpha1/cluster_types.go
@@ -19,6 +19,14 @@ var (
 	// ClusterConditionProcessed indicates that the status fields have been
 	// processed.
 	ClusterConditionProcessed = "Processed"
+	// ClusterConditionAgentVersionUpToDate indicates whether the downstream
+	// agent runs the same version as the fleet-controller. The controller and
+	// agent are built and released together, so the controller compares its
+	// own binary version against the version reported by the running agent
+	// binary (independent of the configured agent image, which may be a moving
+	// tag or a custom image). It is Unknown when either side does not report a
+	// comparable version, e.g. for unstamped "dev" builds.
+	ClusterConditionAgentVersionUpToDate = "AgentVersionUpToDate"
 	// ClusterNamespaceAnnotation used on a cluster namespace to refer to
 	// the cluster registration namespace, which contains the cluster
 	// resource.
@@ -306,4 +314,8 @@ type AgentStatus struct {
 	// +nullable
 	// +optional
 	Namespace string `json:"namespace"`
+	// Version is the agent's version as reported by the running agent binary.
+	// +nullable
+	// +optional
+	Version string `json:"version,omitempty"`
 }

--- a/pkg/apis/fleet.cattle.io/v1alpha1/cluster_types.go
+++ b/pkg/apis/fleet.cattle.io/v1alpha1/cluster_types.go
@@ -19,6 +19,14 @@ var (
 	// ClusterConditionProcessed indicates that the status fields have been
 	// processed.
 	ClusterConditionProcessed = "Processed"
+	// ClusterConditionAgentVersionUpToDate indicates whether the downstream
+	// agent runs the same version as the fleet-controller. The controller and
+	// agent are built and released together, so the controller compares its
+	// own binary version against the version reported by the running agent
+	// binary (independent of the configured agent image, which may be a moving
+	// tag or a custom image). It is Unknown when either side does not report a
+	// comparable version, e.g. for unstamped "dev" builds.
+	ClusterConditionAgentVersionUpToDate = "AgentVersionUpToDate"
 	// ClusterNamespaceAnnotation used on a cluster namespace to refer to
 	// the cluster registration namespace, which contains the cluster
 	// resource.
@@ -301,4 +309,8 @@ type AgentStatus struct {
 	// +nullable
 	// +optional
 	Namespace string `json:"namespace"`
+	// Version is the agent's version as reported by the running agent binary.
+	// +nullable
+	// +optional
+	Version string `json:"version,omitempty"`
 }


### PR DESCRIPTION
## report agent version and surface version mismatch as a cluster condition

The agent reports its binary version in AgentStatus on every check-in. The controller compares it against its own binary version and sets an AgentVersionUpToDate condition on the Cluster resource, making version drift visible without having to inspect pods directly. The controller and agent are built and released together, so the controller's own version is the version agents are expected to run, independent of the configured agent image (which may be a moving tag, a custom image, or otherwise not reflect the actual released version).

Versions that cannot be compared as semver (unstamped "dev" builds) result in Unknown. An agent that has checked in but reports no version is marked outdated (False): every version-reporting agent writes its version alongside LastSeen, so an empty version can only mean the agent predates version reporting. An agent that has never checked in stays Unknown. Detecting an agent that checked in before but has since gone silent is the job of the WaitCheckIn state in the cluster reconciler, not this write-triggered handler.

The condition is informational only. It is legitimately False for a short window during a rolling upgrade while downstream agents catch up to the controller, so it must not feed cluster readiness (Ready is derived solely from the bundle summary), and its Reason is deliberately left unset to keep Rancher's condition summarizer from surfacing routine version skew as a cluster error.

<!-- Specify the issue ID that this pull request is solving -->
Refers to #4813
<!-- Make sure that the referenced issue provides steps to reproduce it -->

<!-- Describe the changes introduced by this pull request -->

<!--
  Please provide a unit, integration (`./integrationtests/`) or e2e (`./e2e/`) test if possible.
-->

## Additional Information

### Checklist

- [ ] <!-- If applicable,--> I have updated the documentation via a pull request in the [fleet-product-docs](https://github.com/rancher/fleet-product-docs) repository.
