### PR TITLE
Run Ginkgo suites through go test

### DIFF
--- a/.github/scripts/check-for-auto-generated-changes.sh
+++ b/.github/scripts/check-for-auto-generated-changes.sh
@@ -2,7 +2,6 @@
 set -euo pipefail
 
 go generate
-ginkgo unfocus
 
 if [ -n "$(git status --porcelain)" ]; then
     printf 'Generated files have either been changed manually or were not updated.\n\n'

--- a/.github/scripts/run-integration-tests-group1.sh
+++ b/.github/scripts/run-integration-tests-group1.sh
@@ -12,7 +12,7 @@ KUBEBUILDER_ASSETS=$(setup-envtest use --use-env -p path "$ENVTEST_K8S_VERSION")
 export KUBEBUILDER_ASSETS
 
 # Group 1: Run specific packages (adjust these based on execution time analysis)
-go test -count=1 -timeout=1h -p 1 \
+go test -v -count=1 -timeout=1h -p 1 \
   ./integrationtests/agent/... \
   ./integrationtests/cli/... \
   ./integrationtests/controller/... \

--- a/.github/scripts/run-integration-tests-group1.sh
+++ b/.github/scripts/run-integration-tests-group1.sh
@@ -12,7 +12,8 @@ KUBEBUILDER_ASSETS=$(setup-envtest use --use-env -p path "$ENVTEST_K8S_VERSION")
 export KUBEBUILDER_ASSETS
 
 # Group 1: Run specific packages (adjust these based on execution time analysis)
-ginkgo --github-output --trace\
+go test -count=1 -timeout=1h -p 1 \
   ./integrationtests/agent/... \
   ./integrationtests/cli/... \
-  ./integrationtests/controller/...
+  ./integrationtests/controller/... \
+  -args -ginkgo.github-output -ginkgo.trace

--- a/.github/scripts/run-integration-tests-group2.sh
+++ b/.github/scripts/run-integration-tests-group2.sh
@@ -26,4 +26,4 @@ if [ "${#group2_packages[@]}" -eq 0 ]; then
   exit 0
 fi
 
-go test -count=1 -timeout=1h -p 1 "${group2_packages[@]}" -args -ginkgo.github-output -ginkgo.trace
+go test -v -count=1 -timeout=1h -p 1 "${group2_packages[@]}" -args -ginkgo.github-output -ginkgo.trace

--- a/.github/scripts/run-integration-tests-group2.sh
+++ b/.github/scripts/run-integration-tests-group2.sh
@@ -26,4 +26,4 @@ if [ "${#group2_packages[@]}" -eq 0 ]; then
   exit 0
 fi
 
-ginkgo --github-output --trace "${group2_packages[@]}"
+go test -count=1 -timeout=1h -p 1 "${group2_packages[@]}" -args -ginkgo.github-output -ginkgo.trace

--- a/.github/scripts/run-integration-tests.sh
+++ b/.github/scripts/run-integration-tests.sh
@@ -12,4 +12,4 @@ KUBEBUILDER_ASSETS=$(setup-envtest use --use-env -p path "$ENVTEST_K8S_VERSION")
 export KUBEBUILDER_ASSETS
 
 # run integration tests
-ginkgo --github-output --trace ./integrationtests/...
+go test -count=1 -timeout=1h -p 1 ./integrationtests/... -args -ginkgo.github-output -ginkgo.trace

--- a/.github/scripts/run-integration-tests.sh
+++ b/.github/scripts/run-integration-tests.sh
@@ -12,4 +12,4 @@ KUBEBUILDER_ASSETS=$(setup-envtest use --use-env -p path "$ENVTEST_K8S_VERSION")
 export KUBEBUILDER_ASSETS
 
 # run integration tests
-go test -count=1 -timeout=1h -p 1 ./integrationtests/... -args -ginkgo.github-output -ginkgo.trace
+go test -v -count=1 -timeout=1h -p 1 ./integrationtests/... -args -ginkgo.github-output -ginkgo.trace

--- a/.github/workflows/check-changes.yml
+++ b/.github/workflows/check-changes.yml
@@ -29,9 +29,6 @@ jobs:
         with:
           go-version-file: 'go.mod'
       -
-        name: Install Ginkgo CLI
-        run: go install github.com/onsi/ginkgo/v2/ginkgo
-      -
         name: go.mod
         run: ./.github/scripts/check-for-go-mod-changes.sh
       -

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,9 +65,6 @@ jobs:
         with:
           go-version-file: 'go.mod'
       -
