### PR TITLE
Report bundle deployment state as Kubernetes events

### DIFF
--- a/charts/fleet/templates/configmap.yaml
+++ b/charts/fleet/templates/configmap.yaml
@@ -25,6 +25,20 @@ data:
       "imagePullSecrets": {{toJson .Values.global.cattle.imagePullSecrets}},
       {{ end }}
       "ignoreClusterRegistrationLabels": {{.Values.ignoreClusterRegistrationLabels}},
+      {{- with .Values.deploymentEvents }}
+      "deploymentEvents": {
+        "disabled": {{toJson .disabled}},
+        {{ if .debounce }}
+        "debounce": "{{.debounce}}",
+        {{ end }}
+        {{ if .minInterval }}
+        "minInterval": "{{.minInterval}}",
+        {{ end }}
+        "reportRecovery": {{toJson .reportRecovery}},
+        "perDeployment": {{toJson .perDeployment}},
+        "maxCauses": {{toJson .maxCauses}}
+      },
+      {{- end }}
       "bootstrap": {
         "paths": "{{.Values.bootstrap.paths}}",
         "repo": "{{.Values.bootstrap.repo}}",

--- a/charts/fleet/templates/rbac.yaml
+++ b/charts/fleet/templates/rbac.yaml
@@ -34,6 +34,7 @@ rules:
   - '*'
 - apiGroups:
     - ""
+    - "events.k8s.io"
   resources:
     - 'events'
   verbs:

--- a/charts/fleet/values.schema.json
+++ b/charts/fleet/values.schema.json
@@ -12,9 +12,13 @@
         {
           "type": "integer",
           "enum": [0]
+        },
+        {
+          "type": "string",
+          "const": ""
         }
       ],
-      "description": "A Go duration string. Valid units: ns, us, µs, ms, s, m, h (e.g. 15s, 5m, 2h, 1h30m). Units like d (days) or w (weeks) are NOT supported by Go's time.ParseDuration and will be dropped; use 0 to fall back to the built-in default."
+      "description": "A Go duration string. Valid units: ns, us, µs, ms, s, m, h (e.g. 15s, 5m, 2h, 1h30m). Units like d (days) or w (weeks) are NOT supported by Go's time.ParseDuration and will be dropped; use 0, or the empty string, to fall back to the built-in default."
     }
   },
   "properties": {
@@ -29,6 +33,30 @@
     },
     "clusterEnqueueDelay": {
       "$ref": "#/definitions/goDuration"
+    },
+    "deploymentEvents": {
+      "type": "object",
+      "properties": {
+        "disabled": {
+          "type": "boolean"
+        },
+        "debounce": {
+          "$ref": "#/definitions/goDuration"
+        },
+        "minInterval": {
+          "$ref": "#/definitions/goDuration"
+        },
+        "reportRecovery": {
+          "type": "boolean"
+        },
+        "perDeployment": {
+          "type": "boolean"
+        },
+        "maxCauses": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
     },
     "gitops": {
       "type": "object",

--- a/charts/fleet/values.yaml
+++ b/charts/fleet/values.yaml
@@ -30,6 +30,34 @@ garbageCollectionInterval: "15m"
 # Whether you want to allow cluster upon registration to specify their labels.
 ignoreClusterRegistrationLabels: false
 
+# Events reporting the deployment state of bundles, on the bundle they are about.
+deploymentEvents:
+  # Turns off events about the deployment state of bundles. Unsetting the whole
+  # block keeps the defaults below, which report.
+  disabled: false
+  # How long to wait for a burst of failures to settle before reporting it, so
+  # that the event describes the whole burst instead of only its first failure.
+  # A bundle failing on 500 clusters over 3s reports once, as "500/500 bundle
+  # deployments failing", instead of first reporting "1/500".
+  debounce: 5s
+  # The minimum time between two events about the same object. It bounds how
+  # often a flapping deployment reports: one failing and recovering every 10s
+  # reports about once a minute, instead of on every transition.
+  minInterval: 1m
+  # Report bundles whose deployments all became ready again after a failure.
+  # Only bundles which were failing report, so healthy ones stay silent.
+  reportRecovery: true
+  # Additionally report each failing bundle deployment, in the namespace of its
+  # cluster. This is more detailed, but produces one event per failing
+  # deployment, of which there is one per cluster a bundle is deployed to: a
+  # bundle failing on 500 clusters reports 501 events instead of 1.
+  perDeployment: false
+  # How many distinct failure causes a single event describes. The bundle's
+  # status.summary.nonReadyResources lists more of them, up to 10, which is
+  # therefore the highest value with an effect. Causes beyond it are reported as
+  # "(+117 more, see status.summary.nonReadyResources)".
+  maxCauses: 3
+
 # Counts from gitrepo are out of sync with bundleDeployment state.
 # Just retry in a number of seconds as there is no great way to trigger an event that doesn't cause a loop.
 # If not set default is 15 seconds.

--- a/internal/cmd/controller/bundleevents/note.go
+++ b/internal/cmd/controller/bundleevents/note.go
@@ -1,0 +1,188 @@
+package bundleevents
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
+)
+
+const (
+	// noteMaxLength stays below the 1kB limit the API enforces on an event's note.
+	noteMaxLength = 1000
+
+	// messageMaxLength bounds a single cause, so that one long Helm error
+	// cannot take up the whole note.
+	messageMaxLength = 200
+
+	// statusHint points at the bundle status, which lists more causes than
+	// fit into a note.
+	statusHint = "see status.summary.nonReadyResources"
+)
+
+// failureCounts returns the number of bundle deployments which failed to deploy
+// or are deployed but not ready, together with the state to report for them.
+// Transient states, like Pending or WaitApplied, are not failures: they are
+// reported once they either settle or turn into a failure.
+func failureCounts(s fleet.BundleSummary) (int, fleet.BundleState) {
+	switch {
+	case s.ErrApplied > 0:
+		// ErrApplied outranks NotReady, see fleet.StateRank.
+		return s.ErrApplied + s.NotReady, fleet.ErrApplied
+	case s.NotReady > 0:
+		return s.NotReady, fleet.NotReady
+	}
+
+	return 0, fleet.Ready
+}
+
+// failureReason is the reason to report for a failure state.
+func failureReason(state fleet.BundleState) string {
+	if state == fleet.NotReady {
+		return ReasonNotReady
+	}
+
+	return ReasonDeployFailed
+}
+
+// failureFingerprint describes the failures of a summary: how many deployments
+// are affected, the reason to report them under, and a fingerprint which
+// changes whenever the failures are worth reporting again.
+func failureFingerprint(s fleet.BundleSummary) (int, string, fingerprint) {
+	failing, state := failureCounts(s)
+	if failing == 0 {
+		return 0, "", fingerprint{}
+	}
+
+	reason := failureReason(state)
+
+	return failing, reason, fingerprintOf("failing", reason, magnitude(failing), causeKeys(s))
+}
+
+// failureCauses returns the failing entries of the summary's non-ready
+// resources. The summary stores at most 10 of them.
+func failureCauses(s fleet.BundleSummary) []fleet.NonReadyResource {
+	causes := make([]fleet.NonReadyResource, 0, len(s.NonReadyResources))
+	for _, r := range s.NonReadyResources {
+		if r.State == fleet.ErrApplied || r.State == fleet.NotReady {
+			causes = append(causes, r)
+		}
+	}
+
+	return causes
+}
+
+// causeKeys returns the distinct state and message pairs of the failing
+// resources, sorted, so that the same set of causes always produces the same
+// keys. Cluster names are deliberately left out: the same failure on more
+// clusters is not a new cause and must not produce another event.
+func causeKeys(s fleet.BundleSummary) []string {
+	seen := make(map[string]struct{})
+	keys := make([]string, 0, len(s.NonReadyResources))
+
+	for _, c := range failureCauses(s) {
+		key := string(c.State) + "|" + c.Message
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	return keys
+}
+
+// magnitude buckets a number of failures, so that a deployment failing on one
+// more cluster does not warrant another event, while an order of magnitude
+// more, or fewer, failures does.
+func magnitude(n int) string {
+	switch {
+	case n <= 1:
+		return "1"
+	case n <= 5:
+		return "2-5"
+	case n <= 20:
+		return "6-20"
+	case n <= 100:
+		return "21-100"
+	case n <= 1000:
+		return "101-1000"
+	}
+
+	return "1000+"
+}
+
+// failureNote describes how many bundle deployments are failing and why, for up
+// to maxCauses distinct clusters. Causes which do not fit are represented by a
+// count and a pointer to the bundle status, which holds more of them.
+func failureNote(s fleet.BundleSummary, maxCauses int) string {
+	failing, _ := failureCounts(s)
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "%d/%d bundle deployments failing", failing, s.DesiredReady)
+	if s.ErrApplied > 0 && s.NotReady > 0 {
+		fmt.Fprintf(&b, " (errApplied %d, notReady %d)", s.ErrApplied, s.NotReady)
+	}
+	b.WriteString(".")
+
+	// Leave room for the trailing hint, which is more useful than one more cause.
+	budget := noteMaxLength - len(statusHint) - 32
+
+	causes := failureCauses(s)
+	written := 0
+	for _, c := range causes {
+		if written >= maxCauses {
+			break
+		}
+
+		cause := fmt.Sprintf(" %s: %s: %s;", c.Name, c.State, truncate(c.Message, messageMaxLength))
+		if b.Len()+len(cause) > budget {
+			break
+		}
+
+		b.WriteString(cause)
+		written++
+	}
+
+	// The hint counts the causes left in the status, not the failing
+	// deployments: the summary records at most 10 causes for any number of
+	// them, so counting deployments would point at causes which are not
+	// there. How many deployments are failing is already in the first
+	// sentence.
+	if remaining := len(causes) - written; remaining > 0 {
+		fmt.Fprintf(&b, " (+%d more, %s)", remaining, statusHint)
+	}
+
+	return truncate(b.String(), noteMaxLength)
+}
+
+// readyNote describes a bundle whose deployments are all ready again.
+func readyNote(s fleet.BundleSummary) string {
+	return fmt.Sprintf("%d/%d bundle deployments ready", s.Ready, s.DesiredReady)
+}
+
+// deploymentNote describes the state of a single bundle deployment.
+func deploymentNote(bundle string, state fleet.BundleState, message string) string {
+	if bundle == "" {
+		bundle = "unknown"
+	}
+	if message == "" {
+		return fmt.Sprintf("bundle %s: %s", bundle, state)
+	}
+
+	return truncate(fmt.Sprintf("bundle %s: %s: %s", bundle, state, message), noteMaxLength)
+}
+
+// truncate shortens s to max bytes, without cutting a rune in half.
+func truncate(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	if max <= 3 {
+		return strings.ToValidUTF8(s[:max], "")
+	}
+
+	return strings.ToValidUTF8(s[:max-3], "") + "..."
+}

--- a/internal/cmd/controller/bundleevents/note.go
+++ b/internal/cmd/controller/bundleevents/note.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/rancher/fleet/internal/cmd/controller/summary"
 	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
 )
 
@@ -37,13 +38,34 @@ func failureCounts(s fleet.BundleSummary) (int, fleet.BundleState) {
 	return 0, fleet.Ready
 }
 
-// failureReason is the reason to report for a failure state.
-func failureReason(state fleet.BundleState) string {
+// isFailure reports whether a state is one this package reports as a failure.
+func isFailure(state fleet.BundleState) bool {
+	return state == fleet.ErrApplied || state == fleet.NotReady
+}
+
+// recovered reports whether every bundle deployment of a bundle is ready. A
+// bundle without targets has no deployments to report as recovered.
+func recovered(s fleet.BundleSummary) bool {
+	return s.DesiredReady > 0 && summary.IsReady(s)
+}
+
+// bundleFailureReason is the reason to report for a bundle in a failure state.
+func bundleFailureReason(state fleet.BundleState) string {
 	if state == fleet.NotReady {
-		return ReasonNotReady
+		return ReasonBundleNotReady
 	}
 
-	return ReasonDeployFailed
+	return ReasonBundleDeployFailed
+}
+
+// deploymentFailureReason is the reason to report for a single bundle
+// deployment in a failure state.
+func deploymentFailureReason(state fleet.BundleState) string {
+	if state == fleet.NotReady {
+		return ReasonBundleDeploymentNotReady
+	}
+
+	return ReasonBundleDeploymentFailed
 }
 
 // failureFingerprint describes the failures of a summary: how many deployments
@@ -55,7 +77,7 @@ func failureFingerprint(s fleet.BundleSummary) (int, string, fingerprint) {
 		return 0, "", fingerprint{}
 	}
 
-	reason := failureReason(state)
+	reason := bundleFailureReason(state)
 
 	return failing, reason, fingerprintOf("failing", reason, magnitude(failing), causeKeys(s))
 }
