### PR TITLE
fix(webhook): evaluate SSH URLs from webhook payloads

### DIFF
--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -116,6 +116,9 @@ func (w *Webhook) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 		}
 		seen[key] = struct{}{}
 
+		if u.EscapedPath() == "" {
+			continue
+		}
 		path := strings.Replace(regexp.QuoteMeta(u.EscapedPath()[1:]), `/_git/`, `(/_git)?/`, 1)
 		regexpStr := `(?i)(http://|https://|\w+@|ssh://(\w+@)?|git@(ssh\.)?)` + regexp.QuoteMeta(u.Hostname()) +
 			"(:[0-9]+|)[:/](v\\d/)?" + path + "(\\.git)?$"

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -99,22 +99,17 @@ func (w *Webhook) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// A payload can yield several URLs (e.g. a web URL and an SSH URL) that
-	// resolve to the same host and path, most commonly when the SSH host equals
-	// the web host (github.com). Track those with `seen` so a matching GitRepo is
-	// processed once per request instead of letting it be processed repeatedly.
-	seen := make(map[string]struct{}, len(repoURLs))
+	// A payload can yield several URLs (e.g. a web URL and an SSH URL), and more
+	// than one can match the same GitRepo (most commonly when the SSH host equals
+	// the web host, github.com). Track the GitRepos already updated in `seen` so
+	// each is processed once per request, no matter how many URLs resolve to it.
+	seen := make(map[types.NamespacedName]struct{})
 	for _, repo := range repoURLs {
 		u, err := url.Parse(repo)
 		if err != nil {
 			w.logAndReturn(rw, err)
 			return
 		}
-		key := u.Hostname() + "\x00" + u.EscapedPath()
-		if _, ok := seen[key]; ok {
-			continue
-		}
-		seen[key] = struct{}{}
 
 		if u.EscapedPath() == "" {
 			continue
@@ -128,6 +123,10 @@ func (w *Webhook) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 			return
 		}
 		for _, gitrepo := range gitRepoList.Items {
+			gitrepoResource := types.NamespacedName{Namespace: gitrepo.Namespace, Name: gitrepo.Name}
+			if _, ok := seen[gitrepoResource]; ok {
+				continue
+			}
 			if gitrepo.Spec.Revision != "" {
 				continue
 			}
@@ -199,6 +198,7 @@ func (w *Webhook) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 					}
 				}
 			}