-        name: Install Ginkgo CLI
-        run: go install github.com/onsi/ginkgo/v2/ginkgo
-      -
         name: integration-tests-group1
         env:
           # renovate: datasource=go depName=sigs.k8s.io/controller-runtime
@@ -87,9 +84,6 @@ jobs:
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: 'go.mod'
-      -
-        name: Install Ginkgo CLI
-        run: go install github.com/onsi/ginkgo/v2/ginkgo
       -
         name: integration-tests-group2
         env:

--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -151,28 +151,28 @@ jobs:
         env:
           FLEET_E2E_NS: fleet-local
         run: |
-          go test -count=1 -timeout=1h -p 1 ./e2e/single-cluster ./e2e/keep-resources -args -ginkgo.github-output -ginkgo.trace -ginkgo.label-filter='!infra-setup && !sharding'
+          go test -v -count=1 -timeout=1h -p 1 ./e2e/single-cluster ./e2e/keep-resources -args -ginkgo.github-output -ginkgo.trace -ginkgo.label-filter='!infra-setup && !sharding'
       -
         name: E2E Sharding Tests
         if: ${{ matrix.test_type.name == 'sharding' }}
         env:
           FLEET_E2E_NS: fleet-local
         run: |
-          go test -count=1 -timeout=1h ./e2e/single-cluster -args -ginkgo.github-output -ginkgo.trace -ginkgo.label-filter='sharding'
+          go test -v -count=1 -timeout=1h ./e2e/single-cluster -args -ginkgo.github-output -ginkgo.trace -ginkgo.label-filter='sharding'
       -
         name: E2E Sharded Metrics
         if: ${{ matrix.test_type.name == 'sharded-metrics' }}
         env:
           FLEET_E2E_NS: fleet-local
         run: |
-          SHARD=shard0 go test -count=1 -timeout=1h ./e2e/metrics -args -ginkgo.github-output -ginkgo.trace -ginkgo.label-filter='!oci-registry'
+          SHARD=shard0 go test -v -count=1 -timeout=1h ./e2e/metrics -args -ginkgo.github-output -ginkgo.trace -ginkgo.label-filter='!oci-registry'
       -
         name: E2E Metrics Tests
         if: ${{ matrix.test_type.name == 'metrics' }}
         env:
           FLEET_E2E_NS: fleet-local
         run: |
-          go test -count=1 -timeout=1h ./e2e/metrics -args -ginkgo.github-output -ginkgo.trace -ginkgo.label-filter='!oci-registry'
+          go test -v -count=1 -timeout=1h ./e2e/metrics -args -ginkgo.github-output -ginkgo.trace -ginkgo.label-filter='!oci-registry'
       -
         name: Create Zot certificates for OCI tests
         if: ${{ startsWith(matrix.test_type.name, 'infra-setup') }}
@@ -193,7 +193,7 @@ jobs:
 
           # Run tests requiring only the git server
           e2e/testenv/infra/infra setup --git-server=true
-          go test -count=1 -timeout=1h ./e2e/single-cluster/ -args -ginkgo.github-output -ginkgo.trace -ginkgo.label-filter='infra-setup && !helm-registry && !oci-registry'
+          go test -v -count=1 -timeout=1h ./e2e/single-cluster/ -args -ginkgo.github-output -ginkgo.trace -ginkgo.label-filter='infra-setup && !helm-registry && !oci-registry'
 
           e2e/testenv/infra/infra teardown
       -
@@ -212,7 +212,7 @@ jobs:
           e2e/testenv/infra/infra setup --git-server=true
           e2e/testenv/infra/infra setup --helm-registry=true
 
-          go test -count=1 -timeout=1h ./e2e/single-cluster -args -ginkgo.github-output -ginkgo.trace -ginkgo.label-filter='helm-registry'
+          go test -v -count=1 -timeout=1h ./e2e/single-cluster -args -ginkgo.github-output -ginkgo.trace -ginkgo.label-filter='helm-registry'
 
           e2e/testenv/infra/infra teardown
       -
@@ -244,8 +244,8 @@ jobs:
 
           # OCI tests can be flaky due to registry setup timing issues
           # Run with flake attempts to retry failed tests