@@ -65,7 +87,7 @@ func failureFingerprint(s fleet.BundleSummary) (int, string, fingerprint) {
 func failureCauses(s fleet.BundleSummary) []fleet.NonReadyResource {
 	causes := make([]fleet.NonReadyResource, 0, len(s.NonReadyResources))
 	for _, r := range s.NonReadyResources {
-		if r.State == fleet.ErrApplied || r.State == fleet.NotReady {
+		if isFailure(r.State) {
 			causes = append(causes, r)
 		}
 	}

--- a/internal/cmd/controller/bundleevents/note_test.go
+++ b/internal/cmd/controller/bundleevents/note_test.go
@@ -1,0 +1,176 @@
+package bundleevents
+
+import (
+	"strings"
+	"testing"
+
+	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
+)
+
+func TestFailureNoteDescribesCountsAndCauses(t *testing.T) {
+	summary := fleet.BundleSummary{
+		DesiredReady: 500,
+		Ready:        200,
+		ErrApplied:   290,
+		NotReady:     10,
+		NonReadyResources: []fleet.NonReadyResource{
+			{Name: "fleet-default/cluster-a", State: fleet.ErrApplied, Message: renderError},
+			{Name: "fleet-default/cluster-b", State: fleet.ErrApplied, Message: nsForbidden},
+			{Name: "fleet-default/cluster-c", State: fleet.NotReady, Message: "0/3 replicas ready"},
+			{Name: "fleet-default/cluster-d", State: fleet.ErrApplied, Message: renderError},
+		},
+	}
+
+	note := failureNote(summary, 3)
+
+	if !strings.HasPrefix(note, "300/500 bundle deployments failing (errApplied 290, notReady 10).") {
+		t.Errorf("unexpected counts: %q", note)
+	}
+	for _, want := range []string{"fleet-default/cluster-a", "fleet-default/cluster-b", "fleet-default/cluster-c"} {
+		if !strings.Contains(note, want) {
+			t.Errorf("expected %q in the note, got %q", want, note)
+		}
+	}
+	if strings.Contains(note, "cluster-d") {
+		t.Errorf("expected at most 3 causes, got %q", note)
+	}
+	// One cause is left in the status: four are recorded, three fit.
+	if !strings.Contains(note, "(+1 more, see status.summary.nonReadyResources)") {
+		t.Errorf("expected the remaining causes to be counted, got %q", note)
+	}
+}
+
+func TestFailureNoteStaysWithinTheNoteLimit(t *testing.T) {
+	summary := fleet.BundleSummary{DesiredReady: 10, ErrApplied: 10}
+	for range 10 {
+		summary.NonReadyResources = append(summary.NonReadyResources, fleet.NonReadyResource{
+			Name:    "fleet-default/cluster-" + strings.Repeat("x", 50),
+			State:   fleet.ErrApplied,
+			Message: strings.Repeat("a very long helm error ", 100),
+		})
+	}
+
+	note := failureNote(summary, 10)
+
+	if len(note) > noteMaxLength {
+		t.Errorf("expected the note to be at most %d bytes, got %d", noteMaxLength, len(note))
+	}
+	if !strings.Contains(note, "more, see status.summary.nonReadyResources") {
+		t.Errorf("expected a pointer to the status, got %q", note)
+	}
+}
+
+func TestFailureNoteWithoutCausesStillReportsCounts(t *testing.T) {
+	note := failureNote(fleet.BundleSummary{DesiredReady: 3, ErrApplied: 3}, 3)
+
+	// No causes are recorded, so there is nothing to point at in the status.
+	if note != "3/3 bundle deployments failing." {
+		t.Errorf("unexpected note: %q", note)
+	}
+}
+
+func TestFailureNoteOmitsTheHintOnceEveryCauseFits(t *testing.T) {
+	// Many deployments failing for the one reason the summary recorded: the
+	// note describes it in full, so there is nothing more to look up.
+	summary := fleet.BundleSummary{
+		DesiredReady: 500,
+		Ready:        450,
+		ErrApplied:   50,
+		NonReadyResources: []fleet.NonReadyResource{
+			{Name: "fleet-default/cluster-a", State: fleet.ErrApplied, Message: renderError},
+		},
+	}
+
+	note := failureNote(summary, 3)
+
+	if !strings.HasPrefix(note, "50/500 bundle deployments failing.") {
+		t.Errorf("unexpected counts: %q", note)
+	}
+	if strings.Contains(note, "more, "+statusHint) {
+		t.Errorf("expected no pointer to the status, got %q", note)
+	}
+}
+
+func TestFailureCountsIgnoreTransientStates(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		summary fleet.BundleSummary
+		failing int
+		state   fleet.BundleState
+	}{
+		{
+			name:    "pending and waiting are not failures",
+			summary: fleet.BundleSummary{DesiredReady: 5, Pending: 2, WaitApplied: 2, OutOfSync: 1},
+			failing: 0,
+			state:   fleet.Ready,
+		},
+		{
+			name:    "errApplied outranks notReady",
+			summary: fleet.BundleSummary{DesiredReady: 5, ErrApplied: 2, NotReady: 3},
+			failing: 5,
+			state:   fleet.ErrApplied,
+		},
+		{
+			name:    "notReady on its own",
+			summary: fleet.BundleSummary{DesiredReady: 5, NotReady: 3},
+			failing: 3,
+			state:   fleet.NotReady,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			failing, state := failureCounts(test.summary)
+			if failing != test.failing || state != test.state {
+				t.Errorf("expected %d/%s, got %d/%s", test.failing, test.state, failing, state)
+			}
+		})
+	}
+}
+
+func TestCauseKeysIgnoreClusterNames(t *testing.T) {
+	first := fleet.BundleSummary{NonReadyResources: []fleet.NonReadyResource{
+		{Name: "fleet-default/cluster-a", State: fleet.ErrApplied, Message: renderError},
+	}}
+	second := fleet.BundleSummary{NonReadyResources: []fleet.NonReadyResource{
+		{Name: "fleet-default/cluster-b", State: fleet.ErrApplied, Message: renderError},
+		{Name: "fleet-default/cluster-c", State: fleet.ErrApplied, Message: renderError},
+	}}
+
+	if got, want := causeKeys(second), causeKeys(first); len(got) != len(want) || got[0] != want[0] {
+		t.Errorf("expected the same cause on more clusters to produce the same keys, got %v and %v", got, want)
+	}
+}
+
+func TestMagnitudeBuckets(t *testing.T) {
+	for _, test := range []struct {
+		n    int
+		want string
+	}{
+		{n: 1, want: "1"},
+		{n: 2, want: "2-5"},
+		{n: 5, want: "2-5"},
+		{n: 6, want: "6-20"},
+		{n: 100, want: "21-100"},
+		{n: 500, want: "101-1000"},
+		{n: 5000, want: "1000+"},
+	} {
+		if got := magnitude(test.n); got != test.want {
+			t.Errorf("magnitude(%d) = %q, want %q", test.n, got, test.want)
+		}
+	}
+}
+
+func TestTruncateKeepsValidUTF8(t *testing.T) {
+	truncated := truncate(strings.Repeat("ü", 20), 10)
+
+	if len(truncated) > 10 {
+		t.Errorf("expected at most 10 bytes, got %d", len(truncated))
+	}
+	if !strings.HasSuffix(truncated, "...") {
+		t.Errorf("expected an ellipsis, got %q", truncated)
+	}
+	for _, r := range truncated {
+		if r == '�' {
+			t.Errorf("expected valid UTF-8, got %q", truncated)
+		}
+	}
+}

--- a/internal/cmd/controller/bundleevents/notifier.go
+++ b/internal/cmd/controller/bundleevents/notifier.go
@@ -1,0 +1,638 @@
+// Package bundleevents reports the deployment state of bundles as Kubernetes
+// events.
+//
+// Events are created directly, instead of through client-go's event recorder.
+// The recorder deduplicates events by every field except their note, and keeps
+// the note of the first event of a series, so notes describing different
+// failures of the same bundle would be dropped. Deduplication happens here
+// instead, based on a fingerprint of the failure causes and of how many
+// deployments are affected, so that each event which does get created describes
+// the state accurately.
+package bundleevents
+
+import (
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/rancher/fleet/internal/cmd/controller/summary"
+	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
+
+	corev1 "k8s.io/api/core/v1"
+	eventsv1 "k8s.io/api/events/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/reference"
+	"k8s.io/client-go/util/flowcontrol"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+const (
+	// ReasonDeployFailed reports bundle deployments which failed to apply their resources.
+	ReasonDeployFailed = "BundleDeployFailed"
+
+	// ReasonNotReady reports bundle deployments which applied their resources, but those are not ready.
+	ReasonNotReady = "BundleNotReady"
+
+	// ReasonReady reports a bundle whose deployments are all ready again.
+	ReasonReady = "BundleDeploymentsReady"
+
+	// actionDeploy is the operation all events reported here relate to.
+	actionDeploy = "Deploy"
+
+	// tickInterval is how often pending events are checked for being due.
+	tickInterval = time.Second
+
+	// entryTTL is how long an object without a pending event is remembered.
+	entryTTL = time.Hour
+
+	// createRetryDelay is how long to wait before retrying a failed event creation.
+	createRetryDelay = 10 * time.Second
+
+	// maxCreateAttempts is how often creating one event is tried before it
+	// is dropped. Retrying forever would keep the object's entry alive,
+	// which exempts it from both the size limit and the TTL, and would
+	// spend the rate limit which events that can be created need.
+	maxCreateAttempts = 5
+
+	// reportingInstanceMaxLength is the maximum length the API accepts for reportingInstance.
+	reportingInstanceMaxLength = 128
+)
+
+// Notifier observes objects after their status has been updated, and reports
+// state changes worth an event.
+type Notifier interface {
+	// ObserveBundle reports failures and recoveries of a bundle's
+	// deployments. Old is the bundle as previously persisted, which makes
+	// the state change survive a restart of the controller.
+	ObserveBundle(ctx context.Context, old, cur *fleet.Bundle)
+
+	// ObserveBundleDeployment reports a single bundle deployment, if
+	// per-deployment reporting is enabled.
+	ObserveBundleDeployment(ctx context.Context, old, cur *fleet.BundleDeployment)
+
+	// Forget drops everything remembered about an object. Callers report
+	// objects which are going away, so that nothing is kept for them.
+	Forget(uid types.UID)
+}
+
+// fingerprint identifies what an event says, so that saying it again can be skipped.
+type fingerprint [sha256.Size]byte
+
+// snapshot is an event waiting to be created.
+type snapshot struct {
+	regarding corev1.ObjectReference
+	eventType string
+	reason    string
+	note      string
+	fp        fingerprint
+}
+
+// entry is the emitter's memory of one object.
+type entry struct {
+	// emitted is the fingerprint of the last event created for the object.
+	emitted fingerprint
+	hasSent bool
+
+	// lastEmit is when that event was created.
+	lastEmit time.Time
+
+	// pending is the next event to create, and dueAt is when it may be created.
+	pending *snapshot
+	dueAt   time.Time
+
+	// attempts is how often creating the pending event has failed.
+	attempts int
+
+	// touched is when the object was last observed, used to forget it again.
+	touched time.Time
+}
+
+// dueEvent is an event which has been claimed for creation, together with the
+// object it belongs to.
+type dueEvent struct {
+	uid  types.UID
+	snap *snapshot
+}
+
+// Emitter implements Notifier. It also implements manager.Runnable: pending
+// events are created by its Start method.
+type Emitter struct {
+	client              client.Client
+	scheme              *runtime.Scheme
+	reportingController string
+	reportingInstance   string
+	options             func() Options
+	now                 func() time.Time
+	limiter             flowcontrol.RateLimiter
+
+	mu      sync.Mutex
+	entries map[types.UID]*entry
+}
+
+// Option overrides an emitter's defaults.
+type Option func(*Emitter)
+
+// WithClock replaces the emitter's source of time.
+func WithClock(now func() time.Time) Option {
+	return func(e *Emitter) { e.now = now }
+}
+
+// WithRateLimiter replaces the emitter's rate limiter.
+func WithRateLimiter(limiter flowcontrol.RateLimiter) Option {
+	return func(e *Emitter) { e.limiter = limiter }
+}
+
+// New returns an emitter which creates events with the given reporting
+// controller name. Options are read on every use, so that configuration changes
+// take effect without a restart.
+func New(c client.Client, scheme *runtime.Scheme, reportingController string, options func() Options, opts ...Option) *Emitter {
+	hostname, _ := os.Hostname()
+	e := &Emitter{
+		client:              c,
+		scheme:              scheme,
+		reportingController: reportingController,
+		reportingInstance:   truncate(reportingController+"-"+hostname, reportingInstanceMaxLength),
+		options:             options,
+		now:                 time.Now,
+		limiter:             flowcontrol.NewTokenBucketRateLimiter(defaultQPS, defaultBurst),
+		entries:             map[types.UID]*entry{},
+	}
+
+	for _, opt := range opts {
+		opt(e)
+	}
+
+	return e
+}
+
+// Start creates pending events once they are due. It returns when the context
+// is cancelled.
+func (e *Emitter) Start(ctx context.Context) error {
+	ticker := time.NewTicker(tickInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+			e.flush(ctx, e.options())
+			e.forgetStale()
+		}
+	}
+}
+
+// ObserveBundle reports failures and recoveries of a bundle's deployments.
+func (e *Emitter) ObserveBundle(ctx context.Context, old, cur *fleet.Bundle) {
+	opts := e.options()
+	if !opts.Enabled || old == nil || cur == nil {
+		return
+	}
+	if !cur.DeletionTimestamp.IsZero() {
+		e.Forget(cur.UID)
+		return
+	}
+
+	failing, reason, fp := failureFingerprint(cur.Status.Summary)
+	wasFailing, _, previous := failureFingerprint(old.Status.Summary)
+
+	switch {
+	case failing > 0:
+		if wasFailing > 0 && previous == fp {
+			// The same failures were already part of the previously
+			// persisted status, so this is not a state change. Comparing
+			// persisted statuses, instead of remembering the last event,
+			// keeps this true across restarts of the controller.
+			return
+		}
+
+		e.schedule(ctx, cur.UID, e.snapshotFor(
+			ctx,
+			cur,
+			corev1.EventTypeWarning,
+			reason,
+			failureNote(cur.Status.Summary, opts.MaxCauses),
+			fp,
+		), opts)
+
+	case wasFailing > 0 && opts.ReportRecovery:
+		e.schedule(ctx, cur.UID, e.snapshotFor(
+			ctx,
+			cur,
+			corev1.EventTypeNormal,
+			ReasonReady,
+			readyNote(cur.Status.Summary),
+			fingerprintOf("ready", ReasonReady),
+		), opts)
+
+	default:
+		// Nothing to report. Forget which event was last created for this
+		// bundle, so that a failure recurring later is reported again.
+		e.clearEmitted(cur.UID)
+	}
+}
+
+// ObserveBundleDeployment reports a single bundle deployment, if per-deployment
+// reporting is enabled.
+func (e *Emitter) ObserveBundleDeployment(ctx context.Context, old, cur *fleet.BundleDeployment) {
+	opts := e.options()
+	if !opts.Enabled || !opts.PerDeployment || old == nil || cur == nil {
+		return
+	}
+	if !cur.DeletionTimestamp.IsZero() {
+		e.Forget(cur.UID)
+		return
+	}
+
+	state := fleet.BundleState(cur.Status.Display.State)
+	previous := fleet.BundleState(old.Status.Display.State)
+	if state == previous {
+		return
+	}
+
+	bundle := cur.Labels[fleet.BundleLabel]
+
+	switch state {
+	case fleet.ErrApplied, fleet.NotReady:
+		reason := failureReason(state)
+		message := summary.MessageFromDeployment(cur)
+
+		e.schedule(ctx, cur.UID, e.snapshotFor(
+			ctx,
+			cur,
+			corev1.EventTypeWarning,
+			reason,
+			deploymentNote(bundle, state, message),
+			fingerprintOf("failing", reason, string(state), []string{message}),
+		), opts)
+
+	case fleet.Ready:
+		if !opts.ReportRecovery || (previous != fleet.ErrApplied && previous != fleet.NotReady) {
+			return
+		}
+
+		e.schedule(ctx, cur.UID, e.snapshotFor(
+			ctx,
+			cur,
+			corev1.EventTypeNormal,
+			ReasonReady,
+			deploymentNote(bundle, fleet.Ready, ""),
+			fingerprintOf("ready", ReasonReady),
+		), opts)
+	}
+}
+
+// snapshotFor builds the event to create for an object. It returns nil if no
+// reference to the object can be built, in which case no event can be reported.
+func (e *Emitter) snapshotFor(
+	ctx context.Context,
+	obj client.Object,
+	eventType, reason, note string,
+	fp fingerprint,
+) *snapshot {
+	ref, err := reference.GetReference(e.scheme, obj)
+	if err != nil {
+		log.FromContext(ctx).V(1).Info(
+			"Cannot report deployment state, failed to build a reference to the object",
+			"name", obj.GetName(),
+			"namespace", obj.GetNamespace(),
+			"error", err,
+		)
+
+		return nil
+	}
+
+	return &snapshot{
+		regarding: *ref,
+		eventType: eventType,
+		reason:    reason,
+		note:      note,
+		fp:        fp,
+	}
+}
+
+// schedule queues an event, unless the same event was already reported. Events
+// are created by the flush loop once they are due, which lets a burst of
+// changes collapse into a single event describing all of them.
+func (e *Emitter) schedule(ctx context.Context, uid types.UID, snap *snapshot, opts Options) {
+	if snap == nil {
+		return
+	}
+
+	if e.queue(uid, snap, opts) {
+		e.flush(ctx, opts)
+	}
+}
+
+// queue stores the event and reports whether it is due immediately, in which
+// case the caller creates it. Creating it is left to the caller because the
+// lock must not be held while events are written.
+func (e *Emitter) queue(uid types.UID, snap *snapshot, opts Options) bool {
+	now := e.now()
+
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	ent, ok := e.entries[uid]
+	if !ok {
+		ent = &entry{touched: now}
+		e.entries[uid] = ent
+		e.evict(opts.MaxTracked, uid)
+	}
+	ent.touched = now
+
+	switch {
+	case ent.hasSent && ent.emitted == snap.fp:
+		// Already reported and nothing has changed since.
+		return false
+
+	case ent.pending != nil && ent.pending.fp == snap.fp:
+		// Already queued, keep the earlier due time.
+		return false
+	}
+
+	// A new description of the object replaces whatever was queued, and
+	// starts over with a full budget of creation attempts.
+	ent.pending = snap
+	ent.attempts = 0
+	if ent.dueAt.IsZero() {
+		ent.dueAt = e.dueTime(now, ent.lastEmit, opts)
+
+		return !ent.dueAt.After(now)
+	}
+
+	return false
+}
+
+// dueTime is when an event may be created: after the debounce, and not before
+// the minimum interval since the last event for the same object has passed.
+func (e *Emitter) dueTime(now, lastEmit time.Time, opts Options) time.Time {
+	due := now.Add(opts.Debounce)
+	if earliest := lastEmit.Add(opts.MinInterval); !lastEmit.IsZero() && earliest.After(due) {
+		return earliest
+	}
+
+	return due
+}
+
+// flush creates all events which are due, within the rate limit. Events which
+// do not fit stay queued and are retried on the next tick, where they may be
+// replaced by a newer description of the same object.
+func (e *Emitter) flush(ctx context.Context, opts Options) {
+	now := e.now()
+
+	for _, p := range e.claimDue(now) {
+		if !e.limiter.TryAccept() {
+			e.requeue(p.uid, p.snap, now.Add(tickInterval))
+			continue
+		}
+
+		if err := e.create(ctx, p.snap); err != nil {
+			e.createFailed(ctx, p.uid, p.snap, now, err)
+
+			continue
+		}
+
+		e.recordEmit(p.uid, p.snap.fp, now, opts)
+	}
+}
+
+// claimDue takes the events which are due, so that a concurrent flush does not
+// create them a second time.
+func (e *Emitter) claimDue(now time.Time) []dueEvent {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	var pending []dueEvent
+
+	for uid, ent := range e.entries {
+		if ent.pending == nil || ent.dueAt.IsZero() || ent.dueAt.After(now) {
+			continue
+		}
+		pending = append(pending, dueEvent{uid: uid, snap: ent.pending})
+		ent.pending = nil
+		ent.dueAt = time.Time{}
+	}
+
+	return pending
+}
+
+// recordEmit remembers the event which was created, and schedules whatever was
+// observed while it was being created.
+func (e *Emitter) recordEmit(uid types.UID, fp fingerprint, now time.Time, opts Options) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	ent, ok := e.entries[uid]
+	if !ok {
+		return
+	}
+
+	ent.emitted = fp
+	ent.hasSent = true
+	ent.lastEmit = now
+	ent.attempts = 0
+	if ent.pending != nil {
+		// Something was observed while this event was created.
+		ent.dueAt = e.dueTime(now, ent.lastEmit, opts)
+	}
+}
+
+// createFailed retries the event, unless it has been tried too often or the
+// error says that trying again can only fail the same way. Giving up drops the
+// event, which lets the entry be forgotten again: what the event describes is
+// still in the object's status, whereas holding on to it would keep the entry
+// alive and spend the rate limit which events that can be created need.
+//
+// Nothing is lost permanently: the next change to the object queues a new
+// event, with a full budget of attempts, so a cause which is fixed in the
+// meantime reports again.
+func (e *Emitter) createFailed(ctx context.Context, uid types.UID, snap *snapshot, now time.Time, err error) {
+	e.mu.Lock()
+
+	ent, ok := e.entries[uid]
+	if !ok {
+		e.mu.Unlock()
+
+		return
+	}
+
+	ent.attempts++
+	attempts := ent.attempts
+	retry := attempts < maxCreateAttempts && !permanentError(err)
+
+	// A newer event may have taken its place while this one was created.
+	if retry && ent.pending == nil {
+		ent.pending = snap
+		ent.dueAt = now.Add(createRetryDelay)
+	}
+
+	e.mu.Unlock()
+
+	logger := log.FromContext(ctx).WithValues(
+		"name", snap.regarding.Name,
+		"namespace", snap.regarding.Namespace,
+		"reason", snap.reason,
+		"attempts", attempts,
+	)
+
+	if retry {
+		logger.V(1).Info("Failed to create event for deployment state, retrying", "error", err)
+
+		return
+	}
+
+	// A dropped event is a gap in what the cluster reports about itself,
+	// which is worth seeing without debug logging turned on.
+	logger.Error(err, "Giving up on reporting deployment state as an event")
+}
+
+// permanentError reports whether creating the event again can only fail the
+// same way, because the request is rejected for what it is rather than for
+// when it arrived.
+func permanentError(err error) bool {
+	return apierrors.IsForbidden(err) ||
+		apierrors.IsUnauthorized(err) ||
+		apierrors.IsInvalid(err) ||
+		apierrors.IsBadRequest(err) ||
+		apierrors.IsNotFound(err) ||
+		apierrors.IsRequestEntityTooLargeError(err) ||
+		apierrors.IsMethodNotSupported(err)
+}
+
+// requeue puts an event back, unless a newer one has taken its place.
+func (e *Emitter) requeue(uid types.UID, snap *snapshot, dueAt time.Time) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	ent, ok := e.entries[uid]
+	if !ok || ent.pending != nil {
+		return
+	}
+
+	ent.pending = snap
+	ent.dueAt = dueAt
+}
+
+// create writes the event. Its name follows the convention used by client-go,
+// and its namespace has to be the one of the object it is about.
+func (e *Emitter) create(ctx context.Context, snap *snapshot) error {
+	now := e.now()
+
+	namespace := snap.regarding.Namespace
+	if namespace == "" {
+		namespace = metav1.NamespaceDefault
+	}
+
+	return e.client.Create(ctx, &eventsv1.Event{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%s.%x", snap.regarding.Name, now.UnixNano()),
+			Namespace: namespace,
+		},
+		EventTime:           metav1.MicroTime{Time: now},
+		Type:                snap.eventType,
+		Reason:              snap.reason,
+		Action:              actionDeploy,
+		ReportingController: e.reportingController,
+		ReportingInstance:   e.reportingInstance,
+		Regarding:           snap.regarding,
+		Note:                snap.note,
+	})
+}
+
+// clearEmitted forgets which event was last created for an object, without
+// dropping an event which has not been created yet.
+func (e *Emitter) clearEmitted(uid types.UID) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	if ent, ok := e.entries[uid]; ok {
+		ent.emitted = fingerprint{}
+		ent.hasSent = false
+		ent.touched = e.now()
+	}
+}
+
+// Forget drops everything remembered about an object.
+func (e *Emitter) Forget(uid types.UID) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	delete(e.entries, uid)
+}
+
+// forgetStale drops objects which have not been observed for a while and have
+// no event waiting to be created.
+func (e *Emitter) forgetStale() {
+	now := e.now()
+
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	for uid, ent := range e.entries {
+		if ent.pending == nil && now.Sub(ent.touched) > entryTTL {
+			delete(e.entries, uid)
+		}
+	}
+}
+
+// evict makes room for the entry of keep by forgetting the objects observed
+// longest ago. Forgetting an object may cost one duplicate event later. The
+// caller holds the lock.
+//
+// The entry being made room for is never a candidate. Objects with an event
+// waiting are exempt, and during a burst that is every object except the one
+// just observed, which would otherwise leave it as the only candidate and drop
+// its event. Exempting it lets the map exceed maxTracked instead, which the
+// next flush undoes as it drains the pending events.
+func (e *Emitter) evict(maxTracked int, keep types.UID) {
+	if maxTracked <= 0 || len(e.entries) <= maxTracked {
+		return
+	}
+
+	candidates := make([]types.UID, 0, len(e.entries))
+	for uid, ent := range e.entries {
+		if ent.pending == nil && uid != keep {
+			candidates = append(candidates, uid)
+		}
+	}
+	sort.Slice(candidates, func(i, j int) bool {
+		return e.entries[candidates[i]].touched.Before(e.entries[candidates[j]].touched)
+	})
+
+	// Evict in batches, so that eviction does not run on every new object.
+	target := len(e.entries) - maxTracked*9/10
+	for i := 0; i < len(candidates) && i < target; i++ {
+		delete(e.entries, candidates[i])
+	}
+}
+
+// fingerprintOf builds the fingerprint of an event from the parts which, when they
+// change, make the event worth reporting again.
+func fingerprintOf(parts ...any) fingerprint {
+	var b strings.Builder
+
+	for _, part := range parts {
+		switch v := part.(type) {
+		case string:
+			b.WriteString(v)
+		case []string:
+			for _, s := range v {
+				b.WriteString(s)
+				b.WriteByte(0)
+			}
+		}
+		b.WriteByte(0)
+	}
+
+	return sha256.Sum256([]byte(b.String()))
+}