+			seen[gitrepoResource] = struct{}{}
 		}
 	}
 	rw.WriteHeader(http.StatusOK)

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -99,12 +99,23 @@ func (w *Webhook) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// A payload can yield several URLs (e.g. a web URL and an SSH URL) that
+	// resolve to the same host and path, most commonly when the SSH host equals
+	// the web host (github.com). Track those with `seen` so a matching GitRepo is
+	// processed once per request instead of letting it be processed repeatedly.
+	seen := make(map[string]struct{}, len(repoURLs))
 	for _, repo := range repoURLs {
 		u, err := url.Parse(repo)
 		if err != nil {
 			w.logAndReturn(rw, err)
 			return
 		}
+		key := u.Hostname() + "\x00" + u.EscapedPath()
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+
 		path := strings.Replace(regexp.QuoteMeta(u.EscapedPath()[1:]), `/_git/`, `(/_git)?/`, 1)
 		regexpStr := `(?i)(http://|https://|\w+@|ssh://(\w+@)?|git@(ssh\.)?)` + regexp.QuoteMeta(u.Hostname()) +
 			"(:[0-9]+|)[:/](v\\d/)?" + path + "(\\.git)?$"
@@ -294,6 +305,10 @@ func sshURLToParsable(raw string) string {
 	}
 	host, path, ok := strings.Cut(rest, ":")
 	if !ok {
+		return ""
+	}
+	if path == "" {
+		// skip if git URL has no path
 		return ""
 	}
 	return fmt.Sprintf("ssh://%s@%s/%s", user, host, path)

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -272,6 +272,33 @@ func getBranchTagFromRef(ref string) (string, string) {
 	return "", ""
 }
 
+// sshURLToParsable converts an scp-style git remote such as
+// "git@github-ssh.example.com:owner/repo.git" into an "ssh://" URL that
+// net/url can parse, so the webhook matching loop can extract its hostname and
+// path.
+func sshURLToParsable(raw string) string {
+	if raw == "" {
+		return ""
+	}
+	// Drop a trailing ".git" so the "(\.git)?$" in the match regexp stays
+	// optional and matches GitRepos configured with or without the suffix.
+	// This must happen before the "://" check so it applies to both scp-style
+	// remotes and ready-made "ssh://" URLs.
+	raw = strings.TrimSuffix(raw, ".git")
+	if strings.Contains(raw, "://") {
+		return raw
+	}
+	user, rest, ok := strings.Cut(raw, "@")
+	if !ok {
+		return ""
+	}
+	host, path, ok := strings.Cut(rest, ":")
+	if !ok {
+		return ""
+	}
+	return fmt.Sprintf("ssh://%s@%s/%s", user, host, path)
+}
+
 // parsePayload extracts git information from a request payload, depending on its type.
 // Returns a revision, branch, tag and a slice of repo URLs.
 func parsePayload(payload any) (revision, branch, tag string, repoURLs []string) {
@@ -281,14 +308,23 @@ func parsePayload(payload any) (revision, branch, tag string, repoURLs []string)
 		branch, tag = getBranchTagFromRef(t.Ref)
 		revision = t.After
 		repoURLs = append(repoURLs, t.Repository.HTMLURL)
+		if sshURL := sshURLToParsable(t.Repository.SSHURL); sshURL != "" {
+			repoURLs = append(repoURLs, sshURL)
+		}
 	case gitlab.PushEventPayload:
 		branch, tag = getBranchTagFromRef(t.Ref)
 		revision = t.CheckoutSHA
 		repoURLs = append(repoURLs, t.Project.WebURL)
+		if sshURL := sshURLToParsable(t.Project.GitSSHURL); sshURL != "" {
+			repoURLs = append(repoURLs, sshURL)
+		}
 	case gitlab.TagEventPayload:
 		branch, tag = getBranchTagFromRef(t.Ref)
 		revision = t.CheckoutSHA
 		repoURLs = append(repoURLs, t.Project.WebURL)
+		if sshURL := sshURLToParsable(t.Project.GitSSHURL); sshURL != "" {
+			repoURLs = append(repoURLs, sshURL)
+		}
 	// https://support.atlassian.com/bitbucket-cloud/docs/event-payloads/#Push
 	case bitbucket.RepoPushPayload:
 		repoURLs = append(repoURLs, t.Repository.Links.HTML.Href)
@@ -321,6 +357,9 @@ func parsePayload(payload any) (revision, branch, tag string, repoURLs []string)
 		}
 	case gogsclient.PushPayload:
 		repoURLs = append(repoURLs, t.Repo.HTMLURL)
+		if sshURL := sshURLToParsable(t.Repo.SSHURL); sshURL != "" {
+			repoURLs = append(repoURLs, sshURL)
+		}
 		branch, tag = getBranchTagFromRef(t.Ref)
 		revision = t.After
 	case azuredevops.GitPushEvent:

--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -794,7 +794,9 @@ func TestGitRepoURLMatch(t *testing.T) {
 
 	cases := map[string]struct {
 		gitRepos        []v1alpha1.GitRepo
-		repository      string
+		eventHeader     string
+		eventValue      string
+		body            string
 		matchedRepoName string
 	}{
 		"web URL matches https repo": {
@@ -813,10 +815,12 @@ func TestGitRepoURLMatch(t *testing.T) {
 				},
 				ignoredGitRepo,
 			},
-			repository:      `{"html_url":"https://github.com/example/repo"}`,
+			eventHeader:     "X-Github-Event",
+			eventValue:      "push",
+			body:            `{"ref":"refs/heads/main","after":"` + expectedCommit + `","repository":{"html_url":"https://github.com/example/repo"}}`,
 			matchedRepoName: "intended-gitrepo",
 		},
-		"ssh URL matches scp-style repo on a different host": {
+		"ssh URL matches scp-style repo on a different github host": {
 			gitRepos: []v1alpha1.GitRepo{
 				{
 					ObjectMeta: metav1.ObjectMeta{
@@ -832,7 +836,9 @@ func TestGitRepoURLMatch(t *testing.T) {
 				},
 				ignoredGitRepo,
 			},
-			repository:      `{"html_url":"https://github.example.com/example/repo","ssh_url":"git@github-ssh.example.com:example/repo.git"}`,
+			eventHeader:     "X-Github-Event",
+			eventValue:      "push",
+			body:            `{"ref":"refs/heads/main","after":"` + expectedCommit + `","repository":{"html_url":"https://github.example.com/example/repo","ssh_url":"git@github-ssh.example.com:example/repo.git"}}`,
 			matchedRepoName: "intended-gitrepo",
 		},
 		// Same host for web and SSH (e.g. github.com): the two URLs must be
@@ -853,7 +859,72 @@ func TestGitRepoURLMatch(t *testing.T) {
 				},
 				ignoredGitRepo,
 			},
-			repository:      `{"html_url":"https://github.com/example/repo","ssh_url":"git@github.com:example/repo.git"}`,
+			eventHeader:     "X-Github-Event",
+			eventValue:      "push",
+			body:            `{"ref":"refs/heads/main","after":"` + expectedCommit + `","repository":{"html_url":"https://github.com/example/repo","ssh_url":"git@github.com:example/repo.git"}}`,
+			matchedRepoName: "intended-gitrepo",
+		},
+		"ssh URL matches scp-style repo on a different gitlab host": {
+			gitRepos: []v1alpha1.GitRepo{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "intended-gitrepo",
+						Namespace: "my-namespace",
+					},
+					Spec: v1alpha1.GitRepoSpec{
+						Repo: "git@gitlab-ssh.example.com:example/repo.git",
+					},
+					Status: v1alpha1.GitRepoStatus{
+						WebhookCommit: "12345abcdef",
+					},
+				},
+				ignoredGitRepo,
+			},
+			eventHeader:     "X-Gitlab-Event",
+			eventValue:      "Push Hook",
+			body:            `{"ref":"refs/heads/main","checkout_sha":"` + expectedCommit + `","project":{"web_url":"https://gitlab.example.com/example/repo","git_ssh_url":"git@gitlab-ssh.example.com:example/repo.git"}}`,
+			matchedRepoName: "intended-gitrepo",
+		},
+		"ssh URL matches scp-style repo on a gitlab tag push": {
+			gitRepos: []v1alpha1.GitRepo{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "intended-gitrepo",
+						Namespace: "my-namespace",
+					},
+					Spec: v1alpha1.GitRepoSpec{
+						Repo: "git@gitlab-ssh.example.com:example/repo.git",
+					},
+					Status: v1alpha1.GitRepoStatus{
+						WebhookCommit: "12345abcdef",
+					},
+				},
+				ignoredGitRepo,
+			},
+			eventHeader:     "X-Gitlab-Event",
+			eventValue:      "Tag Push Hook",
+			body:            `{"ref":"refs/tags/v1.0.0","checkout_sha":"` + expectedCommit + `","project":{"web_url":"https://gitlab.example.com/example/repo","git_ssh_url":"git@gitlab-ssh.example.com:example/repo.git"}}`,
+			matchedRepoName: "intended-gitrepo",
+		},
+		"ssh URL matches scp-style repo on a different gogs host": {
+			gitRepos: []v1alpha1.GitRepo{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "intended-gitrepo",
+						Namespace: "my-namespace",
+					},
+					Spec: v1alpha1.GitRepoSpec{
+						Repo: "git@gogs-ssh.example.com:example/repo.git",
+					},
+					Status: v1alpha1.GitRepoStatus{
+						WebhookCommit: "12345abcdef",
+					},
+				},
+				ignoredGitRepo,
+			},
+			eventHeader:     "X-Gogs-Event",
+			eventValue:      "push",
+			body:            `{"ref":"refs/heads/main","after":"` + expectedCommit + `","repository":{"html_url":"https://gogs.example.com/example/repo","ssh_url":"git@gogs-ssh.example.com:example/repo.git"}}`,
 			matchedRepoName: "intended-gitrepo",
 		},
 	}