-          go test -count=1 -timeout=1h ./e2e/single-cluster -args -ginkgo.github-output -ginkgo.trace -ginkgo.flake-attempts=2 -ginkgo.label-filter='oci-registry'
-          go test -count=1 -timeout=1h ./e2e/metrics -args -ginkgo.github-output -ginkgo.trace -ginkgo.flake-attempts=2 -ginkgo.label-filter='oci-registry'
+          go test -v -count=1 -timeout=1h ./e2e/single-cluster -args -ginkgo.github-output -ginkgo.trace -ginkgo.flake-attempts=2 -ginkgo.label-filter='oci-registry'
+          go test -v -count=1 -timeout=1h ./e2e/metrics -args -ginkgo.github-output -ginkgo.trace -ginkgo.flake-attempts=2 -ginkgo.label-filter='oci-registry'
 
           e2e/testenv/infra/infra teardown
       -
@@ -274,7 +274,7 @@ jobs:
           echo "${{ secrets.CI_SSH_KEY }}" > "$GIT_SSH_KEY"
           echo "${{ secrets.CI_SSH_PUBKEY }}" > "$GIT_SSH_PUBKEY"
 
-          go test -count=1 -timeout=1h ./e2e/require-secrets -args -ginkgo.github-output -ginkgo.trace
+          go test -v -count=1 -timeout=1h ./e2e/require-secrets -args -ginkgo.github-output -ginkgo.trace
       -
         name: Upload Logs
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -51,9 +51,6 @@ jobs:
         with:
           go-version-file: 'go.mod'
       -
-        name: Install Ginkgo CLI
-        run: go install github.com/onsi/ginkgo/v2/ginkgo
-      -
         name: Cache crust-gather CLI
         id: cache-crust
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -154,28 +151,28 @@ jobs:
         env:
           FLEET_E2E_NS: fleet-local
         run: |
-          ginkgo --github-output --trace --label-filter='!infra-setup && !sharding' e2e/single-cluster e2e/keep-resources
+          go test -count=1 -timeout=1h -p 1 ./e2e/single-cluster ./e2e/keep-resources -args -ginkgo.github-output -ginkgo.trace -ginkgo.label-filter='!infra-setup && !sharding'
       -
         name: E2E Sharding Tests
         if: ${{ matrix.test_type.name == 'sharding' }}
         env:
           FLEET_E2E_NS: fleet-local
         run: |
-          ginkgo --github-output --trace --label-filter='sharding' e2e/single-cluster
+          go test -count=1 -timeout=1h ./e2e/single-cluster -args -ginkgo.github-output -ginkgo.trace -ginkgo.label-filter='sharding'
       -
         name: E2E Sharded Metrics
         if: ${{ matrix.test_type.name == 'sharded-metrics' }}
         env:
           FLEET_E2E_NS: fleet-local
         run: |
-          SHARD=shard0 ginkgo --github-output --trace --label-filter='!oci-registry' e2e/metrics
+          SHARD=shard0 go test -count=1 -timeout=1h ./e2e/metrics -args -ginkgo.github-output -ginkgo.trace -ginkgo.label-filter='!oci-registry'
       -
         name: E2E Metrics Tests
         if: ${{ matrix.test_type.name == 'metrics' }}
         env:
           FLEET_E2E_NS: fleet-local
         run: |
-          ginkgo --github-output --trace --label-filter='!oci-registry' e2e/metrics
+          go test -count=1 -timeout=1h ./e2e/metrics -args -ginkgo.github-output -ginkgo.trace -ginkgo.label-filter='!oci-registry'
       -
         name: Create Zot certificates for OCI tests
         if: ${{ startsWith(matrix.test_type.name, 'infra-setup') }}
@@ -196,7 +193,7 @@ jobs:
 
           # Run tests requiring only the git server
           e2e/testenv/infra/infra setup --git-server=true
-          ginkgo --github-output --trace --label-filter='infra-setup && !helm-registry && !oci-registry' e2e/single-cluster/
+          go test -count=1 -timeout=1h ./e2e/single-cluster/ -args -ginkgo.github-output -ginkgo.trace -ginkgo.label-filter='infra-setup && !helm-registry && !oci-registry'
 
           e2e/testenv/infra/infra teardown
       -
@@ -215,7 +212,7 @@ jobs:
           e2e/testenv/infra/infra setup --git-server=true
           e2e/testenv/infra/infra setup --helm-registry=true
 
