### PR TITLE
feat(webhook): warn on unauthenticated webhook calls

### DIFF
--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -150,6 +150,18 @@ func (w *Webhook) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 						w.logAndReturn(rw, err)
 						return
 					}
+				} else {
+					w.log.Info(
+						"Warning: unauthenticated webhook call accepted",
+						"gitrepo", gitrepo.Name,
+						"namespace", gitrepo.Namespace,
+					)
+					// see #5297
+					w.log.Info(
+						"Support for unauthenticated webhooks is a security risk and therefore deprecated. It will be removed in a future release. Configure GitRepo.spec.webhookSecret or create the global \"gitjob-webhook\" secret to authenticate this GitRepo.",
+						"gitrepo", gitrepo.Name,
+						"namespace", gitrepo.Namespace,
+					)
 				}
 
 				var gitRepoFromCluster fleet.GitRepo


### PR DESCRIPTION
Emit a log the moment Fleet acts on unauthenticate call, so operators
can get notified and secure the affected repos beforehand.

The log sits in the no-secret branch of an actual new-revision sync, and maps
one-to-one to the repos that need attention. It records only the
GitRepo name and namespace.

Refers to #5298