@@ -907,14 +978,11 @@ func TestGitRepoURLMatch(t *testing.T) {
 				},
 			).Times(1)
 
-			// we set only the values that we're going to use in the push event to make things simple
-			jsonBody := fmt.Appendf(nil, `{"ref":"refs/heads/main","after":"%s","repository":%s}`, expectedCommit, tc.repository)
-
-			req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, "/", bytes.NewReader(jsonBody))
+			req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, "/", bytes.NewReader([]byte(tc.body)))
 			if err != nil {
 				t.Fatalf("Failed to create HTTP request: %v", err)
 			}
-			req.Header.Set("X-Github-Event", "push")
+			req.Header.Set(tc.eventHeader, tc.eventValue)
 
 			rr := httptest.NewRecorder()
 			w := &Webhook{

--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -835,6 +835,27 @@ func TestGitRepoURLMatch(t *testing.T) {
 			repository:      `{"html_url":"https://github.example.com/example/repo","ssh_url":"git@github-ssh.example.com:example/repo.git"}`,
 			matchedRepoName: "intended-gitrepo",
 		},
+		// Same host for web and SSH (e.g. github.com): the two URLs must be
+		// deduplicated so the matching GitRepo is patched once, not twice.
+		"web and SSH URLs on the same host match once": {
+			gitRepos: []v1alpha1.GitRepo{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "intended-gitrepo",
+						Namespace: "my-namespace",
+					},
+					Spec: v1alpha1.GitRepoSpec{
+						Repo: "https://github.com/example/repo",
+					},
+					Status: v1alpha1.GitRepoStatus{
+						WebhookCommit: "12345abcdef",
+					},
+				},
+				ignoredGitRepo,
+			},
+			repository:      `{"html_url":"https://github.com/example/repo","ssh_url":"git@github.com:example/repo.git"}`,
+			matchedRepoName: "intended-gitrepo",
+		},
 	}
 
 	for name, tc := range cases {
@@ -921,6 +942,7 @@ func TestSSHURLToParsable(t *testing.T) {
 		"already ssh scheme":    {in: "ssh://git@bitbucket.example.com:7999/proj/repo.git", expected: "ssh://git@bitbucket.example.com:7999/proj/repo"},
 		"without user":          {in: "github-ssh.example.com:owner/repo.git", expected: ""},
 		"without colon":         {in: "git@github-ssh.example.com", expected: ""},
+		"empty path":            {in: "git@github-ssh.example.com:", expected: ""},
 	}
 
 	for name, tc := range cases {

--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -777,112 +777,157 @@ func TestGitHubSecretAndCommitUpdated(t *testing.T) {
 }
 
 func TestGitRepoURLMatch(t *testing.T) {
-	ctlr := gomock.NewController(t)
-	mockClient := mocks.NewMockK8sClient(ctlr)
-
 	expectedCommit := "af69d162de5a276abc86e0686b2b44033cd3f442"
 
-	gitRepos := []v1alpha1.GitRepo{
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "intended-gitrepo",
-				Namespace: "my-namespace",
-			},
-			Spec: v1alpha1.GitRepoSpec{
-				Repo: "https://github.com/example/repo",
-			},
-			Status: v1alpha1.GitRepoStatus{
-				WebhookCommit: "12345abcdef", // different from expectedCommit
-			},
+	ignoredGitRepo := v1alpha1.GitRepo{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "gitrepo-which-should-be-ignored",
+			Namespace: "my-namespace",
 		},
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "gitrepo-which-should-be-ignored",
-				Namespace: "my-namespace",
-			},
-			Spec: v1alpha1.GitRepoSpec{
-				Repo: "https://github.com/example/repo-with-suffix",
-			},
-			Status: v1alpha1.GitRepoStatus{
-				WebhookCommit: "12345abcdef", // different from expectedCommit
-			},
+		Spec: v1alpha1.GitRepoSpec{
+			Repo: "https://github.com/example/repo-with-suffix",
+		},
+		Status: v1alpha1.GitRepoStatus{
+			WebhookCommit: "12345abcdef", // different from expectedCommit
 		},
 	}
 
-	// List GitRepos mock call
-	mockClient.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().DoAndReturn(
-		func(ctx context.Context, list *v1alpha1.GitRepoList, opts ...client.ListOption) error {
-			list.Items = append(list.Items, gitRepos...)
-
-			return nil
+	cases := map[string]struct {
+		gitRepos        []v1alpha1.GitRepo
+		repository      string
+		matchedRepoName string
+	}{
+		"web URL matches https repo": {
+			gitRepos: []v1alpha1.GitRepo{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "intended-gitrepo",
+						Namespace: "my-namespace",
+					},
+					Spec: v1alpha1.GitRepoSpec{
+						Repo: "https://github.com/example/repo",
+					},
+					Status: v1alpha1.GitRepoStatus{
+						WebhookCommit: "12345abcdef",
+					},
+				},
+				ignoredGitRepo,
+			},
+			repository:      `{"html_url":"https://github.com/example/repo"}`,
+			matchedRepoName: "intended-gitrepo",
 		},
-	)
-
-	nn := types.NamespacedName{Name: webhookSecretName, Namespace: "my-namespace"}
-	// The following calls should happen only _once_, for the GitRepo with the exact URL match, hence the explicit
-	// `.Times(1)` calls.
-	mockClient.EXPECT().Get(gomock.Any(), nn, gomock.Any()).Return(apierrors.NewNotFound(schema.GroupResource{}, "")).Times(1)
-
-	mockClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
-		func(ctx context.Context, name types.NamespacedName, gitrepo *v1alpha1.GitRepo, _ ...any) error {
-			// check that the GitRepo is the expected one
-			if name.Name != "intended-gitrepo" {
-				t.Errorf("wrong gitrepo matched: expected 'intended-gitrepo', got %s", name.Name)
-			}
-
-			return nil
+		"ssh URL matches scp-style repo on a different host": {
+			gitRepos: []v1alpha1.GitRepo{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "intended-gitrepo",
+						Namespace: "my-namespace",
+					},
+					Spec: v1alpha1.GitRepoSpec{
+						Repo: "git@github-ssh.example.com:example/repo.git",
+					},
+					Status: v1alpha1.GitRepoStatus{
+						WebhookCommit: "12345abcdef",
+					},
+				},
+				ignoredGitRepo,
+			},
+			repository:      `{"html_url":"https://github.example.com/example/repo","ssh_url":"git@github-ssh.example.com:example/repo.git"}`,
+			matchedRepoName: "intended-gitrepo",
 		},