-          ginkgo --github-output --trace --label-filter='helm-registry' e2e/single-cluster
+          go test -count=1 -timeout=1h ./e2e/single-cluster -args -ginkgo.github-output -ginkgo.trace -ginkgo.label-filter='helm-registry'
 
           e2e/testenv/infra/infra teardown
       -
@@ -247,8 +244,8 @@ jobs:
 
           # OCI tests can be flaky due to registry setup timing issues
           # Run with flake attempts to retry failed tests
-          ginkgo --github-output --trace --flake-attempts=2 --label-filter='oci-registry' e2e/single-cluster
-          ginkgo --github-output --trace --flake-attempts=2 --label-filter='oci-registry' e2e/metrics
+          go test -count=1 -timeout=1h ./e2e/single-cluster -args -ginkgo.github-output -ginkgo.trace -ginkgo.flake-attempts=2 -ginkgo.label-filter='oci-registry'
+          go test -count=1 -timeout=1h ./e2e/metrics -args -ginkgo.github-output -ginkgo.trace -ginkgo.flake-attempts=2 -ginkgo.label-filter='oci-registry'
 
           e2e/testenv/infra/infra teardown
       -
@@ -277,7 +274,7 @@ jobs:
           echo "${{ secrets.CI_SSH_KEY }}" > "$GIT_SSH_KEY"
           echo "${{ secrets.CI_SSH_PUBKEY }}" > "$GIT_SSH_PUBKEY"
 
-          ginkgo --github-output --trace e2e/require-secrets
+          go test -count=1 -timeout=1h ./e2e/require-secrets -args -ginkgo.github-output -ginkgo.trace
       -
         name: Upload Logs
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/e2e-fleet-upgrade-ci.yml
+++ b/.github/workflows/e2e-fleet-upgrade-ci.yml
@@ -117,7 +117,7 @@ jobs:
         env:
           FLEET_E2E_NS: fleet-local
         run: |
-          go test -count=1 -timeout=1h ./e2e/installation -args -ginkgo.github-output -ginkgo.trace -ginkgo.label-filter="!multi-cluster"
+          go test -v -count=1 -timeout=1h ./e2e/installation -args -ginkgo.github-output -ginkgo.trace -ginkgo.label-filter="!multi-cluster"
       -
         name: Upload Logs
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/e2e-fleet-upgrade-ci.yml
+++ b/.github/workflows/e2e-fleet-upgrade-ci.yml
@@ -35,9 +35,6 @@ jobs:
         with:
           go-version-file: 'go.mod'
       -
-        name: Install Ginkgo CLI
-        run: go install github.com/onsi/ginkgo/v2/ginkgo
-      -
         name: Cache crust-gather CLI
         id: cache-crust
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -120,7 +117,7 @@ jobs:
         env:
           FLEET_E2E_NS: fleet-local
         run: |
-          ginkgo --github-output --trace --label-filter="!multi-cluster" e2e/installation
+          go test -count=1 -timeout=1h ./e2e/installation -args -ginkgo.github-output -ginkgo.trace -ginkgo.label-filter="!multi-cluster"
       -
         name: Upload Logs
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/e2e-multicluster-ci.yml
+++ b/.github/workflows/e2e-multicluster-ci.yml
@@ -31,9 +31,6 @@ jobs:
         with:
           go-version-file: 'go.mod'
       -
-        name: Install Ginkgo CLI
-        run: go install github.com/onsi/ginkgo/v2/ginkgo
-      -
         name: Cache crust-gather CLI
         id: cache-crust
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -228,7 +225,7 @@ jobs:
           export CI_REGISTERED_CLUSTER
 
           kubectl config use-context k3d-upstream
-          ginkgo --github-output --trace e2e/multi-cluster
+          go test -count=1 -timeout=1h ./e2e/multi-cluster -args -ginkgo.github-output -ginkgo.trace
       -
         name: E2E tests with managed downstream agent
         env:
@@ -237,7 +234,7 @@ jobs:
           FLEET_E2E_CLUSTER_DOWNSTREAM: k3d-managed-downstream
         run: |
           kubectl config use-context k3d-upstream
-          ginkgo --github-output --trace e2e/multi-cluster/installation
+          go test -count=1 -timeout=1h ./e2e/multi-cluster/installation -args -ginkgo.github-output -ginkgo.trace
       -
         name: Acceptance Tests for Examples
         if: >
@@ -246,7 +243,7 @@ jobs:
           FLEET_E2E_NS: fleet-local
           FLEET_E2E_NS_DOWNSTREAM: fleet-default
         run: |
