### PR TITLE
feat(agent): Server-Side Apply for namespace labels and annotations

### DIFF
--- a/e2e/assets/single-cluster/bundle-namespace-metadata.yaml
+++ b/e2e/assets/single-cluster/bundle-namespace-metadata.yaml
@@ -1,0 +1,24 @@
+kind: Bundle
+apiVersion: fleet.cattle.io/v1alpha1
+metadata:
+  name: namespace-metadata
+spec:
+  namespace: {{.TargetNamespace}}
+  namespaceLabels:
+    fleet.e2e/keep: one
+    fleet.e2e/prune: two
+  namespaceAnnotations:
+    fleet.e2e/keep: one
+    fleet.e2e/prune: two
+  resources:
+  - content: |
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: app-config
+      data:
+        test: "value"
+  targets:
+  - clusterGroup: default
+    ignore: {}
+    name: default

--- a/e2e/single-cluster/namespace_metadata_test.go
+++ b/e2e/single-cluster/namespace_metadata_test.go
@@ -1,0 +1,117 @@
+package singlecluster_test
+
+import (
+	"encoding/json"
+	"math/rand"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/rancher/fleet/e2e/testenv"
+	"github.com/rancher/fleet/e2e/testenv/kubectl"
+)
+
+// Fleet server-side applies the namespace labels and annotations from the
+// bundle options with a dedicated field manager, so it owns exactly the keys it
+// declares: a key it stops declaring is pruned, and keys held by any other
+// field manager are left alone.
+//
+// The previous read-modify-write update deleted every key that was not listed
+// in the options, no matter who wrote it, which wiped metadata owned by others
+// (Rancher's field.cattle.io/projectId, for example). See issue #4564.
+var _ = Describe("Namespace label and annotation ownership", func() {
+	const (
+		bundleName = "namespace-metadata"
+
+		// Written straight to the namespace with kubectl, so the API server
+		// records kubectl as the owning field manager. Fleet must not touch it.
+		foreignKey   = "e2e.fleet.cattle.io/owned-elsewhere"
+		foreignValue = "survives"
+
+		// Both start out in the bundle options; only prunedKey is removed from
+		// them later in the spec.
+		keptKey   = "fleet.e2e/keep"
+		prunedKey = "fleet.e2e/prune"
+	)
+
+	var (
+		k               kubectl.Command
+		r               = rand.New(rand.NewSource(GinkgoRandomSeed()))
+		targetNamespace string
+	)
+
+	type TemplateData struct {
+		TargetNamespace string
+	}
+
+	// nsMetadata reads .metadata.<field> off the target namespace, where field
+	// is "labels" or "annotations".
+	nsMetadata := func(g Gomega, field string) map[string]string {
+		out, err := k.Get("ns", targetNamespace, "-o", "jsonpath={.metadata."+field+"}")
+		g.Expect(err).ToNot(HaveOccurred(), out)
+
+		m := map[string]string{}
+		g.Expect(json.Unmarshal([]byte(out), &m)).To(Succeed(), out)
+
+		return m
+	}
+
+	BeforeEach(func() {
+		k = env.Kubectl.Namespace(env.Namespace)
+		targetNamespace = testenv.NewNamespaceName("ns-metadata", r)
+
+		DeferCleanup(func() {
+			out, err := k.Delete("bundle", bundleName)
+			Expect(err).ToNot(HaveOccurred(), out)
+
+			_, _ = k.Delete("ns", targetNamespace, "--wait=false")
+		})
+
+		Expect(testenv.ApplyTemplate(
+			k,
+			testenv.AssetPath("single-cluster/bundle-namespace-metadata.yaml"),
+			TemplateData{TargetNamespace: targetNamespace},
+		)).To(Succeed())
+	})
+
+	It("prunes only the keys it declares itself", func() {
+		By("applying the bundle's namespaceLabels and namespaceAnnotations to the release namespace")
+		Eventually(func(g Gomega) {
+			g.Expect(nsMetadata(g, "labels")).To(HaveKeyWithValue(prunedKey, "two"))
+			g.Expect(nsMetadata(g, "annotations")).To(HaveKeyWithValue(prunedKey, "two"))
+		}).Should(Succeed())
+
+		By("adding a label and an annotation owned by a different field manager")
+		out, err := k.Label("ns", targetNamespace, foreignKey+"="+foreignValue)
+		Expect(err).ToNot(HaveOccurred(), out)
+
+		out, err = k.Run("annotate", "ns", targetNamespace, foreignKey+"="+foreignValue)
+		Expect(err).ToNot(HaveOccurred(), out)
+
+		By("dropping one key from the bundle's namespaceLabels and namespaceAnnotations")
+		out, err = k.Patch(
+			"bundle",
+			bundleName,
+			"--type=merge",
+			"-p",
+			`{"spec":{"namespaceLabels":{"`+prunedKey+`":null},"namespaceAnnotations":{"`+prunedKey+`":null}}}`,
+		)
+		Expect(err).ToNot(HaveOccurred(), out)
+
+		By("pruning the dropped key and leaving every other key in place")
+		Eventually(func(g Gomega) {
+			g.Expect(nsMetadata(g, "labels")).To(Equal(map[string]string{
+				keptKey:    "one",
+				foreignKey: foreignValue,
+				// Added by Kubernetes on namespace creation.
+				"kubernetes.io/metadata.name": targetNamespace,
+				// Added by Helm when it creates the release namespace.
+				"name": targetNamespace,
+			}))
+
+			g.Expect(nsMetadata(g, "annotations")).To(Equal(map[string]string{
+				keptKey:    "one",
+				foreignKey: foreignValue,
+			}))
+		}).Should(Succeed())
+	})
+})

