### PR TITLE
[v0.14] Approve Renovate auto-merge PRs

### DIFF
--- a/.github/workflows/auto-approve-bot-prs.yml
+++ b/.github/workflows/auto-approve-bot-prs.yml
@@ -1,0 +1,58 @@
+name: Renovate Bot Auto-Approve
+
+on:
+  pull_request:
+    types: [auto_merge_enabled]
+
+permissions:
+  id-token: write
+  contents: read
+  pull-requests: read
+
+jobs:
+  auto-approve:
+    name: Approve Renovate PR
+    if: >-
+      github.event.pull_request.state == 'open' &&
+      github.event.pull_request.auto_merge != null &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.user.login == (vars.RENOVATE_BOT_USERNAME || 'renovate-rancher[bot]') &&
+      startsWith(github.event.pull_request.head.ref, 'renovate/')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Read App Secrets
+        uses: rancher-eio/read-vault-secrets@0da85151ad1f19ed7986c41587e45aac1ace74b6 # v3
+        with:
+          secrets: |
+            secret/data/github/repo/${{ github.repository }}/github/auto-approve/app-credentials appId | APP_ID ;
+            secret/data/github/repo/${{ github.repository }}/github/auto-approve/app-credentials privateKey | PRIVATE_KEY
+
+      - name: Create App Token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ env.APP_ID }}
+          private-key: ${{ env.PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: |
+            ${{ github.event.repository.name }}
+          permission-pull-requests: write
+
+      - name: Approve PR
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          review_decision=$(gh pr view "$PR_NUMBER" --repo "$REPO" \
+            --json reviewDecision --jq '.reviewDecision')
+
+          if [[ "$review_decision" == "APPROVED" ]]; then
+            echo "PR is currently approved."
+            exit 0
+          fi
+
+          gh pr review "$PR_NUMBER" \
+            --repo "$REPO" \
+            --approve \
+            --body "Auto-approving Renovate PR with auto-merge enabled."


### PR DESCRIPTION
Approve Renovate pull requests only when auto-merge is enabled, using the repository App token.

Backports #5459