-	).Times(1)
-	statusClient := mocks.NewMockStatusWriter(ctlr)
-	mockClient.EXPECT().Status().Return(statusClient).Times(1)
-	statusClient.EXPECT().Patch(gomock.Any(), gomock.Any(), gomock.Any()).Do(
-		func(ctx context.Context, repo *v1alpha1.GitRepo, _ client.Patch, opts ...any) {
-			// check that the commit is the expected one
-			if repo.Status.WebhookCommit != expectedCommit {
-				t.Errorf("expecting gitrepo webhook commit %s, got %s", expectedCommit, repo.Status.WebhookCommit)
-			}
-			// PollingInterval must NOT be set via Status().Patch(); it uses a separate spec patch
-			if repo.Spec.PollingInterval != nil {
-				t.Errorf("PollingInterval must not appear in the status patch, got %s", repo.Spec.PollingInterval.Duration)
-			}
-		},
-	).Times(1)
-	// PollingInterval is nil on both GitRepo fixtures, so a spec Patch() must follow for the matching one
-	mockClient.EXPECT().Patch(gomock.Any(), gomock.Any(), gomock.Any()).Do(
-		func(ctx context.Context, repo *v1alpha1.GitRepo, _ client.Patch, opts ...any) {
-			if repo.Spec.PollingInterval == nil || repo.Spec.PollingInterval.Duration != time.Hour {
-				t.Errorf("expecting polling interval 1h in spec patch, got %v", repo.Spec.PollingInterval)
-			}
-		},
-	).Times(1)
-
-	// we set only the values that we're going to use in the push event to make things simple
-	jsonBody := fmt.Appendf(nil, `
-		{
-		  "ref":"refs/heads/main",
-		  "after":"%s",
-		  "repository":{
-			"html_url":"https://github.com/example/repo"
-		  }
-		}`, expectedCommit)
-
-	// Request creation
-	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, "/", bytes.NewReader(jsonBody))
-	if err != nil {
-		t.Fatalf("Failed to create HTTP request: %v", err)
 	}