-          ginkgo --github-output --trace e2e/acceptance/multi-cluster-examples
+          go test -count=1 -timeout=1h ./e2e/acceptance/multi-cluster-examples -args -ginkgo.github-output -ginkgo.trace
       -
         name: Dump Failed Downstream Environment
         if: failure()

--- a/.github/workflows/e2e-multicluster-ci.yml
+++ b/.github/workflows/e2e-multicluster-ci.yml
@@ -225,7 +225,7 @@ jobs:
           export CI_REGISTERED_CLUSTER
 
           kubectl config use-context k3d-upstream
-          go test -count=1 -timeout=1h ./e2e/multi-cluster -args -ginkgo.github-output -ginkgo.trace
+          go test -v -count=1 -timeout=1h ./e2e/multi-cluster -args -ginkgo.github-output -ginkgo.trace
       -
         name: E2E tests with managed downstream agent
         env:
@@ -234,7 +234,7 @@ jobs:
           FLEET_E2E_CLUSTER_DOWNSTREAM: k3d-managed-downstream
         run: |
           kubectl config use-context k3d-upstream
-          go test -count=1 -timeout=1h ./e2e/multi-cluster/installation -args -ginkgo.github-output -ginkgo.trace
+          go test -v -count=1 -timeout=1h ./e2e/multi-cluster/installation -args -ginkgo.github-output -ginkgo.trace
       -
         name: Acceptance Tests for Examples
         if: >
@@ -243,7 +243,7 @@ jobs:
           FLEET_E2E_NS: fleet-local
           FLEET_E2E_NS_DOWNSTREAM: fleet-default
         run: |
-          go test -count=1 -timeout=1h ./e2e/acceptance/multi-cluster-examples -args -ginkgo.github-output -ginkgo.trace
+          go test -v -count=1 -timeout=1h ./e2e/acceptance/multi-cluster-examples -args -ginkgo.github-output -ginkgo.trace
       -
         name: Dump Failed Downstream Environment
         if: failure()

--- a/.github/workflows/e2e-nightly-ci.yml
+++ b/.github/workflows/e2e-nightly-ci.yml
@@ -57,9 +57,6 @@ jobs:
         with:
           go-version-file: 'go.mod'
       -
-        name: Install Ginkgo CLI
-        run: go install github.com/onsi/ginkgo/v2/ginkgo
-      -
         name: Cache crust-gather CLI
         id: cache-crust
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -157,26 +154,26 @@ jobs:
           export CI_OCI_CERTS_DIR
 
           # 1. Run test cases not needing infra
-          ginkgo --github-output --trace --label-filter='!infra-setup' e2e/single-cluster e2e/keep-resources
+          go test -count=1 -timeout=1h -p 1 ./e2e/single-cluster ./e2e/keep-resources -args -ginkgo.github-output -ginkgo.trace -ginkgo.label-filter='!infra-setup'
 
           # 2. Run tests for metrics
-          ginkgo --github-output --trace --label-filter='!oci-registry' e2e/metrics
-          SHARD=shard1 ginkgo --github-output --trace --label-filter='!oci-registry' e2e/metrics
+          go test -count=1 -timeout=1h ./e2e/metrics -args -ginkgo.github-output -ginkgo.trace -ginkgo.label-filter='!oci-registry'
+          SHARD=shard1 go test -count=1 -timeout=1h ./e2e/metrics -args -ginkgo.github-output -ginkgo.trace -ginkgo.label-filter='!oci-registry'
 
           # 3. Run tests requiring only the git server
           e2e/testenv/infra/infra setup --git-server=true
-          ginkgo --github-output --trace --label-filter='infra-setup && !helm-registry && !oci-registry' e2e/single-cluster/
+          go test -count=1 -timeout=1h ./e2e/single-cluster/ -args -ginkgo.github-output -ginkgo.trace -ginkgo.label-filter='infra-setup && !helm-registry && !oci-registry'
 
           # 4. Run tests requiring a Helm registry
           e2e/testenv/infra/infra setup --helm-registry=true
-          ginkgo --github-output --trace --label-filter='helm-registry' e2e/single-cluster
+          go test -count=1 -timeout=1h ./e2e/single-cluster -args -ginkgo.github-output -ginkgo.trace -ginkgo.label-filter='helm-registry'
 
           e2e/testenv/infra/infra teardown --helm-registry=true
 
           # 5. Run tests requiring an OCI registry
           e2e/testenv/infra/infra setup --oci-registry=true