--- a/internal/cmd/controller/bundleevents/notifier.go
+++ b/internal/cmd/controller/bundleevents/notifier.go
@@ -65,6 +65,9 @@ const (
 
 	// reportingInstanceMaxLength is the maximum length the API accepts for reportingInstance.
 	reportingInstanceMaxLength = 128
+
+	// eventNameMaxLength is the maximum length the API accepts for an object name.
+	eventNameMaxLength = 253
 )
 
 // Notifier observes objects after their status has been updated, and reports
@@ -388,6 +391,17 @@ func (e *Emitter) dueTime(now, lastEmit time.Time, opts Options) time.Time {
 // do not fit stay queued and are retried on the next tick, where they may be
 // replaced by a newer description of the same object.
 func (e *Emitter) flush(ctx context.Context, opts Options) {
+	if !opts.Enabled {
+		// Options are read live, so reporting can be turned off while
+		// events are queued. Those describe a state which is still in the
+		// object's status, so they are dropped instead of being created
+		// after the fact. Dropping them also lets their entries be
+		// forgotten again, which a pending event exempts them from.
+		e.dropPending()
+
+		return
+	}
+
 	now := e.now()
 
 	for _, p := range e.claimDue(now) {
@@ -403,6 +417,18 @@ func (e *Emitter) flush(ctx context.Context, opts Options) {
 		}
 
 		e.recordEmit(p.uid, p.snap.fp, now, opts)
+	}
+}
+
+// dropPending discards every event waiting to be created.
+func (e *Emitter) dropPending() {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	for _, ent := range e.entries {
+		ent.pending = nil
+		ent.dueAt = time.Time{}
+		ent.attempts = 0
 	}
 }
 
@@ -535,7 +561,7 @@ func (e *Emitter) create(ctx context.Context, snap *snapshot) error {
 
 	return e.client.Create(ctx, &eventsv1.Event{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("%s.%x", snap.regarding.Name, now.UnixNano()),
+			Name:      eventName(snap.regarding.Name, now),
 			Namespace: namespace,
 		},
 		EventTime:           metav1.MicroTime{Time: now},
@@ -547,6 +573,20 @@ func (e *Emitter) create(ctx context.Context, snap *snapshot) error {
 		Regarding:           snap.regarding,
 		Note:                snap.note,
 	})
+}
+
+// eventName builds the name of the event about an object, following the
+// convention used by client-go. The name of the object it is about is shortened
+// if the two together would not fit what the API accepts, since a rejected name
+// is a permanent error, which would drop the event.
+func eventName(regarding string, now time.Time) string {
+	suffix := fmt.Sprintf(".%x", now.UnixNano())
+	if len(regarding)+len(suffix) > eventNameMaxLength {
+		regarding = regarding[:eventNameMaxLength-len(suffix)]
+	}
+
+	// A name may not end in a separator, which cutting it can leave behind.
+	return strings.TrimRight(regarding, "-._") + suffix
 }
 
 // clearEmitted forgets which event was last created for an object, without

--- a/internal/cmd/controller/bundleevents/notifier.go
+++ b/internal/cmd/controller/bundleevents/notifier.go
@@ -36,14 +36,28 @@ import (
 )
 
 const (
-	// ReasonDeployFailed reports bundle deployments which failed to apply their resources.
-	ReasonDeployFailed = "BundleDeployFailed"
+	// Reasons are scoped to the kind they are reported on, so that an event
+	// can be selected by its reason alone: the bundle-level reasons describe
+	// a bundle across all of its deployments, the deployment-level ones a
+	// single deployment on one cluster.
 
-	// ReasonNotReady reports bundle deployments which applied their resources, but those are not ready.
-	ReasonNotReady = "BundleNotReady"
+	// ReasonBundleDeployFailed reports a bundle with deployments which failed to apply their resources.
+	ReasonBundleDeployFailed = "BundleDeployFailed"
 
-	// ReasonReady reports a bundle whose deployments are all ready again.
-	ReasonReady = "BundleDeploymentsReady"
+	// ReasonBundleNotReady reports a bundle with deployments which applied their resources, but those are not ready.
+	ReasonBundleNotReady = "BundleNotReady"
+
+	// ReasonBundleReady reports a bundle whose deployments are all ready again.
+	ReasonBundleReady = "BundleReady"
+
+	// ReasonBundleDeploymentFailed reports a single bundle deployment which failed to apply its resources.
+	ReasonBundleDeploymentFailed = "BundleDeploymentFailed"
+
+	// ReasonBundleDeploymentNotReady reports a single bundle deployment which applied its resources, but those are not ready.
+	ReasonBundleDeploymentNotReady = "BundleDeploymentNotReady"
+
+	// ReasonBundleDeploymentReady reports a single bundle deployment which is ready again.
+	ReasonBundleDeploymentReady = "BundleDeploymentReady"
 
 	// actionDeploy is the operation all events reported here relate to.
 	actionDeploy = "Deploy"
@@ -114,6 +128,14 @@ type entry struct {
 
 	// attempts is how often creating the pending event has failed.
 	attempts int
+
+	// awaitingRecovery records that the object was seen failing, so that
+	// its recovery is reported once it is ready again. Between a failure
+	// and a recovery an object is neither: it goes through transient
+	// states, in which nothing is failing but nothing is ready either.
+	// Remembering the failure is what lets the recovery be reported from
+	// there, instead of on merely leaving the failing state.
+	awaitingRecovery bool
 
 	// touched is when the object was last observed, used to forget it again.
 	touched time.Time
@@ -208,13 +230,34 @@ func (e *Emitter) ObserveBundle(ctx context.Context, old, cur *fleet.Bundle) {
 	failing, reason, fp := failureFingerprint(cur.Status.Summary)
 	wasFailing, _, previous := failureFingerprint(old.Status.Summary)
 
-	switch {
-	case failing > 0:
+	if failing > 0 {
+		// Remember the failure, so that the recovery is reported once the
+		// bundle is ready again, however many transient states it passes
+		// through on the way.
+		e.awaitRecovery(cur.UID, opts)
+
 		if wasFailing > 0 && previous == fp {
 			// The same failures were already part of the previously
 			// persisted status, so this is not a state change. Comparing
 			// persisted statuses, instead of remembering the last event,
 			// keeps this true across restarts of the controller.
+			//
+			// An event queued earlier in the burst is still refreshed,
+			// though. How many deployments are failing is bucketed, so
+			// agents reporting one after another mostly fingerprint the
+			// same, and the note would otherwise describe the counts as
+			// they were when the first agent reported.
+			if e.hasPending(cur.UID) {
+				e.schedule(ctx, cur.UID, e.snapshotFor(
+					ctx,
+					cur,
+					corev1.EventTypeWarning,
+					reason,
+					failureNote(cur.Status.Summary, opts.MaxCauses),
+					fp,
+				), opts)
+			}
+
 			return
 		}
 
@@ -227,21 +270,40 @@ func (e *Emitter) ObserveBundle(ctx context.Context, old, cur *fleet.Bundle) {
 			fp,
 		), opts)
 
-	case wasFailing > 0 && opts.ReportRecovery:
-		e.schedule(ctx, cur.UID, e.snapshotFor(
-			ctx,
-			cur,
-			corev1.EventTypeNormal,
-			ReasonReady,
-			readyNote(cur.Status.Summary),
-			fingerprintOf("ready", ReasonReady),
-		), opts)
-
-	default:
-		// Nothing to report. Forget which event was last created for this
-		// bundle, so that a failure recurring later is reported again.
-		e.clearEmitted(cur.UID)
+		return
 	}
+
+	// Nothing is failing. Forget which event was last created for this
+	// bundle, so that a failure recurring later is reported again.
+	e.clearEmitted(cur.UID)
+
+	if !opts.ReportRecovery {
+		e.stopAwaitingRecovery(cur.UID)
+		return
+	}
+
+	// wasFailing covers the failure and the recovery landing in one status
+	// update, which is the only form a restart can still detect.
+	if !e.awaitingRecovery(cur.UID) && wasFailing == 0 {
+		return
+	}
+
+	if !recovered(cur.Status.Summary) {
+		// Not failing, but not ready either: the bundle is still being
+		// deployed. Reporting here would call deployments ready which are
+		// not, so keep waiting for the state the event describes.
+		return
+	}
+
+	e.stopAwaitingRecovery(cur.UID)
+	e.schedule(ctx, cur.UID, e.snapshotFor(
+		ctx,
+		cur,
+		corev1.EventTypeNormal,
+		ReasonBundleReady,
+		readyNote(cur.Status.Summary),
+		fingerprintOf("ready", ReasonBundleReady),
+	), opts)
 }
 
 // ObserveBundleDeployment reports a single bundle deployment, if per-deployment
@@ -258,15 +320,22 @@ func (e *Emitter) ObserveBundleDeployment(ctx context.Context, old, cur *fleet.B
 
 	state := fleet.BundleState(cur.Status.Display.State)
 	previous := fleet.BundleState(old.Status.Display.State)
+
+	if isFailure(state) {
+		// As for bundles, remember the failure, so that the recovery is
+		// reported from whichever state the deployment reaches Ready.
+		e.awaitRecovery(cur.UID, opts)
+	}
+
 	if state == previous {
 		return
 	}
 
 	bundle := cur.Labels[fleet.BundleLabel]
 
-	switch state {
-	case fleet.ErrApplied, fleet.NotReady:
-		reason := failureReason(state)
+	switch {
+	case isFailure(state):
+		reason := deploymentFailureReason(state)
 		message := summary.MessageFromDeployment(cur)
 
 		e.schedule(ctx, cur.UID, e.snapshotFor(
@@ -278,19 +347,74 @@ func (e *Emitter) ObserveBundleDeployment(ctx context.Context, old, cur *fleet.B
 			fingerprintOf("failing", reason, string(state), []string{message}),
 		), opts)
 
-	case fleet.Ready:
-		if !opts.ReportRecovery || (previous != fleet.ErrApplied && previous != fleet.NotReady) {
+	case state == fleet.Ready:
+		if !opts.ReportRecovery {
+			e.stopAwaitingRecovery(cur.UID)
+			return
+		}
+		if !e.awaitingRecovery(cur.UID) && !isFailure(previous) {
 			return
 		}
 
+		e.stopAwaitingRecovery(cur.UID)
 		e.schedule(ctx, cur.UID, e.snapshotFor(
 			ctx,
 			cur,
 			corev1.EventTypeNormal,
-			ReasonReady,
+			ReasonBundleDeploymentReady,
 			deploymentNote(bundle, fleet.Ready, ""),
-			fingerprintOf("ready", ReasonReady),
+			fingerprintOf("ready", ReasonBundleDeploymentReady),
 		), opts)
+	}
+}
+
+// awaitRecovery remembers that an object is failing, so that its recovery is
+// reported once it is ready again. It records the wait; it does not block.
+func (e *Emitter) awaitRecovery(uid types.UID, opts Options) {
+	now := e.now()
+
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	ent, ok := e.entries[uid]
+	if !ok {
+		ent = &entry{touched: now}
+		e.entries[uid] = ent
+		e.evict(opts.MaxTracked, uid)
+	}
+	ent.touched = now
+	ent.awaitingRecovery = true
+}
+
+// hasPending reports whether an event for the object is waiting to be created.
+func (e *Emitter) hasPending(uid types.UID) bool {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	ent, ok := e.entries[uid]
+
+	return ok && ent.pending != nil
+}
+
+// awaitingRecovery reports whether a failure is waiting to be reported as
+// recovered.
+func (e *Emitter) awaitingRecovery(uid types.UID) bool {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	ent, ok := e.entries[uid]
+
+	return ok && ent.awaitingRecovery
+}
+
+// stopAwaitingRecovery forgets a failure, either because its recovery has just
+// been reported or because it is not going to be.
+func (e *Emitter) stopAwaitingRecovery(uid types.UID) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	if ent, ok := e.entries[uid]; ok {
+		ent.awaitingRecovery = false
 	}
 }
 
@@ -359,7 +483,18 @@ func (e *Emitter) queue(uid types.UID, snap *snapshot, opts Options) bool {
 		return false
 
 	case ent.pending != nil && ent.pending.fp == snap.fp:
-		// Already queued, keep the earlier due time.
+		// The same event, but a newer description of it. Replacing the
+		// queued snapshot is what lets a burst collapse into one event
+		// carrying the settled counts: the fingerprint buckets how many
+		// deployments are failing, so most of a burst fingerprints the
+		// same and would otherwise leave the note describing the state
+		// the burst started from.
+		//
+		// The due time is kept, so this does not delay the event, and so
+		// is the attempt budget: it is still the same event, and a state
+		// which keeps being re-observed must not keep buying retries.
+		ent.pending = snap
+
 		return false
 	}
 

--- a/internal/cmd/controller/bundleevents/notifier_test.go
+++ b/internal/cmd/controller/bundleevents/notifier_test.go
@@ -19,6 +19,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/validation"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/util/flowcontrol"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -399,6 +400,52 @@ func TestDisabledEmitsNothing(t *testing.T) {
 
 	if got := f.events(t); len(got) != 0 {
 		t.Fatalf("expected no events, got %d", len(got))
+	}
+}
+
+func TestDisablingDropsQueuedEvents(t *testing.T) {
+	f := newFixture(t, nil)
+
+	f.emitter.ObserveBundle(context.TODO(), bundle(ready()), bundle(failing(500, renderError)))
+
+	if ent := f.bundleEntry(); ent == nil || ent.pending == nil {
+		t.Fatal("expected the event to be queued while reporting is enabled")
+	}
+
+	f.opts.Enabled = false
+	f.flush(t)
+
+	if got := f.events(t); len(got) != 0 {
+		t.Fatalf("expected the queued event to be dropped, got %d", len(got))
+	}
+
+	// A pending event exempts the entry from the TTL, so it has to be
+	// cleared for the object to be forgotten again.
+	if ent := f.bundleEntry(); ent != nil && ent.pending != nil {
+		t.Fatal("expected the queued event to be cleared")
+	}
+}
+
+func TestEventNameFitsTheObjectNameLimit(t *testing.T) {
+	now := time.Date(2026, 7, 30, 10, 0, 0, 0, time.UTC)
+
+	for _, name := range []string{
+		"my-repo-app",
+		strings.Repeat("a", 236),
+		strings.Repeat("a", 253),
+		strings.Repeat("a", 235) + "-",
+	} {
+		got := eventName(name, now)
+
+		if len(got) > eventNameMaxLength {
+			t.Errorf("event name for a %d character object name is %d characters", len(name), len(got))
+		}
+		if errs := validation.IsDNS1123Subdomain(got); len(errs) > 0 {
+			t.Errorf("event name %q for a %d character object name is invalid: %v", got, len(name), errs)
+		}
+		if !strings.HasSuffix(got, fmt.Sprintf(".%x", now.UnixNano())) {
+			t.Errorf("event name %q does not carry the timestamp suffix", got)
+		}
 	}
 }
 

--- a/internal/cmd/controller/bundleevents/notifier_test.go
+++ b/internal/cmd/controller/bundleevents/notifier_test.go
@@ -1,0 +1,688 @@
+package bundleevents
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
+
+	corev1 "k8s.io/api/core/v1"
+	eventsv1 "k8s.io/api/events/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/util/flowcontrol"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+const (
+	renderError = "chart render failed: template: app/templates/deploy.yaml:12: nil pointer"
+	nsForbidden = `namespace "prod" is forbidden by AllowedTargetNamespaceSelector`
+)
+
+type testClock struct {
+	now time.Time
+}
+
+func (c *testClock) Now() time.Time {
+	return c.now
+}
+
+func (c *testClock) advance(d time.Duration) {
+	c.now = c.now.Add(d)
+}
+
+type fixture struct {
+	emitter *Emitter
+	client  client.Client
+	clock   *testClock
+	opts    *Options
+
+	// createErr decides how creating an event fails. Nil lets it succeed.
+	createErr func() error
+}
+
+// failingClient lets a test fail event creation the way the API server would.
+type failingClient struct {
+	client.Client
+
+	fixture *fixture
+}
+
+func (c *failingClient) Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
+	if c.fixture.createErr != nil {
+		if err := c.fixture.createErr(); err != nil {
+			return err
+		}
+	}
+
+	return c.Client.Create(ctx, obj, opts...)
+}
+
+func newFixture(t *testing.T, limiter flowcontrol.RateLimiter) *fixture {
+	t.Helper()
+
+	scheme := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(fleet.AddToScheme(scheme))
+
+	opts := DefaultOptions()
+	clock := &testClock{now: time.Date(2026, 7, 30, 10, 0, 0, 0, time.UTC)}
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	if limiter == nil {
+		limiter = flowcontrol.NewFakeAlwaysRateLimiter()
+	}
+
+	f := &fixture{client: c, clock: clock, opts: &opts}
+	f.emitter = New(&failingClient{Client: c, fixture: f}, scheme, "fleet-bundle-ctrl",
+		func() Options { return *f.opts },
+		WithClock(clock.Now), WithRateLimiter(limiter))
+
+	return f
+}
+
+// bundleEntry returns what the emitter remembers about the test bundle, or nil.
+func (f *fixture) bundleEntry() *entry {
+	f.emitter.mu.Lock()
+	defer f.emitter.mu.Unlock()
+
+	return f.emitter.entries[bundleUID]
+}
+
+// retry advances past the retry delay and flushes, n times.
+func (f *fixture) retry(n int) {
+	for range n {
+		f.clock.advance(createRetryDelay + time.Second)
+		f.emitter.flush(context.TODO(), *f.opts)
+	}
+}
+
+// flush advances the clock past the debounce and creates all due events.
+func (f *fixture) flush(t *testing.T) {
+	t.Helper()
+
+	f.clock.advance(f.opts.Debounce + time.Second)
+	f.emitter.flush(context.TODO(), *f.opts)
+}
+
+func (f *fixture) events(t *testing.T) []eventsv1.Event {
+	t.Helper()
+
+	list := &eventsv1.EventList{}
+	if err := f.client.List(context.TODO(), list); err != nil {
+		t.Fatalf("listing events: %v", err)
+	}
+	sort.Slice(list.Items, func(i, j int) bool {
+		return list.Items[i].EventTime.Before(&list.Items[j].EventTime)
+	})
+
+	return list.Items
+}
+
+func bundle(summary fleet.BundleSummary) *fleet.Bundle {
+	return &fleet.Bundle{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-repo-app",
+			Namespace: "fleet-default",
+			UID:       bundleUID,
+		},
+		Status: fleet.BundleStatus{Summary: summary},
+	}
+}
+
+// targets is the number of clusters the test bundle is deployed to.
+const targets = 500
+
+func ready() fleet.BundleSummary {
+	return fleet.BundleSummary{DesiredReady: targets, Ready: targets}
+}
+
+func failing(errApplied int, messages ...string) fleet.BundleSummary {
+	s := fleet.BundleSummary{
+		DesiredReady: targets,
+		Ready:        targets - errApplied,
+		ErrApplied:   errApplied,
+	}
+
+	for i, message := range messages {
+		s.NonReadyResources = append(s.NonReadyResources, fleet.NonReadyResource{
+			Name:    "fleet-default/cluster-" + string(rune('a'+i)),
+			State:   fleet.ErrApplied,
+			Message: message,
+		})
+	}
+
+	return s
+}
+
+func TestBurstIsReportedAsOneEventWithFinalCounts(t *testing.T) {
+	f := newFixture(t, nil)
+
+	// The first failure of the burst, followed by the rest of it, before the
+	// debounce has elapsed.
+	f.emitter.ObserveBundle(context.TODO(), bundle(ready()), bundle(failing(1, renderError)))
+	f.emitter.ObserveBundle(context.TODO(), bundle(failing(1, renderError)), bundle(failing(500, renderError)))
+
+	if got := f.events(t); len(got) != 0 {
+		t.Fatalf("expected no event before the debounce elapsed, got %d", len(got))
+	}
+
+	f.flush(t)
+
+	events := f.events(t)
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+
+	event := events[0]
+	if event.Type != corev1.EventTypeWarning || event.Reason != ReasonDeployFailed || event.Action != actionDeploy {
+		t.Errorf("unexpected type/reason/action: %s/%s/%s", event.Type, event.Reason, event.Action)
+	}
+	if event.Namespace != "fleet-default" || event.Regarding.Kind != "Bundle" || event.Regarding.Name != "my-repo-app" {
+		t.Errorf("unexpected namespace or regarding object: %s, %+v", event.Namespace, event.Regarding)
+	}
+	if !strings.HasPrefix(event.Note, "500/500 bundle deployments failing.") {
+		t.Errorf("expected the note to describe the whole burst, got %q", event.Note)
+	}
+	if !strings.Contains(event.Note, renderError) {
+		t.Errorf("expected the note to name the cause, got %q", event.Note)
+	}
+	if event.ReportingController != "fleet-bundle-ctrl" || event.ReportingInstance == "" {
+		t.Errorf("unexpected reporting controller/instance: %q/%q", event.ReportingController, event.ReportingInstance)
+	}
+	if event.Series != nil {
+		t.Errorf("expected a standalone event, got a series: %+v", event.Series)
+	}
+}
+
+func TestUnchangedFailureIsReportedOnce(t *testing.T) {
+	f := newFixture(t, nil)
+
+	f.emitter.ObserveBundle(context.TODO(), bundle(ready()), bundle(failing(500, renderError)))
+	f.flush(t)
+
+	// Every bundle deployment reporting its failure triggers a reconcile of
+	// the bundle, with an unchanged summary.
+	for range 100 {
+		f.emitter.ObserveBundle(context.TODO(), bundle(failing(500, renderError)), bundle(failing(500, renderError)))
+	}
+	f.clock.advance(2 * f.opts.MinInterval)
+	f.flush(t)
+
+	if got := f.events(t); len(got) != 1 {
+		t.Fatalf("expected the failure to be reported once, got %d events", len(got))
+	}
+}
+
+func TestNewCauseIsReported(t *testing.T) {
+	f := newFixture(t, nil)
+
+	f.emitter.ObserveBundle(context.TODO(), bundle(ready()), bundle(failing(500, renderError)))
+	f.flush(t)
+
+	f.clock.advance(f.opts.MinInterval)
+	f.emitter.ObserveBundle(context.TODO(),
+		bundle(failing(500, renderError)),
+		bundle(failing(500, renderError, nsForbidden)),
+	)
+	f.flush(t)
+
+	events := f.events(t)
+	if len(events) != 2 {
+		t.Fatalf("expected the new cause to be reported, got %d events", len(events))
+	}
+	if !strings.Contains(events[1].Note, nsForbidden) {
+		t.Errorf("expected the second event to name the new cause, got %q", events[1].Note)
+	}
+	if !strings.Contains(events[0].Note, renderError) || strings.Contains(events[0].Note, nsForbidden) {
+		t.Errorf("expected the first event to keep its own note, got %q", events[0].Note)
+	}
+}
+
+func TestMagnitudeChangeIsReportedOnceItLeavesTheBucket(t *testing.T) {
+	f := newFixture(t, nil)
+
+	f.emitter.ObserveBundle(context.TODO(), bundle(ready()), bundle(failing(500, renderError)))
+	f.flush(t)
+
+	// Same order of magnitude, nothing new to say.
+	f.clock.advance(f.opts.MinInterval)
+	f.emitter.ObserveBundle(context.TODO(), bundle(failing(500, renderError)), bundle(failing(300, renderError)))
+	f.flush(t)
+
+	if got := f.events(t); len(got) != 1 {
+		t.Fatalf("expected no event for 500 -> 300 failures, got %d events", len(got))
+	}
+
+	// An order of magnitude fewer failures is worth reporting.
+	f.clock.advance(f.opts.MinInterval)
+	f.emitter.ObserveBundle(context.TODO(), bundle(failing(300, renderError)), bundle(failing(12, renderError)))
+	f.flush(t)
+
+	events := f.events(t)
+	if len(events) != 2 {
+		t.Fatalf("expected an event for 300 -> 12 failures, got %d events", len(events))
+	}
+	if !strings.HasPrefix(events[1].Note, "12/500 bundle deployments failing.") {
+		t.Errorf("unexpected note: %q", events[1].Note)
+	}
+}
+
+func TestRecoveryIsReported(t *testing.T) {
+	f := newFixture(t, nil)
+
+	f.emitter.ObserveBundle(context.TODO(), bundle(ready()), bundle(failing(500, renderError)))
+	f.flush(t)
+
+	f.clock.advance(f.opts.MinInterval)
+	f.emitter.ObserveBundle(context.TODO(), bundle(failing(500, renderError)), bundle(ready()))
+	f.flush(t)
+
+	// Staying ready is not worth another event.
+	f.clock.advance(f.opts.MinInterval)
+	f.emitter.ObserveBundle(context.TODO(), bundle(ready()), bundle(ready()))
+	f.flush(t)
+
+	events := f.events(t)
+	if len(events) != 2 {
+		t.Fatalf("expected the recovery to be reported once, got %d events", len(events))
+	}
+	if events[1].Type != corev1.EventTypeNormal || events[1].Reason != ReasonReady {
+		t.Errorf("unexpected type/reason: %s/%s", events[1].Type, events[1].Reason)
+	}
+	if events[1].Note != "500/500 bundle deployments ready" {
+		t.Errorf("unexpected note: %q", events[1].Note)
+	}
+}
+
+func TestFailureRecurringAfterARecoveryIsReportedAgain(t *testing.T) {
+	f := newFixture(t, nil)
+	f.opts.ReportRecovery = false
+
+	f.emitter.ObserveBundle(context.TODO(), bundle(ready()), bundle(failing(500, renderError)))
+	f.flush(t)
+
+	f.clock.advance(f.opts.MinInterval)
+	f.emitter.ObserveBundle(context.TODO(), bundle(failing(500, renderError)), bundle(ready()))
+	f.flush(t)
+
+	f.clock.advance(f.opts.MinInterval)
+	f.emitter.ObserveBundle(context.TODO(), bundle(ready()), bundle(failing(500, renderError)))
+	f.flush(t)
+
+	events := f.events(t)
+	if len(events) != 2 {
+		t.Fatalf("expected the recurring failure to be reported, got %d events", len(events))
+	}
+	for _, event := range events {
+		if event.Reason != ReasonDeployFailed {
+			t.Errorf("expected only failures to be reported, got %q", event.Reason)
+		}
+	}
+}
+
+func TestOngoingFailureIsNotReportedAfterARestart(t *testing.T) {
+	f := newFixture(t, nil)
+
+	// A restart loses what was reported before it, so the state change has to
+	// be detected from the persisted status alone.
+	f.emitter.ObserveBundle(context.TODO(), bundle(failing(500, renderError)), bundle(failing(500, renderError)))
+	f.flush(t)
+
+	if got := f.events(t); len(got) != 0 {
+		t.Fatalf("expected no event for an unchanged failure, got %d", len(got))
+	}
+}
+
+func TestMinIntervalDelaysTheNextEvent(t *testing.T) {
+	f := newFixture(t, nil)
+
+	f.emitter.ObserveBundle(context.TODO(), bundle(ready()), bundle(failing(500, renderError)))
+	f.flush(t)
+
+	// A new cause right after the first event has to wait for the minimum
+	// interval, and is reported with the state it has by then.
+	f.emitter.ObserveBundle(context.TODO(),
+		bundle(failing(500, renderError)),
+		bundle(failing(500, renderError, nsForbidden)),
+	)
+	f.flush(t)
+
+	if got := f.events(t); len(got) != 1 {
+		t.Fatalf("expected the second event to be held back, got %d events", len(got))
+	}
+
+	f.clock.advance(f.opts.MinInterval)
+	f.emitter.flush(context.TODO(), *f.opts)
+
+	if got := f.events(t); len(got) != 2 {
+		t.Fatalf("expected the second event once the interval passed, got %d events", len(got))
+	}
+}
+
+func TestRateLimitedEventsStayPending(t *testing.T) {
+	f := newFixture(t, flowcontrol.NewFakeNeverRateLimiter())
+
+	f.emitter.ObserveBundle(context.TODO(), bundle(ready()), bundle(failing(500, renderError)))
+	f.flush(t)
+
+	if got := f.events(t); len(got) != 0 {
+		t.Fatalf("expected the event to be rate limited, got %d", len(got))
+	}
+
+	f.emitter.mu.Lock()
+	defer f.emitter.mu.Unlock()
+
+	ent, ok := f.emitter.entries[types.UID("7b3d")]
+	if !ok || ent.pending == nil {
+		t.Fatal("expected the rate limited event to stay pending")
+	}
+}
+
+func TestDisabledEmitsNothing(t *testing.T) {
+	f := newFixture(t, nil)
+	f.opts.Enabled = false
+
+	f.emitter.ObserveBundle(context.TODO(), bundle(ready()), bundle(failing(500, renderError)))
+	f.flush(t)
+
+	if got := f.events(t); len(got) != 0 {
+		t.Fatalf("expected no events, got %d", len(got))
+	}
+}
+
+func deployment(state fleet.BundleState) *fleet.BundleDeployment {
+	return &fleet.BundleDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-repo-app",
+			Namespace: "cluster-fleet-default-cluster-002-c3d4",
+			UID:       types.UID("8f1c"),
+			Labels:    map[string]string{fleet.BundleLabel: "my-repo-app"},
+		},
+		Status: fleet.BundleDeploymentStatus{
+			Display: fleet.BundleDeploymentDisplay{State: string(state)},
+		},
+	}
+}
+
+func TestBundleDeploymentsAreOnlyReportedWhenEnabled(t *testing.T) {
+	f := newFixture(t, nil)
+
+	f.emitter.ObserveBundleDeployment(context.TODO(), deployment(fleet.Ready), deployment(fleet.ErrApplied))
+	f.flush(t)
+
+	if got := f.events(t); len(got) != 0 {
+		t.Fatalf("expected per-deployment events to be off by default, got %d", len(got))
+	}
+
+	f.opts.PerDeployment = true
+	f.emitter.ObserveBundleDeployment(context.TODO(), deployment(fleet.Ready), deployment(fleet.ErrApplied))
+	f.flush(t)
+
+	events := f.events(t)
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	if events[0].Namespace != "cluster-fleet-default-cluster-002-c3d4" || events[0].Regarding.Kind != "BundleDeployment" {
+		t.Errorf("unexpected namespace or regarding object: %s, %+v", events[0].Namespace, events[0].Regarding)
+	}
+	if !strings.HasPrefix(events[0].Note, "bundle my-repo-app: ErrApplied") {
+		t.Errorf("unexpected note: %q", events[0].Note)
+	}
+}
+
+func TestBundleDeploymentInAnUnchangedStateIsNotReported(t *testing.T) {
+	f := newFixture(t, nil)
+	f.opts.PerDeployment = true
+
+	f.emitter.ObserveBundleDeployment(context.TODO(), deployment(fleet.ErrApplied), deployment(fleet.ErrApplied))
+	f.flush(t)
+
+	if got := f.events(t); len(got) != 0 {
+		t.Fatalf("expected no event without a state change, got %d", len(got))
+	}
+}
+
+// bundleUID is the UID of the bundle the fixture reports on.
+const bundleUID = types.UID("7b3d")
+
+func serverBusy() error {
+	return apierrors.NewTimeoutError("server is busy", 1)
+}
+
+func forbidden() error {
+	return apierrors.NewForbidden(
+		schema.GroupResource{Group: "events.k8s.io", Resource: "events"},
+		"",
+		errors.New("events.k8s.io is forbidden"),
+	)
+}
+
+func TestTransientCreateFailureIsRetried(t *testing.T) {
+	f := newFixture(t, nil)
+
+	failures := 2
+	f.createErr = func() error {
+		if failures == 0 {
+			return nil
+		}
+		failures--
+
+		return serverBusy()
+	}
+
+	f.emitter.ObserveBundle(context.TODO(), bundle(ready()), bundle(failing(500, renderError)))
+	f.flush(t)
+
+	if got := f.events(t); len(got) != 0 {
+		t.Fatalf("expected the first attempt to fail, got %d events", len(got))
+	}
+
+	f.retry(2)
+
+	if got := f.events(t); len(got) != 1 {
+		t.Fatalf("expected the event to be created on a retry, got %d events", len(got))
+	}
+	if ent := f.bundleEntry(); ent == nil || ent.attempts != 0 {
+		t.Error("expected the attempts to be reset once the event was created")
+	}
+}
+
+func TestForbiddenCreateIsNotRetried(t *testing.T) {
+	f := newFixture(t, nil)
+
+	attempts := 0
+	f.createErr = func() error {
+		attempts++
+
+		return forbidden()
+	}
+
+	f.emitter.ObserveBundle(context.TODO(), bundle(ready()), bundle(failing(500, renderError)))
+	f.flush(t)
+	f.retry(2 * maxCreateAttempts)
+
+	// Retrying a request the API server rejects for what it is only fails
+	// the same way again.
+	if attempts != 1 {
+		t.Errorf("expected a single attempt, got %d", attempts)
+	}
+	if ent := f.bundleEntry(); ent == nil || ent.pending != nil {
+		t.Error("expected the event to be dropped, so that the entry can be reclaimed")
+	}
+}
+
+func TestCreateIsGivenUpOnAfterTooManyAttempts(t *testing.T) {
+	f := newFixture(t, nil)
+
+	attempts := 0
+	f.createErr = func() error {
+		attempts++
+
+		return serverBusy()
+	}
+
+	f.emitter.ObserveBundle(context.TODO(), bundle(ready()), bundle(failing(500, renderError)))
+	f.flush(t)
+	f.retry(2 * maxCreateAttempts)
+
+	if attempts != maxCreateAttempts {
+		t.Errorf("expected %d attempts, got %d", maxCreateAttempts, attempts)
+	}
+
+	// An event which is never given up on would keep its entry out of reach
+	// of both the TTL and the size limit.
+	ent := f.bundleEntry()
+	if ent == nil || ent.pending != nil {
+		t.Fatal("expected the event to be dropped")
+	}
+
+	f.clock.advance(entryTTL + time.Minute)
+	f.emitter.forgetStale()
+
+	if f.bundleEntry() != nil {
+		t.Error("expected the entry to be forgotten once its event was dropped")
+	}
+}
+
+func TestFailureIsReportedAgainAfterGivingUp(t *testing.T) {
+	f := newFixture(t, nil)
+
+	f.createErr = serverBusy
+
+	f.emitter.ObserveBundle(context.TODO(), bundle(ready()), bundle(failing(500, renderError)))
+	f.flush(t)
+	f.retry(2 * maxCreateAttempts)
+
+	if got := f.events(t); len(got) != 0 {
+		t.Fatalf("expected no event while creation fails, got %d", len(got))
+	}
+
+	// Whatever made creation fail is fixed, and the bundle fails for a new
+	// reason: nothing was lost permanently.
+	f.createErr = nil
+	f.emitter.ObserveBundle(context.TODO(),
+		bundle(failing(500, renderError)), bundle(failing(500, nsForbidden)))
+	f.flush(t)
+
+	if got := f.events(t); len(got) != 1 {
+		t.Fatalf("expected the new failure to be reported, got %d events", len(got))
+	}
+}
+
+func TestForgetDropsTheObject(t *testing.T) {
+	f := newFixture(t, nil)
+
+	f.emitter.ObserveBundle(context.TODO(), bundle(ready()), bundle(failing(500, renderError)))
+	f.flush(t)
+
+	if f.bundleEntry() == nil {
+		t.Fatal("expected the bundle to be remembered")
+	}
+
+	f.emitter.Forget(bundleUID)
+
+	if f.bundleEntry() != nil {
+		t.Error("expected the bundle to be forgotten")
+	}
+}
+
+// otherBundle is a bundle which is not the one the other tests report on, so
+// that a test can track more than one object.
+func otherBundle(uid types.UID, summary fleet.BundleSummary) *fleet.Bundle {
+	return &fleet.Bundle{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-repo-" + string(uid),
+			Namespace: "fleet-default",
+			UID:       uid,
+		},
+		Status: fleet.BundleStatus{Summary: summary},
+	}
+}
+
+// fill observes n bundles as failing, one per second, so that they are tracked
+// and have distinct times of last observation.
+func (f *fixture) fill(n int) {
+	for i := range n {
+		uid := types.UID(fmt.Sprintf("old-%03d", i))
+		f.emitter.ObserveBundle(
+			context.TODO(),
+			otherBundle(uid, ready()),
+			otherBundle(uid, failing(1, renderError)),
+		)
+		f.clock.advance(time.Second)
+	}
+}
+
+// eventsFor counts the events created about one object.
+func (f *fixture) eventsFor(t *testing.T, uid types.UID) int {
+	t.Helper()
+
+	count := 0
+	for _, event := range f.events(t) {
+		if event.Regarding.UID == uid {
+			count++
+		}
+	}
+
+	return count
+}
+
+const newUID = types.UID("brand-new")
+
+func TestEvictionKeepsTheObjectItMakesRoomFor(t *testing.T) {
+	f := newFixture(t, nil)
+	f.opts.MaxTracked = 10
+
+	f.fill(f.opts.MaxTracked)
+	f.flush(t)
+
+	// The object which pushes the emitter over the limit is the one eviction
+	// is making room for, so it has to survive it, while an object observed
+	// longer ago is forgotten.
+	f.emitter.ObserveBundle(
+		context.TODO(),
+		otherBundle(newUID, ready()),
+		otherBundle(newUID, failing(1, nsForbidden)),
+	)
+	f.flush(t)
+
+	if got := f.eventsFor(t, newUID); got != 1 {
+		t.Errorf("expected the newly tracked bundle to be reported once, got %d events", got)
+	}
+	if len(f.emitter.entries) > f.opts.MaxTracked {
+		t.Errorf("expected at most %d entries, got %d", f.opts.MaxTracked, len(f.emitter.entries))
+	}
+}
+
+func TestEvictionDoesNotDropEventsDuringABurst(t *testing.T) {
+	f := newFixture(t, nil)
+	f.opts.MaxTracked = 10
+
+	// Nothing is flushed, so every tracked object has an event waiting, which
+	// exempts it from eviction. The object observed last must not be evicted
+	// for being the only candidate left.
+	f.fill(f.opts.MaxTracked)
+
+	f.emitter.ObserveBundle(
+		context.TODO(),
+		otherBundle(newUID, ready()),
+		otherBundle(newUID, failing(1, nsForbidden)),
+	)
+	f.flush(t)
+
+	if got := f.eventsFor(t, newUID); got != 1 {
+		t.Errorf("expected the newly tracked bundle to be reported once, got %d events", got)
+	}
+}