-	req.Header.Set("X-Github-Event", "push")
 
-	rr := httptest.NewRecorder()
-	w := &Webhook{
-		client:    mockClient,
-		namespace: "my-namespace",
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			ctlr := gomock.NewController(t)
+			mockClient := mocks.NewMockK8sClient(ctlr)
+
+			gitRepos := tc.gitRepos
+			mockClient.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().DoAndReturn(
+				func(ctx context.Context, list *v1alpha1.GitRepoList, opts ...client.ListOption) error {
+					list.Items = append(list.Items, gitRepos...)
+					return nil
+				},
+			)
+
+			nn := types.NamespacedName{Name: webhookSecretName, Namespace: "my-namespace"}
+			// The following calls should happen only _once_, for the GitRepo with the exact URL match, hence the explicit
+			// `.Times(1)` calls.
+			mockClient.EXPECT().Get(gomock.Any(), nn, gomock.Any()).Return(apierrors.NewNotFound(schema.GroupResource{}, "")).Times(1)
+
+			mockClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+				func(ctx context.Context, name types.NamespacedName, gitrepo *v1alpha1.GitRepo, _ ...any) error {
+					if name.Name != tc.matchedRepoName {
+						t.Errorf("wrong gitrepo matched: expected %q, got %s", tc.matchedRepoName, name.Name)
+					}
+					return nil
+				},
+			).Times(1)
+
+			statusClient := mocks.NewMockStatusWriter(ctlr)
+			mockClient.EXPECT().Status().Return(statusClient).Times(1)
+			statusClient.EXPECT().Patch(gomock.Any(), gomock.Any(), gomock.Any()).Do(
+				func(ctx context.Context, repo *v1alpha1.GitRepo, _ client.Patch, opts ...any) {
+					if repo.Status.WebhookCommit != expectedCommit {
+						t.Errorf("expecting gitrepo webhook commit %s, got %s", expectedCommit, repo.Status.WebhookCommit)
+					}
+					// PollingInterval must NOT be set via Status().Patch(); it uses a separate spec patch
+					if repo.Spec.PollingInterval != nil {
+						t.Errorf("PollingInterval must not appear in the status patch, got %s", repo.Spec.PollingInterval.Duration)
+					}
+				},
+			).Times(1)
+			// PollingInterval is nil on the fixtures, so a spec Patch() must follow for the matching one
+			mockClient.EXPECT().Patch(gomock.Any(), gomock.Any(), gomock.Any()).Do(
+				func(ctx context.Context, repo *v1alpha1.GitRepo, _ client.Patch, opts ...any) {
+					if repo.Spec.PollingInterval == nil || repo.Spec.PollingInterval.Duration != time.Hour {
+						t.Errorf("expecting polling interval 1h in spec patch, got %v", repo.Spec.PollingInterval)
+					}
+				},
+			).Times(1)
+
+			// we set only the values that we're going to use in the push event to make things simple
+			jsonBody := fmt.Appendf(nil, `{"ref":"refs/heads/main","after":"%s","repository":%s}`, expectedCommit, tc.repository)
+
+			req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, "/", bytes.NewReader(jsonBody))
+			if err != nil {
+				t.Fatalf("Failed to create HTTP request: %v", err)
+			}
+			req.Header.Set("X-Github-Event", "push")
+
+			rr := httptest.NewRecorder()
+			w := &Webhook{
+				client:    mockClient,
+				namespace: "my-namespace",
+			}
+			w.ServeHTTP(rr, req)
+
+			if status := rr.Code; status != http.StatusOK {
+				t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusOK)
+			}
+		})
 	}