-          ginkgo --github-output --trace --label-filter='oci-registry' e2e/single-cluster
-          ginkgo --github-output --trace --label-filter='oci-registry' e2e/metrics
+          go test -count=1 -timeout=1h ./e2e/single-cluster -args -ginkgo.github-output -ginkgo.trace -ginkgo.label-filter='oci-registry'
+          go test -count=1 -timeout=1h ./e2e/metrics -args -ginkgo.github-output -ginkgo.trace -ginkgo.label-filter='oci-registry'
 
           # 6. Tear down all infra
           e2e/testenv/infra/infra teardown
@@ -186,7 +183,7 @@ jobs:
         env:
           FLEET_E2E_NS: fleet-local
         run: |
-          ginkgo --github-output --trace e2e/acceptance/single-cluster-examples
+          go test -count=1 -timeout=1h ./e2e/acceptance/single-cluster-examples -args -ginkgo.github-output -ginkgo.trace
       -
         name: Fleet Tests Requiring Github Secrets
         if: ${{ matrix.test_type == 'e2e-secrets' }}
@@ -208,7 +205,7 @@ jobs:
           echo "${{ secrets.CI_SSH_KEY }}" > "$GIT_SSH_KEY"
           echo "${{ secrets.CI_SSH_PUBKEY }}" > "$GIT_SSH_PUBKEY"
 
-          ginkgo --github-output --trace e2e/require-secrets
+          go test -count=1 -timeout=1h ./e2e/require-secrets -args -ginkgo.github-output -ginkgo.trace
       -
         name: Upload Logs
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/e2e-nightly-ci.yml
+++ b/.github/workflows/e2e-nightly-ci.yml
@@ -154,26 +154,26 @@ jobs:
           export CI_OCI_CERTS_DIR
 
           # 1. Run test cases not needing infra
-          go test -count=1 -timeout=1h -p 1 ./e2e/single-cluster ./e2e/keep-resources -args -ginkgo.github-output -ginkgo.trace -ginkgo.label-filter='!infra-setup'
+          go test -v -count=1 -timeout=1h -p 1 ./e2e/single-cluster ./e2e/keep-resources -args -ginkgo.github-output -ginkgo.trace -ginkgo.label-filter='!infra-setup'
 
           # 2. Run tests for metrics
-          go test -count=1 -timeout=1h ./e2e/metrics -args -ginkgo.github-output -ginkgo.trace -ginkgo.label-filter='!oci-registry'
-          SHARD=shard1 go test -count=1 -timeout=1h ./e2e/metrics -args -ginkgo.github-output -ginkgo.trace -ginkgo.label-filter='!oci-registry'
+          go test -v -count=1 -timeout=1h ./e2e/metrics -args -ginkgo.github-output -ginkgo.trace -ginkgo.label-filter='!oci-registry'
+          SHARD=shard1 go test -v -count=1 -timeout=1h ./e2e/metrics -args -ginkgo.github-output -ginkgo.trace -ginkgo.label-filter='!oci-registry'
 
           # 3. Run tests requiring only the git server
           e2e/testenv/infra/infra setup --git-server=true
-          go test -count=1 -timeout=1h ./e2e/single-cluster/ -args -ginkgo.github-output -ginkgo.trace -ginkgo.label-filter='infra-setup && !helm-registry && !oci-registry'
+          go test -v -count=1 -timeout=1h ./e2e/single-cluster/ -args -ginkgo.github-output -ginkgo.trace -ginkgo.label-filter='infra-setup && !helm-registry && !oci-registry'
 
           # 4. Run tests requiring a Helm registry
           e2e/testenv/infra/infra setup --helm-registry=true
-          go test -count=1 -timeout=1h ./e2e/single-cluster -args -ginkgo.github-output -ginkgo.trace -ginkgo.label-filter='helm-registry'
+          go test -v -count=1 -timeout=1h ./e2e/single-cluster -args -ginkgo.github-output -ginkgo.trace -ginkgo.label-filter='helm-registry'
 
           e2e/testenv/infra/infra teardown --helm-registry=true
 
           # 5. Run tests requiring an OCI registry
           e2e/testenv/infra/infra setup --oci-registry=true