--- a/e2e/single-cluster/target_customization_test.go
+++ b/e2e/single-cluster/target_customization_test.go
@@ -87,7 +87,10 @@ var _ = Describe("Helm deploy options", func() {
 				Eventually(func(g Gomega) {
 					labels, err := k.Get("ns", "ns-1", "-o", "jsonpath={.metadata.labels}")
 					g.Expect(err).ToNot(HaveOccurred())
-					g.Expect(labels).To(Equal(`{"foo":"bar","kubernetes.io/metadata.name":"ns-1","this.is/a":"test"}`))
+					// The `name` label is added by Helm when it creates the release
+					// namespace. Fleet server-side applies only the keys it declares, so
+					// labels owned by other managers survive (see issue #4564).
+					g.Expect(labels).To(Equal(`{"foo":"bar","kubernetes.io/metadata.name":"ns-1","name":"ns-1","this.is/a":"test"}`))
 
 					ann, err := k.Get("ns", "ns-1", "-o", "jsonpath={.metadata.annotations}")
 					g.Expect(err).ToNot(HaveOccurred())
@@ -153,7 +156,10 @@ var _ = Describe("Helm deploy options", func() {
 				Eventually(func(g Gomega) {
 					labels, err := k.Get("ns", "no-defaults-ns-1", "-o", "jsonpath={.metadata.labels}")
 					g.Expect(err).ToNot(HaveOccurred())
-					g.Expect(labels).To(Equal(`{"kubernetes.io/metadata.name":"no-defaults-ns-1","this.is/a":"test"}`))
+					// The `name` label is added by Helm when it creates the release
+					// namespace. Fleet server-side applies only the keys it declares, so
+					// labels owned by other managers survive (see issue #4564).
+					g.Expect(labels).To(Equal(`{"kubernetes.io/metadata.name":"no-defaults-ns-1","name":"no-defaults-ns-1","this.is/a":"test"}`))
 
 					ann, err := k.Get("ns", "no-defaults-ns-1", "-o", "jsonpath={.metadata.annotations}")
 					g.Expect(err).ToNot(HaveOccurred())

--- a/e2e/single-cluster/target_customization_test.go
+++ b/e2e/single-cluster/target_customization_test.go
@@ -87,9 +87,11 @@ var _ = Describe("Helm deploy options", func() {
 				Eventually(func(g Gomega) {
 					labels, err := k.Get("ns", "ns-1", "-o", "jsonpath={.metadata.labels}")
 					g.Expect(err).ToNot(HaveOccurred())
-					// The `name` label is added by Helm when it creates the release
-					// namespace. Fleet server-side applies only the keys it declares, so
-					// labels owned by other managers survive (see issue #4564).
+					// Helm adds the `name` label when it creates the release namespace,
+					// under the agent's own "fleetagent" field manager. Fleet server-side
+					// applies the options with a separate field manager and owns only the
+					// keys it declares there, so this label is not pruned. Ownership is per
+					// field manager, not per writer. See issue #4564.
 					g.Expect(labels).To(Equal(`{"foo":"bar","kubernetes.io/metadata.name":"ns-1","name":"ns-1","this.is/a":"test"}`))
 
 					ann, err := k.Get("ns", "ns-1", "-o", "jsonpath={.metadata.annotations}")
@@ -156,9 +158,11 @@ var _ = Describe("Helm deploy options", func() {
 				Eventually(func(g Gomega) {
 					labels, err := k.Get("ns", "no-defaults-ns-1", "-o", "jsonpath={.metadata.labels}")
 					g.Expect(err).ToNot(HaveOccurred())
-					// The `name` label is added by Helm when it creates the release
-					// namespace. Fleet server-side applies only the keys it declares, so
-					// labels owned by other managers survive (see issue #4564).
+					// Helm adds the `name` label when it creates the release namespace,
+					// under the agent's own "fleetagent" field manager. Fleet server-side
+					// applies the options with a separate field manager and owns only the
+					// keys it declares there, so this label is not pruned. Ownership is per
+					// field manager, not per writer. See issue #4564.
 					g.Expect(labels).To(Equal(`{"kubernetes.io/metadata.name":"no-defaults-ns-1","name":"no-defaults-ns-1","this.is/a":"test"}`))
 
 					ann, err := k.Get("ns", "no-defaults-ns-1", "-o", "jsonpath={.metadata.annotations}")

--- a/go.mod
+++ b/go.mod
@@ -105,6 +105,7 @@ require (
 	sigs.k8s.io/controller-tools v0.21.0
 	sigs.k8s.io/kustomize/api v0.21.1
 	sigs.k8s.io/kustomize/kyaml v0.21.1
+	sigs.k8s.io/structured-merge-diff/v6 v6.4.0
 	sigs.k8s.io/yaml v1.6.0
 )
 
@@ -273,5 +274,4 @@ require (
 	k8s.io/utils v0.0.0-20260319190234-28399d86e0b5 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
-	sigs.k8s.io/structured-merge-diff/v6 v6.4.0 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -106,6 +106,7 @@ require (
 	sigs.k8s.io/controller-tools v0.21.0
 	sigs.k8s.io/kustomize/api v0.21.1
 	sigs.k8s.io/kustomize/kyaml v0.21.1
+	sigs.k8s.io/structured-merge-diff/v6 v6.4.0
 	sigs.k8s.io/yaml v1.6.0
 )
 
@@ -276,5 +277,4 @@ require (
 	k8s.io/utils v0.0.0-20260626114624-be93311217bd // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
-	sigs.k8s.io/structured-merge-diff/v6 v6.4.0 // indirect
 )

--- a/internal/cmd/agent/deployer/deployer.go
+++ b/internal/cmd/agent/deployer/deployer.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"maps"
 	"regexp"
 	"slices"
 	"strings"
@@ -23,6 +22,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	corev1ac "k8s.io/client-go/applyconfigurations/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
@@ -231,7 +231,20 @@ func (d *Deployer) helmdeploy(ctx context.Context, logger logr.Logger, bd *fleet
 	return resourceID, nil
 }
 
-// setNamespaceLabelsAndAnnotations updates the namespace for the release, applying all labels and annotations to that namespace as configured in the bundle spec.
+// setNamespaceLabelsAndAnnotations applies the labels and annotations configured
+// in the bundle spec to the release namespace.
+//
+// It server-side applies with a dedicated Fleet field manager, so Fleet owns
+// exactly the keys it declares. Labels and annotations set by other actors (for
+// example Rancher's field.cattle.io/projectId, added when a namespace is moved
+// into a Project) are left untouched, and a key that Fleet stops declaring is
+// pruned. This replaced an earlier read-modify-write that deleted every key not
+// present in the options and could only preserve a hardcoded allowlist (see
+// issue #4564).
+//
+// Labels and annotations are applied independently: a bundle that sets only
+// namespaceLabels never asserts ownership of (and therefore never prunes)
+// annotations, and vice versa.
 func (d *Deployer) setNamespaceLabelsAndAnnotations(ctx context.Context, bd *fleet.BundleDeployment, releaseID string) error {
 	if bd.Spec.Options.NamespaceLabels == nil && bd.Spec.Options.NamespaceAnnotations == nil {
 		return nil
@@ -247,33 +260,25 @@ func (d *Deployer) setNamespaceLabelsAndAnnotations(ctx context.Context, bd *fle
 		return err
 	}
 
-	ns, err := fetchNamespace(ctx, c, releaseID)
-	if err != nil {
+	name, _, _ := strings.Cut(releaseID, "/")
+
+	// Fleet manages the namespace's metadata but does not create it; creation is
+	// Helm's responsibility (see CreateNamespace). Verify the namespace exists,
+	// and surface a clear RBAC error if the deployment's service account cannot
+	// see it, before attempting the apply.
+	if err := ensureNamespaceExists(ctx, c, name); err != nil {
 		return err
 	}
 
-	desiredLabels := maps.Clone(ns.Labels)
+	var labels, annotations map[string]string
 	if bd.Spec.Options.NamespaceLabels != nil {
-		if desiredLabels == nil {
-			desiredLabels = make(map[string]string)
-		}
-		addLabelsFromOptions(log.FromContext(ctx), desiredLabels, bd.Spec.Options.NamespaceLabels)
+		labels = filterPodSecurityLabels(log.FromContext(ctx), bd.Spec.Options.NamespaceLabels)
 	}
-	desiredAnnotations := maps.Clone(ns.Annotations)
 	if bd.Spec.Options.NamespaceAnnotations != nil {
-		if desiredAnnotations == nil {
-			desiredAnnotations = make(map[string]string)
-		}
-		addAnnotationsFromOptions(desiredAnnotations, bd.Spec.Options.NamespaceAnnotations)
+		annotations = bd.Spec.Options.NamespaceAnnotations
 	}
 
-	if maps.Equal(desiredLabels, ns.Labels) && maps.Equal(desiredAnnotations, ns.Annotations) {
-		return nil
-	}
-
-	ns.Labels = desiredLabels
-	ns.Annotations = desiredAnnotations
-	return updateNamespace(ctx, c, ns)
+	return applyNamespaceMetadata(ctx, c, name, labels, annotations)
 }
 
 // namespaceClient returns the client to use for namespace label/annotation
@@ -298,13 +303,31 @@ func (d *Deployer) namespaceClient(ctx context.Context, bd *fleet.BundleDeployme
 	return d.client, nil
 }
 
-// updateNamespace updates a namespace resource in the cluster.
-func updateNamespace(ctx context.Context, c client.Client, ns *corev1.Namespace) error {
-	if err := c.Update(ctx, ns); err != nil {
+// namespaceFieldOwner is the server-side apply field manager Fleet uses for the
+// namespace labels/annotations it manages. It must stay stable across reconciles
+// so that dropping a key from the options prunes it (SSA removes fields this
+// manager previously owned but no longer declares).
+const namespaceFieldOwner = "fleet-agent-namespace-metadata"
+
+// applyNamespaceMetadata server-side applies the given labels and annotations to
+// the named namespace. Passing a nil map leaves that field alone; passing a
+// non-nil map makes Fleet the owner of exactly those keys. ForceOwnership adopts
+// keys previously written via the old read-modify-write update so the first
+// apply after upgrade does not conflict.
+func applyNamespaceMetadata(ctx context.Context, c client.Client, name string, labels, annotations map[string]string) error {
+	nsac := corev1ac.Namespace(name)
+	if labels != nil {
+		nsac = nsac.WithLabels(labels)
+	}
+	if annotations != nil {
+		nsac = nsac.WithAnnotations(annotations)
+	}
+
+	if err := c.Apply(ctx, nsac, client.FieldOwner(namespaceFieldOwner), client.ForceOwnership); err != nil {
 		if apierrors.IsForbidden(err) {
-			return fmt.Errorf("the deployment's service account is not allowed to update namespace %q; "+
-				"grant it 'update' on this namespace (scoped via resourceNames) or remove "+
-				"namespaceLabels/namespaceAnnotations: %w", ns.Name, err)
+			return fmt.Errorf("the deployment's service account is not allowed to patch namespace %q; "+
+				"grant it 'patch' on this namespace (scoped via resourceNames) or remove "+
+				"namespaceLabels/namespaceAnnotations: %w", name, err)
 		}
 		return err
 	}
@@ -312,28 +335,27 @@ func updateNamespace(ctx context.Context, c client.Client, ns *corev1.Namespace)
 	return nil
 }
 
-// fetchNamespace gets the namespace matching the release ID. Returns an error if none is found.
-// releaseID is composed of release.Namespace/release.Name/release.Version
-func fetchNamespace(ctx context.Context, c client.Client, releaseID string) (*corev1.Namespace, error) {
-	namespace := strings.Split(releaseID, "/")[0]
+// ensureNamespaceExists returns nil if the namespace exists, a NotFound error if
+// it does not, or a wrapped Forbidden error if the deployment's service account
+// is not allowed to see it.
+func ensureNamespaceExists(ctx context.Context, c client.Client, name string) error {
 	ns := &corev1.Namespace{}
-	if err := c.Get(ctx, types.NamespacedName{Name: namespace}, ns); err != nil {
+	if err := c.Get(ctx, types.NamespacedName{Name: name}, ns); err != nil {
 		if apierrors.IsForbidden(err) {
-			return nil, fmt.Errorf("the deployment's service account is not allowed to get namespace %q; "+
+			return fmt.Errorf("the deployment's service account is not allowed to get namespace %q; "+
 				"grant it 'get' on this namespace (scoped via resourceNames) or remove "+
-				"namespaceLabels/namespaceAnnotations: %w", namespace, err)
+				"namespaceLabels/namespaceAnnotations: %w", name, err)
 		}
-		return nil, err
+		return err
 	}
-	return ns, nil
+
+	return nil
 }
 
 const podSecurityLabelPrefix = "pod-security.kubernetes.io/"
 
-// addLabelsFromOptions updates nsLabels to contain labels from optLabels, while preserving
-// the `kubernetes.io/metadata.name` label added by Kubernetes when creating the namespace
-// and any existing `pod-security.kubernetes.io/*` labels. Labels with the
-// `pod-security.kubernetes.io/` prefix in optLabels are ignored.
+// filterPodSecurityLabels returns a copy of optLabels with any
+// `pod-security.kubernetes.io/*` labels removed.
 //
 // This filtering is intentionally unconditional and independent of the
 // service-account impersonation used for the namespace patch: it must also hold
@@ -342,38 +364,20 @@ const podSecurityLabelPrefix = "pod-security.kubernetes.io/"
 // bundle escalating pod-security enforcement on its target namespace. To set
 // pod-security labels on a namespace, declare them on the Namespace resource in
 // the bundle instead.
-func addLabelsFromOptions(logger logr.Logger, nsLabels map[string]string, optLabels map[string]string) {
+//
+// Existing pod-security labels on the namespace are preserved automatically:
+// Fleet never declares them, so the server-side apply does not touch them.
+func filterPodSecurityLabels(logger logr.Logger, optLabels map[string]string) map[string]string {
+	filtered := make(map[string]string, len(optLabels))
 	for k, v := range optLabels {
 		if strings.HasPrefix(k, podSecurityLabelPrefix) {
-			logger.V(1).Info("Ignoring label from options", "label", k)
+			logger.V(1).Info("Ignoring pod-security label from options", "label", k)
 			continue
 		}
-		nsLabels[k] = v
+		filtered[k] = v
 	}
 
-	// Delete labels not defined in the options.
-	// Keep the `kubernetes.io/metadata.name` label as it is added by kubernetes when creating the namespace.
-	// Keep pod-security.kubernetes.io/ labels as they are managed by cluster administrators.
-	for k := range nsLabels {
-		if strings.HasPrefix(k, podSecurityLabelPrefix) {
-			continue
-		}
-		if _, ok := optLabels[k]; k != corev1.LabelMetadataName && !ok {
-			delete(nsLabels, k)
-		}
-	}
-}
-
-// addAnnotationsFromOptions updates nsAnnotations so that it only contains all annotations specified in optAnnotations.
-func addAnnotationsFromOptions(nsAnnotations map[string]string, optAnnotations map[string]string) {
-	maps.Copy(nsAnnotations, optAnnotations)
-
-	// Delete Annotations not defined in the options.
-	for k := range nsAnnotations {
-		if _, ok := optAnnotations[k]; !ok {
-			delete(nsAnnotations, k)
-		}
-	}
+	return filtered
 }
 
 // deployErrToStatus converts an error into a status update

--- a/internal/cmd/agent/deployer/deployer.go
+++ b/internal/cmd/agent/deployer/deployer.go
@@ -266,7 +266,18 @@ func (d *Deployer) setNamespaceLabelsAndAnnotations(ctx context.Context, bd *fle
 	// Helm's responsibility (see CreateNamespace). Verify the namespace exists,
 	// and surface a clear RBAC error if the deployment's service account cannot
 	// see it, before attempting the apply.
-	if err := ensureNamespaceExists(ctx, c, name); err != nil {
+	ns, err := fetchExistingNamespace(ctx, c, name)
+	if err != nil {
+		return err
+	}
+
+	// One-time (self-healing, idempotent) migration for namespaces that
+	// predate the switch to server-side apply: absorb ownership of the
+	// labels/annotations keys the old read-modify-write update still holds,
+	// so this apply can actually prune them. No-op once migrated. See
+	// migrateLegacyNamespaceManagedFields for why this is scoped rather than
+	// using k8s.io/client-go/util/csaupgrade directly.
+	if err := migrateLegacyNamespaceManagedFields(ctx, c, ns); err != nil {
 		return err
 	}
 
@@ -335,21 +346,21 @@ func applyNamespaceMetadata(ctx context.Context, c client.Client, name string, l
 	return nil
 }
 
-// ensureNamespaceExists returns nil if the namespace exists, a NotFound error if
-// it does not, or a wrapped Forbidden error if the deployment's service account
-// is not allowed to see it.
-func ensureNamespaceExists(ctx context.Context, c client.Client, name string) error {
+// fetchExistingNamespace returns the namespace if it exists, a NotFound error
+// if it does not, or a wrapped Forbidden error if the deployment's service
+// account is not allowed to see it.
+func fetchExistingNamespace(ctx context.Context, c client.Client, name string) (*corev1.Namespace, error) {
 	ns := &corev1.Namespace{}
 	if err := c.Get(ctx, types.NamespacedName{Name: name}, ns); err != nil {
 		if apierrors.IsForbidden(err) {
-			return fmt.Errorf("the deployment's service account is not allowed to get namespace %q; "+
+			return nil, fmt.Errorf("the deployment's service account is not allowed to get namespace %q; "+
 				"grant it 'get' on this namespace (scoped via resourceNames) or remove "+
 				"namespaceLabels/namespaceAnnotations: %w", name, err)
 		}
-		return err
+		return nil, err
 	}
 
-	return nil
+	return ns, nil
 }
 
 const podSecurityLabelPrefix = "pod-security.kubernetes.io/"

--- a/internal/cmd/agent/deployer/deployer.go
+++ b/internal/cmd/agent/deployer/deployer.go
@@ -305,7 +305,18 @@ func (d *Deployer) setNamespaceLabelsAndAnnotations(ctx context.Context, bd *fle
 	// Helm's responsibility (see CreateNamespace). Verify the namespace exists,
 	// and surface a clear RBAC error if the deployment's service account cannot
 	// see it, before attempting the apply.
-	if err := ensureNamespaceExists(ctx, c, name); err != nil {
+	ns, err := fetchExistingNamespace(ctx, c, name)
+	if err != nil {
+		return err
+	}
+
+	// One-time (self-healing, idempotent) migration for namespaces that
+	// predate the switch to server-side apply: absorb ownership of the
+	// labels/annotations keys the old read-modify-write update still holds,
+	// so this apply can actually prune them. No-op once migrated. See
+	// migrateLegacyNamespaceManagedFields for why this is scoped rather than
+	// using k8s.io/client-go/util/csaupgrade directly.
+	if err := migrateLegacyNamespaceManagedFields(ctx, c, ns); err != nil {
 		return err
 	}
 
@@ -374,21 +385,21 @@ func applyNamespaceMetadata(ctx context.Context, c client.Client, name string, l
 	return nil
 }
 
-// ensureNamespaceExists returns nil if the namespace exists, a NotFound error if
-// it does not, or a wrapped Forbidden error if the deployment's service account
-// is not allowed to see it.
-func ensureNamespaceExists(ctx context.Context, c client.Client, name string) error {
+// fetchExistingNamespace returns the namespace if it exists, a NotFound error
+// if it does not, or a wrapped Forbidden error if the deployment's service
+// account is not allowed to see it.
+func fetchExistingNamespace(ctx context.Context, c client.Client, name string) (*corev1.Namespace, error) {
 	ns := &corev1.Namespace{}
 	if err := c.Get(ctx, types.NamespacedName{Name: name}, ns); err != nil {
 		if apierrors.IsForbidden(err) {
-			return fmt.Errorf("the deployment's service account is not allowed to get namespace %q; "+
+			return nil, fmt.Errorf("the deployment's service account is not allowed to get namespace %q; "+
 				"grant it 'get' on this namespace (scoped via resourceNames) or remove "+
 				"namespaceLabels/namespaceAnnotations: %w", name, err)
 		}
-		return err
+		return nil, err
 	}
 
-	return nil
+	return ns, nil
 }
 
 // deployErrToStatus converts an error into a status update

--- a/internal/cmd/agent/deployer/deployer.go
+++ b/internal/cmd/agent/deployer/deployer.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"maps"
 	"regexp"
 	"slices"
 	"strings"
@@ -23,6 +22,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	corev1ac "k8s.io/client-go/applyconfigurations/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
@@ -266,7 +266,20 @@ func (d *Deployer) helmdeploy(ctx context.Context, logger logr.Logger, bd *fleet
 	return resourceID, nil
 }
 
-// setNamespaceLabelsAndAnnotations updates the namespace for the release, applying all labels and annotations to that namespace as configured in the bundle spec.
+// setNamespaceLabelsAndAnnotations applies the labels and annotations configured
+// in the bundle spec to the release namespace.
+//
+// It server-side applies with a dedicated Fleet field manager, so Fleet owns
+// exactly the keys it declares. Labels and annotations set by other actors (for
+// example Rancher's field.cattle.io/projectId, added when a namespace is moved
+// into a Project) are left untouched, and a key that Fleet stops declaring is
+// pruned. This replaced an earlier read-modify-write that deleted every key not
+// present in the options and could only preserve a hardcoded allowlist (see
+// issue #4564).
+//
+// Labels and annotations are applied independently: a bundle that sets only
+// namespaceLabels never asserts ownership of (and therefore never prunes)
+// annotations, and vice versa.
 func (d *Deployer) setNamespaceLabelsAndAnnotations(ctx context.Context, bd *fleet.BundleDeployment, releaseID string) error {
 	if bd.Spec.Options.NamespaceLabels == nil && bd.Spec.Options.NamespaceAnnotations == nil {
 		return nil
@@ -282,33 +295,29 @@ func (d *Deployer) setNamespaceLabelsAndAnnotations(ctx context.Context, bd *fle
 		return err
 	}
 
-	ns, err := fetchNamespace(ctx, c, releaseID)
-	if err != nil {
+	// releaseID is composed of release.Namespace/release.Name/release.Version
+	name, _, found := strings.Cut(releaseID, "/")
+	if !found {
+		return fmt.Errorf("malformed release ID, without slash separator after namespace: %q", releaseID)
+	}
+
+	// Fleet manages the namespace's metadata but does not create it; creation is
+	// Helm's responsibility (see CreateNamespace). Verify the namespace exists,
+	// and surface a clear RBAC error if the deployment's service account cannot
+	// see it, before attempting the apply.
+	if err := ensureNamespaceExists(ctx, c, name); err != nil {
 		return err
 	}
 
-	desiredLabels := maps.Clone(ns.Labels)
+	var labels, annotations map[string]string
 	if bd.Spec.Options.NamespaceLabels != nil {
-		if desiredLabels == nil {
-			desiredLabels = make(map[string]string)
-		}
-		addLabelsFromOptions(desiredLabels, bd.Spec.Options.NamespaceLabels)
+		labels = bd.Spec.Options.NamespaceLabels
 	}
-	desiredAnnotations := maps.Clone(ns.Annotations)
 	if bd.Spec.Options.NamespaceAnnotations != nil {
-		if desiredAnnotations == nil {
-			desiredAnnotations = make(map[string]string)
-		}
-		addAnnotationsFromOptions(desiredAnnotations, bd.Spec.Options.NamespaceAnnotations)
+		annotations = bd.Spec.Options.NamespaceAnnotations
 	}
 
-	if maps.Equal(desiredLabels, ns.Labels) && maps.Equal(desiredAnnotations, ns.Annotations) {
-		return nil
-	}
-
-	ns.Labels = desiredLabels
-	ns.Annotations = desiredAnnotations
-	return updateNamespace(ctx, c, ns)
+	return applyNamespaceMetadata(ctx, c, name, labels, annotations)
 }
 
 // namespaceClient returns the client to use for namespace label/annotation
@@ -333,13 +342,31 @@ func (d *Deployer) namespaceClient(ctx context.Context, bd *fleet.BundleDeployme
 	return d.client, nil
 }
 
-// updateNamespace updates a namespace resource in the cluster.
-func updateNamespace(ctx context.Context, c client.Client, ns *corev1.Namespace) error {
-	if err := c.Update(ctx, ns); err != nil {
+// namespaceFieldOwner is the server-side apply field manager Fleet uses for the
+// namespace labels/annotations it manages. It must stay stable across reconciles
+// so that dropping a key from the options prunes it (SSA removes fields this
+// manager previously owned but no longer declares).
+const namespaceFieldOwner = "fleet-agent-namespace-metadata"
+
+// applyNamespaceMetadata server-side applies the given labels and annotations to
+// the named namespace. Passing a nil map leaves that field alone; passing a
+// non-nil map makes Fleet the owner of exactly those keys. ForceOwnership adopts
+// keys previously written via the old read-modify-write update so the first
+// apply after upgrade does not conflict.
+func applyNamespaceMetadata(ctx context.Context, c client.Client, name string, labels, annotations map[string]string) error {
+	nsac := corev1ac.Namespace(name)
+	if labels != nil {
+		nsac = nsac.WithLabels(labels)
+	}
+	if annotations != nil {
+		nsac = nsac.WithAnnotations(annotations)
+	}
+
+	if err := c.Apply(ctx, nsac, client.FieldOwner(namespaceFieldOwner), client.ForceOwnership); err != nil {
 		if apierrors.IsForbidden(err) {
-			return fmt.Errorf("the deployment's service account is not allowed to update namespace %q; "+
-				"grant it 'update' on this namespace (scoped via resourceNames) or remove "+
-				"namespaceLabels/namespaceAnnotations: %w", ns.Name, err)
+			return fmt.Errorf("the deployment's service account is not allowed to patch namespace %q; "+
+				"grant it 'patch' on this namespace (scoped via resourceNames) or remove "+
+				"namespaceLabels/namespaceAnnotations: %w", name, err)
 		}
 		return err
 	}
@@ -347,57 +374,21 @@ func updateNamespace(ctx context.Context, c client.Client, ns *corev1.Namespace)
 	return nil
 }
 
-// fetchNamespace gets the namespace matching the release ID. Returns an error if none is found.
-// releaseID is composed of release.Namespace/release.Name/release.Version
-func fetchNamespace(ctx context.Context, c client.Client, releaseID string) (*corev1.Namespace, error) {
-	namespace, _, found := strings.Cut(releaseID, "/")
-	if !found {
-		return nil, fmt.Errorf("malformed release ID, without slash separator after namespace: %q", releaseID)
-	}
-
+// ensureNamespaceExists returns nil if the namespace exists, a NotFound error if
+// it does not, or a wrapped Forbidden error if the deployment's service account
+// is not allowed to see it.
+func ensureNamespaceExists(ctx context.Context, c client.Client, name string) error {
 	ns := &corev1.Namespace{}
-	if err := c.Get(ctx, types.NamespacedName{Name: namespace}, ns); err != nil {
+	if err := c.Get(ctx, types.NamespacedName{Name: name}, ns); err != nil {
 		if apierrors.IsForbidden(err) {
-			return nil, fmt.Errorf("the deployment's service account is not allowed to get namespace %q; "+
+			return fmt.Errorf("the deployment's service account is not allowed to get namespace %q; "+
 				"grant it 'get' on this namespace (scoped via resourceNames) or remove "+
-				"namespaceLabels/namespaceAnnotations: %w", namespace, err)
+				"namespaceLabels/namespaceAnnotations: %w", name, err)
 		}
-		return nil, err
+		return err
 	}
-	return ns, nil
-}
 
-// addLabelsFromOptions updates nsLabels to contain the labels from optLabels, while preserving
-// the `kubernetes.io/metadata.name` label added by Kubernetes when creating the namespace.
-//
-// Security-sensitive labels such as `pod-security.kubernetes.io/*` are not
-// filtered here. The namespace is patched as the deployment's service account
-// (see namespaceClient), so which labels a bundle may set on its target
-// namespace is gated by the downstream RBAC of that account. Deployments that
-// resolve to no service account still run as the agent, so restricting them
-// requires pinning a service account, either in the bundle or through a Policy.
-func addLabelsFromOptions(nsLabels map[string]string, optLabels map[string]string) {
-	maps.Copy(nsLabels, optLabels)
-
-	// Delete labels not defined in the options.
-	// Keep the `kubernetes.io/metadata.name` label as it is added by kubernetes when creating the namespace.
-	for k := range nsLabels {
-		if _, ok := optLabels[k]; k != corev1.LabelMetadataName && !ok {
-			delete(nsLabels, k)
-		}
-	}
-}
-
-// addAnnotationsFromOptions updates nsAnnotations so that it only contains all annotations specified in optAnnotations.
-func addAnnotationsFromOptions(nsAnnotations map[string]string, optAnnotations map[string]string) {
-	maps.Copy(nsAnnotations, optAnnotations)
-
-	// Delete Annotations not defined in the options.
-	for k := range nsAnnotations {
-		if _, ok := optAnnotations[k]; !ok {
-			delete(nsAnnotations, k)
-		}
-	}
+	return nil
 }
 
 // deployErrToStatus converts an error into a status update

--- a/internal/cmd/agent/deployer/deployer_ssa_envtest_test.go
+++ b/internal/cmd/agent/deployer/deployer_ssa_envtest_test.go
@@ -1,0 +1,142 @@
+package deployer
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+)
+
+// TestSetNamespaceLabelsAndAnnotations_ServerSideApply exercises the namespace
+// metadata sync against a real API server (envtest), which — unlike the
+// controller-runtime fake client — tracks server-side-apply field ownership.
+// This is the authoritative check for issue #4564: foreign metadata is
+// preserved, and a key that Fleet stops declaring is pruned.
+//
+// It is skipped unless KUBEBUILDER_ASSETS points at envtest binaries (e.g. via
+// `setup-envtest use -p env`).
+func TestSetNamespaceLabelsAndAnnotations_ServerSideApply(t *testing.T) {
+	if os.Getenv("KUBEBUILDER_ASSETS") == "" {
+		t.Skip("KUBEBUILDER_ASSETS not set; skipping envtest-backed server-side apply test")
+	}
+
+	env := &envtest.Environment{}
+	cfg, err := env.Start()
+	if err != nil {
+		t.Fatalf("failed to start envtest: %v", err)
+	}
+	t.Cleanup(func() { _ = env.Stop() })
+
+	scheme := clientgoscheme.Scheme
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	c, err := client.New(cfg, client.Options{Scheme: scheme})
+	if err != nil {
+		t.Fatalf("failed to build client: %v", err)
+	}
+
+	ctx := context.Background()
+
+	get := func(name string) *corev1.Namespace {
+		t.Helper()
+		ns := &corev1.Namespace{}
+		if err := c.Get(ctx, types.NamespacedName{Name: name}, ns); err != nil {
+			t.Fatalf("get namespace %q: %v", name, err)
+		}
+		return ns
+	}
+
+	t.Run("foreign metadata preserved and dropped keys pruned", func(t *testing.T) {
+		// A namespace with a foreign annotation, as if Rancher had moved it into
+		// a Project. It is owned by a different field manager than Fleet's.
+		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+			Name:        "issue-4564",
+			Annotations: map[string]string{"field.cattle.io/projectId": "p-abc123"},
+		}}
+		if err := c.Create(ctx, ns, client.FieldOwner("rancher")); err != nil {
+			t.Fatalf("create namespace: %v", err)
+		}
+
+		d := Deployer{client: c}
+
+		// First sync: Fleet declares two annotations and a label.
+		bd := &fleet.BundleDeployment{Spec: fleet.BundleDeploymentSpec{
+			Options: fleet.BundleDeploymentOptions{
+				NamespaceLabels:      map[string]string{"team": "blue"},
+				NamespaceAnnotations: map[string]string{"fleet-a": "1", "fleet-b": "2"},
+			},
+		}}
+		if err := d.setNamespaceLabelsAndAnnotations(ctx, bd, "issue-4564/rel/1"); err != nil {
+			t.Fatalf("first sync: %v", err)
+		}
+
+		got := get("issue-4564")
+		if got.Annotations["field.cattle.io/projectId"] != "p-abc123" {
+			t.Errorf("foreign projectId annotation not preserved: %v", got.Annotations)
+		}
+		if got.Annotations["fleet-a"] != "1" || got.Annotations["fleet-b"] != "2" {
+			t.Errorf("Fleet annotations not applied: %v", got.Annotations)
+		}
+		if got.Labels["team"] != "blue" {
+			t.Errorf("Fleet label not applied: %v", got.Labels)
+		}
+
+		// Second sync: Fleet drops fleet-b from the options. Because Fleet owns
+		// exactly the keys it declares, fleet-b must be pruned, while the foreign
+		// annotation and the still-declared keys remain.
+		bd.Spec.Options.NamespaceAnnotations = map[string]string{"fleet-a": "1"}
+		if err := d.setNamespaceLabelsAndAnnotations(ctx, bd, "issue-4564/rel/1"); err != nil {
+			t.Fatalf("second sync: %v", err)
+		}
+
+		got = get("issue-4564")
+		if _, ok := got.Annotations["fleet-b"]; ok {
+			t.Errorf("dropped annotation fleet-b was not pruned: %v", got.Annotations)
+		}
+		if got.Annotations["fleet-a"] != "1" {
+			t.Errorf("still-declared annotation fleet-a missing: %v", got.Annotations)
+		}
+		if got.Annotations["field.cattle.io/projectId"] != "p-abc123" {
+			t.Errorf("foreign projectId annotation lost after prune: %v", got.Annotations)
+		}
+	})
+
+	t.Run("pod-security labels are neither applied nor overwritten", func(t *testing.T) {
+		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+			Name:   "podsec",
+			Labels: map[string]string{"pod-security.kubernetes.io/enforce": "restricted"},
+		}}
+		if err := c.Create(ctx, ns, client.FieldOwner("cluster-admin")); err != nil {
+			t.Fatalf("create namespace: %v", err)
+		}
+
+		d := Deployer{client: c}
+		bd := &fleet.BundleDeployment{Spec: fleet.BundleDeploymentSpec{
+			Options: fleet.BundleDeploymentOptions{
+				NamespaceLabels: map[string]string{
+					"pod-security.kubernetes.io/enforce": "privileged",
+					"app-label":                          "value",
+				},
+			},
+		}}
+		if err := d.setNamespaceLabelsAndAnnotations(ctx, bd, "podsec/rel/1"); err != nil {
+			t.Fatalf("sync: %v", err)
+		}
+
+		got := get("podsec")
+		if got.Labels["pod-security.kubernetes.io/enforce"] != "restricted" {
+			t.Errorf("pod-security enforce label was overwritten: %v", got.Labels)
+		}
+		if got.Labels["app-label"] != "value" {
+			t.Errorf("non-security label not applied: %v", got.Labels)
+		}
+	})
+}

--- a/internal/cmd/agent/deployer/deployer_ssa_envtest_test.go
+++ b/internal/cmd/agent/deployer/deployer_ssa_envtest_test.go
@@ -109,6 +109,77 @@ func TestSetNamespaceLabelsAndAnnotations_ServerSideApply(t *testing.T) {
 		}
 	})
 
+	// Reproduces the in-place-upgrade scenario: a namespace whose Fleet
+	// annotations were written by the old read-modify-write Update (recorded
+	// under the "fleetagent" manager), before Fleet switched to SSA.
+	// ForceOwnership on the first apply gives the SSA manager co-ownership but
+	// does not, by itself, remove the stale Update entry. Without the scoped
+	// managed-fields migration, a key later dropped from the bundle would stay
+	// on the namespace forever, because the stale entry still owns it.
+	t.Run("legacy update-owned annotation is migrated so it can later be pruned", func(t *testing.T) {
+		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "legacy-migration"}}
+		if err := c.Create(ctx, ns, client.FieldOwner("cluster-admin")); err != nil {
+			t.Fatalf("create namespace: %v", err)
+		}
+
+		// Simulate the pre-SSA agent: a plain Update (PUT), recorded under the
+		// "fleetagent" manager, exactly like the old read-modify-write path.
+		got := get("legacy-migration")
+		got.Annotations = map[string]string{"fleet-a": "1", "fleet-b": "2"}
+		got.Labels = map[string]string{"team": "blue"}
+		if err := c.Update(ctx, got, client.FieldOwner(legacyNamespaceFieldManager)); err != nil {
+			t.Fatalf("legacy update: %v", err)
+		}
+
+		got = get("legacy-migration")
+		foundLegacy := false
+		for _, mf := range got.ManagedFields {
+			if mf.Manager == legacyNamespaceFieldManager && mf.Operation == metav1.ManagedFieldsOperationUpdate {
+				foundLegacy = true
+			}
+		}
+		if !foundLegacy {
+			t.Fatalf("test setup did not produce a legacy fleetagent Update entry: %v", got.ManagedFields)
+		}
+
+		d := Deployer{client: c}
+		bd := &fleet.BundleDeployment{Spec: fleet.BundleDeploymentSpec{
+			Options: fleet.BundleDeploymentOptions{
+				NamespaceLabels:      map[string]string{"team": "blue"},
+				NamespaceAnnotations: map[string]string{"fleet-a": "1", "fleet-b": "2"},
+			},
+		}}
+		// First sync after the (simulated) upgrade: migrates the stale entry.
+		if err := d.setNamespaceLabelsAndAnnotations(ctx, bd, "legacy-migration/rel/1"); err != nil {
+			t.Fatalf("first sync: %v", err)
+		}
+
+		got = get("legacy-migration")
+		for _, mf := range got.ManagedFields {
+			if mf.Manager == legacyNamespaceFieldManager && mf.Operation == metav1.ManagedFieldsOperationUpdate {
+				t.Errorf("legacy fleetagent Update entry was not migrated away: %v", got.ManagedFields)
+			}
+		}
+
+		// Now drop fleet-b: without the migration this would stay behind
+		// forever, because the stale entry still owned it.
+		bd.Spec.Options.NamespaceAnnotations = map[string]string{"fleet-a": "1"}
+		if err := d.setNamespaceLabelsAndAnnotations(ctx, bd, "legacy-migration/rel/1"); err != nil {
+			t.Fatalf("second sync: %v", err)
+		}
+
+		got = get("legacy-migration")
+		if _, ok := got.Annotations["fleet-b"]; ok {
+			t.Errorf("dropped annotation fleet-b was not pruned after migration: %v", got.Annotations)
+		}
+		if got.Annotations["fleet-a"] != "1" {
+			t.Errorf("still-declared annotation fleet-a missing: %v", got.Annotations)
+		}
+		if got.Labels["team"] != "blue" {
+			t.Errorf("still-declared label team missing: %v", got.Labels)
+		}
+	})
+
 	t.Run("pod-security labels are neither applied nor overwritten", func(t *testing.T) {
 		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
 			Name:   "podsec",

--- a/internal/cmd/agent/deployer/deployer_ssa_envtest_test.go
+++ b/internal/cmd/agent/deployer/deployer_ssa_envtest_test.go
@@ -1,0 +1,142 @@
+package deployer
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+)
+
+// TestSetNamespaceLabelsAndAnnotations_ServerSideApply exercises the namespace
+// metadata sync against a real API server (envtest), which — unlike the
+// controller-runtime fake client — tracks server-side-apply field ownership.
+// This is the authoritative check for issue #4564: foreign metadata is
+// preserved, and a key that Fleet stops declaring is pruned.
+//
+// It is skipped unless KUBEBUILDER_ASSETS points at envtest binaries (e.g. via
+// `setup-envtest use -p env`).
+func TestSetNamespaceLabelsAndAnnotations_ServerSideApply(t *testing.T) {
+	if os.Getenv("KUBEBUILDER_ASSETS") == "" {
+		t.Skip("KUBEBUILDER_ASSETS not set; skipping envtest-backed server-side apply test")
+	}
+
+	env := &envtest.Environment{}
+	cfg, err := env.Start()
+	if err != nil {
+		t.Fatalf("failed to start envtest: %v", err)
+	}
+	t.Cleanup(func() { _ = env.Stop() })
+
+	scheme := clientgoscheme.Scheme
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	c, err := client.New(cfg, client.Options{Scheme: scheme})
+	if err != nil {
+		t.Fatalf("failed to build client: %v", err)
+	}
+
+	ctx := context.Background()
+
+	get := func(name string) *corev1.Namespace {
+		t.Helper()
+		ns := &corev1.Namespace{}
+		if err := c.Get(ctx, types.NamespacedName{Name: name}, ns); err != nil {
+			t.Fatalf("get namespace %q: %v", name, err)
+		}
+		return ns
+	}
+
+	t.Run("foreign metadata preserved and dropped keys pruned", func(t *testing.T) {
+		// A namespace with a foreign annotation, as if Rancher had moved it into
+		// a Project. It is owned by a different field manager than Fleet's.
+		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+			Name:        "issue-4564",
+			Annotations: map[string]string{"field.cattle.io/projectId": "p-abc123"},
+		}}
+		if err := c.Create(ctx, ns, client.FieldOwner("rancher")); err != nil {
+			t.Fatalf("create namespace: %v", err)
+		}
+
+		d := Deployer{client: c}
+
+		// First sync: Fleet declares two annotations and a label.
+		bd := &fleet.BundleDeployment{Spec: fleet.BundleDeploymentSpec{
+			Options: fleet.BundleDeploymentOptions{
+				NamespaceLabels:      map[string]string{"team": "blue"},
+				NamespaceAnnotations: map[string]string{"fleet-a": "1", "fleet-b": "2"},
+			},
+		}}
+		if err := d.setNamespaceLabelsAndAnnotations(ctx, bd, "issue-4564/rel/1"); err != nil {
+			t.Fatalf("first sync: %v", err)
+		}
+
+		got := get("issue-4564")
+		if got.Annotations["field.cattle.io/projectId"] != "p-abc123" {
+			t.Errorf("foreign projectId annotation not preserved: %v", got.Annotations)
+		}
+		if got.Annotations["fleet-a"] != "1" || got.Annotations["fleet-b"] != "2" {
+			t.Errorf("Fleet annotations not applied: %v", got.Annotations)
+		}
+		if got.Labels["team"] != "blue" {
+			t.Errorf("Fleet label not applied: %v", got.Labels)
+		}
+
+		// Second sync: Fleet drops fleet-b from the options. Because Fleet owns
+		// exactly the keys it declares, fleet-b must be pruned, while the foreign
+		// annotation and the still-declared keys remain.
+		bd.Spec.Options.NamespaceAnnotations = map[string]string{"fleet-a": "1"}
+		if err := d.setNamespaceLabelsAndAnnotations(ctx, bd, "issue-4564/rel/1"); err != nil {
+			t.Fatalf("second sync: %v", err)
+		}
+
+		got = get("issue-4564")
+		if _, ok := got.Annotations["fleet-b"]; ok {
+			t.Errorf("dropped annotation fleet-b was not pruned: %v", got.Annotations)
+		}
+		if got.Annotations["fleet-a"] != "1" {
+			t.Errorf("still-declared annotation fleet-a missing: %v", got.Annotations)
+		}
+		if got.Annotations["field.cattle.io/projectId"] != "p-abc123" {
+			t.Errorf("foreign projectId annotation lost after prune: %v", got.Annotations)
+		}
+	})
+
+	t.Run("pod-security labels are applied and overwritten like any other label", func(t *testing.T) {
+		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+			Name:   "podsec",
+			Labels: map[string]string{"pod-security.kubernetes.io/enforce": "restricted"},
+		}}
+		if err := c.Create(ctx, ns, client.FieldOwner("cluster-admin")); err != nil {
+			t.Fatalf("create namespace: %v", err)
+		}
+
+		d := Deployer{client: c}
+		bd := &fleet.BundleDeployment{Spec: fleet.BundleDeploymentSpec{
+			Options: fleet.BundleDeploymentOptions{
+				NamespaceLabels: map[string]string{
+					"pod-security.kubernetes.io/enforce": "privileged",
+					"app-label":                          "value",
+				},
+			},
+		}}
+		if err := d.setNamespaceLabelsAndAnnotations(ctx, bd, "podsec/rel/1"); err != nil {
+			t.Fatalf("sync: %v", err)
+		}
+
+		got := get("podsec")
+		if got.Labels["pod-security.kubernetes.io/enforce"] != "privileged" {
+			t.Errorf("pod-security enforce label was not applied: %v", got.Labels)
+		}
+		if got.Labels["app-label"] != "value" {
+			t.Errorf("non-security label not applied: %v", got.Labels)
+		}
+	})
+}

--- a/internal/cmd/agent/deployer/deployer_ssa_envtest_test.go
+++ b/internal/cmd/agent/deployer/deployer_ssa_envtest_test.go
@@ -109,6 +109,77 @@ func TestSetNamespaceLabelsAndAnnotations_ServerSideApply(t *testing.T) {
 		}
 	})
 
+	// Reproduces the in-place-upgrade scenario: a namespace whose Fleet
+	// annotations were written by the old read-modify-write Update (recorded
+	// under the "fleetagent" manager), before Fleet switched to SSA.
+	// ForceOwnership on the first apply gives the SSA manager co-ownership but
+	// does not, by itself, remove the stale Update entry. Without the scoped
+	// managed-fields migration, a key later dropped from the bundle would stay
+	// on the namespace forever, because the stale entry still owns it.
+	t.Run("legacy update-owned annotation is migrated so it can later be pruned", func(t *testing.T) {
+		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "legacy-migration"}}
+		if err := c.Create(ctx, ns, client.FieldOwner("cluster-admin")); err != nil {
+			t.Fatalf("create namespace: %v", err)
+		}
+
+		// Simulate the pre-SSA agent: a plain Update (PUT), recorded under the
+		// "fleetagent" manager, exactly like the old read-modify-write path.
+		got := get("legacy-migration")
+		got.Annotations = map[string]string{"fleet-a": "1", "fleet-b": "2"}
+		got.Labels = map[string]string{"team": "blue"}
+		if err := c.Update(ctx, got, client.FieldOwner(legacyNamespaceFieldManager)); err != nil {
+			t.Fatalf("legacy update: %v", err)
+		}
+
+		got = get("legacy-migration")
+		foundLegacy := false
+		for _, mf := range got.ManagedFields {
+			if mf.Manager == legacyNamespaceFieldManager && mf.Operation == metav1.ManagedFieldsOperationUpdate {
+				foundLegacy = true
+			}
+		}
+		if !foundLegacy {
+			t.Fatalf("test setup did not produce a legacy fleetagent Update entry: %v", got.ManagedFields)
+		}
+
+		d := Deployer{client: c}
+		bd := &fleet.BundleDeployment{Spec: fleet.BundleDeploymentSpec{
+			Options: fleet.BundleDeploymentOptions{
+				NamespaceLabels:      map[string]string{"team": "blue"},
+				NamespaceAnnotations: map[string]string{"fleet-a": "1", "fleet-b": "2"},
+			},
+		}}
+		// First sync after the (simulated) upgrade: migrates the stale entry.
+		if err := d.setNamespaceLabelsAndAnnotations(ctx, bd, "legacy-migration/rel/1"); err != nil {
+			t.Fatalf("first sync: %v", err)
+		}
+
+		got = get("legacy-migration")
+		for _, mf := range got.ManagedFields {
+			if mf.Manager == legacyNamespaceFieldManager && mf.Operation == metav1.ManagedFieldsOperationUpdate {
+				t.Errorf("legacy fleetagent Update entry was not migrated away: %v", got.ManagedFields)
+			}
+		}
+
+		// Now drop fleet-b: without the migration this would stay behind
+		// forever, because the stale entry still owned it.
+		bd.Spec.Options.NamespaceAnnotations = map[string]string{"fleet-a": "1"}
+		if err := d.setNamespaceLabelsAndAnnotations(ctx, bd, "legacy-migration/rel/1"); err != nil {
+			t.Fatalf("second sync: %v", err)
+		}
+
+		got = get("legacy-migration")
+		if _, ok := got.Annotations["fleet-b"]; ok {
+			t.Errorf("dropped annotation fleet-b was not pruned after migration: %v", got.Annotations)
+		}
+		if got.Annotations["fleet-a"] != "1" {
+			t.Errorf("still-declared annotation fleet-a missing: %v", got.Annotations)
+		}
+		if got.Labels["team"] != "blue" {
+			t.Errorf("still-declared label team missing: %v", got.Labels)
+		}
+	})
+
 	t.Run("pod-security labels are applied and overwritten like any other label", func(t *testing.T) {
 		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
 			Name:   "podsec",

--- a/internal/cmd/agent/deployer/deployer_test.go
+++ b/internal/cmd/agent/deployer/deployer_test.go
@@ -76,26 +76,26 @@ func TestSetNamespaceLabelsAndAnnotations(t *testing.T) {
 			},
 		},
 
-		"NamespaceLabels and NamespaceAnnotations removes entries that are not in the options, except the name label": {
+		"foreign labels and annotations not in the options are preserved (issue #4564)": {
 			bd: &fleet.BundleDeployment{Spec: fleet.BundleDeploymentSpec{
 				Options: fleet.BundleDeploymentOptions{
 					NamespaceLabels:      map[string]string{"optLabel": "optValue"},
-					NamespaceAnnotations: map[string]string{},
+					NamespaceAnnotations: map[string]string{"optAnn": "optValue"},
 				},
 			}},
 			ns: corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        "namespace",
 					Labels:      map[string]string{"nsLabel": "nsValue", "kubernetes.io/metadata.name": "namespace"},
-					Annotations: map[string]string{"nsAnn": "nsValue"},
+					Annotations: map[string]string{"field.cattle.io/projectId": "p-abc123"},
 				},
 			},
 			release: "namespace/foo/bar",
 			expectedNs: corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        "namespace",
-					Labels:      map[string]string{"optLabel": "optValue", "kubernetes.io/metadata.name": "namespace"},
-					Annotations: map[string]string{},
+					Labels:      map[string]string{"optLabel": "optValue", "nsLabel": "nsValue", "kubernetes.io/metadata.name": "namespace"},
+					Annotations: map[string]string{"optAnn": "optValue", "field.cattle.io/projectId": "p-abc123"},
 				},
 			},
 		},
@@ -181,14 +181,14 @@ func TestSetNamespaceLabelsAndAnnotations_CreateNamespaceFalse(t *testing.T) {
 	scheme := runtime.NewScheme()
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 
-	updateCalled := false
+	applyCalled := false
 	fakeClient := fake.NewClientBuilder().
 		WithScheme(scheme).
 		WithObjects(&ns).
 		WithInterceptorFuncs(interceptor.Funcs{
-			Update: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
-				updateCalled = true
-				return c.Update(ctx, obj, opts...)
+			Apply: func(ctx context.Context, c client.WithWatch, obj runtime.ApplyConfiguration, opts ...client.ApplyOption) error {
+				applyCalled = true
+				return c.Apply(ctx, obj, opts...)
 			},
 		}).
 		Build()
@@ -198,8 +198,8 @@ func TestSetNamespaceLabelsAndAnnotations_CreateNamespaceFalse(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if !updateCalled {
-		t.Error("namespace UPDATE was not attempted when CreateNamespace is false; mutation must not be gated by CreateNamespace")
+	if !applyCalled {
+		t.Error("namespace APPLY was not attempted when CreateNamespace is false; mutation must not be gated by CreateNamespace")
 	}
 
 	result := &corev1.Namespace{}
@@ -240,7 +240,7 @@ func TestSetNamespaceLabelsAndAnnotations_ForbiddenSurfaces(t *testing.T) {
 		WithScheme(scheme).
 		WithObjects(&ns).
 		WithInterceptorFuncs(interceptor.Funcs{
-			Update: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+			Apply: func(ctx context.Context, c client.WithWatch, obj runtime.ApplyConfiguration, opts ...client.ApplyOption) error {
 				return forbidden
 			},
 		}).
@@ -303,12 +303,13 @@ func TestSetNamespaceLabelsAndAnnotationsError(t *testing.T) {
 	}
 }
 
-// TestSetNamespaceLabelsAndAnnotations_NoUpdateWhenAlreadyCorrect verifies that
-// updateNamespace is not called when the namespace already reflects the desired state.
-// This guards against the broken reflect.DeepEqual check that compared raw option
-// labels to ns.Labels; ns.Labels always includes kubernetes.io/metadata.name and
-// may include preserved pod-security labels, so a direct equality check never holds.
-func TestSetNamespaceLabelsAndAnnotations_NoUpdateWhenAlreadyCorrect(t *testing.T) {
+// TestSetNamespaceLabelsAndAnnotations_Idempotent verifies that applying the
+// same options twice is safe: it does not error and leaves both Fleet's keys and
+// a foreign annotation intact. The server-side apply is intentionally issued on
+// every reconcile (there is no skip-if-unchanged shortcut, since a correct one
+// would require knowing which keys Fleet previously owned), so it must be
+// idempotent.
+func TestSetNamespaceLabelsAndAnnotations_Idempotent(t *testing.T) {
 	bd := &fleet.BundleDeployment{Spec: fleet.BundleDeploymentSpec{
 		Options: fleet.BundleDeploymentOptions{
 			NamespaceLabels:      map[string]string{"optLabel": "optValue"},
@@ -318,109 +319,85 @@ func TestSetNamespaceLabelsAndAnnotations_NoUpdateWhenAlreadyCorrect(t *testing.
 	ns := corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        "namespace",
-			Labels:      map[string]string{"kubernetes.io/metadata.name": "namespace", "optLabel": "optValue"},
-			Annotations: map[string]string{"optAnn": "optValue"},
+			Labels:      map[string]string{"kubernetes.io/metadata.name": "namespace"},
+			Annotations: map[string]string{"field.cattle.io/projectId": "p-abc123"},
 		},
 	}
 
 	scheme := runtime.NewScheme()
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
-
-	updateCalled := false
-	fakeClient := fake.NewClientBuilder().
-		WithScheme(scheme).
-		WithObjects(&ns).
-		WithInterceptorFuncs(interceptor.Funcs{
-			Update: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
-				updateCalled = true
-				return c.Update(ctx, obj, opts...)
-			},
-		}).
-		Build()
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(&ns).Build()
 
 	h := Deployer{client: fakeClient}
-	err := h.setNamespaceLabelsAndAnnotations(context.Background(), bd, "namespace/foo/bar")
-	if err != nil {
+	for i := range 2 {
+		if err := h.setNamespaceLabelsAndAnnotations(context.Background(), bd, "namespace/foo/bar"); err != nil {
+			t.Fatalf("apply %d: unexpected error: %v", i, err)
+		}
+	}
+
+	result := &corev1.Namespace{}
+	if err := fakeClient.Get(context.Background(), types.NamespacedName{Name: "namespace"}, result); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if updateCalled {
-		t.Error("updateNamespace was called when namespace was already in the desired state")
+	if result.Labels["optLabel"] != "optValue" {
+		t.Errorf("optLabel: got %q, want %q", result.Labels["optLabel"], "optValue")
+	}
+	if result.Annotations["optAnn"] != "optValue" {
+		t.Errorf("optAnn: got %q, want %q", result.Annotations["optAnn"], "optValue")
+	}
+	if result.Annotations["field.cattle.io/projectId"] != "p-abc123" {
+		t.Errorf("foreign projectId annotation was not preserved: got %q", result.Annotations["field.cattle.io/projectId"])
 	}
 }
 
-func TestAddLabelsFromOptions_PodSecurityLabelsFiltered(t *testing.T) {
+func TestFilterPodSecurityLabels(t *testing.T) {
 	tests := map[string]struct {
-		nsLabels       map[string]string
-		optLabels      map[string]string
-		expectedLabels map[string]string
+		optLabels map[string]string
+		expected  map[string]string
 	}{
-		"pod-security.kubernetes.io labels in optLabels are not applied to namespace": {
-			nsLabels: map[string]string{"kubernetes.io/metadata.name": "ns"},
+		"pod-security.kubernetes.io labels are removed from the options": {
 			optLabels: map[string]string{
 				"pod-security.kubernetes.io/enforce": "privileged",
 				"pod-security.kubernetes.io/audit":   "privileged",
 				"pod-security.kubernetes.io/warn":    "privileged",
 				"safe-label":                         "value",
 			},
-			expectedLabels: map[string]string{
-				"kubernetes.io/metadata.name": "ns",
-				"safe-label":                  "value",
+			expected: map[string]string{
+				"safe-label": "value",
 			},
 		},
-		"existing pod-security.kubernetes.io labels on namespace are preserved": {
-			nsLabels: map[string]string{
-				"kubernetes.io/metadata.name":        "ns",
-				"pod-security.kubernetes.io/enforce": "baseline",
-				"pod-security.kubernetes.io/audit":   "baseline",
-			},
-			optLabels: map[string]string{
-				"pod-security.kubernetes.io/enforce": "privileged",
-				"app-label":                          "value",
-			},
-			expectedLabels: map[string]string{
-				"kubernetes.io/metadata.name":        "ns",
-				"pod-security.kubernetes.io/enforce": "baseline",
-				"pod-security.kubernetes.io/audit":   "baseline",
-				"app-label":                          "value",
-			},
-		},
-		"non-security labels work normally": {
-			nsLabels: map[string]string{
-				"kubernetes.io/metadata.name": "ns",
-				"old-label":                   "old-value",
-			},
+		"non-security labels pass through unchanged": {
 			optLabels: map[string]string{
 				"new-label": "new-value",
+				"app-label": "value",
 			},
-			expectedLabels: map[string]string{
-				"kubernetes.io/metadata.name": "ns",
-				"new-label":                   "new-value",
+			expected: map[string]string{
+				"new-label": "new-value",
+				"app-label": "value",
 			},
 		},
 		"pod-security.kubernetes.io labels with custom suffixes are also filtered": {
-			nsLabels: map[string]string{"kubernetes.io/metadata.name": "ns"},
 			optLabels: map[string]string{
 				"pod-security.kubernetes.io/enforce-version": "v1.25",
 				"pod-security.kubernetes.io/audit-version":   "v1.25",
 				"safe-label": "value",
 			},
-			expectedLabels: map[string]string{
-				"kubernetes.io/metadata.name": "ns",
-				"safe-label":                  "value",
+			expected: map[string]string{
+				"safe-label": "value",
 			},
 		},
 	}
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			addLabelsFromOptions(logr.Discard(), test.nsLabels, test.optLabels)
+			got := filterPodSecurityLabels(logr.Discard(), test.optLabels)
 
-			if len(test.nsLabels) != len(test.expectedLabels) {
-				t.Errorf("expected %d labels, got %d: %v", len(test.expectedLabels), len(test.nsLabels), test.nsLabels)
+			if len(got) != len(test.expected) {
+				t.Errorf("expected %d labels, got %d: %v", len(test.expected), len(got), got)
 			}
-			for k, v := range test.expectedLabels {
-				if test.nsLabels[k] != v {
-					t.Errorf("expected label %s=%s, got %s", k, v, test.nsLabels[k])
+			for k, v := range test.expected {
+				if got[k] != v {
+					t.Errorf("expected label %s=%s, got %s", k, v, got[k])
 				}
 			}
 		})

--- a/internal/cmd/agent/deployer/deployer_test.go
+++ b/internal/cmd/agent/deployer/deployer_test.go
@@ -76,26 +76,26 @@ func TestSetNamespaceLabelsAndAnnotations(t *testing.T) {
 			},
 		},
 
-		"NamespaceLabels and NamespaceAnnotations removes entries that are not in the options, except the name label": {
+		"foreign labels and annotations not in the options are preserved (issue #4564)": {
 			bd: &fleet.BundleDeployment{Spec: fleet.BundleDeploymentSpec{
 				Options: fleet.BundleDeploymentOptions{
 					NamespaceLabels:      map[string]string{"optLabel": "optValue"},
-					NamespaceAnnotations: map[string]string{},
+					NamespaceAnnotations: map[string]string{"optAnn": "optValue"},
 				},
 			}},
 			ns: corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        "namespace",
 					Labels:      map[string]string{"nsLabel": "nsValue", "kubernetes.io/metadata.name": "namespace"},
-					Annotations: map[string]string{"nsAnn": "nsValue"},
+					Annotations: map[string]string{"field.cattle.io/projectId": "p-abc123"},
 				},
 			},
 			release: "namespace/foo/bar",
 			expectedNs: corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        "namespace",
-					Labels:      map[string]string{"optLabel": "optValue", "kubernetes.io/metadata.name": "namespace"},
-					Annotations: map[string]string{},
+					Labels:      map[string]string{"optLabel": "optValue", "nsLabel": "nsValue", "kubernetes.io/metadata.name": "namespace"},
+					Annotations: map[string]string{"optAnn": "optValue", "field.cattle.io/projectId": "p-abc123"},
 				},
 			},
 		},
@@ -181,14 +181,14 @@ func TestSetNamespaceLabelsAndAnnotations_CreateNamespaceFalse(t *testing.T) {
 	scheme := runtime.NewScheme()
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 
-	updateCalled := false
+	applyCalled := false
 	fakeClient := fake.NewClientBuilder().
 		WithScheme(scheme).
 		WithObjects(&ns).
 		WithInterceptorFuncs(interceptor.Funcs{
-			Update: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
-				updateCalled = true
-				return c.Update(ctx, obj, opts...)
+			Apply: func(ctx context.Context, c client.WithWatch, obj runtime.ApplyConfiguration, opts ...client.ApplyOption) error {
+				applyCalled = true
+				return c.Apply(ctx, obj, opts...)
 			},
 		}).
 		Build()
@@ -198,8 +198,8 @@ func TestSetNamespaceLabelsAndAnnotations_CreateNamespaceFalse(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if !updateCalled {
-		t.Error("namespace UPDATE was not attempted when CreateNamespace is false; mutation must not be gated by CreateNamespace")
+	if !applyCalled {
+		t.Error("namespace APPLY was not attempted when CreateNamespace is false; mutation must not be gated by CreateNamespace")
 	}
 
 	result := &corev1.Namespace{}
@@ -240,7 +240,7 @@ func TestSetNamespaceLabelsAndAnnotations_ForbiddenSurfaces(t *testing.T) {
 		WithScheme(scheme).
 		WithObjects(&ns).
 		WithInterceptorFuncs(interceptor.Funcs{
-			Update: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+			Apply: func(ctx context.Context, c client.WithWatch, obj runtime.ApplyConfiguration, opts ...client.ApplyOption) error {
 				return forbidden
 			},
 		}).
@@ -301,12 +301,13 @@ func TestSetNamespaceLabelsAndAnnotationsError(t *testing.T) {
 	}
 }
 
-// TestSetNamespaceLabelsAndAnnotations_NoUpdateWhenAlreadyCorrect verifies that
-// updateNamespace is not called when the namespace already reflects the desired state.
-// This guards against the broken reflect.DeepEqual check that compared raw option
-// labels to ns.Labels; ns.Labels always includes kubernetes.io/metadata.name, so a
-// direct equality check never holds.
-func TestSetNamespaceLabelsAndAnnotations_NoUpdateWhenAlreadyCorrect(t *testing.T) {
+// TestSetNamespaceLabelsAndAnnotations_Idempotent verifies that applying the
+// same options twice is safe: it does not error and leaves both Fleet's keys and
+// a foreign annotation intact. The server-side apply is intentionally issued on
+// every reconcile (there is no skip-if-unchanged shortcut, since a correct one
+// would require knowing which keys Fleet previously owned), so it must be
+// idempotent.
+func TestSetNamespaceLabelsAndAnnotations_Idempotent(t *testing.T) {
 	bd := &fleet.BundleDeployment{Spec: fleet.BundleDeploymentSpec{
 		Options: fleet.BundleDeploymentOptions{
 			NamespaceLabels:      map[string]string{"optLabel": "optValue"},
@@ -316,128 +317,34 @@ func TestSetNamespaceLabelsAndAnnotations_NoUpdateWhenAlreadyCorrect(t *testing.
 	ns := corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        "namespace",
-			Labels:      map[string]string{"kubernetes.io/metadata.name": "namespace", "optLabel": "optValue"},
-			Annotations: map[string]string{"optAnn": "optValue"},
+			Labels:      map[string]string{"kubernetes.io/metadata.name": "namespace"},
+			Annotations: map[string]string{"field.cattle.io/projectId": "p-abc123"},
 		},
 	}
 
 	scheme := runtime.NewScheme()
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
-
-	updateCalled := false
-	fakeClient := fake.NewClientBuilder().
-		WithScheme(scheme).
-		WithObjects(&ns).
-		WithInterceptorFuncs(interceptor.Funcs{
-			Update: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
-				updateCalled = true
-				return c.Update(ctx, obj, opts...)
-			},
-		}).
-		Build()
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(&ns).Build()
 
 	h := Deployer{client: fakeClient}
-	err := h.setNamespaceLabelsAndAnnotations(context.Background(), bd, "namespace/foo/bar")
-	if err != nil {
+	for i := range 2 {
+		if err := h.setNamespaceLabelsAndAnnotations(context.Background(), bd, "namespace/foo/bar"); err != nil {
+			t.Fatalf("apply %d: unexpected error: %v", i, err)
+		}
+	}
+
+	result := &corev1.Namespace{}
+	if err := fakeClient.Get(context.Background(), types.NamespacedName{Name: "namespace"}, result); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if updateCalled {
-		t.Error("updateNamespace was called when namespace was already in the desired state")
+	if result.Labels["optLabel"] != "optValue" {
+		t.Errorf("optLabel: got %q, want %q", result.Labels["optLabel"], "optValue")
 	}
-}
-
-func TestAddLabelsFromOptions_PodSecurityLabels(t *testing.T) {
-	tests := map[string]struct {
-		nsLabels       map[string]string
-		optLabels      map[string]string
-		expectedLabels map[string]string
-	}{
-		"pod-security.kubernetes.io labels in optLabels are applied to the namespace": {
-			nsLabels: map[string]string{"kubernetes.io/metadata.name": "ns"},
-			optLabels: map[string]string{
-				"pod-security.kubernetes.io/enforce": "privileged",
-				"pod-security.kubernetes.io/audit":   "privileged",
-				"pod-security.kubernetes.io/warn":    "privileged",
-				"safe-label":                         "value",
-			},
-			expectedLabels: map[string]string{
-				"kubernetes.io/metadata.name":        "ns",
-				"pod-security.kubernetes.io/enforce": "privileged",
-				"pod-security.kubernetes.io/audit":   "privileged",
-				"pod-security.kubernetes.io/warn":    "privileged",
-				"safe-label":                         "value",
-			},
-		},
-		"existing pod-security.kubernetes.io labels on the namespace are overwritten": {
-			nsLabels: map[string]string{
-				"kubernetes.io/metadata.name":        "ns",
-				"pod-security.kubernetes.io/enforce": "baseline",
-			},
-			optLabels: map[string]string{
-				"pod-security.kubernetes.io/enforce": "privileged",
-				"app-label":                          "value",
-			},
-			expectedLabels: map[string]string{
-				"kubernetes.io/metadata.name":        "ns",
-				"pod-security.kubernetes.io/enforce": "privileged",
-				"app-label":                          "value",
-			},
-		},
-		"pod-security.kubernetes.io labels not in optLabels are removed like any other label": {
-			nsLabels: map[string]string{
-				"kubernetes.io/metadata.name":      "ns",
-				"pod-security.kubernetes.io/audit": "baseline",
-			},
-			optLabels: map[string]string{
-				"app-label": "value",
-			},
-			expectedLabels: map[string]string{
-				"kubernetes.io/metadata.name": "ns",
-				"app-label":                   "value",
-			},
-		},
-		"non-security labels work normally": {
-			nsLabels: map[string]string{
-				"kubernetes.io/metadata.name": "ns",
-				"old-label":                   "old-value",
-			},
-			optLabels: map[string]string{
-				"new-label": "new-value",
-			},
-			expectedLabels: map[string]string{
-				"kubernetes.io/metadata.name": "ns",
-				"new-label":                   "new-value",
-			},
-		},
-		"pod-security.kubernetes.io labels with version suffixes are applied as well": {
-			nsLabels: map[string]string{"kubernetes.io/metadata.name": "ns"},
-			optLabels: map[string]string{
-				"pod-security.kubernetes.io/enforce-version": "v1.25",
-				"pod-security.kubernetes.io/audit-version":   "v1.25",
-				"safe-label": "value",
-			},
-			expectedLabels: map[string]string{
-				"kubernetes.io/metadata.name":                "ns",
-				"pod-security.kubernetes.io/enforce-version": "v1.25",
-				"pod-security.kubernetes.io/audit-version":   "v1.25",
-				"safe-label": "value",
-			},
-		},
+	if result.Annotations["optAnn"] != "optValue" {
+		t.Errorf("optAnn: got %q, want %q", result.Annotations["optAnn"], "optValue")
 	}
-
-	for name, test := range tests {
-		t.Run(name, func(t *testing.T) {
-			addLabelsFromOptions(test.nsLabels, test.optLabels)
-
-			if len(test.nsLabels) != len(test.expectedLabels) {
-				t.Errorf("expected %d labels, got %d: %v", len(test.expectedLabels), len(test.nsLabels), test.nsLabels)
-			}
-			for k, v := range test.expectedLabels {
-				if test.nsLabels[k] != v {
-					t.Errorf("expected label %s=%s, got %s", k, v, test.nsLabels[k])
-				}
-			}
-		})
+	if result.Annotations["field.cattle.io/projectId"] != "p-abc123" {
+		t.Errorf("foreign projectId annotation was not preserved: got %q", result.Annotations["field.cattle.io/projectId"])
 	}
 }
 

--- a/internal/cmd/agent/deployer/namespace_managed_fields.go
+++ b/internal/cmd/agent/deployer/namespace_managed_fields.go
@@ -1,0 +1,201 @@
+package deployer
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/structured-merge-diff/v6/fieldpath"
+)
+
+// legacyNamespaceFieldManager is the field manager name the agent's old
+// read-modify-write namespace update recorded, before namespace metadata was
+// switched to server-side apply. client-go derives it from the binary name
+// (see cmd/fleetagent), so it is stable as long as that binary keeps its
+// name.
+const legacyNamespaceFieldManager = "fleetagent"
+
+// migrateLegacyNamespaceManagedFields transfers ownership of the
+// metadata.labels/metadata.annotations fields the legacy Update-based field
+// manager still holds on ns into namespaceFieldOwner's Apply entry.
+//
+// Background: ForceOwnership on the first post-upgrade apply makes Fleet's
+// SSA manager co-own any key it declares, but it does not strip the old
+// "fleetagent" Update entry from managedFields. A field is only pruned once
+// no manager owns it, so a key dropped from the bundle later stays behind
+// forever on any namespace that predates the SSA switch, because the stale
+// Update entry still owns it.
+//
+// This is deliberately scoped to metadata.labels/metadata.annotations rather
+// than absorbing the whole legacy manager entry (as
+// k8s.io/client-go/util/csaupgrade would): "fleetagent" is the agent's
+// general-purpose field manager, so on some namespaces it may also own
+// unrelated fields (for example finalizers) from other code paths. Blindly
+// merging the entire entry into namespaceFieldOwner would make Fleet's
+// namespace-metadata manager own -- and later prune -- fields it never
+// declared and has no business managing.
+//
+// Returns nil if there is nothing to migrate (no stale entry, or the stale
+// entry does not own any labels/annotations).
+func migrateLegacyNamespaceManagedFields(ctx context.Context, c client.Client, ns *corev1.Namespace) error {
+	patch, err := buildManagedFieldsMigrationPatch(ns)
+	if err != nil {
+		return fmt.Errorf("building managed fields migration patch for namespace %q: %w", ns.Name, err)
+	}
+	if patch == nil {
+		return nil
+	}
+
+	if err := c.Patch(ctx, ns, client.RawPatch(types.JSONPatchType, patch)); err != nil {
+		if apierrors.IsForbidden(err) {
+			return fmt.Errorf("the deployment's service account is not allowed to patch namespace %q; "+
+				"grant it 'patch' on this namespace (scoped via resourceNames) or remove "+
+				"namespaceLabels/namespaceAnnotations: %w", ns.Name, err)
+		}
+		return err
+	}
+
+	return nil
+}
+
+// buildManagedFieldsMigrationPatch computes a JSON patch that moves ownership
+// of the metadata.labels/metadata.annotations fields the legacy field manager
+// (legacyNamespaceFieldManager) holds via an Update operation into
+// namespaceFieldOwner's Apply entry, leaving any other fields the legacy
+// manager owns untouched. It returns a nil patch (and nil error) if the legacy
+// manager holds no such Update entry, or if that entry does not own any
+// labels/annotations fields.
+func buildManagedFieldsMigrationPatch(ns *corev1.Namespace) ([]byte, error) {
+	entries := ns.ManagedFields
+
+	legacyIdx := -1
+	for i, e := range entries {
+		if e.Manager == legacyNamespaceFieldManager && e.Operation == metav1.ManagedFieldsOperationUpdate && e.Subresource == "" {
+			legacyIdx = i
+			break
+		}
+	}
+	if legacyIdx < 0 {
+		return nil, nil
+	}
+
+	legacySet, err := decodeFieldsV1(entries[legacyIdx].FieldsV1)
+	if err != nil {
+		return nil, fmt.Errorf("decoding legacy managed fields: %w", err)
+	}
+
+	scoped := scopeToLabelsAndAnnotations(legacySet)
+	if scoped.Empty() {
+		return nil, nil
+	}
+
+	remaining := legacySet.Difference(scoped)
+
+	ssaIdx := -1
+	for i, e := range entries {
+		if e.Manager == namespaceFieldOwner && e.Operation == metav1.ManagedFieldsOperationApply && e.Subresource == "" {
+			ssaIdx = i
+			break
+		}
+	}
+
+	ssaSet := &fieldpath.Set{}
+	if ssaIdx >= 0 {
+		ssaSet, err = decodeFieldsV1(entries[ssaIdx].FieldsV1)
+		if err != nil {
+			return nil, fmt.Errorf("decoding ssa managed fields: %w", err)
+		}
+	}
+	ssaSet = ssaSet.Union(scoped)
+
+	newEntries := make([]metav1.ManagedFieldsEntry, 0, len(entries)+1)
+	for i, e := range entries {
+		switch i {
+		case legacyIdx:
+			if remaining.Empty() {
+				continue // the legacy manager owns nothing else; drop the entry
+			}
+			raw, err := remaining.ToJSON()
+			if err != nil {
+				return nil, fmt.Errorf("encoding remaining legacy fields: %w", err)
+			}
+			e.FieldsV1 = &metav1.FieldsV1{}
+			e.FieldsV1.SetRawBytes(raw)
+		case ssaIdx:
+			raw, err := ssaSet.ToJSON()
+			if err != nil {
+				return nil, fmt.Errorf("encoding ssa fields: %w", err)
+			}
+			e.FieldsV1 = &metav1.FieldsV1{}
+			e.FieldsV1.SetRawBytes(raw)
+		}
+		newEntries = append(newEntries, e)
+	}
+	if ssaIdx < 0 {
+		raw, err := ssaSet.ToJSON()
+		if err != nil {
+			return nil, fmt.Errorf("encoding ssa fields: %w", err)
+		}
+		fields := &metav1.FieldsV1{}
+		fields.SetRawBytes(raw)
+		newEntries = append(newEntries, metav1.ManagedFieldsEntry{
+			Manager:    namespaceFieldOwner,
+			Operation:  metav1.ManagedFieldsOperationApply,
+			APIVersion: "v1",
+			FieldsType: "FieldsV1",
+			FieldsV1:   fields,
+		})
+	}
+
+	jsonPatch := []map[string]any{
+		{
+			"op":    "replace",
+			"path":  "/metadata/managedFields",
+			"value": newEntries,
+		},
+		{
+			// Use "replace" instead of "test" so the API server rejects a
+			// concurrent modification with a 409 conflict rather than a
+			// generic invalid-request error.
+			"op":    "replace",
+			"path":  "/metadata/resourceVersion",
+			"value": ns.ResourceVersion,
+		},
+	}
+	return json.Marshal(jsonPatch)
+}
+
+// scopeToLabelsAndAnnotations returns the subset of s whose paths are rooted
+// at metadata.labels or metadata.annotations.
+func scopeToLabelsAndAnnotations(s *fieldpath.Set) *fieldpath.Set {
+	scoped := &fieldpath.Set{}
+	s.Iterate(func(p fieldpath.Path) {
+		if len(p) < 2 || p[0].FieldName == nil || p[1].FieldName == nil {
+			return
+		}
+		if *p[0].FieldName != "metadata" {
+			return
+		}
+		if *p[1].FieldName != "labels" && *p[1].FieldName != "annotations" {
+			return
+		}
+		scoped.Insert(p)
+	})
+	return scoped
+}
+
+func decodeFieldsV1(f *metav1.FieldsV1) (*fieldpath.Set, error) {
+	s := &fieldpath.Set{}
+	if f == nil {
+		return s, nil
+	}
+	if err := s.FromJSON(f.GetRawReader()); err != nil {
+		return nil, err
+	}
+	return s, nil
+}

--- a/internal/cmd/agent/deployer/namespace_managed_fields_test.go
+++ b/internal/cmd/agent/deployer/namespace_managed_fields_test.go
@@ -1,0 +1,190 @@
+package deployer
+
+import (
+	"encoding/json"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/structured-merge-diff/v6/fieldpath"
+)
+
+func fieldsV1FromPaths(t *testing.T, paths ...fieldpath.Path) *metav1.FieldsV1 {
+	t.Helper()
+	s := fieldpath.NewSet(paths...)
+	raw, err := s.ToJSON()
+	if err != nil {
+		t.Fatalf("encode set: %v", err)
+	}
+	f := &metav1.FieldsV1{}
+	f.SetRawBytes(raw)
+	return f
+}
+
+func pe(name string) fieldpath.PathElement { return fieldpath.FieldNameElement(name) }
+
+func TestBuildManagedFieldsMigrationPatch_NoLegacyEntry(t *testing.T) {
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			ManagedFields: []metav1.ManagedFieldsEntry{
+				{Manager: "someone-else", Operation: metav1.ManagedFieldsOperationUpdate},
+			},
+		},
+	}
+
+	patch, err := buildManagedFieldsMigrationPatch(ns)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if patch != nil {
+		t.Errorf("expected nil patch when there is no legacy entry, got %s", patch)
+	}
+}
+
+func TestBuildManagedFieldsMigrationPatch_LegacyEntryWithoutLabelsOrAnnotations(t *testing.T) {
+	// The legacy manager owns something unrelated (e.g. finalizers); nothing
+	// under metadata.labels/annotations, so there is nothing to migrate.
+	fields := fieldsV1FromPaths(t, fieldpath.Path{pe("metadata"), pe("finalizers")})
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+		ResourceVersion: "1",
+		ManagedFields: []metav1.ManagedFieldsEntry{
+			{Manager: legacyNamespaceFieldManager, Operation: metav1.ManagedFieldsOperationUpdate, FieldsV1: fields},
+		},
+	}}
+
+	patch, err := buildManagedFieldsMigrationPatch(ns)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if patch != nil {
+		t.Errorf("expected nil patch, got %s", patch)
+	}
+}
+
+func TestBuildManagedFieldsMigrationPatch_ScopesToLabelsAndAnnotationsOnly(t *testing.T) {
+	// The legacy manager owns an annotation, a label, AND an unrelated field
+	// (finalizers). Only the annotation/label paths must move to the SSA
+	// manager; finalizers must stay with the legacy manager untouched.
+	fields := fieldsV1FromPaths(
+		t,
+		fieldpath.Path{pe("metadata"), pe("annotations"), pe("fleet-a")},
+		fieldpath.Path{pe("metadata"), pe("labels"), pe("team")},
+		fieldpath.Path{pe("metadata"), pe("finalizers")},
+	)
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+		Name:            "test",
+		ResourceVersion: "42",
+		ManagedFields: []metav1.ManagedFieldsEntry{
+			{Manager: legacyNamespaceFieldManager, Operation: metav1.ManagedFieldsOperationUpdate, APIVersion: "v1", FieldsV1: fields},
+		},
+	}}
+
+	patch, err := buildManagedFieldsMigrationPatch(ns)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if patch == nil {
+		t.Fatalf("expected a non-nil patch")
+	}
+
+	var ops []map[string]json.RawMessage
+	if err := json.Unmarshal(patch, &ops); err != nil {
+		t.Fatalf("unmarshal patch: %v", err)
+	}
+	if len(ops) != 2 {
+		t.Fatalf("expected 2 patch ops, got %d: %s", len(ops), patch)
+	}
+
+	var newEntries []metav1.ManagedFieldsEntry
+	if err := json.Unmarshal(ops[0]["value"], &newEntries); err != nil {
+		t.Fatalf("unmarshal managedFields value: %v", err)
+	}
+
+	var legacyEntry, ssaEntry *metav1.ManagedFieldsEntry
+	for i := range newEntries {
+		switch newEntries[i].Manager {
+		case legacyNamespaceFieldManager:
+			legacyEntry = &newEntries[i]
+		case namespaceFieldOwner:
+			ssaEntry = &newEntries[i]
+		}
+	}
+
+	if legacyEntry == nil {
+		t.Fatalf("legacy entry should still exist (it still owns finalizers): %+v", newEntries)
+	}
+	legacySet, err := decodeFieldsV1(legacyEntry.FieldsV1)
+	if err != nil {
+		t.Fatalf("decode legacy fields: %v", err)
+	}
+	if legacySet.Has(fieldpath.Path{pe("metadata"), pe("annotations"), pe("fleet-a")}) {
+		t.Errorf("legacy entry should no longer own the migrated annotation")
+	}
+	if legacySet.Has(fieldpath.Path{pe("metadata"), pe("labels"), pe("team")}) {
+		t.Errorf("legacy entry should no longer own the migrated label")
+	}
+	if !legacySet.Has(fieldpath.Path{pe("metadata"), pe("finalizers")}) {
+		t.Errorf("legacy entry must keep ownership of unrelated fields like finalizers")
+	}
+
+	if ssaEntry == nil {
+		t.Fatalf("expected a new/updated SSA manager entry: %+v", newEntries)
+	}
+	if ssaEntry.Operation != metav1.ManagedFieldsOperationApply {
+		t.Errorf("expected SSA entry operation Apply, got %v", ssaEntry.Operation)
+	}
+	ssaSet, err := decodeFieldsV1(ssaEntry.FieldsV1)
+	if err != nil {
+		t.Fatalf("decode ssa fields: %v", err)
+	}
+	if !ssaSet.Has(fieldpath.Path{pe("metadata"), pe("annotations"), pe("fleet-a")}) {
+		t.Errorf("SSA entry should now own the migrated annotation")
+	}
+	if !ssaSet.Has(fieldpath.Path{pe("metadata"), pe("labels"), pe("team")}) {
+		t.Errorf("SSA entry should now own the migrated label")
+	}
+	if ssaSet.Has(fieldpath.Path{pe("metadata"), pe("finalizers")}) {
+		t.Errorf("SSA entry must never absorb unrelated fields like finalizers")
+	}
+}
+
+func TestBuildManagedFieldsMigrationPatch_DropsLegacyEntryWhenFullyMigrated(t *testing.T) {
+	// The legacy manager owns only labels/annotations; once migrated, its
+	// entry should be removed entirely rather than left behind empty.
+	fields := fieldsV1FromPaths(
+		t,
+		fieldpath.Path{pe("metadata"), pe("annotations"), pe("fleet-a")},
+	)
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+		ResourceVersion: "1",
+		ManagedFields: []metav1.ManagedFieldsEntry{
+			{Manager: legacyNamespaceFieldManager, Operation: metav1.ManagedFieldsOperationUpdate, APIVersion: "v1", FieldsV1: fields},
+		},
+	}}
+
+	patch, err := buildManagedFieldsMigrationPatch(ns)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if patch == nil {
+		t.Fatalf("expected a non-nil patch")
+	}
+
+	var ops []map[string]json.RawMessage
+	if err := json.Unmarshal(patch, &ops); err != nil {
+		t.Fatalf("unmarshal patch: %v", err)
+	}
+	var newEntries []metav1.ManagedFieldsEntry
+	if err := json.Unmarshal(ops[0]["value"], &newEntries); err != nil {
+		t.Fatalf("unmarshal managedFields value: %v", err)
+	}
+
+	for _, e := range newEntries {
+		if e.Manager == legacyNamespaceFieldManager {
+			t.Errorf("legacy entry should have been dropped entirely, got %+v", e)
+		}
+	}
+	if len(newEntries) != 1 || newEntries[0].Manager != namespaceFieldOwner {
+		t.Fatalf("expected exactly one SSA entry, got %+v", newEntries)
+	}
+}


### PR DESCRIPTION
## SSA for namespaces

Manage the release namespace's labels and annotations with server-side apply instead of a read-modify-write update.

The previous approach fetched the namespace, merged in the configured labels/annotations, and then deleted every key not present in the options, preserving only a hardcoded allowlist (kubernetes.io/metadata.name). That clobbered metadata set by other actors -- most notably field.cattle.io/projectId, which Rancher adds when a namespace is moved into a Project -- and the allowlist could never be made complete. See issue #4564.

Fleet now applies with a dedicated field manager ("fleet-agent-namespace-metadata"), so it owns exactly the keys it declares: keys owned by other managers are left untouched, and a key Fleet stops declaring is pruned by the apiserver. ForceOwnership adopts keys previously written by the old update, so the first apply after upgrade does not conflict.

Labels and annotations are applied independently. A bundle that sets only namespaceLabels never asserts ownership of annotations (and so never prunes them), and vice versa.

Security-sensitive labels such as pod-security.kubernetes.io/* are not filtered out of the options; #5687 removed that filter. A bundle that declares one applies it like any other label, gated by the downstream RBAC of the deployment's service account, since the namespace is patched as that account. Deployments that resolve to no service account still run as the agent, so restricting them requires pinning a service account, either in the bundle or through a Policy. A pod-security label already on the namespace that the bundle does not declare is now preserved implicitly: Fleet never declares it, so the apply does not touch it.

The deployment's service account now needs 'patch' on the namespace instead of 'update'; the RBAC error messages are updated accordingly. Namespace creation remains Helm's responsibility -- fetchExistingNamespace only verifies the namespace is present and surfaces a clear RBAC error before the apply.

## Migrate legacy namespace managed fields to enable SSA pruning

Namespaces that predate the switch to server-side apply still carry a "fleetagent" Update field-manager entry that owns their labels and annotations. ForceOwnership on the first post-upgrade apply makes Fleet's SSA manager co-own those keys but does not strip the stale Update entry, and a field is only pruned once no manager owns it. As a result, a key dropped from a bundle stays behind forever on any such namespace.

Add a self-healing, idempotent migration that moves ownership of the metadata.labels/metadata.annotations keys the bundle currently declares from the legacy Update entry into the SSA apply entry, leaving every other field the general-purpose "fleetagent" manager owns untouched, including finalizers and any label or annotation the bundle does not declare. This is scoped deliberately rather than absorbing the whole entry via csaupgrade. It runs before the namespace metadata apply and is a no-op once migrated.

Scoping the migration to the declared keys is what keeps it from taking metadata Fleet has no claim to. The legacy manager cannot be identified any more precisely than by name, and that name is shared: client-go derives it from the binary, and so does Helm. The entry Helm leaves behind when it creates the release namespace, carrying its "name: <namespace>" label, is therefore indistinguishable from the entry the old read-modify-write update left. Absorbing it wholesale would make Fleet own Helm's label and prune it on the next apply. A key Fleet declares, by contrast, is one it is about to own anyway. With Helm 4 the collision is limited to namespaces that predate the SSA switch and to bundles using takeOwnership or force, because Helm 4 otherwise creates the namespace with server-side apply and records the label under an Apply entry of its own.

Known trade-off: a key dropped from the bundle in the same change that upgraded Fleet is never absorbed and stays on the namespace. It self-heals if the key is re-added and then dropped again.

## Tests

Unit tests for the managed-fields migration in internal/cmd/agent/deployer, integration tests in ./integrationtests/agent that drive real BundleDeployment reconciles against envtest, and e2e specs in ./e2e/single-cluster.

<!-- Specify the issue ID that this pull request is solving -->
Refers to #4564

<!-- Make sure that the referenced issue provides steps to reproduce it -->

<!-- Describe the changes introduced by this pull request -->

<!--
  Please provide a unit, integration (`./integrationtests/`) or e2e (`./e2e/`) test if possible.
-->

## Additional Information

### Checklist

- [ ] <!-- If applicable,--> I have updated the documentation via a pull request in the [fleet-product-docs](https://github.com/rancher/fleet-product-docs) repository.
