### PR TITLE
Use GitHub App token for bot PR auto-merge

### DIFF
--- a/.github/workflows/auto-approve-bot-prs.yml
+++ b/.github/workflows/auto-approve-bot-prs.yml
@@ -13,6 +13,7 @@ jobs:
   auto-approve-and-merge:
     name: Approve and Auto-Merge
     if: >-
+      github.repository == 'rancher/fleet' &&
       github.event.pull_request.state == 'open' &&
       github.event.pull_request.user.type == 'Bot' &&
       github.event.pull_request.head.repo.full_name == github.repository &&

--- a/.github/workflows/auto-approve-bot-prs.yml
+++ b/.github/workflows/auto-approve-bot-prs.yml
@@ -5,6 +5,7 @@ on:
     types: [opened]
 
 permissions:
+  id-token: write
   contents: write
   pull-requests: write
 
@@ -23,17 +24,36 @@ jobs:
       )
     runs-on: ubuntu-latest
     steps:
+      - name: Read App Secrets
+        uses: rancher-eio/read-vault-secrets@0da85151ad1f19ed7986c41587e45aac1ace74b6 # v3
+        with:
+          secrets: |
+            secret/data/github/repo/${{ github.repository }}/github/workflow-dispatcher/app-credentials appId | APP_ID ;
+            secret/data/github/repo/${{ github.repository }}/github/workflow-dispatcher/app-credentials privateKey | PRIVATE_KEY
+
+      - name: Create App Token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ env.APP_ID }}
+          private-key: ${{ env.PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: |
+            fleet
+          permission-contents: write
+          permission-pull-requests: write
+
       - name: Approve PR
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
         run: |
           review_state=$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" \
-            --jq '[.[] | select(.user.login == "github-actions[bot]")] | last | .state // ""')
+            --jq '[.[] | select(.state == "APPROVED")] | length')
 
-          if [[ "$review_state" == "APPROVED" ]]; then
-            echo "PR is already approved by github-actions[bot]."
+          if [[ "$review_state" -gt 0 ]]; then
+            echo "PR already has an approval review."
             exit 0
           fi
 
@@ -44,7 +64,7 @@ jobs:
 
       - name: Enable auto-merge
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
         run: |

--- a/.github/workflows/auto-approve-bot-prs.yml
+++ b/.github/workflows/auto-approve-bot-prs.yml
@@ -50,11 +50,11 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
         run: |
-          review_state=$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" \
-            --jq '[.[] | select(.state == "APPROVED")] | length')
+          review_decision=$(gh pr view "$PR_NUMBER" --repo "$REPO" \
+            --json reviewDecision --jq '.reviewDecision')
 
-          if [[ "$review_state" -gt 0 ]]; then
-            echo "PR already has an approval review."
+          if [[ "$review_decision" == "APPROVED" ]]; then
+            echo "PR is currently approved."
             exit 0
           fi
 

--- a/.github/workflows/auto-approve-bot-prs.yml
+++ b/.github/workflows/auto-approve-bot-prs.yml
@@ -6,8 +6,8 @@ on:
 
 permissions:
   id-token: write
-  contents: write
-  pull-requests: write
+  contents: read
+  pull-requests: read
 
 jobs:
   auto-approve-and-merge:


### PR DESCRIPTION
Read app credentials from Vault and mint a GitHub App token in `.github/workflows/auto-approve-bot-prs.yml`, then use it for PR approval and auto-merge operations so branch-protected merge enablement can be authorized by app policy.