### PR TITLE
[v0.16] Disable SARIF upload on forks

### DIFF
--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -24,4 +24,5 @@ jobs:
       - name: Run zizmor 🌈
         uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa # v0.5.7
         with:
+          advanced-security: ${{ github.repository == 'rancher/fleet' }}
           config: .github/zizmor.yml


### PR DESCRIPTION
Keep zizmor analysis running in fork repositories without requiring GitHub Advanced Security permissions.

This prevents failed CI results on forks.

Backports #5527