### PR TITLE
Reduce Fleet Helm values go.mod MinimumGroupSize to two

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -54,6 +54,13 @@
       "extends": [
         "github>rancher/renovate-config//rancher-2.11#release"
       ]
+    },
+    {
+      "description": "Wait for paired Kubernetes updates in Helm values module",
+      "matchManagers": ["gomod"],
+      "matchFileNames": ["pkg/helmvalues/go.mod"],
+      "groupName": "Kubernetes dependencies",
+      "minimumGroupSize": 2
     }
   ]
 }


### PR DESCRIPTION
to allow Kubernetes updates in `pkg/helmvalues/go.mod` to be updated at the same time as the other Kubernetes dependencies. Because helm go.mod only has two Kubernetes entries.

Should fix CI failures as https://github.com/rancher/fleet/pull/5510 .

The issue was that Kubernetes bumps require `minimumGroupSize` of 15 to prevent tons of Renovate Kubernetes bumps of the same version but with different release times. `pkg/helmvalues/go.mod` did not have that many entries.