-	w.ServeHTTP(rr, req)
+}
 
-	// Verify the response status code is correct
-	if status := rr.Code; status != http.StatusOK {
-		t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusOK)
+func TestSSHURLToParsable(t *testing.T) {
+	cases := map[string]struct {
+		in       string
+		expected string
+	}{
+		"empty":                 {in: "", expected: ""},
+		"already https scheme":  {in: "https://github.com/owner/repo", expected: "https://github.com/owner/repo"},
+		"scp-style with .git":   {in: "git@github-ssh.example.com:owner/repo.git", expected: "ssh://git@github-ssh.example.com/owner/repo"},
+		"scp-style without git": {in: "git@github-ssh.example.com:owner/repo", expected: "ssh://git@github-ssh.example.com/owner/repo"},
+		"already ssh scheme":    {in: "ssh://git@bitbucket.example.com:7999/proj/repo.git", expected: "ssh://git@bitbucket.example.com:7999/proj/repo"},
+		"without user":          {in: "github-ssh.example.com:owner/repo.git", expected: ""},
+		"without colon":         {in: "git@github-ssh.example.com", expected: ""},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := sshURLToParsable(tc.in)
+			assert.Equal(t, tc.expected, got)
+		})
 	}
 }
 


### PR DESCRIPTION
- Use `parsePayload` to include giturl and allow the outer loop to process git along with https url
- Apply fix to all the providers for consistency
- dedup payload URLs and skip empty SSH paths
- update and refactor webhook_test.go to cover each edge case from `sshURLToParsable` and prevent regression

Refers to #3720