--- a/internal/cmd/controller/bundleevents/notifier_test.go
+++ b/internal/cmd/controller/bundleevents/notifier_test.go
@@ -149,6 +149,13 @@ func ready() fleet.BundleSummary {
 	return fleet.BundleSummary{DesiredReady: targets, Ready: targets}
 }
 
+// deploying is the state in between a failure and a recovery: the agent has
+// been handed new content, so nothing is failing any more, but nothing is ready
+// yet either.
+func deploying() fleet.BundleSummary {
+	return fleet.BundleSummary{DesiredReady: targets, Pending: targets}
+}
+
 func failing(errApplied int, messages ...string) fleet.BundleSummary {
 	s := fleet.BundleSummary{
 		DesiredReady: targets,
@@ -187,7 +194,7 @@ func TestBurstIsReportedAsOneEventWithFinalCounts(t *testing.T) {
 	}
 
 	event := events[0]
-	if event.Type != corev1.EventTypeWarning || event.Reason != ReasonDeployFailed || event.Action != actionDeploy {
+	if event.Type != corev1.EventTypeWarning || event.Reason != ReasonBundleDeployFailed || event.Action != actionDeploy {
 		t.Errorf("unexpected type/reason/action: %s/%s/%s", event.Type, event.Reason, event.Action)
 	}
 	if event.Namespace != "fleet-default" || event.Regarding.Kind != "Bundle" || event.Regarding.Name != "my-repo-app" {
@@ -204,6 +211,25 @@ func TestBurstIsReportedAsOneEventWithFinalCounts(t *testing.T) {
 	}
 	if event.Series != nil {
 		t.Errorf("expected a standalone event, got a series: %+v", event.Series)
+	}
+}
+
+func TestBurstWithinOneMagnitudeBucketCarriesTheSettledCounts(t *testing.T) {
+	f := newFixture(t, nil)
+
+	few := failing(2, renderError)
+	many := failing(5, renderError)
+
+	f.emitter.ObserveBundle(context.TODO(), bundle(ready()), bundle(few))
+	f.emitter.ObserveBundle(context.TODO(), bundle(few), bundle(many))
+	f.flush(t)
+
+	events := f.events(t)
+	if len(events) != 1 {
+		t.Fatalf("expected the burst to collapse into 1 event, got %d", len(events))
+	}
+	if !strings.HasPrefix(events[0].Note, "5/500 bundle deployments failing.") {
+		t.Errorf("expected the note to carry the settled counts, got %q", events[0].Note)
 	}
 }
 
@@ -299,11 +325,91 @@ func TestRecoveryIsReported(t *testing.T) {
 	if len(events) != 2 {
 		t.Fatalf("expected the recovery to be reported once, got %d events", len(events))
 	}
-	if events[1].Type != corev1.EventTypeNormal || events[1].Reason != ReasonReady {
+	if events[1].Type != corev1.EventTypeNormal || events[1].Reason != ReasonBundleReady {
 		t.Errorf("unexpected type/reason: %s/%s", events[1].Type, events[1].Reason)
 	}
 	if events[1].Note != "500/500 bundle deployments ready" {
 		t.Errorf("unexpected note: %q", events[1].Note)
+	}
+}
+
+func TestRecoveryIsOnlyReportedOnceTheBundleIsReady(t *testing.T) {
+	f := newFixture(t, nil)
+
+	f.emitter.ObserveBundle(context.TODO(), bundle(ready()), bundle(failing(500, renderError)))
+	f.flush(t)
+
+	// Fixing the bundle redeploys it, so it stops failing before it is ready.
+	f.clock.advance(f.opts.MinInterval)
+	f.emitter.ObserveBundle(context.TODO(), bundle(failing(500, renderError)), bundle(deploying()))
+	f.flush(t)
+
+	if got := f.events(t); len(got) != 1 {
+		t.Fatalf("expected no event while the bundle is being deployed, got %d", len(got))
+	}
+
+	f.clock.advance(f.opts.MinInterval)
+	f.emitter.ObserveBundle(context.TODO(), bundle(deploying()), bundle(ready()))
+	f.flush(t)
+
+	events := f.events(t)
+	if len(events) != 2 {
+		t.Fatalf("expected the recovery to be reported once ready, got %d events", len(events))
+	}
+	if events[1].Reason != ReasonBundleReady {
+		t.Fatalf("unexpected reason: %s", events[1].Reason)
+	}
+	if events[1].Note != "500/500 bundle deployments ready" {
+		t.Errorf("expected the note to describe the ready bundle, got %q", events[1].Note)
+	}
+}
+
+func TestBundleFailingAgainWhileDeployingIsReportedAgain(t *testing.T) {
+	f := newFixture(t, nil)
+
+	f.emitter.ObserveBundle(context.TODO(), bundle(ready()), bundle(failing(500, renderError)))
+	f.flush(t)
+
+	// The redeploy hits the same failure again, without ever being ready in
+	// between, so no recovery is reported and the failure is.
+	f.clock.advance(f.opts.MinInterval)
+	f.emitter.ObserveBundle(context.TODO(), bundle(failing(500, renderError)), bundle(deploying()))
+	f.flush(t)
+
+	f.clock.advance(f.opts.MinInterval)
+	f.emitter.ObserveBundle(context.TODO(), bundle(deploying()), bundle(failing(500, renderError)))
+	f.flush(t)
+
+	events := f.events(t)
+	if len(events) != 2 {
+		t.Fatalf("expected the recurring failure to be reported, got %d events", len(events))
+	}
+	for _, event := range events {
+		if event.Reason != ReasonBundleDeployFailed {
+			t.Errorf("expected only failures to be reported, got %q", event.Reason)
+		}
+	}
+}
+
+func TestBundleWhichLosesItsTargetsIsNotReportedAsRecovered(t *testing.T) {
+	f := newFixture(t, nil)
+
+	f.emitter.ObserveBundle(context.TODO(), bundle(ready()), bundle(failing(500, renderError)))
+	f.flush(t)
+
+	// The bundle stops targeting any cluster, which leaves no deployment to
+	// call ready.
+	none := fleet.BundleSummary{}
+	f.clock.advance(f.opts.MinInterval)
+	f.emitter.ObserveBundle(context.TODO(), bundle(failing(500, renderError)), bundle(none))
+	f.flush(t)
+
+	f.clock.advance(f.opts.MinInterval)
+	f.emitter.ObserveBundle(context.TODO(), bundle(none), bundle(none))
+	f.flush(t)
+
+	if got := f.events(t); len(got) != 1 {
+		t.Fatalf("expected no recovery for a bundle without targets, got %d events", len(got))
 	}
 }
 
@@ -327,7 +433,7 @@ func TestFailureRecurringAfterARecoveryIsReportedAgain(t *testing.T) {
 		t.Fatalf("expected the recurring failure to be reported, got %d events", len(events))
 	}
 	for _, event := range events {
-		if event.Reason != ReasonDeployFailed {
+		if event.Reason != ReasonBundleDeployFailed {
 			t.Errorf("expected only failures to be reported, got %q", event.Reason)
 		}
 	}
@@ -484,8 +590,52 @@ func TestBundleDeploymentsAreOnlyReportedWhenEnabled(t *testing.T) {
 	if events[0].Namespace != "cluster-fleet-default-cluster-002-c3d4" || events[0].Regarding.Kind != "BundleDeployment" {
 		t.Errorf("unexpected namespace or regarding object: %s, %+v", events[0].Namespace, events[0].Regarding)
 	}
+	if events[0].Reason != ReasonBundleDeploymentFailed {
+		t.Errorf("expected a deployment-scoped reason, got %q", events[0].Reason)
+	}
 	if !strings.HasPrefix(events[0].Note, "bundle my-repo-app: ErrApplied") {
 		t.Errorf("unexpected note: %q", events[0].Note)
+	}
+}
+
+func TestBundleDeploymentRecoveryIsReportedAcrossTransientStates(t *testing.T) {
+	f := newFixture(t, nil)
+	f.opts.PerDeployment = true
+
+	f.emitter.ObserveBundleDeployment(context.TODO(), deployment(fleet.Pending), deployment(fleet.ErrApplied))
+	f.flush(t)
+
+	// Redeploying takes the deployment through Pending, so it does not
+	// reach Ready straight from the failing state.
+	f.clock.advance(f.opts.MinInterval)
+	f.emitter.ObserveBundleDeployment(context.TODO(), deployment(fleet.ErrApplied), deployment(fleet.Pending))
+	f.flush(t)
+
+	f.clock.advance(f.opts.MinInterval)
+	f.emitter.ObserveBundleDeployment(context.TODO(), deployment(fleet.Pending), deployment(fleet.Ready))
+	f.flush(t)
+
+	events := f.events(t)
+	if len(events) != 2 {
+		t.Fatalf("expected the failure and its recovery to be reported, got %d events", len(events))
+	}
+	if events[1].Type != corev1.EventTypeNormal || events[1].Reason != ReasonBundleDeploymentReady {
+		t.Errorf("unexpected type/reason: %s/%s", events[1].Type, events[1].Reason)
+	}
+	if events[1].Note != "bundle my-repo-app: Ready" {
+		t.Errorf("unexpected note: %q", events[1].Note)
+	}
+}
+
+func TestBundleDeploymentReadyWithoutAFailureIsNotReported(t *testing.T) {
+	f := newFixture(t, nil)
+	f.opts.PerDeployment = true
+
+	f.emitter.ObserveBundleDeployment(context.TODO(), deployment(fleet.Pending), deployment(fleet.Ready))
+	f.flush(t)
+
+	if got := f.events(t); len(got) != 0 {
+		t.Fatalf("expected no event for a deployment which never failed, got %d", len(got))
 	}
 }
 
@@ -498,6 +648,29 @@ func TestBundleDeploymentInAnUnchangedStateIsNotReported(t *testing.T) {
 
 	if got := f.events(t); len(got) != 0 {
 		t.Fatalf("expected no event without a state change, got %d", len(got))
+	}
+}
+
+func TestReasonsAreScopedToTheKindTheyAreReportedOn(t *testing.T) {
+	f := newFixture(t, nil)
+	f.opts.PerDeployment = true
+
+	f.emitter.ObserveBundle(context.TODO(), bundle(ready()), bundle(failing(500, renderError)))
+	f.emitter.ObserveBundleDeployment(context.TODO(), deployment(fleet.Ready), deployment(fleet.NotReady))
+	f.flush(t)
+
+	byKind := map[string]string{}
+	for _, event := range f.events(t) {
+		byKind[event.Regarding.Kind] = event.Reason
+	}
+
+	// A reason names the kind its event is about, so that alerting can
+	// select on the reason alone.
+	if byKind["Bundle"] != ReasonBundleDeployFailed {
+		t.Errorf("unexpected reason on the bundle: %q", byKind["Bundle"])
+	}
+	if byKind["BundleDeployment"] != ReasonBundleDeploymentNotReady {
+		t.Errorf("unexpected reason on the deployment: %q", byKind["BundleDeployment"])
 	}
 }
 

--- a/internal/cmd/controller/bundleevents/options.go
+++ b/internal/cmd/controller/bundleevents/options.go
@@ -1,0 +1,106 @@
+package bundleevents
+
+import (
+	"time"
+
+	"github.com/rancher/fleet/internal/config"
+	"github.com/rancher/fleet/pkg/durations"
+)
+
+const (
+	// defaultMaxCauses is how many distinct failure causes a single event describes.
+	defaultMaxCauses = 3
+
+	// defaultQPS and defaultBurst pace event creation across all bundles. A
+	// cluster going away fails every bundle targeting it, and those events
+	// cannot be merged, as they are about different objects.
+	defaultQPS   = 5
+	defaultBurst = 25
+
+	// defaultMaxTracked bounds the number of objects the emitter remembers.
+	defaultMaxTracked = 20000
+)
+
+// Options configure which deployment state changes are reported as events, and
+// how often.
+type Options struct {
+	// Enabled turns event reporting on or off.
+	Enabled bool
+
+	// Debounce is how long to wait for a burst of failures to settle before
+	// reporting it, so that the reported counts and causes describe the
+	// whole burst instead of only its first failure.
+	Debounce time.Duration
+
+	// MinInterval is the minimum time between two events for the same
+	// object. It bounds how often a flapping deployment reports.
+	MinInterval time.Duration
+
+	// ReportRecovery reports bundles whose deployments all became ready
+	// again after a failure.
+	ReportRecovery bool
+
+	// PerDeployment additionally reports each failing bundle deployment.
+	// This is more detailed, but produces one event per failing deployment,
+	// in the namespace of its cluster.
+	PerDeployment bool
+
+	// MaxCauses is how many distinct failure causes a single event describes.
+	MaxCauses int
+
+	// MaxTracked is the number of objects the emitter remembers in order to
+	// deduplicate their events.
+	MaxTracked int
+}
+
+// DefaultOptions returns the options used when nothing is configured.
+func DefaultOptions() Options {
+	return Options{
+		Enabled:        true,
+		Debounce:       durations.BundleEventsDebounce,
+		MinInterval:    durations.BundleEventsMinInterval,
+		ReportRecovery: true,
+		PerDeployment:  false,
+		MaxCauses:      defaultMaxCauses,
+		MaxTracked:     defaultMaxTracked,
+	}
+}
+
+// OptionsFromConfig turns the fleet controller's config into options. Unset
+// durations keep their default, as elsewhere in the config.
+func OptionsFromConfig(cfg *config.Config) Options {
+	opts := DefaultOptions()
+	if cfg == nil {
+		return opts
+	}
+
+	events := cfg.DeploymentEvents
+
+	if events.Disabled {
+		opts.Enabled = false
+	}
+	if events.Debounce.Duration > 0 {
+		opts.Debounce = events.Debounce.Duration
+	}
+	if events.MinInterval.Duration > 0 {
+		opts.MinInterval = events.MinInterval.Duration
+	}
+	if events.ReportRecovery != nil {
+		opts.ReportRecovery = *events.ReportRecovery
+	}
+	if events.PerDeployment {
+		opts.PerDeployment = true
+	}
+	if events.MaxCauses > 0 {
+		opts.MaxCauses = events.MaxCauses
+	}
+
+	return opts
+}
+
+// OptionsFromGlobalConfig reads the options from the fleet controller's config.
+// It is read on every use, so that changes to the configmap take effect without
+// a restart.
+func OptionsFromGlobalConfig() Options {
+	return OptionsFromConfig(config.Get())
+}

--- a/internal/cmd/controller/bundleevents/options_test.go
+++ b/internal/cmd/controller/bundleevents/options_test.go
@@ -1,0 +1,67 @@
+package bundleevents
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/rancher/fleet/internal/config"
+)
+
+// rendered is the deploymentEvents section as the fleet chart renders it into
+// the controller's configmap.
+const rendered = `{
+  "deploymentEvents": {
+    "disabled": false,
+    "debounce": "10s",
+    "minInterval": "2m",
+    "reportRecovery": false,
+    "perDeployment": true,
+    "maxCauses": 5
+  }
+}`
+
+func TestOptionsFromRenderedConfig(t *testing.T) {
+	cfg := &config.Config{}
+	if err := json.Unmarshal([]byte(rendered), cfg); err != nil {
+		t.Fatalf("reading config: %v", err)
+	}
+
+	opts := OptionsFromConfig(cfg)
+
+	if !opts.Enabled {
+		t.Error("expected events to be enabled")
+	}
+	if opts.Debounce != 10*time.Second {
+		t.Errorf("unexpected debounce: %s", opts.Debounce)
+	}
+	if opts.MinInterval != 2*time.Minute {
+		t.Errorf("unexpected minimum interval: %s", opts.MinInterval)
+	}
+	if opts.ReportRecovery {
+		t.Error("expected recovery reporting to be off")
+	}
+	if !opts.PerDeployment {
+		t.Error("expected per-deployment reporting to be on")
+	}
+	if opts.MaxCauses != 5 {
+		t.Errorf("unexpected number of causes: %d", opts.MaxCauses)
+	}
+}
+
+func TestOptionsFallBackToDefaults(t *testing.T) {
+	opts := OptionsFromConfig(&config.Config{})
+	defaults := DefaultOptions()
+
+	if opts != defaults {
+		t.Errorf("expected the defaults for an empty config, got %+v", opts)
+	}
+}
+
+func TestOptionsCanBeDisabled(t *testing.T) {
+	cfg := &config.Config{DeploymentEvents: config.DeploymentEvents{Disabled: true}}
+
+	if OptionsFromConfig(cfg).Enabled {
+		t.Error("expected events to be disabled")
+	}
+}

--- a/internal/cmd/controller/operator.go
+++ b/internal/cmd/controller/operator.go
@@ -10,6 +10,7 @@ import (
 	"github.com/reugn/go-quartz/quartz"
 
 	"github.com/rancher/fleet/internal/cmd"
+	"github.com/rancher/fleet/internal/cmd/controller/bundleevents"
 	"github.com/rancher/fleet/internal/cmd/controller/reconciler"
 	"github.com/rancher/fleet/internal/cmd/controller/target"
 	"github.com/rancher/fleet/internal/config"
@@ -117,11 +118,26 @@ func start(
 	if shardID != "" {
 		shardIDSuffix = "-" + shardID
 	}
+
+	// Reports the deployment state of bundles, and of their bundle
+	// deployments, as events.
+	bundleEvents := bundleevents.New(
+		mgr.GetClient(),
+		mgr.GetScheme(),
+		"fleet-bundle-ctrl"+shardIDSuffix,
+		bundleevents.OptionsFromGlobalConfig,
+	)
+	if err := mgr.Add(bundleEvents); err != nil {
+		setupLog.Error(err, "unable to add runnable", "runnable", "BundleEvents")
+		return err
+	}
+
 	if err = (&reconciler.BundleReconciler{
 		Client:    mgr.GetClient(),
 		Scheme:    mgr.GetScheme(),
 		Recorder:  mgr.GetEventRecorder("fleet-bundle-ctrl" + shardIDSuffix),
 		APIReader: mgr.GetAPIReader(),
+		Events:    bundleEvents,
 
 		Builder: builder,
 		Store:   store,
@@ -155,6 +171,7 @@ func start(
 		Client:  mgr.GetClient(),
 		Scheme:  mgr.GetScheme(),
 		ShardID: shardID,
+		Events:  bundleEvents,
 
 		Workers: workersOpts.BundleDeployment,
 	}).SetupWithManager(mgr); err != nil {

--- a/internal/cmd/controller/reconciler/bundle_controller.go
+++ b/internal/cmd/controller/reconciler/bundle_controller.go
@@ -15,6 +15,7 @@ import (
 	"github.com/Masterminds/semver/v3"
 	"github.com/go-logr/logr"
 	"github.com/rancher/fleet/internal/cmd/agent/deployer/kv"
+	"github.com/rancher/fleet/internal/cmd/controller/bundleevents"
 	fleetutil "github.com/rancher/fleet/internal/cmd/controller/errorutil"
 	"github.com/rancher/fleet/internal/cmd/controller/finalize"
 	"github.com/rancher/fleet/internal/cmd/controller/summary"
@@ -71,6 +72,10 @@ type BundleReconciler struct {
 	Scheme    *runtime.Scheme
 	Recorder  events.EventRecorder
 	APIReader client.Reader
+
+	// Events reports the deployment state of the bundle's deployments. It
+	// may be nil, in which case no such events are created.
+	Events bundleevents.Notifier
 
 	Builder TargetBuilder
 	Store   Store
@@ -287,6 +292,12 @@ func (r *BundleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	}
 
 	if !bundle.DeletionTimestamp.IsZero() {
+		// The deployment state of a bundle which is going away is not
+		// worth reporting any more.
+		if r.Events != nil {
+			r.Events.Forget(bundle.UID)
+		}
+
 		return r.handleDelete(ctx, logger, req, bundle)
 	}
 
@@ -969,6 +980,16 @@ func (r *BundleReconciler) updateStatus(ctx context.Context, orig *fleet.Bundle,
 		return err
 	}
 	metrics.BundleCollector.Collect(ctx, bundle)
+
+	// The summary is only reported once it is persisted, and against the
+	// previously persisted one, so that the state change is detected even if
+	// the controller restarted in between. Reporting here, rather than at the
+	// end of Reconcile, covers the paths which persist a summary and then
+	// return early on an error.
+	if r.Events != nil {
+		r.Events.ObserveBundle(ctx, orig, bundle)
+	}
+
 	return nil
 }
 

--- a/internal/cmd/controller/reconciler/bundle_controller_test.go
+++ b/internal/cmd/controller/reconciler/bundle_controller_test.go
@@ -583,6 +583,24 @@ func TestReconcile_OptionsSecretDeletionError(t *testing.T) {
 	}
 }
 
+// fakeNotifier counts the bundles reported to it, to check that a persisted
+// status is reported no matter which path persisted it.
+type fakeNotifier struct {
+	observed int
+}
+
+func (f *fakeNotifier) ObserveBundle(_ context.Context, _, _ *fleetv1.Bundle) {
+	f.observed++
+}
+
+func (f *fakeNotifier) ObserveBundleDeployment(
+	_ context.Context,
+	_, _ *fleetv1.BundleDeployment,
+) {
+}
+
+func (f *fakeNotifier) Forget(_ types.UID) {}
+
 func TestReconcile_OCIReferenceSecretResolutionError(t *testing.T) {
 	cases := []struct {
 		name               string
@@ -664,11 +682,14 @@ func TestReconcile_OCIReferenceSecretResolutionError(t *testing.T) {
 			targetBuilderMock := mocks.NewMockTargetBuilder(mockCtrl)
 			targetBuilderMock.EXPECT().Targets(gomock.Any(), gomock.Any(), gomock.Any()).Return(matchedTargets, false, nil)
 
+			notifier := &fakeNotifier{}
+
 			r := reconciler.BundleReconciler{
 				Client:   mockClient,
 				Scheme:   scheme,
 				Recorder: recorderMock,
 				Builder:  targetBuilderMock,
+				Events:   notifier,
 			}
 
 			ctx := context.TODO()
@@ -682,6 +703,19 @@ func TestReconcile_OCIReferenceSecretResolutionError(t *testing.T) {
 
 			if c.expectedErrMsg == "" && rs.RequeueAfter == 0 {
 				t.Errorf("expected non-zero RequeueAfter in result")
+			}
+
+			// This path persists the summary and then returns an error,
+			// without reaching the end of Reconcile. The state it persisted
+			// still has to be reported, or it never will be: the next
+			// reconcile compares against the status persisted here and sees
+			// no change.
+			want := 0
+			if c.expectStatusUpdate {
+				want = 1
+			}
+			if notifier.observed != want {
+				t.Errorf("expected %d bundles reported to the notifier, got %d", want, notifier.observed)
 			}
 		})
 	}

--- a/internal/cmd/controller/reconciler/bundledeployment_controller.go
+++ b/internal/cmd/controller/reconciler/bundledeployment_controller.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"reflect"
 
+	"github.com/rancher/fleet/internal/cmd/controller/bundleevents"
 	"github.com/rancher/fleet/internal/cmd/controller/finalize"
 	"github.com/rancher/fleet/internal/cmd/controller/summary"
 	"github.com/rancher/fleet/internal/metrics"
@@ -32,6 +33,11 @@ type BundleDeploymentReconciler struct {
 	client.Client
 	Scheme  *runtime.Scheme
 	ShardID string
+
+	// Events reports the deployment state of this bundle deployment, if
+	// per-deployment reporting is enabled. It may be nil, in which case no
+	// such events are created.
+	Events bundleevents.Notifier
 
 	Workers int
 }
@@ -72,6 +78,12 @@ func (r *BundleDeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Req
 
 	// The bundle reconciler takes care of adding the finalizer when creating a bundle deployment
 	if !bd.DeletionTimestamp.IsZero() {
+		// The state of a bundle deployment which is going away is not
+		// worth reporting any more.
+		if r.Events != nil {
+			r.Events.Forget(bd.UID)
+		}
+
 		if controllerutil.ContainsFinalizer(bd, finalize.BundleDeploymentFinalizer) {
 			err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
 				err := r.Get(ctx, req.NamespacedName, bd)
@@ -121,12 +133,22 @@ func (r *BundleDeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		// skip update if patch is empty
 		return ctrl.Result{}, nil
 	}
-	if err := r.Status().Patch(ctx, bd, statusPatch); client.IgnoreNotFound(err) != nil {
-		logger.V(1).Info("Reconcile failed update to bundledeployment status, requeuing", "status", bd.Status, "error", err)
+	patchErr := r.Status().Patch(ctx, bd, statusPatch)
+	if client.IgnoreNotFound(patchErr) != nil {
+		logger.V(1).Info("Reconcile failed update to bundledeployment status, requeuing", "status", bd.Status, "error", patchErr)
 		// Use explicit requeue timing instead of error backoff for predictable retry behavior
 		// Status patch failures are often transient (conflicts) and don't need exponential backoff
 		//nolint:nilerr // Intentionally using fixed requeue interval instead of error backoff
 		return ctrl.Result{RequeueAfter: durations.DefaultRequeueAfter}, nil
+	}
+
+	// The display state is only reported once it is persisted, and against
+	// the previously persisted one, so that the state change is detected even
+	// if the controller restarted in between. A NotFound patch persisted
+	// nothing: the bundle deployment was deleted while it was reconciled, so
+	// there is no state change to report.
+	if r.Events != nil && patchErr == nil {
+		r.Events.ObserveBundleDeployment(ctx, orig, bd)
 	}
 
 	metrics.BundleDeploymentCollector.Collect(ctx, bd)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,6 +4,7 @@ package config
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"sync"
 	"time"
 
@@ -166,6 +167,40 @@ type Config struct {
 	// ImagePullSecrets references secrets located in the same namespace as the Fleet controller deployment, to be
 	// propagated to downstream clusters and used as image pull secrets for Fleet agent images.
 	ImagePullSecrets []v1.LocalObjectReference `json:"imagePullSecrets,omitempty"`
+
+	// DeploymentEvents configures the events reporting the deployment state of bundles.
+	DeploymentEvents DeploymentEvents `json:"deploymentEvents,omitzero"`
+}
+
+// DeploymentEvents configures the events the fleet controller creates for
+// failing, and recovering, bundle deployments. Unset durations use their
+// default.
+type DeploymentEvents struct {
+	// Disabled turns off events about the deployment state of bundles.
+	Disabled bool `json:"disabled,omitempty"`
+
+	// Debounce is how long to wait for a burst of failures to settle before
+	// reporting it, defaults to 5s. Reporting a burst immediately would
+	// describe its first failure only.
+	Debounce metav1.Duration `json:"debounce,omitzero"`
+
+	// MinInterval is the minimum time between two events about the same
+	// object, defaults to 1m. It bounds how often a flapping deployment
+	// reports.
+	MinInterval metav1.Duration `json:"minInterval,omitzero"`
+
+	// ReportRecovery reports bundles whose deployments all became ready
+	// again after a failure, defaults to true.
+	ReportRecovery *bool `json:"reportRecovery,omitempty"`
+
+	// PerDeployment additionally reports each failing bundle deployment, in
+	// the namespace of its cluster. This is more detailed, but produces one
+	// event per failing deployment.
+	PerDeployment bool `json:"perDeployment,omitempty"`
+
+	// MaxCauses is how many distinct failure causes a single event
+	// describes, defaults to 3. The bundle status lists more of them.
+	MaxCauses int `json:"maxCauses,omitempty"`
 }
 
 type AgentWorkers struct {
@@ -262,10 +297,15 @@ func DefaultConfig() *Config {
 	}
 }
 
-var durationConfigKeys = []string{
-	"agentCheckinInterval",
-	"gitClientTimeout",
-	"garbageCollectionInterval",
+// durationConfigKeys are the paths of the duration fields in the config. A path
+// with more than one element addresses a duration nested in a block, so that it
+// is sanitized like a top-level one.
+var durationConfigKeys = [][]string{
+	{"agentCheckinInterval"},
+	{"gitClientTimeout"},
+	{"garbageCollectionInterval"},
+	{"deploymentEvents", "debounce"},
+	{"deploymentEvents", "minInterval"},
 }
 
 func ReadConfig(cm *v1.ConfigMap) (*Config, error) {
@@ -308,8 +348,14 @@ func sanitizeDurations(data string) (string, error) {
 
 	logger := log.Log.WithName("fleet-config")
 	changed := false
-	for _, key := range durationConfigKeys {
-		v, ok := raw[key]
+	for _, path := range durationConfigKeys {
+		parent := parentOf(raw, path)
+		if parent == nil {
+			continue
+		}
+
+		key := path[len(path)-1]
+		v, ok := parent[key]
 		if !ok {
 			continue
 		}
@@ -318,19 +364,24 @@ func sanitizeDurations(data string) (string, error) {
 			if _, err := time.ParseDuration(s); err == nil {
 				continue // valid Go duration, keep it
 			}
-			logger.Info("ignoring invalid duration in fleet config; using built-in default",
-				"key", key, "value", s,
-				"hint", "must be a Go duration like 15s, 5m, 2h, 1h30m; units d/w/y are not supported")
+			if s == "" {
+				// An empty string means the value was not set; drop it
+				// silently and let the default apply.
+			} else {
+				logger.Info("ignoring invalid duration in fleet config; using built-in default",
+					"key", strings.Join(path, "."), "value", s,
+					"hint", "must be a Go duration like 15s, 5m, 2h, 1h30m; units d/w/y are not supported")
+			}
 		} else if isZeroNumber(v) {
 			// 0 is the documented "fall back to the default" sentinel; so drop it
 			// silently and let the default apply.
 		} else {
 			logger.Info("ignoring invalid duration in fleet config; using built-in default",
-				"key", key, "value", v,
+				"key", strings.Join(path, "."), "value", v,
 				"hint", `must be a Go duration string like "15s", "5m", "2h"`)
 		}
 
-		delete(raw, key)
+		delete(parent, key)
 		changed = true
 	}
 
@@ -343,6 +394,22 @@ func sanitizeDurations(data string) (string, error) {
 		return data, err
 	}
 	return string(out), nil
+}
+
+// parentOf walks to the map holding the last element of path. It returns nil if
+// a step along the way is absent, or is not a block, in which case there is no
+// value to sanitize.
+func parentOf(raw map[string]any, path []string) map[string]any {
+	m := raw
+	for _, step := range path[:len(path)-1] {
+		nested, ok := m[step].(map[string]any)
+		if !ok {
+			return nil
+		}
+		m = nested
+	}
+
+	return m
 }
 
 func isZeroNumber(v any) bool {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -192,6 +192,95 @@ var _ = Describe("Config", func() {
 		})
 	})
 
+	When("a duration nested in a block is not a valid Go duration", func() {
+		It("does not error and falls back to the default for that key", func() {
+			cfg, err := config.ReadConfig(&v1.ConfigMap{Data: map[string]string{
+				"config": `{"deploymentEvents": {"debounce": "1d"}}`,
+			}})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(cfg.DeploymentEvents.Debounce.Duration).To(Equal(time.Duration(0)))
+		})
+
+		It("handles every nested duration key", func() {
+			cfg, err := config.ReadConfig(&v1.ConfigMap{Data: map[string]string{
+				"config": `{"deploymentEvents": {
+					"debounce": "1d",
+					"minInterval": "1w"
+				}}`,
+			}})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(cfg.DeploymentEvents.Debounce.Duration).To(Equal(time.Duration(0)))
+			Expect(cfg.DeploymentEvents.MinInterval.Duration).To(Equal(time.Duration(0)))
+		})
+
+		It("keeps the valid siblings in the same block", func() {
+			cfg, err := config.ReadConfig(&v1.ConfigMap{Data: map[string]string{
+				"config": `{"deploymentEvents": {
+					"debounce": "1d",
+					"minInterval": "2m",
+					"perDeployment": true,
+					"maxCauses": 7
+				}}`,
+			}})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(cfg.DeploymentEvents.Debounce.Duration).To(Equal(time.Duration(0)))
+			Expect(cfg.DeploymentEvents.MinInterval.Duration).To(Equal(2 * time.Minute))
+			Expect(cfg.DeploymentEvents.PerDeployment).To(BeTrue())
+			Expect(cfg.DeploymentEvents.MaxCauses).To(Equal(7))
+		})
+
+		It("sanitizes top-level and nested durations together", func() {
+			cfg, err := config.ReadConfig(&v1.ConfigMap{Data: map[string]string{
+				"config": `{
+					"gitClientTimeout": "20s",
+					"garbageCollectionInterval": "1d",
+					"deploymentEvents": {"debounce": "1d", "minInterval": "30s"}
+				}`,
+			}})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(cfg.GitClientTimeout.Duration).To(Equal(20 * time.Second))
+			Expect(cfg.GarbageCollectionInterval.Duration).To(Equal(time.Duration(0)))
+			Expect(cfg.DeploymentEvents.Debounce.Duration).To(Equal(time.Duration(0)))
+			Expect(cfg.DeploymentEvents.MinInterval.Duration).To(Equal(30 * time.Second))
+		})
+
+		It("treats a bare 0 as the default sentinel", func() {
+			cfg, err := config.ReadConfig(&v1.ConfigMap{Data: map[string]string{
+				"config": `{"deploymentEvents": {"debounce": 0}}`,
+			}})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(cfg.DeploymentEvents.Debounce.Duration).To(Equal(time.Duration(0)))
+		})
+
+		It("treats an empty string as unset", func() {
+			cfg, err := config.ReadConfig(&v1.ConfigMap{Data: map[string]string{
+				"config": `{"deploymentEvents": {"minInterval": ""}}`,
+			}})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(cfg.DeploymentEvents.MinInterval.Duration).To(Equal(time.Duration(0)))
+		})
+
+		It("does not trip over the block being absent or not a block", func() {
+			for _, data := range []string{
+				`{"gitClientTimeout": "20s"}`,
+				`{"deploymentEvents": null}`,
+				`{"deploymentEvents": "nonsense"}`,
+			} {
+				cfg, err := config.ReadConfig(&v1.ConfigMap{Data: map[string]string{
+					"config": data,
+				}})
+				if data == `{"deploymentEvents": "nonsense"}` {
+					// A block of the wrong type is left to the typed
+					// unmarshal to reject, as before.
+					Expect(err).To(HaveOccurred())
+					continue
+				}
+				Expect(err).ToNot(HaveOccurred(), data)
+				Expect(cfg.DeploymentEvents.Debounce.Duration).To(Equal(time.Duration(0)))
+			}
+		})
+	})
+
 	When("the config is not a valid mapping at all", func() {
 		It("still surfaces the unmarshal error", func() {
 			cfg, err := config.ReadConfig(&v1.ConfigMap{Data: map[string]string{

--- a/pkg/durations/durations.go
+++ b/pkg/durations/durations.go
@@ -46,6 +46,13 @@ const (
 	// a reconcile on its own, so the agent requeues at this interval to
 	// converge once the permission is added.
 	NamespacePermissionRequeueInterval = time.Minute * 2
+	// BundleEventsDebounce lets a burst of bundle deployment failures settle
+	// before it is reported as an event, so that the event describes the
+	// whole burst instead of only its first failure.
+	BundleEventsDebounce = time.Second * 5
+	// BundleEventsMinInterval is the minimum time between two events about
+	// the deployment state of the same object.
+	BundleEventsMinInterval = time.Minute * 1
 )
 
 // Equal reports whether the duration t is equal to u.

--- a/pkg/durations/durations.go
+++ b/pkg/durations/durations.go
@@ -54,6 +54,13 @@ const (
 	// StaleCacheRequeueMax caps the wait between those attempts, so that a
 	// cache which never catches up polls the API server with this periodicity.
 	StaleCacheRequeueMax = time.Minute * 10
+	// BundleEventsDebounce lets a burst of bundle deployment failures settle
+	// before it is reported as an event, so that the event describes the
+	// whole burst instead of only its first failure.
+	BundleEventsDebounce = time.Second * 5
+	// BundleEventsMinInterval is the minimum time between two events about
+	// the deployment state of the same object.
+	BundleEventsMinInterval = time.Minute * 1
 )
 
 // Equal reports whether the duration t is equal to u.


### PR DESCRIPTION
Fleet exposes deployment failures only in bundle status, which is easy to miss. This adds events on the bundle when its deployments fail, and when they all become ready again, so `kubectl describe bundle` and any event- based tooling can see them.

Events are created directly rather than through client-go's recorder: the recorder keeps the note of the first event in a series, which would drop notes describing different failures of the same bundle. Deduplication happens on a fingerprint of the failure causes and how many deployments are affected instead, so a burst collapses into one accurate event, and comparing against the last persisted status keeps that true across controller restarts.

Configurable via the `deploymentEvents` block in the fleet chart: debounce, minimum interval per object, recovery reporting, how many causes an event names, and optional per-bundle-deployment events (off by default). Reporting is on by default and can be turned off entirely.

Refers to: https://github.com/rancher/fleet/issues/4455


## Additional Information

### Checklist

- [ ] <!-- If applicable,--> I have updated the documentation via a pull request in the [fleet-product-docs](https://github.com/rancher/fleet-product-docs) repository.
