### PR TITLE
Skip unsplit Fleet submodules in release preflight

### DIFF
--- a/.github/scripts/release-against-rancher.sh
+++ b/.github/scripts/release-against-rancher.sh
@@ -15,6 +15,17 @@ bump_fleet_module() {
     # module and its nested pkg/apis module), so update every go.mod that
     # requires the module, not just the root one.
     local module="github.com/rancher/fleet/$1"
+    local tag="$1/v${NEW_FLEET_VERSION}"
+
+    # Guard against a tag that predates the module being split out of the main
+    # Fleet module: without its own go.mod, `go get` silently falls back to
+    # resolving the root `github.com/rancher/fleet` module instead.
+    if ! git -C ../fleet cat-file -e "${tag}:$1/go.mod" 2>/dev/null; then
+        printf 'ERROR: %s does not contain %s/go.mod\n' "${tag}" "$1" >&2
+        printf 'The tag does not point at a standalone Go module; refusing to bump.\n' >&2
+        exit 1
+    fi
+
     local modfiles
     modfiles=$(grep -rlE "${module}[[:space:]]" --include=go.mod . || true)
     if [ -z "${modfiles}" ]; then

--- a/.github/scripts/release-against-rancher.sh
+++ b/.github/scripts/release-against-rancher.sh
@@ -15,6 +15,7 @@ bump_fleet_module() {
     # module and its nested pkg/apis module), so update every go.mod that
     # requires the module, not just the root one.
     local module="github.com/rancher/fleet/$1"
+    local escaped_module="${module//./\\.}"
     local tag="$1/v${NEW_FLEET_VERSION}"
 
     # Guard against a tag that predates the module being split out of the main
@@ -27,7 +28,7 @@ bump_fleet_module() {
     fi
 
     local modfiles
-    modfiles=$(grep -rlE "${module}[[:space:]]" --include=go.mod . || true)
+    modfiles=$(grep -rlE "^[[:space:]]*require[[:space:]]+${escaped_module}[[:space:]]|^[[:space:]]+${escaped_module}[[:space:]]" --include=go.mod . || true)
     if [ -z "${modfiles}" ]; then
         printf 'ERROR: no go.mod in rancher/rancher requires %s\n' "${module}" >&2
         exit 1

--- a/.github/workflows/release-against-rancher.yml
+++ b/.github/workflows/release-against-rancher.yml
@@ -38,6 +38,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
+          ref: ${{ inputs.fleet_branch }}
           path: fleet
           persist-credentials: false
 

--- a/.github/workflows/release-against-rancher.yml
+++ b/.github/workflows/release-against-rancher.yml
@@ -69,14 +69,33 @@ jobs:
             exit 0
           fi
 
-          # For a new final minor version, pkg/apis and pkg/helmvalues must be tagged in the fleet repo.
+          # For a new final minor version, every Fleet submodule that has already been split
+          # out on this branch (i.e. <mod>/go.mod exists in the fleet checkout) must be tagged,
+          # and the tag must point at a commit that actually contains <mod>/go.mod. A submodule
+          # not yet split out on this branch (e.g. pkg/helmvalues before it is backported) is not
+          # required, since rancher/rancher cannot consume it yet either way.
           if [[ "${NEW_FLEET}" =~ \.0$ ]]; then
             for mod in pkg/apis pkg/helmvalues; do
-              if ! git -C fleet tag -l "${mod}/v${NEW_FLEET}" | grep -q .; then
+              if [ ! -f "fleet/${mod}/go.mod" ]; then
+                printf 'INFO: %s/go.mod not present on this branch; skipping %s tag requirement\n' "${mod}" "${mod}"
+                continue
+              fi
+
+              tag="${mod}/v${NEW_FLEET}"
+              if ! git -C fleet tag -l "${tag}" | grep -q .; then
                 {
-                  printf 'ERROR: %s/v%s tag not found in the fleet repo!\n' "${mod}" "${NEW_FLEET}"
+                  printf 'ERROR: %s tag not found in the fleet repo!\n' "${tag}"
                   printf 'For a new final minor version, %s must be bumped first.\n' "${mod}"
-                  printf 'Please create the tag: git tag %s/v%s\n' "${mod}" "${NEW_FLEET}"
+                  printf 'Please create the tag: git tag %s\n' "${tag}"
+                } >&2
+                exit 1
+              fi
+
+              if ! git -C fleet cat-file -e "${tag}:${mod}/go.mod" 2>/dev/null; then
+                {
+                  printf 'ERROR: %s exists but %s/go.mod is missing at that commit!\n' "${tag}" "${mod}"
+                  printf 'The tag likely predates %s being split into its own Go module.\n' "${mod}"
+                  printf 'Delete and recreate the tag from a commit where %s/go.mod exists.\n' "${mod}"
                 } >&2
                 exit 1
               fi


### PR DESCRIPTION
The workflow required a tag for every Fleet submodule on every new final minor version, even when that submodule has not been split out on the release branch yet (e.g. `pkg/helmvalues` before it is backported to a `release/vX.Y` branch). Skip the requirement when `<mod>/go.mod` is absent from the checked-out branch, since rancher/rancher cannot consume it either way.

Also verify that any tag that is required actually points at a commit containing `<mod>/go.mod`, and add the same guard to `bump_fleet_module()` in `release-against-rancher.sh`. Without it, a tag cut before the module split silently resolves to the root github.com/rancher/fleet module instead of failing loudly.

This was the error during the [release run](https://github.com/rancher/fleet/actions/runs/29909263651/job/88888003649):
```
2026-07-22T09:49:11.4332737Z go: downloading github.com/xiang90/probing v0.0.0-20221125231312-a49e3df8f510
2026-07-22T09:49:11.6092101Z ERROR: no go.mod in rancher/rancher requires github.com/rancher/fleet/pkg/helmvalues
2026-07-22T09:49:11.6100320Z ##[error]Process completed with exit code 1.
```

And this is the original commit 0b65aed1b37492c13963a5b12ded0982758e99b5 introducing this additional check, but these changes were not part of `release/v0.16`, so `pkg/helmvalues` was missing a go.mod and can not be imported from this branch.

Successful [release run](https://github.com/rancher/fleet/actions/runs/29938694901) with this branch.