### PR TITLE
test(gitcloner): drop network-dependent capability detection tests

### DIFF
--- a/internal/cmd/cli/gitcloner/submodule/capability/discovery_test.go
+++ b/internal/cmd/cli/gitcloner/submodule/capability/discovery_test.go
@@ -244,6 +244,11 @@ func TestDetect_Success(t *testing.T) {
 	if caps.AllowTipSHA1InWant {
 		t.Error("expected AllowTipSHA1InWant to be false")
 	}
+
+	// End-to-end: a shallow, reachable-SHA-capable server yields StrategyShallowSHA.
+	if got := detector.ChooseStrategy(caps); got != StrategyShallowSHA {
+		t.Errorf("got strategy %s, want %s", got, StrategyShallowSHA)
+	}
 }
 
 func TestDetect_SessionFactoryError(t *testing.T) {
@@ -350,61 +355,4 @@ func TestNewCapabilityDetectorWithFactory(t *testing.T) {
 	if detector.factory != factory {
 		t.Error("factory not set correctly")
 	}
-}
-
-func TestDetect_GitHub(t *testing.T) {
-	detector := NewCapabilityDetector()
-
-	caps, err := detector.Detect("https://github.com/go-git/go-git", nil)
-	if err != nil {
-		t.Fatalf("Detect failed: %v", err)
-	}
-
-	// GitHub supports shallow clones
-	if !caps.Shallow {
-		t.Error("expected GitHub to support shallow clones")
-	}
-
-	t.Logf("GitHub capabilities: AllowReachableSHA1InWant=%v, AllowTipSHA1InWant=%v, Shallow=%v",
-		caps.AllowReachableSHA1InWant,
-		caps.AllowTipSHA1InWant,
-		caps.Shallow,
-	)
-
-	strategy := detector.ChooseStrategy(caps)
-	t.Logf("Chosen strategy: %s", strategy)
-}
-
-func TestDetect_GitLab(t *testing.T) {
-	detector := NewCapabilityDetector()
-
-	caps, err := detector.Detect("https://gitlab.com/gitlab-org/gitlab", nil)
-	if err != nil {
-		t.Fatalf("Detect failed: %v", err)
-	}
-
-	// GitLab supports shallow clones
-	if !caps.Shallow {
-		t.Error("expected GitLab to support shallow clones")
-	}
-
-	t.Logf("GitLab capabilities: AllowReachableSHA1InWant=%v, AllowTipSHA1InWant=%v, Shallow=%v",
-		caps.AllowReachableSHA1InWant,
-		caps.AllowTipSHA1InWant,
-		caps.Shallow,
-	)
-
-	strategy := detector.ChooseStrategy(caps)
-	t.Logf("Chosen strategy: %s", strategy)
-}
-
-func TestDetect_InvalidURL(t *testing.T) {
-	detector := NewCapabilityDetector()
-
-	_, err := detector.Detect("https://nonexistent.invalid/repo", nil)
-	if err == nil {
-		t.Error("expected error for invalid URL")
-	}
-
-	t.Logf("Expected error: %v", err)
 }


### PR DESCRIPTION
TestDetect_GitHub, TestDetect_GitLab and TestDetect_InvalidURL made live git-upload-pack/DNS requests and were flaky under rate limiting, so they did not belong in the unit-test suite.

The detection logic they exercised is already covered hermetically by the mock-based TestDetect_Success and the error-path tests. Extend TestDetect_Success with a ChooseStrategy assertion so the end-to-end Detect -> ChooseStrategy flow stays covered without touching the network.

<!-- Specify the issue ID that this pull request is solving -->

<!-- Make sure that the referenced issue provides steps to reproduce it -->

<!-- Describe the changes introduced by this pull request -->

<!--
  Please provide a unit, integration (`./integrationtests/`) or e2e (`./e2e/`) test if possible.
-->

## Additional Information

### Checklist

- [ ] <!-- If applicable,--> I have updated the documentation via a pull request in the [fleet-product-docs](https://github.com/rancher/fleet-product-docs) repository.