-          go test -count=1 -timeout=1h ./e2e/single-cluster -args -ginkgo.github-output -ginkgo.trace -ginkgo.label-filter='oci-registry'
-          go test -count=1 -timeout=1h ./e2e/metrics -args -ginkgo.github-output -ginkgo.trace -ginkgo.label-filter='oci-registry'
+          go test -v -count=1 -timeout=1h ./e2e/single-cluster -args -ginkgo.github-output -ginkgo.trace -ginkgo.label-filter='oci-registry'
+          go test -v -count=1 -timeout=1h ./e2e/metrics -args -ginkgo.github-output -ginkgo.trace -ginkgo.label-filter='oci-registry'
 
           # 6. Tear down all infra
           e2e/testenv/infra/infra teardown
@@ -183,7 +183,7 @@ jobs:
         env:
           FLEET_E2E_NS: fleet-local
         run: |
-          go test -count=1 -timeout=1h ./e2e/acceptance/single-cluster-examples -args -ginkgo.github-output -ginkgo.trace
+          go test -v -count=1 -timeout=1h ./e2e/acceptance/single-cluster-examples -args -ginkgo.github-output -ginkgo.trace
       -
         name: Fleet Tests Requiring Github Secrets
         if: ${{ matrix.test_type == 'e2e-secrets' }}
@@ -205,7 +205,7 @@ jobs:
           echo "${{ secrets.CI_SSH_KEY }}" > "$GIT_SSH_KEY"
           echo "${{ secrets.CI_SSH_PUBKEY }}" > "$GIT_SSH_PUBKEY"
 
-          go test -count=1 -timeout=1h ./e2e/require-secrets -args -ginkgo.github-output -ginkgo.trace
+          go test -v -count=1 -timeout=1h ./e2e/require-secrets -args -ginkgo.github-output -ginkgo.trace
       -
         name: Upload Logs
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/e2e-rancher-upgrade-fleet-to-head-ci.yml
+++ b/.github/workflows/e2e-rancher-upgrade-fleet-to-head-ci.yml
@@ -40,9 +40,6 @@ jobs:
         with:
           go-version-file: 'go.mod'
       -
-        name: Install Ginkgo CLI
-        run: go install github.com/onsi/ginkgo/v2/ginkgo
-      -
         name: Cache crust-gather CLI
         id: cache-crust
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -237,7 +234,7 @@ jobs:
           kubectl config use-context k3d-upstream
           CI_REGISTERED_CLUSTER=$(kubectl get clusters.fleet.cattle.io -n "$FLEET_E2E_NS_DOWNSTREAM" -o jsonpath='{..name}')
           export CI_REGISTERED_CLUSTER
-          ginkgo --github-output --trace e2e/multi-cluster
+          go test -count=1 -timeout=1h ./e2e/multi-cluster -args -ginkgo.github-output -ginkgo.trace
       -
         name: Dump Failed Downstream Environment
         if: failure()

--- a/.github/workflows/e2e-rancher-upgrade-fleet-to-head-ci.yml
+++ b/.github/workflows/e2e-rancher-upgrade-fleet-to-head-ci.yml
@@ -234,7 +234,7 @@ jobs:
           kubectl config use-context k3d-upstream
           CI_REGISTERED_CLUSTER=$(kubectl get clusters.fleet.cattle.io -n "$FLEET_E2E_NS_DOWNSTREAM" -o jsonpath='{..name}')
           export CI_REGISTERED_CLUSTER
-          go test -count=1 -timeout=1h ./e2e/multi-cluster -args -ginkgo.github-output -ginkgo.trace
+          go test -v -count=1 -timeout=1h ./e2e/multi-cluster -args -ginkgo.github-output -ginkgo.trace
       -
         name: Dump Failed Downstream Environment
         if: failure()

--- a/.github/workflows/e2e-rancher-upgrade-fleet.yml
+++ b/.github/workflows/e2e-rancher-upgrade-fleet.yml
@@ -58,9 +58,6 @@ jobs:
         with:
           go-version-file: 'go.mod'
       -
-        name: Install Ginkgo CLI
-        run: go install github.com/onsi/ginkgo/v2/ginkgo
-      -
         name: Cache crust-gather CLI
         id: cache-crust
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -210,7 +207,7 @@ jobs:
           FLEET_AGENT_NAMESPACE: "cattle-fleet-system"
         run: |
           # this doesn't work with <0.10
-          ginkgo --github-output --trace --label-filter='!single-cluster' e2e/installation
+          go test -count=1 -timeout=1h ./e2e/installation -args -ginkgo.github-output -ginkgo.trace -ginkgo.label-filter='!single-cluster'
       -
         name: E2E tests for examples
         env:
