### PR TITLE
ci(release): checkout Fleet twice to fix ref skew in release workflow

### DIFF
--- a/.github/scripts/release-against-rancher.sh
+++ b/.github/scripts/release-against-rancher.sh
@@ -21,7 +21,7 @@ bump_fleet_module() {
     # Guard against a tag that predates the module being split out of the main
     # Fleet module: without its own go.mod, `go get` silently falls back to
     # resolving the root `github.com/rancher/fleet` module instead.
-    if ! git -C ../fleet cat-file -e "${tag}:$1/go.mod" 2>/dev/null; then
+    if ! git -C "${FLEET_REPO_DIR}" cat-file -e "${tag}:$1/go.mod" 2>/dev/null; then
         printf 'ERROR: %s does not contain %s/go.mod\n' "${tag}" "$1" >&2
         printf 'The tag does not point at a standalone Go module; refusing to bump.\n' >&2
         exit 1
@@ -46,6 +46,12 @@ bump_fleet_module() {
 }
 
 RANCHER_DIR="${RANCHER_DIR:-"$(dirname -- "$0")/../../../rancher"}"
+
+# this script may run from a different Fleet checkout than the one being
+# released, so the two must not be conflict. Resolved to an absolute path
+# because every read below happens after the pushd.
+FLEET_REPO_DIR="${FLEET_REPO_DIR:-"$(dirname -- "$0")/../.."}"
+FLEET_REPO_DIR="$(cd -- "${FLEET_REPO_DIR}" && pwd)"
 
 pushd "${RANCHER_DIR}" > /dev/null
 
@@ -100,13 +106,13 @@ go generate
 git add build.yaml pkg/buildconfig/constants.go
 
 # Bump the Fleet API when a pkg/apis tag for this exact version exists in the fleet repo.
-if git -C ../fleet tag -l "pkg/apis/v${NEW_FLEET_VERSION}" | grep -q .; then
+if git -C "${FLEET_REPO_DIR}" tag -l "pkg/apis/v${NEW_FLEET_VERSION}" | grep -q .; then
     bump_fleet_module pkg/apis
 fi
 
 # Bump the Fleet helmvalues module when a pkg/helmvalues tag for this exact version
 # exists in the fleet repo.
-if git -C ../fleet tag -l "pkg/helmvalues/v${NEW_FLEET_VERSION}" | grep -q .; then
+if git -C "${FLEET_REPO_DIR}" tag -l "pkg/helmvalues/v${NEW_FLEET_VERSION}" | grep -q .; then
     bump_fleet_module pkg/helmvalues
 fi
 

--- a/.github/scripts/release-against-rancher.sh
+++ b/.github/scripts/release-against-rancher.sh
@@ -47,8 +47,8 @@ bump_fleet_module() {
 
 RANCHER_DIR="${RANCHER_DIR:-"$(dirname -- "$0")/../../../rancher"}"
 
-# this script may run from a different Fleet checkout than the one being
-# released, so the two must not be conflict. Resolved to an absolute path
+# This script may run from a different Fleet checkout than the one being
+# released, so the two must not conflict. Resolve FLEET_REPO_DIR to an absolute path
 # because every read below happens after the pushd.
 FLEET_REPO_DIR="${FLEET_REPO_DIR:-"$(dirname -- "$0")/../.."}"
 FLEET_REPO_DIR="$(cd -- "${FLEET_REPO_DIR}" && pwd)"

--- a/.github/workflows/release-against-rancher.yml
+++ b/.github/workflows/release-against-rancher.yml
@@ -35,11 +35,20 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Checkout Fleet (scripts)
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          path: fleet
+          persist-credentials: false
+
+      # Release checkout, at the branch being released. Used only as a data
+      # source: git tags, and which submodules are split out on that branch.
+      - name: Checkout Fleet (release branch)
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           ref: ${{ inputs.fleet_branch }}
-          path: fleet
+          path: fleet-release
           persist-credentials: false
 
       - name: Compute versions
@@ -47,6 +56,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           FLEET_BRANCH: ${{ inputs.fleet_branch }}
+          FLEET_REPO_DIR: ./fleet-release
         run: fleet/.github/scripts/compute-rancher-versions.sh
 
       - name: Checkout rancher/rancher
@@ -71,19 +81,19 @@ jobs:
           fi
 
           # For a new final minor version, every Fleet submodule that has already been split
-          # out on this branch (i.e. <mod>/go.mod exists in the fleet checkout) must be tagged,
+          # out on this branch (i.e. <mod>/go.mod exists in the release checkout) must be tagged,
           # and the tag must point at a commit that actually contains <mod>/go.mod. A submodule
           # not yet split out on this branch (e.g. pkg/helmvalues before it is backported) is not
           # required, since rancher/rancher cannot consume it yet either way.
           if [[ "${NEW_FLEET}" =~ \.0$ ]]; then
             for mod in pkg/apis pkg/helmvalues; do
-              if [ ! -f "fleet/${mod}/go.mod" ]; then
+              if [ ! -f "fleet-release/${mod}/go.mod" ]; then
                 printf 'INFO: %s/go.mod not present on this branch; skipping %s tag requirement\n' "${mod}" "${mod}"
                 continue
               fi
 
               tag="${mod}/v${NEW_FLEET}"
-              if ! git -C fleet tag -l "${tag}" | grep -q .; then
+              if ! git -C fleet-release tag -l "${tag}" | grep -q .; then
                 {
                   printf 'ERROR: %s tag not found in the fleet repo!\n' "${tag}"
                   printf 'For a new final minor version, %s must be bumped first.\n' "${mod}"
@@ -92,7 +102,7 @@ jobs:
                 exit 1
               fi
 
-              if ! git -C fleet cat-file -e "${tag}:${mod}/go.mod" 2>/dev/null; then
+              if ! git -C fleet-release cat-file -e "${tag}:${mod}/go.mod" 2>/dev/null; then
                 {
                   printf 'ERROR: %s exists but %s/go.mod is missing at that commit!\n' "${tag}" "${mod}"
                   printf 'The tag likely predates %s being split into its own Go module.\n' "${mod}"
@@ -105,7 +115,7 @@ jobs:
 
           # For any final version, rancher/rancher must not reference a pre-release Fleet API
           # so there must be a Fleet `pkg/apis/v<VERSION>` tag that the api is bumped in this action
-          if ! git -C fleet tag -l "pkg/apis/v${NEW_FLEET}" | grep -q .; then
+          if ! git -C fleet-release tag -l "pkg/apis/v${NEW_FLEET}" | grep -q .; then
             # Tag doesn't exist; check if rancher/rancher has a pre-release version that does not need to be bumped.
             RANCHER_FLEET_API_VERSION=$(grep 'github.com/rancher/fleet/pkg/apis' rancher/pkg/apis/go.mod | awk '{print $NF}')
             if [[ "${RANCHER_FLEET_API_VERSION:-}" =~ - ]]; then
@@ -123,7 +133,7 @@ jobs:
           # pre-release reference in a later file.
           # -o restricts the match to "<module> <version>" so a trailing " // indirect" is
           # excluded; otherwise awk would read "indirect" as the version and drop the match.
-          if ! git -C fleet tag -l "pkg/helmvalues/v${NEW_FLEET}" | grep -q .; then
+          if ! git -C fleet-release tag -l "pkg/helmvalues/v${NEW_FLEET}" | grep -q .; then
             RANCHER_FLEET_HELMVALUES_PRERELEASES=$(grep -rhsoE 'github.com/rancher/fleet/pkg/helmvalues[[:space:]]+v[0-9][^[:space:]]*' rancher --include=go.mod | awk '{print $NF}' | grep -- - | sort -u || true)
             if [ -n "${RANCHER_FLEET_HELMVALUES_PRERELEASES}" ]; then
               {
@@ -147,6 +157,8 @@ jobs:
         env:
           NEW_FLEET: ${{ steps.versions.outputs.new_fleet }}
           NEW_CHART: ${{ steps.versions.outputs.new_chart }}
+          # the script reads the absolute path after changing into the rancher checkout.
+          FLEET_REPO_DIR: ${{ github.workspace }}/fleet-release
         run: |
           ./fleet/.github/scripts/release-against-rancher.sh \
             "$NEW_FLEET" \


### PR DESCRIPTION
The "Release Fleet against rancher/rancher" workflow checked out the Fleet repo once, at inputs.fleet_branch, into fleet/, and ran every script from that checkout. A workflow_dispatch always executes the workflow YAML itself from the dispatched ref (main), so this paired main's calling convention with whatever copy of the scripts happened to sit on the release branch.

That skew broke fleet_branch=release/v0.15: PR #4796 dropped the should_bump_api input and rewrote release-against-rancher.sh to take 2 args, deriving the API bump from a pkg/apis tag instead. main's workflow now passes 2 args, but release/v0.15 still has the pre-#4796 script, whose line 9 reads $3 under set -ue and fails with "unbound variable". PR #5508 backported compute-rancher-versions.sh to that branch and only moved the failure one step further down the chain, because it fixed the same skew for one script without removing the underlying mismatch.

Design choice: check Fleet out twice instead of backporting scripts. fleet/ has no ref, so it lands on the workflow's own ref, and every script now runs from there. fleet-release/ stays pinned to inputs.fleet_branch with fetch-depth: 0, and is read only as a data source for git tags and which submodules are split out on that branch. The release checkout is passed to the scripts as FLEET_REPO_DIR, absolute for the release-against-rancher.sh step because that script pushd's into the rancher checkout before reading it. In the script, three hardcoded `git -C ../fleet` reads become `git -C "${FLEET_REPO_DIR}"`, defaulting to the script's own checkout so manual invocation is unaffected.

Behavior change: none for the tag reads themselves. fetch-depth: 0 makes git tag/cat-file lookups branch-independent, so pointing FLEET_REPO_DIR at either checkout returns the same answer today. The change is about sourcing scripts and tooling from a single consistent ref, not about changing what is read.

Intentionally left out: no backport to release branches. Each release branch already carries a self-consistent workflow+script pair (its own manual-input workflow and matching 3-arg script). The old failure only happened because main's YAML was mixed with a release branch's scripts; running scripts from the workflow's own ref permanently removes that mix, so release branches never need this backport again.

