### PR TITLE
Remove obsolete integration test go.mod reference

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -15,20 +15,6 @@
   ],
   "packageRules": [
     {
-      "description": "Update indirect dependencies in integrationtests/go.mod only when the same dependency is updated elsewhere in the workspace",
-      "matchManagers": [
-        "gomod"
-      ],
-      "matchDepTypes": [
-        "indirect"
-      ],
-      "matchFileNames": [
-        "integrationtests/go.mod"
-      ],
-      "enabled": true,
-      "minimumGroupSize": 2
-    },
-    {
       "matchBaseBranches": [
         "release/v0.15"
       ],


### PR DESCRIPTION
the `integrationtests/go.mod` does not exist anymore.