@@ -222,7 +219,7 @@ jobs:
           export CI_REGISTERED_CLUSTER
 
           kubectl config use-context k3d-upstream
-          ginkgo --github-output --trace e2e/multi-cluster
+          go test -count=1 -timeout=1h ./e2e/multi-cluster -args -ginkgo.github-output -ginkgo.trace
       -
         name: Dump Failed Downstream Environment
         if: failure()

--- a/.github/workflows/e2e-rancher-upgrade-fleet.yml
+++ b/.github/workflows/e2e-rancher-upgrade-fleet.yml
@@ -207,7 +207,7 @@ jobs:
           FLEET_AGENT_NAMESPACE: "cattle-fleet-system"
         run: |
           # this doesn't work with <0.10
-          go test -count=1 -timeout=1h ./e2e/installation -args -ginkgo.github-output -ginkgo.trace -ginkgo.label-filter='!single-cluster'
+          go test -v -count=1 -timeout=1h ./e2e/installation -args -ginkgo.github-output -ginkgo.trace -ginkgo.label-filter='!single-cluster'
       -
         name: E2E tests for examples
         env:
@@ -219,7 +219,7 @@ jobs:
           export CI_REGISTERED_CLUSTER
 
           kubectl config use-context k3d-upstream
-          go test -count=1 -timeout=1h ./e2e/multi-cluster -args -ginkgo.github-output -ginkgo.trace
+          go test -v -count=1 -timeout=1h ./e2e/multi-cluster -args -ginkgo.github-output -ginkgo.trace
       -
         name: Dump Failed Downstream Environment
         if: failure()

--- a/.github/workflows/e2e-test-fleet-in-rancher.yml
+++ b/.github/workflows/e2e-test-fleet-in-rancher.yml
@@ -65,12 +65,6 @@ jobs:
           go-version-file: "fleet/go.mod"
 
       -
-        name: Install Ginkgo CLI
-        run: |
-          cd fleet
-          go install github.com/onsi/ginkgo/v2/ginkgo
-
-      -
         name: Cache crust-gather CLI
         id: cache-crust
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -307,12 +301,12 @@ jobs:
         run: |
           kubectl config use-context k3d-upstream
           cd fleet
-          ginkgo --github-output --trace e2e/acceptance/single-cluster-examples
+          go test -count=1 -timeout=1h ./e2e/acceptance/single-cluster-examples -args -ginkgo.github-output -ginkgo.trace
 
           CI_REGISTERED_CLUSTER=$(kubectl get clusters.fleet.cattle.io -n "$FLEET_E2E_NS_DOWNSTREAM" -o jsonpath='{..name}')
           export CI_REGISTERED_CLUSTER
 
-          ginkgo --github-output --trace e2e/multi-cluster
+          go test -count=1 -timeout=1h ./e2e/multi-cluster -args -ginkgo.github-output -ginkgo.trace
 
       -
         name: Dump Failed Downstream Environment

--- a/.github/workflows/e2e-test-fleet-in-rancher.yml
+++ b/.github/workflows/e2e-test-fleet-in-rancher.yml
@@ -301,12 +301,12 @@ jobs:
         run: |
           kubectl config use-context k3d-upstream
           cd fleet
-          go test -count=1 -timeout=1h ./e2e/acceptance/single-cluster-examples -args -ginkgo.github-output -ginkgo.trace
+          go test -v -count=1 -timeout=1h ./e2e/acceptance/single-cluster-examples -args -ginkgo.github-output -ginkgo.trace
 
           CI_REGISTERED_CLUSTER=$(kubectl get clusters.fleet.cattle.io -n "$FLEET_E2E_NS_DOWNSTREAM" -o jsonpath='{..name}')
           export CI_REGISTERED_CLUSTER
 
-          go test -count=1 -timeout=1h ./e2e/multi-cluster -args -ginkgo.github-output -ginkgo.trace
+          go test -v -count=1 -timeout=1h ./e2e/multi-cluster -args -ginkgo.github-output -ginkgo.trace
 
       -
         name: Dump Failed Downstream Environment


### PR DESCRIPTION
Use Go test for Ginkgo suites to remove redundant CLI setup. Disable test caching so CI preserves one-run suite behavior.

`gingko unfocus` was accidentally introduced by 4f84c1598e8fa0627b71dcfbbb84fdaad7caa787.