### PR TITLE
Remove logrus usage

### DIFF
--- a/cmd/codegen/cleanup/main.go
+++ b/cmd/codegen/cleanup/main.go
@@ -1,18 +1,17 @@
 package main
 
 import (
+	"log"
 	"os"
-
-	"github.com/sirupsen/logrus"
 
 	"github.com/rancher/wrangler/v3/pkg/cleanup"
 )
 
 func main() {
 	if err := cleanup.Cleanup("./pkg/apis"); err != nil {
-		logrus.Fatal(err)
+		log.Fatal(err)
 	}
 	if err := os.RemoveAll("./pkg/generated"); err != nil {
-		logrus.Fatal(err)
+		log.Fatal(err)
 	}
 }

--- a/cmd/fleetagent/main.go
+++ b/cmd/fleetagent/main.go
@@ -2,18 +2,18 @@
 package main
 
 import (
+	"log"
 	_ "net/http/pprof"
 
 	"github.com/rancher/fleet/internal/cmd/agent"
 
 	"github.com/rancher/wrangler/v3/pkg/signals"
-	"github.com/sirupsen/logrus"
 )
 
 func main() {
 	ctx := signals.SetupSignalContext()
 	cmd := agent.App()
 	if err := cmd.ExecuteContext(ctx); err != nil {
-		logrus.Fatal(err)
+		log.Fatal(err)
 	}
 }

--- a/cmd/fleetcli/main.go
+++ b/cmd/fleetcli/main.go
@@ -2,6 +2,8 @@
 package main
 
 import (
+	"log"
+	"log/slog"
 	"os"
 	"strings"
 
@@ -16,7 +18,6 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
 	"github.com/rancher/wrangler/v3/pkg/signals"
-	"github.com/sirupsen/logrus"
 
 	cmds "github.com/rancher/fleet/internal/cmd/cli"
 	fleetapply "github.com/rancher/fleet/internal/cmd/cli/apply"
@@ -27,15 +28,11 @@ func main() {
 	cmd := cmds.App()
 	if err := cmd.ExecuteContext(ctx); err != nil {
 		if strings.ToLower(os.Getenv(fleetapply.JSONOutputEnvVar)) == "true" {
-			log := logrus.New()
-			log.SetFormatter(&logrus.JSONFormatter{})
-			// use a fleet specific field name so we are sure logs from other libraries
-			// are not considered.
-			log.WithFields(logrus.Fields{
-				"fleetErrorMessage": err.Error(),
-			}).Fatal("Fleet cli failed")
+			logger := slog.New(slog.NewJSONHandler(os.Stderr, nil))
+			logger.Error("Fleet cli failed", "fleetErrorMessage", err.Error())
+			os.Exit(1)
 		} else {
-			logrus.Fatal(err)
+			log.Fatal(err)
 		}
 	}
 }

--- a/cmd/fleetcontroller/main.go
+++ b/cmd/fleetcontroller/main.go
@@ -2,12 +2,12 @@
 package main
 
 import (
+	"log"
 	_ "net/http/pprof"
 
 	_ "github.com/rancher/wrangler/v3/pkg/generated/controllers/apiextensions.k8s.io"
 	_ "github.com/rancher/wrangler/v3/pkg/generated/controllers/networking.k8s.io"
 	"github.com/rancher/wrangler/v3/pkg/signals"
-	"github.com/sirupsen/logrus"
 
 	"github.com/rancher/fleet/internal/cmd/controller"
 )
@@ -16,6 +16,6 @@ func main() {
 	ctx := signals.SetupSignalContext()
 	cmd := controller.App()
 	if err := cmd.ExecuteContext(ctx); err != nil {
-		logrus.Fatal(err)
+		log.Fatal(err)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -76,7 +76,6 @@ require (
 	github.com/rancher/lasso v0.2.9
 	github.com/rancher/wrangler/v3 v3.7.0
 	github.com/reugn/go-quartz v0.15.2
-	github.com/sirupsen/logrus v1.9.4
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
 	github.com/testcontainers/testcontainers-go v0.43.0
@@ -228,6 +227,7 @@ require (
 	github.com/sergi/go-diff v1.4.0 // indirect
 	github.com/shirou/gopsutil/v4 v4.26.5 // indirect
 	github.com/shopspring/decimal v1.4.0 // indirect
+	github.com/sirupsen/logrus v1.9.4 // indirect
 	github.com/skeema/knownhosts v1.3.1 // indirect
 	github.com/spf13/cast v1.7.0 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect

--- a/integrationtests/utils/envtest.go
+++ b/integrationtests/utils/envtest.go
@@ -10,8 +10,6 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
-	"github.com/sirupsen/logrus"
-
 	"github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
 
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -47,11 +45,9 @@ func ShouldSuppressLogs() bool {
 //
 // This suppresses:
 // - Go standard library logger (log package) - used by Helm SDK for warnings
-// - Logrus logger - used by Fleet components for info/debug messages
 func SuppressLogs() {
 	if ShouldSuppressLogs() {
 		log.SetOutput(io.Discard)
-		logrus.SetOutput(io.Discard)
 	}
 }
 

--- a/internal/bundlereader/charturl.go
+++ b/internal/bundlereader/charturl.go
@@ -21,9 +21,9 @@ import (
 	"github.com/Masterminds/semver/v3"
 	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
 	fleetgit "github.com/rancher/fleet/pkg/git"
-	"github.com/sirupsen/logrus"
 	"golang.org/x/sync/singleflight"
 	repov1 "helm.sh/helm/v4/pkg/repo/v1"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/yaml"
 
 	"oras.land/oras-go/v2/registry"
@@ -279,7 +279,7 @@ func transportForAuth(insecureSkipVerify bool, caBundle []byte) http.RoundTrippe
 		proxyBytes := []byte(proxyCAPEM)
 		tmpPool := x509.NewCertPool()
 		if !tmpPool.AppendCertsFromPEM(proxyBytes) {
-			logrus.Warnf("%s is set but contains no valid PEM certificates; ignoring proxy CA bundle", fleetgit.ProxyCABundleEnvVar)
+			log.Log.Info(fleetgit.ProxyCABundleEnvVar + " is set but contains no valid PEM certificates; ignoring proxy CA bundle")
 		} else {
 			caBundle = append(caBundle, '\n')
 			caBundle = append(caBundle, proxyBytes...)

--- a/internal/bundlereader/gitclone.go
+++ b/internal/bundlereader/gitclone.go
@@ -14,7 +14,7 @@ import (
 	gogit "github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
 	httpgit "github.com/go-git/go-git/v5/plumbing/transport/http"
-	"github.com/sirupsen/logrus"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	fleetssh "github.com/rancher/fleet/internal/ssh"
 	fleetgit "github.com/rancher/fleet/pkg/git"
@@ -74,7 +74,7 @@ func gitDownload(ctx context.Context, dst, rawURL string, auth Auth) error {
 		proxyBytes := []byte(proxyCAPEM)
 		tmpPool := x509.NewCertPool()
 		if !tmpPool.AppendCertsFromPEM(proxyBytes) {
-			logrus.Warnf("%s is set but contains no valid PEM certificates; ignoring proxy CA bundle", fleetgit.ProxyCABundleEnvVar)
+			log.Log.Info(fleetgit.ProxyCABundleEnvVar + " is set but contains no valid PEM certificates; ignoring proxy CA bundle")
 		} else {
 			if len(caBundle) > 0 && caBundle[len(caBundle)-1] != '\n' {
 				caBundle = append(caBundle, '\n')

--- a/internal/bundlereader/read.go
+++ b/internal/bundlereader/read.go
@@ -17,8 +17,8 @@ import (
 	"github.com/rancher/fleet/internal/names"
 	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
 
-	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/yaml"
 )
 
@@ -236,7 +236,7 @@ func bundleFromDir(ctx context.Context, name, baseDir string, bundleData []byte,
 	// Targets defined in the GitRepo are stored in the targets file, which will be used if OverrideTargets is not provided.
 	// Use targets from OverrideTargets if found in the fleet.yaml.
 	if fy.OverrideTargets != nil {
-		logrus.Debugf("Overriding targets for Bundle '%s' ", bundle.Name)
+		log.Log.V(1).Info(fmt.Sprintf("Overriding targets for Bundle '%s' ", bundle.Name))
 		for _, target := range fy.OverrideTargets {
 			bundle.Spec.Targets = append(bundle.Spec.Targets, fleet.BundleTarget{
 				Name:                 target.Name,

--- a/internal/bundlereader/resources.go
+++ b/internal/bundlereader/resources.go
@@ -12,12 +12,12 @@ import (
 	"sync"
 
 	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
-	"github.com/sirupsen/logrus"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/sync/semaphore"
 
 	"github.com/rancher/wrangler/v3/pkg/data"
 
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/yaml"
 )
 
@@ -35,7 +35,7 @@ func readResources(ctx context.Context, spec *fleet.BundleSpec, compress bool, b
 
 	if spec.Helm != nil && (spec.Helm.Chart != "" || spec.Helm.Repo != "") {
 		if strings.HasPrefix(spec.Helm.Chart, ociURLPrefix) {
-			logrus.Warnf("helm.chart contains an OCI URL %q; use helm.repo instead (helm.chart for OCI URLs is deprecated)", spec.Helm.Chart)
+			log.Log.Info(fmt.Sprintf("helm.chart contains an OCI URL %q; use helm.repo instead (helm.chart for OCI URLs is deprecated)", spec.Helm.Chart))
 		}
 		if err := parseValuesFiles(base, spec.Helm); err != nil {
 			return nil, err
@@ -46,7 +46,7 @@ func readResources(ctx context.Context, spec *fleet.BundleSpec, compress bool, b
 	for _, target := range spec.Targets {
 		if target.Helm != nil {
 			if strings.HasPrefix(target.Helm.Chart, ociURLPrefix) {
-				logrus.Warnf("helm.chart contains an OCI URL %q in target customization %q; use helm.repo instead (helm.chart for OCI URLs is deprecated)", target.Helm.Chart, target.Name)
+				log.Log.Info(fmt.Sprintf("helm.chart contains an OCI URL %q in target customization %q; use helm.repo instead (helm.chart for OCI URLs is deprecated)", target.Helm.Chart, target.Name))
 			}
 			err := parseValuesFiles(base, target.Helm)
 			if err != nil {
@@ -230,7 +230,7 @@ func addRemoteCharts(ctx context.Context, directories []directory, base string, 
 					strippedCredentialsForEmptyRegex = true
 				}
 				if !warnedOnce && strippedCredentialsForEmptyRegex {
-					logrus.Warn("helmRepoURLRegex is empty: Helm credentials will not be forwarded to any repository; set spec.helmRepoURLRegex to enable credential forwarding")
+					log.Log.Info("helmRepoURLRegex is empty: Helm credentials will not be forwarded to any repository; set spec.helmRepoURLRegex to enable credential forwarding")
 					warnedOnce = true
 				}
 				// Only clear credentials; preserve transport settings (BasicHTTP, CABundle, InsecureSkipVerify)

--- a/internal/bundlereader/resources_test.go
+++ b/internal/bundlereader/resources_test.go
@@ -3,16 +3,28 @@ package bundlereader
 import (
 	"bytes"
 	"context"
+	"fmt"
+	"strings"
 	"testing"
-
-	"github.com/sirupsen/logrus"
 
 	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
 
+	"github.com/go-logr/logr/testr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/util/yaml"
+	ctrlog "sigs.k8s.io/controller-runtime/pkg/log"
 )
+
+type logRecorder struct {
+	lines []string
+}
+
+func (r *logRecorder) Helper() {}
+
+func (r *logRecorder) Log(args ...any) {
+	r.lines = append(r.lines, fmt.Sprint(args...))
+}
 
 const (
 	valuesOneYaml = `microService1:
@@ -213,6 +225,12 @@ func TestAddRemoteChartsStripsCredentials(t *testing.T) {
 
 func TestAddRemoteChartsWarnsMissingRegex(t *testing.T) {
 	remoteChart := []*fleet.HelmOptions{{Chart: "/nonexistent/chart"}}
+	recorder := &logRecorder{}
+	oldLogger := ctrlog.Log
+	ctrlog.SetLogger(testr.NewWithInterface(recorder, testr.Options{Verbosity: 1}))
+	t.Cleanup(func() {
+		ctrlog.SetLogger(oldLogger)
+	})
 
 	tests := []struct {
 		name        string
@@ -260,23 +278,15 @@ func TestAddRemoteChartsWarnsMissingRegex(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var buf bytes.Buffer
-			oldOut := logrus.StandardLogger().Out
-			oldLevel := logrus.GetLevel()
-			logrus.SetOutput(&buf)
-			logrus.SetLevel(logrus.WarnLevel)
-			t.Cleanup(func() {
-				logrus.SetOutput(oldOut)
-				logrus.SetLevel(oldLevel)
-			})
+			recorder.lines = nil
 
 			_, err := addRemoteCharts(context.Background(), nil, t.TempDir(), tt.charts, tt.auth, tt.regex)
 			require.NoError(t, err)
 
 			if tt.wantWarning {
-				assert.Contains(t, buf.String(), "helmRepoURLRegex")
+				assert.Contains(t, strings.Join(recorder.lines, "\n"), "helmRepoURLRegex")
 			} else {
-				assert.NotContains(t, buf.String(), "helmRepoURLRegex")
+				assert.NotContains(t, strings.Join(recorder.lines, "\n"), "helmRepoURLRegex")
 			}
 		})
 	}

--- a/internal/cmd/agent/deployer/internal/normalizers/diff_normalizer.go
+++ b/internal/cmd/agent/deployer/internal/normalizers/diff_normalizer.go
@@ -6,9 +6,10 @@ package normalizers
 
 import (
 	"encoding/json"
+	"fmt"
 
 	jsonpatch "github.com/evanphx/json-patch"
-	log "github.com/sirupsen/logrus"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -34,7 +35,7 @@ func NewIgnoreNormalizer(ignore []resource.ResourceIgnoreDifferences, overrides 
 	for key, override := range overrides {
 		group, kind, err := getGroupKindForOverrideKey(key)
 		if err != nil {
-			log.Warn(err)
+			log.Log.Info(fmt.Sprint(err))
 		}
 		if len(override.IgnoreDifferences.JSONPointers) > 0 {
 			ignore = append(ignore, resource.ResourceIgnoreDifferences{
@@ -93,7 +94,7 @@ func (n *ignoreNormalizer) Normalize(un *unstructured.Unstructured) error {
 	for _, patch := range matched {
 		patchedData, err := patch.patch.Apply(docData)
 		if err != nil {
-			log.Debugf("Failed to apply normalization: %v", err)
+			log.Log.V(1).Info(fmt.Sprintf("Failed to apply normalization: %v", err))
 			continue
 		}
 		docData = patchedData

--- a/internal/cmd/agent/deployer/internal/normalizers/glob/glob.go
+++ b/internal/cmd/agent/deployer/internal/normalizers/glob/glob.go
@@ -2,14 +2,16 @@
 package glob
 
 import (
+	"fmt"
+
 	"github.com/gobwas/glob"
-	log "github.com/sirupsen/logrus"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 func Match(pattern, text string, separators ...rune) bool {
 	compiledGlob, err := glob.Compile(pattern, separators...)
 	if err != nil {
-		log.Warnf("failed to compile pattern %s due to error %v", pattern, err)
+		log.Log.Info(fmt.Sprintf("failed to compile pattern %s due to error %v", pattern, err))
 		return false
 	}
 	return compiledGlob.Match(text)

--- a/internal/cmd/agent/deployer/internal/normalizers/knowntypes_normalizer.go
+++ b/internal/cmd/agent/deployer/internal/normalizers/knowntypes_normalizer.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	log "github.com/sirupsen/logrus"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/rancher/fleet/internal/cmd/agent/deployer/internal/resource"
 	v1 "k8s.io/api/core/v1"
@@ -33,12 +33,12 @@ func NewKnownTypesNormalizer(overrides map[string]resource.ResourceOverride) (*k
 	for key, override := range overrides {
 		group, kind, err := getGroupKindForOverrideKey(key)
 		if err != nil {
-			log.Warn(err)
+			log.Log.Info(fmt.Sprint(err))
 		}
 		gk := schema.GroupKind{Group: group, Kind: kind}
 		for _, f := range override.KnownTypeFields {
 			if err := normalizer.addKnownField(gk, f.Field, f.Type); err != nil {
-				log.Warnf("Failed to configure known field normalizer: %v", err)
+				log.Log.Info(fmt.Sprintf("Failed to configure known field normalizer: %v", err))
 			}
 		}
 	}

--- a/internal/cmd/agent/deployer/monitor/condition.go
+++ b/internal/cmd/agent/deployer/monitor/condition.go
@@ -2,12 +2,11 @@ package monitor
 
 import (
 	"errors"
+	"log"
 	"reflect"
 	"time"
 
 	"github.com/rancher/lasso/pkg/controller"
-
-	"github.com/sirupsen/logrus"
 )
 
 type Cond string
@@ -128,7 +127,7 @@ func findOrCreateCond(obj any, condName string) reflect.Value {
 func findCond(obj any, val reflect.Value, name string) *reflect.Value {
 	defer func() {
 		if recover() != nil {
-			logrus.Fatalf("failed to find .Status.Conditions field on %v", reflect.TypeOf(obj))
+			log.Fatalf("failed to find .Status.Conditions field on %v", reflect.TypeOf(obj))
 		}
 	}()
 

--- a/internal/cmd/agent/deployer/normalizers/jsonpatch.go
+++ b/internal/cmd/agent/deployer/normalizers/jsonpatch.go
@@ -1,8 +1,6 @@
 package normalizers
 
 import (
-	"fmt"
-
 	jsonpatch "github.com/evanphx/json-patch"
 	"github.com/rancher/fleet/internal/cmd/agent/deployer/objectset"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -38,7 +36,7 @@ func (j JSONPatchNormalizer) Normalize(un *unstructured.Unstructured) error {
 	gvk := un.GroupVersionKind()
 	metaObj, err := meta.Accessor(un)
 	if err != nil {
-		log.Log.Error(nil, fmt.Sprintf("Failed to normalize obj with json patch, error: %v", err))
+		log.Log.Error(err, "Failed to normalize obj with json patch")
 		return nil
 	}
 	key := objectset.ObjectKey{
@@ -53,12 +51,12 @@ func (j JSONPatchNormalizer) Normalize(un *unstructured.Unstructured) error {
 
 	jsondata, err := un.MarshalJSON()
 	if err != nil {
-		log.Log.Error(nil, fmt.Sprintf("Failed to normalize obj with json patch, error: %v", err))
+		log.Log.Error(err, "Failed to normalize obj with json patch")
 		return nil
 	}
 	patched := applyPatches(jsondata, j.patch[gvk][key])
 	if err := un.UnmarshalJSON(patched); err != nil {
-		log.Log.Error(nil, fmt.Sprintf("Failed to normalize obj with json patch, error: %v", err))
+		log.Log.Error(err, "Failed to normalize obj with json patch")
 		return nil
 	}
 	return nil
@@ -83,12 +81,12 @@ func applyPatches(jsondata []byte, patches []JSONPatch) []byte {
 	for _, patch := range patches {
 		p, err := jsonpatch.DecodePatch(patch)
 		if err != nil {
-			log.Log.Error(nil, fmt.Sprintf("Failed to normalize obj with json patch, error: %v", err))
+			log.Log.Error(err, "Failed to normalize obj with json patch")
 			return nil
 		}
 		jsondata, err = p.Apply(jsondata)
 		if err != nil {
-			log.Log.Error(nil, fmt.Sprintf("Failed to normalize obj with json patch, error: %v", err))
+			log.Log.Error(err, "Failed to normalize obj with json patch")
 			return nil
 		}
 	}

--- a/internal/cmd/agent/deployer/normalizers/jsonpatch.go
+++ b/internal/cmd/agent/deployer/normalizers/jsonpatch.go
@@ -1,9 +1,11 @@
 package normalizers
 
 import (
+	"fmt"
+
 	jsonpatch "github.com/evanphx/json-patch"
 	"github.com/rancher/fleet/internal/cmd/agent/deployer/objectset"
-	"github.com/sirupsen/logrus"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -36,7 +38,7 @@ func (j JSONPatchNormalizer) Normalize(un *unstructured.Unstructured) error {
 	gvk := un.GroupVersionKind()
 	metaObj, err := meta.Accessor(un)
 	if err != nil {
-		logrus.Errorf("Failed to normalize obj with json patch, error: %v", err)
+		log.Log.Error(nil, fmt.Sprintf("Failed to normalize obj with json patch, error: %v", err))
 		return nil
 	}
 	key := objectset.ObjectKey{
@@ -51,12 +53,12 @@ func (j JSONPatchNormalizer) Normalize(un *unstructured.Unstructured) error {
 
 	jsondata, err := un.MarshalJSON()
 	if err != nil {
-		logrus.Errorf("Failed to normalize obj with json patch, error: %v", err)
+		log.Log.Error(nil, fmt.Sprintf("Failed to normalize obj with json patch, error: %v", err))
 		return nil
 	}
 	patched := applyPatches(jsondata, j.patch[gvk][key])
 	if err := un.UnmarshalJSON(patched); err != nil {
-		logrus.Errorf("Failed to normalize obj with json patch, error: %v", err)
+		log.Log.Error(nil, fmt.Sprintf("Failed to normalize obj with json patch, error: %v", err))
 		return nil
 	}
 	return nil
@@ -81,12 +83,12 @@ func applyPatches(jsondata []byte, patches []JSONPatch) []byte {
 	for _, patch := range patches {
 		p, err := jsonpatch.DecodePatch(patch)
 		if err != nil {
-			logrus.Errorf("Failed to normalize obj with json patch, error: %v", err)
+			log.Log.Error(nil, fmt.Sprintf("Failed to normalize obj with json patch, error: %v", err))
 			return nil
 		}
 		jsondata, err = p.Apply(jsondata)
 		if err != nil {
-			logrus.Errorf("Failed to normalize obj with json patch, error: %v", err)
+			log.Log.Error(nil, fmt.Sprintf("Failed to normalize obj with json patch, error: %v", err))
 			return nil
 		}
 	}

--- a/internal/cmd/agent/deployer/normalizers/mutatingwebhook.go
+++ b/internal/cmd/agent/deployer/normalizers/mutatingwebhook.go
@@ -1,8 +1,6 @@
 package normalizers
 
 import (
-	"fmt"
-
 	"github.com/rancher/fleet/internal/cmd/agent/deployer/objectset"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -32,7 +30,7 @@ func (m *MutatingWebhookNormalizer) convertMutatingWebhookV1(un *unstructured.Un
 	var webhook adregv1.MutatingWebhookConfiguration
 	err := runtime.DefaultUnstructuredConverter.FromUnstructured(un.Object, &webhook)
 	if err != nil {
-		log.Log.Error(nil, fmt.Sprintf("Failed to convert unstructured to webhook, err: %v", err))
+		log.Log.Error(err, "Failed to convert unstructured to webhook")
 		return nil
 	}
 
@@ -44,7 +42,7 @@ func (m *MutatingWebhookNormalizer) convertMutatingWebhookV1(un *unstructured.Un
 				continue
 			}
 			if err := setMutatingWebhookV1CacertNil(liveWebhook, i); err != nil {
-				log.Log.Error(nil, fmt.Sprintf("Failed to normalize webhook cacert, err: %v", err))
+				log.Log.Error(err, "Failed to normalize webhook cacert")
 				return nil
 			}
 		}
@@ -56,7 +54,7 @@ func setMutatingWebhookV1CacertNil(un *unstructured.Unstructured, index int) err
 	var webhook adregv1.MutatingWebhookConfiguration
 	err := runtime.DefaultUnstructuredConverter.FromUnstructured(un.Object, &webhook)
 	if err != nil {
-		log.Log.Error(nil, fmt.Sprintf("Failed to convert unstructured to webhook, err: %v", err))
+		log.Log.Error(err, "Failed to convert unstructured to webhook")
 		return err
 	}
 
@@ -66,12 +64,12 @@ func setMutatingWebhookV1CacertNil(un *unstructured.Unstructured, index int) err
 	webhook.Webhooks[index].ClientConfig.CABundle = nil
 	newObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&webhook)
 	if err != nil {
-		log.Log.Error(nil, fmt.Sprintf("Failed to convert unstructured to webhook, err: %v", err))
+		log.Log.Error(err, "Failed to convert unstructured to webhook")
 		return err
 	}
 	if webhook.Webhooks != nil {
 		if err = unstructured.SetNestedField(un.Object, newObj["webhooks"], "webhooks"); err != nil {
-			log.Log.Error(nil, fmt.Sprintf("MutatingWebhook normalization error: %v", err))
+			log.Log.Error(err, "MutatingWebhook normalization error")
 			return err
 		}
 	}

--- a/internal/cmd/agent/deployer/normalizers/mutatingwebhook.go
+++ b/internal/cmd/agent/deployer/normalizers/mutatingwebhook.go
@@ -1,9 +1,10 @@
 package normalizers
 
 import (
-	"github.com/sirupsen/logrus"
+	"fmt"
 
 	"github.com/rancher/fleet/internal/cmd/agent/deployer/objectset"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	adregv1 "k8s.io/api/admissionregistration/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -31,7 +32,7 @@ func (m *MutatingWebhookNormalizer) convertMutatingWebhookV1(un *unstructured.Un
 	var webhook adregv1.MutatingWebhookConfiguration
 	err := runtime.DefaultUnstructuredConverter.FromUnstructured(un.Object, &webhook)
 	if err != nil {
-		logrus.Errorf("Failed to convert unstructured to webhook, err: %v", err)
+		log.Log.Error(nil, fmt.Sprintf("Failed to convert unstructured to webhook, err: %v", err))
 		return nil
 	}
 
@@ -43,7 +44,7 @@ func (m *MutatingWebhookNormalizer) convertMutatingWebhookV1(un *unstructured.Un
 				continue
 			}
 			if err := setMutatingWebhookV1CacertNil(liveWebhook, i); err != nil {
-				logrus.Errorf("Failed to normalize webhook cacert, err: %v", err)
+				log.Log.Error(nil, fmt.Sprintf("Failed to normalize webhook cacert, err: %v", err))
 				return nil
 			}
 		}
@@ -55,7 +56,7 @@ func setMutatingWebhookV1CacertNil(un *unstructured.Unstructured, index int) err
 	var webhook adregv1.MutatingWebhookConfiguration
 	err := runtime.DefaultUnstructuredConverter.FromUnstructured(un.Object, &webhook)
 	if err != nil {
-		logrus.Errorf("Failed to convert unstructured to webhook, err: %v", err)
+		log.Log.Error(nil, fmt.Sprintf("Failed to convert unstructured to webhook, err: %v", err))
 		return err
 	}
 
@@ -65,12 +66,12 @@ func setMutatingWebhookV1CacertNil(un *unstructured.Unstructured, index int) err
 	webhook.Webhooks[index].ClientConfig.CABundle = nil
 	newObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&webhook)
 	if err != nil {
-		logrus.Errorf("Failed to convert unstructured to webhook, err: %v", err)
+		log.Log.Error(nil, fmt.Sprintf("Failed to convert unstructured to webhook, err: %v", err))
 		return err
 	}
 	if webhook.Webhooks != nil {
 		if err = unstructured.SetNestedField(un.Object, newObj["webhooks"], "webhooks"); err != nil {
-			logrus.Errorf("MutatingWebhook normalization error: %v", err)
+			log.Log.Error(nil, fmt.Sprintf("MutatingWebhook normalization error: %v", err))
 			return err
 		}
 	}

--- a/internal/cmd/agent/deployer/normalizers/validatingwebhook.go
+++ b/internal/cmd/agent/deployer/normalizers/validatingwebhook.go
@@ -1,8 +1,6 @@
 package normalizers
 
 import (
-	"fmt"
-
 	"github.com/rancher/fleet/internal/cmd/agent/deployer/objectset"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -31,7 +29,7 @@ func (v *ValidatingWebhookNormalizer) convertValidatingWebhookV1(un *unstructure
 	var webhook adregv1.ValidatingWebhookConfiguration
 	err := runtime.DefaultUnstructuredConverter.FromUnstructured(un.Object, &webhook)
 	if err != nil {
-		log.Log.Error(nil, fmt.Sprintf("Failed to convert unstructured to webhook, err: %v", err))
+		log.Log.Error(err, "Failed to convert unstructured to webhook")
 		return nil
 	}
 
@@ -43,7 +41,7 @@ func (v *ValidatingWebhookNormalizer) convertValidatingWebhookV1(un *unstructure
 				continue
 			}
 			if err := setValidatingWebhookV1CacertNil(liveWebhook, i); err != nil {
-				log.Log.Error(nil, fmt.Sprintf("Failed to normalize webhook cacert, err: %v", err))
+				log.Log.Error(err, "Failed to normalize webhook cacert")
 				return nil
 			}
 		}
@@ -55,7 +53,7 @@ func setValidatingWebhookV1CacertNil(un *unstructured.Unstructured, index int) e
 	var webhook adregv1.ValidatingWebhookConfiguration
 	err := runtime.DefaultUnstructuredConverter.FromUnstructured(un.Object, &webhook)
 	if err != nil {
-		log.Log.Error(nil, fmt.Sprintf("Failed to convert unstructured to webhook, err: %v", err))
+		log.Log.Error(err, "Failed to convert unstructured to webhook")
 		return err
 	}
 
@@ -65,12 +63,12 @@ func setValidatingWebhookV1CacertNil(un *unstructured.Unstructured, index int) e
 	webhook.Webhooks[index].ClientConfig.CABundle = nil
 	newObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&webhook)
 	if err != nil {
-		log.Log.Error(nil, fmt.Sprintf("Failed to convert unstructured to webhook, err: %v", err))
+		log.Log.Error(err, "Failed to convert unstructured to webhook")
 		return err
 	}
 	if webhook.Webhooks != nil {
 		if err = unstructured.SetNestedField(un.Object, newObj["webhooks"], "webhooks"); err != nil {
-			log.Log.Error(nil, fmt.Sprintf("ValidatingWebhook normalization error: %v", err))
+			log.Log.Error(err, "ValidatingWebhook normalization error")
 			return err
 		}
 	}

--- a/internal/cmd/agent/deployer/normalizers/validatingwebhook.go
+++ b/internal/cmd/agent/deployer/normalizers/validatingwebhook.go
@@ -1,9 +1,10 @@
 package normalizers
 
 import (
-	"github.com/sirupsen/logrus"
+	"fmt"
 
 	"github.com/rancher/fleet/internal/cmd/agent/deployer/objectset"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	adregv1 "k8s.io/api/admissionregistration/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -30,7 +31,7 @@ func (v *ValidatingWebhookNormalizer) convertValidatingWebhookV1(un *unstructure
 	var webhook adregv1.ValidatingWebhookConfiguration
 	err := runtime.DefaultUnstructuredConverter.FromUnstructured(un.Object, &webhook)
 	if err != nil {
-		logrus.Errorf("Failed to convert unstructured to webhook, err: %v", err)
+		log.Log.Error(nil, fmt.Sprintf("Failed to convert unstructured to webhook, err: %v", err))
 		return nil
 	}
 
@@ -42,7 +43,7 @@ func (v *ValidatingWebhookNormalizer) convertValidatingWebhookV1(un *unstructure
 				continue
 			}
 			if err := setValidatingWebhookV1CacertNil(liveWebhook, i); err != nil {
-				logrus.Errorf("Failed to normalize webhook cacert, err: %v", err)
+				log.Log.Error(nil, fmt.Sprintf("Failed to normalize webhook cacert, err: %v", err))
 				return nil
 			}
 		}
@@ -54,7 +55,7 @@ func setValidatingWebhookV1CacertNil(un *unstructured.Unstructured, index int) e
 	var webhook adregv1.ValidatingWebhookConfiguration
 	err := runtime.DefaultUnstructuredConverter.FromUnstructured(un.Object, &webhook)
 	if err != nil {
-		logrus.Errorf("Failed to convert unstructured to webhook, err: %v", err)
+		log.Log.Error(nil, fmt.Sprintf("Failed to convert unstructured to webhook, err: %v", err))
 		return err
 	}
 
@@ -64,12 +65,12 @@ func setValidatingWebhookV1CacertNil(un *unstructured.Unstructured, index int) e
 	webhook.Webhooks[index].ClientConfig.CABundle = nil
 	newObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&webhook)
 	if err != nil {
-		logrus.Errorf("Failed to convert unstructured to webhook, err: %v", err)
+		log.Log.Error(nil, fmt.Sprintf("Failed to convert unstructured to webhook, err: %v", err))
 		return err
 	}
 	if webhook.Webhooks != nil {
 		if err = unstructured.SetNestedField(un.Object, newObj["webhooks"], "webhooks"); err != nil {
-			logrus.Errorf("ValidatingWebhook normalization error: %v", err)
+			log.Log.Error(nil, fmt.Sprintf("ValidatingWebhook normalization error: %v", err))
 			return err
 		}
 	}

--- a/internal/cmd/agent/deployer/summary/summarizers.go
+++ b/internal/cmd/agent/deployer/summary/summarizers.go
@@ -2,7 +2,6 @@ package summary
 
 import (
 	"encoding/json"
-	"fmt"
 	"maps"
 	"os"
 	"strings"
@@ -157,7 +156,7 @@ func initializeCheckErrors() {
 		log.Log.V(1).Info("GVK Error Mapping Provided")
 		gvkErrorMapping := ConditionTypeStatusErrorMapping{}
 		if err := json.Unmarshal([]byte(gvkConfig), &gvkErrorMapping); err != nil {
-			log.Log.Error(nil, fmt.Sprintln("Unable to parse GVK config: ", err.Error()))
+			log.Log.Error(err, "Unable to parse GVK config")
 			return
 		}
 

--- a/internal/cmd/agent/deployer/summary/summarizers.go
+++ b/internal/cmd/agent/deployer/summary/summarizers.go
@@ -2,6 +2,7 @@ package summary
 
 import (
 	"encoding/json"
+	"fmt"
 	"maps"
 	"os"
 	"strings"
@@ -13,13 +14,12 @@ import (
 	"github.com/rancher/fleet/internal/config"
 	fleetv1 "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1/summary"
 
-	"github.com/sirupsen/logrus"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/sets"
 	kstatus "sigs.k8s.io/cli-utils/pkg/kstatus/status"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 const (
@@ -154,10 +154,10 @@ func init() {
 func initializeCheckErrors() {
 	gvkConfig := os.Getenv(config.EnvVarWranglerCheckGVKErrorMapping)
 	if gvkConfig != "" {
-		logrus.Debugf("GVK Error Mapping Provided")
+		log.Log.V(1).Info("GVK Error Mapping Provided")
 		gvkErrorMapping := ConditionTypeStatusErrorMapping{}
 		if err := json.Unmarshal([]byte(gvkConfig), &gvkErrorMapping); err != nil {
-			logrus.Errorln("Unable to parse GVK config: ", err.Error())
+			log.Log.Error(nil, fmt.Sprintln("Unable to parse GVK config: ", err.Error()))
 			return
 		}
 
@@ -192,10 +192,10 @@ func initializeCheckErrors() {
 			maps.Copy(existingConditionsMap, newConditionsMap)
 			GVKConditionErrorMapping[gvk] = existingConditionsMap
 		}
-		logrus.Debugf("GVK Error Mapping Set")
+		log.Log.V(1).Info("GVK Error Mapping Set")
 		return
 	}
-	logrus.Debugf("GVK Error Mapping not provided, using predefined values")
+	log.Log.V(1).Info("GVK Error Mapping not provided, using predefined values")
 }
 
 func checkOwner(obj data.Object, conditions []Condition, summary fleetv1.Summary) fleetv1.Summary {

--- a/internal/cmd/agent/register/register.go
+++ b/internal/cmd/agent/register/register.go
@@ -56,7 +56,7 @@ func Register(ctx context.Context, namespace string, config *rest.Config) (*Agen
 		if err == nil {
 			return cfg, nil
 		}
-		log.Log.Error(nil, fmt.Sprintf("Failed to register agent: %v", err))
+		log.Log.Error(err, "Failed to register agent")
 		select {
 		case <-ctx.Done():
 			return nil, ctx.Err()
@@ -90,7 +90,7 @@ func tryRegister(ctx context.Context, namespace string, cfg *rest.Config) (*Agen
 		return nil, err
 	} else if err := testClientConfig(secret.Data[Kubeconfig]); err != nil {
 		// skip testClientConfig check if previous error, or IsNotFound fallback succeeded
-		log.Log.Error(nil, fmt.Sprintf("Current credential failed, falling back to reregistering: %v", err))
+		log.Log.Error(err, "Current credential failed, falling back to reregistering")
 		secret, err = runRegistration(ctx, k8s.Core().V1(), namespace)
 		if err != nil {
 			return nil, fmt.Errorf("re-registration failed: %w", err)
@@ -222,7 +222,7 @@ func runRegistration(ctx context.Context, k8s coreInterface, namespace string) (
 
 		newSecret, err := fleetK8s.CoreV1().Secrets(secretNamespace).Get(ctx, secretName, metav1.GetOptions{})
 		if err != nil {
-			log.Log.Info(fmt.Sprintf("Waiting for secret '%s/%s' on management cluster for request '%s/%s': %v", secretNamespace, secretName, request.Namespace, request.Name, err))
+			log.Log.Info(fmt.Sprintf("Waiting for secret '%s/%s' on management cluster for request '%s/%s'", secretNamespace, secretName, request.Namespace, request.Name), "error", err)
 			continue
 		}
 

--- a/internal/cmd/agent/register/register.go
+++ b/internal/cmd/agent/register/register.go
@@ -7,8 +7,6 @@ import (
 	"os"
 	"time"
 
-	"github.com/sirupsen/logrus"
-
 	"github.com/rancher/fleet/internal/config"
 	"github.com/rancher/fleet/internal/registration"
 	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
@@ -26,6 +24,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/yaml"
 )
 
@@ -57,7 +56,7 @@ func Register(ctx context.Context, namespace string, config *rest.Config) (*Agen
 		if err == nil {
 			return cfg, nil
 		}
-		logrus.Errorf("Failed to register agent: %v", err)
+		log.Log.Error(nil, fmt.Sprintf("Failed to register agent: %v", err))
 		select {
 		case <-ctx.Done():
 			return nil, ctx.Err()
@@ -81,7 +80,7 @@ func tryRegister(ctx context.Context, namespace string, cfg *rest.Config) (*Agen
 
 	secret, err := k8s.Core().V1().Secret().Get(namespace, CredName, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
-		logrus.Warn("Cannot find fleet-agent secret, running registration")
+		log.Log.Info("Cannot find fleet-agent secret, running registration")
 		// fallback to local cattle-fleet-system/fleet-agent-bootstrap
 		secret, err = runRegistration(ctx, k8s.Core().V1(), namespace)
 		if err != nil {
@@ -91,7 +90,7 @@ func tryRegister(ctx context.Context, namespace string, cfg *rest.Config) (*Agen
 		return nil, err
 	} else if err := testClientConfig(secret.Data[Kubeconfig]); err != nil {
 		// skip testClientConfig check if previous error, or IsNotFound fallback succeeded
-		logrus.Errorf("Current credential failed, falling back to reregistering: %v", err)
+		log.Log.Error(nil, fmt.Sprintf("Current credential failed, falling back to reregistering: %v", err))
 		secret, err = runRegistration(ctx, k8s.Core().V1(), namespace)
 		if err != nil {
 			return nil, fmt.Errorf("re-registration failed: %w", err)
@@ -189,8 +188,7 @@ func runRegistration(ctx context.Context, k8s coreInterface, namespace string) (
 	cfg.Labels["fleet.cattle.io/created-by-agent-pod"] = os.Getenv("HOSTNAME")
 
 	tokenName := string(values(secret.Data)[TokenName])
-
-	logrus.Infof("Creating clusterregistration with id '%s' for new token", clientID)
+	log.Log.Info(fmt.Sprintf("Creating clusterregistration with id '%s' for new token", clientID))
 	request, err := fc.Fleet().V1alpha1().ClusterRegistration().Create(&fleet.ClusterRegistration{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: "request-",
@@ -224,7 +222,7 @@ func runRegistration(ctx context.Context, k8s coreInterface, namespace string) (
 
 		newSecret, err := fleetK8s.CoreV1().Secrets(secretNamespace).Get(ctx, secretName, metav1.GetOptions{})
 		if err != nil {
-			logrus.Infof("Waiting for secret '%s/%s' on management cluster for request '%s/%s': %v", secretNamespace, secretName, request.Namespace, request.Name, err)
+			log.Log.Info(fmt.Sprintf("Waiting for secret '%s/%s' on management cluster for request '%s/%s': %v", secretNamespace, secretName, request.Namespace, request.Name, err))
 			continue
 		}
 

--- a/internal/cmd/cli/apply.go
+++ b/internal/cmd/cli/apply.go
@@ -9,10 +9,10 @@ import (
 
 	gogit "github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/rancher/fleet/internal/bundlereader"
 	command "github.com/rancher/fleet/internal/cmd"
@@ -91,7 +91,7 @@ func (a *Apply) Run(cmd *cobra.Command, args []string) error {
 	var err error
 	retries, err := apply.GetOnConflictRetries()
 	if err != nil {
-		logrus.Errorf("failed parsing env variable %s, using defaults, err: %v", apply.FleetApplyConflictRetriesEnv, err)
+		log.Log.Error(nil, fmt.Sprintf("failed parsing env variable %s, using defaults, err: %v", apply.FleetApplyConflictRetriesEnv, err))
 	}
 	for range retries {
 		err = a.run(cmd, args)

--- a/internal/cmd/cli/apply.go
+++ b/internal/cmd/cli/apply.go
@@ -91,7 +91,7 @@ func (a *Apply) Run(cmd *cobra.Command, args []string) error {
 	var err error
 	retries, err := apply.GetOnConflictRetries()
 	if err != nil {
-		log.Log.Error(nil, fmt.Sprintf("failed parsing env variable %s, using defaults, err: %v", apply.FleetApplyConflictRetriesEnv, err))
+		log.Log.Error(err, "failed parsing env variable, using defaults", "name", apply.FleetApplyConflictRetriesEnv)
 	}
 	for range retries {
 		err = a.run(cmd, args)

--- a/internal/cmd/cli/apply/apply.go
+++ b/internal/cmd/cli/apply/apply.go
@@ -175,7 +175,7 @@ func CreateBundles(pctx context.Context, client client.Client, r record.EventRec
 						bundle, scans, err := bundleFromDir(ctx, repoName, path, opts)
 						if err != nil {
 							if errors.Is(err, ErrNoResources) {
-								log.Log.Info(fmt.Sprintf("%s: %v", path, err))
+								log.Log.Info(path, "error", err)
 								return nil
 							}
 							return err
@@ -274,7 +274,7 @@ func CreateBundlesDriven(pctx context.Context, client client.Client, r record.Ev
 				bundle, scans, err := bundleFromDir(ctx, repoName, baseDir, opts)
 				if err != nil {
 					if errors.Is(err, ErrNoResources) {
-						log.Log.Info(fmt.Sprintf("%s: %v", baseDir, err))
+						log.Log.Info(baseDir, "error", err)
 						return nil
 					}
 					return err
@@ -610,7 +610,7 @@ func save(ctx context.Context, c client.Client, bundle *fleet.Bundle) (*fleet.Bu
 			if err := deleteOCIManifest(ctx, c, bundle, ocistorage.OCIOpts{}); err != nil {
 				// return the error, since the OCI registry is an external entity to the cluster
 				// and we may encounter various types of transient errors (such as connection or access issues).
-				log.Log.Info(fmt.Sprintf("deleting OCI artifact: %v", err))
+				log.Log.Info("deleting OCI artifact", "error", err)
 				return err
 
 			}
@@ -671,7 +671,7 @@ func saveOCIBundle(ctx context.Context, c client.Client, r record.EventRecorder,
 			if err := deleteOCIManifest(ctx, c, bundle, opts); err != nil {
 				// we log the error and continue, since the OCI registry is an external entity to the cluster
 				// we may encounter various types of transient errors (such as connection or access issues).
-				log.Log.Info(fmt.Sprintf("deleting OCI artifact: %v", err))
+				log.Log.Info("deleting OCI artifact", "error", err)
 				sendWarningEvent(r, bundle.Namespace, bundle.Spec.ContentsID, err)
 			}
 		}

--- a/internal/cmd/cli/apply/apply.go
+++ b/internal/cmd/cli/apply/apply.go
@@ -26,7 +26,6 @@ import (
 	"github.com/rancher/fleet/pkg/helmvalues"
 
 	"github.com/rancher/wrangler/v3/pkg/yaml"
-	"github.com/sirupsen/logrus"
 	"golang.org/x/sync/errgroup"
 	k8syaml "sigs.k8s.io/yaml"
 
@@ -39,6 +38,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 var (
@@ -175,7 +175,7 @@ func CreateBundles(pctx context.Context, client client.Client, r record.EventRec
 						bundle, scans, err := bundleFromDir(ctx, repoName, path, opts)
 						if err != nil {
 							if errors.Is(err, ErrNoResources) {
-								logrus.Warnf("%s: %v", path, err)
+								log.Log.Info(fmt.Sprintf("%s: %v", path, err))
 								return nil
 							}
 							return err
@@ -274,7 +274,7 @@ func CreateBundlesDriven(pctx context.Context, client client.Client, r record.Ev
 				bundle, scans, err := bundleFromDir(ctx, repoName, baseDir, opts)
 				if err != nil {
 					if errors.Is(err, ErrNoResources) {
-						logrus.Warnf("%s: %v", baseDir, err)
+						log.Log.Info(fmt.Sprintf("%s: %v", baseDir, err))
 						return nil
 					}
 					return err
@@ -359,7 +359,7 @@ func pruneBundlesNotFoundInRepo(
 
 	for _, bundle := range bundleList.Items {
 		if _, ok := gitRepoBundlesMap[bundle.Name]; !ok {
-			logrus.Debugf("Bundle to be deleted since it is not found in gitrepo %v anymore %v %v", repoName, bundle.Namespace, bundle.Name)
+			log.Log.V(1).Info(fmt.Sprintf("Bundle to be deleted since it is not found in gitrepo %v anymore %v %v", repoName, bundle.Namespace, bundle.Name))
 
 			// Populate new bundles' `Overwrites` field with possible overlaps between the in-cluster bundle, to be deleted,
 			// and bundles which will be created in the cluster.
@@ -370,17 +370,16 @@ func pruneBundlesNotFoundInRepo(
 			// See fleet#3770 for more context.
 			for _, inClusterRsc := range bundle.Spec.Resources {
 				for _, grb := range gitRepoBundlesMap {
-					logrus.Debugf("gitRepo bundle: %v", grb)
+					log.Log.V(1).Info(fmt.Sprintf("gitRepo bundle: %v", grb))
 					for _, grRsc := range grb.Spec.Resources {
 						if inClusterRsc.Name != grRsc.Name {
 							continue
 						}
-
-						logrus.Debugf("resources: [in cluster] %v\n, [in gitrepo] %v", inClusterRsc, grRsc)
+						log.Log.V(1).Info(fmt.Sprintf("resources: [in cluster] %v\n, [in gitrepo] %v", inClusterRsc, grRsc))
 
 						ow1, err := getKindNS(grRsc, grb.Name)
 						if err != nil {
-							logrus.Debugf("for bundle from git repo, failed to get kind and namespace for resource %v", grRsc)
+							log.Log.V(1).Info(fmt.Sprintf("for bundle from git repo, failed to get kind and namespace for resource %v", grRsc))
 							continue
 						}
 						if ow1.Kind == "" {
@@ -391,7 +390,7 @@ func pruneBundlesNotFoundInRepo(
 
 						ow2, err := getKindNS(inClusterRsc, bundle.Name)
 						if err != nil {
-							logrus.Debugf("for in-cluster bundle, failed to get kind and namespace for resource %v", grRsc)
+							log.Log.V(1).Info(fmt.Sprintf("for in-cluster bundle, failed to get kind and namespace for resource %v", grRsc))
 							continue
 						}
 						if ow2.Kind == "" {
@@ -611,7 +610,7 @@ func save(ctx context.Context, c client.Client, bundle *fleet.Bundle) (*fleet.Bu
 			if err := deleteOCIManifest(ctx, c, bundle, ocistorage.OCIOpts{}); err != nil {
 				// return the error, since the OCI registry is an external entity to the cluster
 				// and we may encounter various types of transient errors (such as connection or access issues).
-				logrus.Warnf("deleting OCI artifact: %v", err)
+				log.Log.Info(fmt.Sprintf("deleting OCI artifact: %v", err))
 				return err
 
 			}
@@ -625,7 +624,7 @@ func save(ctx context.Context, c client.Client, bundle *fleet.Bundle) (*fleet.Bu
 	if err != nil {
 		return nil, err
 	}
-	logrus.Infof("%s (bundle): %s/%s", result, bundle.Namespace, bundle.Name)
+	log.Log.Info(fmt.Sprintf("%s (bundle): %s/%s", result, bundle.Namespace, bundle.Name))
 
 	return bundle, nil
 }
@@ -644,7 +643,7 @@ func saveImageScans(ctx context.Context, c client.Client, bundle *fleet.Bundle, 
 		if err != nil {
 			return err
 		}
-		logrus.Infof("%s (scan): %s/%s", result, scan.Namespace, scan.Name)
+		log.Log.Info(fmt.Sprintf("%s (scan): %s/%s", result, scan.Namespace, scan.Name))
 	}
 	return nil
 }
@@ -654,7 +653,7 @@ func saveOCIBundle(ctx context.Context, c client.Client, r record.EventRecorder,
 	if err != nil {
 		return bundle, err
 	}
-	logrus.Infof("OCI artifact stored successfully: %s %s", bundle.Name, manifestID)
+	log.Log.Info(fmt.Sprintf("OCI artifact stored successfully: %s %s", bundle.Name, manifestID))
 
 	updated := bundle.DeepCopy()
 	_, err = controllerutil.CreateOrUpdate(ctx, c, bundle, func() error {
@@ -672,7 +671,7 @@ func saveOCIBundle(ctx context.Context, c client.Client, r record.EventRecorder,
 			if err := deleteOCIManifest(ctx, c, bundle, opts); err != nil {
 				// we log the error and continue, since the OCI registry is an external entity to the cluster
 				// we may encounter various types of transient errors (such as connection or access issues).
-				logrus.Warnf("deleting OCI artifact: %v", err)
+				log.Log.Info(fmt.Sprintf("deleting OCI artifact: %v", err))
 				sendWarningEvent(r, bundle.Namespace, bundle.Spec.ContentsID, err)
 			}
 		}
@@ -700,7 +699,7 @@ func saveOCIBundle(ctx context.Context, c client.Client, r record.EventRecorder,
 	if err != nil {
 		return nil, err
 	}
-	logrus.Infof("%s (oci secret): %s/%s", result, bundle.Namespace, bundle.Name)
+	log.Log.Info(fmt.Sprintf("%s (oci secret): %s/%s", result, bundle.Namespace, bundle.Name))
 
 	return bundle, nil
 }
@@ -877,7 +876,7 @@ func deleteSecretIfExists(ctx context.Context, c client.Client, name, ns string)
 func sendWarningEvent(r record.EventRecorder, namespace, artifactID string, errorToLog error) {
 	jobName := os.Getenv(JobNameEnvVar)
 	if jobName == "" {
-		logrus.Warnf("%q environment variable not set", JobNameEnvVar)
+		log.Log.Info(fmt.Sprintf("%q environment variable not set", JobNameEnvVar))
 		return
 	}
 	job := &batchv1.Job{
@@ -953,8 +952,8 @@ func getKindNS(br fleet.BundleResource, bundleName string) (fleet.OverwrittenRes
 	if br.Encoding == "base64+gz" {
 		contents, err = content.GUnzip([]byte(br.Content))
 		if err != nil {
-			logrus.Debugf("could not uncompress contents of resource %s in bundle %s;"+
-				" skipping overlap detection for this resource", br.Name, bundleName)
+			log.Log.V(1).Info(fmt.Sprintf("could not uncompress contents of resource %s in bundle %s;"+
+				" skipping overlap detection for this resource", br.Name, bundleName))
 			return fleet.OverwrittenResource{}, nil //nolint:nilerr // intentionally skipping this resource
 		}
 	} else {
@@ -973,14 +972,13 @@ func getKindNS(br fleet.BundleResource, bundleName string) (fleet.OverwrittenRes
 	if err != nil {
 		return fleet.OverwrittenResource{}, fmt.Errorf("could not convert resource contents into object: %w", err)
 	}
-
-	logrus.Debugf("contents from bundle resource: %v", string(contents))
+	log.Log.V(1).Info(fmt.Sprintf("contents from bundle resource: %v", string(contents)))
 
 	or := fleet.OverwrittenResource{
 		Kind:      rsc.Kind,
 		Name:      rsc.Name,
 		Namespace: rsc.Namespace,
 	}
-	logrus.Debugf("returning overwritten resource: %v", or)
+	log.Log.V(1).Info(fmt.Sprintf("returning overwritten resource: %v", or))
 	return or, nil
 }

--- a/internal/cmd/cli/gitcloner/cloner.go
+++ b/internal/cmd/cli/gitcloner/cloner.go
@@ -11,7 +11,7 @@ import (
 	"github.com/go-git/go-git/v5/plumbing/protocol/packp/capability"
 	"github.com/go-git/go-git/v5/plumbing/transport"
 	httpgit "github.com/go-git/go-git/v5/plumbing/transport/http"
-	"github.com/sirupsen/logrus"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/rancher/fleet/internal/cmd/cli/gitcloner/submodule"
 	fleetgithub "github.com/rancher/fleet/internal/github"
@@ -73,7 +73,7 @@ func (c *Cloner) CloneRepo(opts *GitCloner) error {
 
 	if opts.Branch != "" {
 		if opts.Revision != "" {
-			logrus.Warn("Using branch for cloning the repo. Revision will be skipped.")
+			log.Log.Info("Using branch for cloning the repo. Revision will be skipped.")
 		}
 		return cloneBranch(opts, auth, caBundle)
 	}

--- a/internal/cmd/controller/agentmanagement/agent/manifest.go
+++ b/internal/cmd/controller/agentmanagement/agent/manifest.go
@@ -1,16 +1,16 @@
 package agent
 
 import (
+	"fmt"
 	"os"
 	"path"
 	"strconv"
 	"strings"
 
-	"github.com/sirupsen/logrus"
-
 	"github.com/rancher/fleet/internal/cmd"
 	"github.com/rancher/fleet/internal/config"
 	"github.com/rancher/fleet/internal/names"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -62,8 +62,7 @@ func Manifest(namespace string, agentScope string, opts ManifestOptions) []runti
 	}
 
 	admin := serviceAccount(namespace, DefaultName)
-
-	logrus.Debugf("Building manifest for fleet-agent in namespace %s (sa: %s)", namespace, admin.Name)
+	log.Log.V(1).Info(fmt.Sprintf("Building manifest for fleet-agent in namespace %s (sa: %s)", namespace, admin.Name))
 
 	defaultSa := serviceAccount(namespace, "default")
 	defaultSa.AutomountServiceAccountToken = new(bool)

--- a/internal/cmd/controller/agentmanagement/controllers/bootstrap/bootstrap.go
+++ b/internal/cmd/controller/agentmanagement/controllers/bootstrap/bootstrap.go
@@ -2,12 +2,13 @@ package bootstrap
 
 import (
 	"context"
+	"fmt"
 	"maps"
 	"os"
 	"regexp"
 
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	secretutil "github.com/rancher/fleet/internal/cmd/controller/agentmanagement/secret"
 	fleetns "github.com/rancher/fleet/internal/cmd/controller/namespace"
@@ -68,7 +69,7 @@ func Register(ctx context.Context,
 }
 
 func (h *handler) OnConfig(config *fleetconfig.Config) error {
-	logrus.Debugf("Bootstrap config set, building namespace '%s', secret, local cluster, cluster group, ...", config.Bootstrap.Namespace)
+	log.Log.V(1).Info(fmt.Sprintf("Bootstrap config set, building namespace '%s', secret, local cluster, cluster group, ...", config.Bootstrap.Namespace))
 
 	var objs []runtime.Object
 	localClusterLabels := map[string]string{"name": fleet.LocalClusterName}
@@ -243,7 +244,7 @@ func (h *handler) getToken() (string, error) {
 
 	// kubernetes 1.24 doesn't populate sa.Secrets
 	if len(sa.Secrets) == 0 {
-		logrus.Infof("waiting on secret for service account %s/%s", h.systemNamespace, FleetBootstrap)
+		log.Log.Info(fmt.Sprintf("waiting on secret for service account %s/%s", h.systemNamespace, FleetBootstrap))
 		secret, err := secretutil.GetServiceAccountTokenSecret(sa, h.secretsController)
 		if err != nil {
 			return "", err

--- a/internal/cmd/controller/agentmanagement/controllers/cluster/controller.go
+++ b/internal/cmd/controller/agentmanagement/controllers/cluster/controller.go
@@ -3,13 +3,13 @@ package cluster
 
 import (
 	"context"
-
-	"github.com/sirupsen/logrus"
+	"fmt"
 
 	"github.com/rancher/fleet/internal/cmd/controller/agentmanagement/controllers/manageagent"
 	"github.com/rancher/fleet/internal/names"
 	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
 	fleetcontrollers "github.com/rancher/fleet/pkg/generated/controllers/fleet.cattle.io/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	corecontrollers "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
 	"github.com/rancher/wrangler/v3/pkg/kv"
@@ -65,7 +65,7 @@ func Register(ctx context.Context,
 // ensureNSDeleted is a handler that enqueues the cluster registration namespace, when a cluster is deleted.
 func (h *handler) ensureNSDeleted(key string, obj *fleet.Cluster) (*fleet.Cluster, error) {
 	if obj == nil {
-		logrus.Debugf("Cluster %s deleted, enqueue cluster namespace deletion", key)
+		log.Log.V(1).Info(fmt.Sprintf("Cluster %s deleted, enqueue cluster namespace deletion", key))
 		h.namespaces.Enqueue(clusterNamespace(kv.Split(key, "/")))
 	}
 	return obj, nil
@@ -90,7 +90,7 @@ func (h *handler) findClusters(namespaces corecontrollers.NamespaceCache) relate
 		if clusterNS == "" || clusterName == "" {
 			return nil, nil
 		}
-		logrus.Debugf("Enqueueing cluster %s/%s for bundledeployment %s/%s", clusterNS, clusterName, namespace, obj.(*fleet.BundleDeployment).Name)
+		log.Log.V(1).Info(fmt.Sprintf("Enqueueing cluster %s/%s for bundledeployment %s/%s", clusterNS, clusterName, namespace, obj.(*fleet.BundleDeployment).Name))
 		return []relatedresource.Key{
 			{
 				Namespace: clusterNS,
@@ -115,8 +115,7 @@ func (h *handler) OnClusterChanged(cluster *fleet.Cluster, status fleet.ClusterS
 	if manageagent.SkipCluster(cluster) {
 		return status, nil
 	}
-
-	logrus.Debugf("OnClusterChanged for cluster status %s, updating namespace in status", cluster.Name)
+	log.Log.V(1).Info(fmt.Sprintf("OnClusterChanged for cluster status %s, updating namespace in status", cluster.Name))
 	if status.Namespace == "" {
 		status.Namespace = clusterNamespace(cluster.Namespace, cluster.Name)
 	}

--- a/internal/cmd/controller/agentmanagement/controllers/cluster/import.go
+++ b/internal/cmd/controller/agentmanagement/controllers/cluster/import.go
@@ -386,7 +386,7 @@ func (i *importHandler) importCluster(cluster *fleet.Cluster, status fleet.Clust
 	}
 
 	if err := connection.SmokeTestKubeClientConnection(kc); err != nil {
-		log.Log.Error(nil, fmt.Sprintf("Cluster import for '%s/%s'. Smoke test failed: %v", cluster.Namespace, cluster.Name, err))
+		log.Log.Error(err, fmt.Sprintf("Cluster import for '%s/%s'. Smoke test failed", cluster.Namespace, cluster.Name))
 		return status, err
 	}
 
@@ -516,7 +516,7 @@ func (i *importHandler) importCluster(cluster *fleet.Cluster, status fleet.Clust
 	}
 
 	if err := apply.ApplyObjects(objs...); err != nil {
-		log.Log.Error(nil, fmt.Sprintf("Failed cluster import for '%s/%s'. Cannot create agent deployment", cluster.Namespace, cluster.Name))
+		log.Log.Error(err, "Failed cluster import. Cannot create agent deployment", "cluster", cluster.Namespace+"/"+cluster.Name)
 		return status, err
 	}
 	log.Log.Info(fmt.Sprintf("Cluster import for '%s/%s'. Deployed new agent", cluster.Namespace, cluster.Name))

--- a/internal/cmd/controller/agentmanagement/controllers/cluster/import.go
+++ b/internal/cmd/controller/agentmanagement/controllers/cluster/import.go
@@ -12,8 +12,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/labels"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/rancher/fleet/internal/client"
 	"github.com/rancher/fleet/internal/cmd"
@@ -98,7 +98,7 @@ func RegisterImport(
 		}
 		ns, err := allowedKubeConfigSecretNamespace(cluster)
 		if err != nil {
-			logrus.Debugf("Cluster %s/%s: skipping kubeconfig secret index: %v", cluster.Namespace, cluster.Name, err)
+			log.Log.V(1).Info(fmt.Sprintf("Cluster %s/%s: skipping kubeconfig secret index: %v", cluster.Namespace, cluster.Name, err))
 			return []string{}, nil
 		}
 		secretKey := ns + "/" + cluster.Spec.KubeConfigSecret
@@ -112,7 +112,7 @@ func RegisterImport(
 		cfg := config.Get()
 		for _, cluster := range clusters {
 			if err := h.checkForConfigChange(cfg, cluster, secret); err != nil {
-				logrus.WithError(err).Errorf("cluster %s/%s: could not check for config changes", cluster.Namespace, cluster.Name)
+				log.Log.Error(err, fmt.Sprintf("cluster %s/%s: could not check for config changes", cluster.Namespace, cluster.Name))
 			}
 		}
 		// Successfully checked all clusters for config changes. No secret modification needed,
@@ -146,7 +146,7 @@ func (i *importHandler) onConfig(cfg *config.Config) error {
 
 		kubeConfigNS, err := allowedKubeConfigSecretNamespace(cluster)
 		if err != nil {
-			logrus.WithError(err).Warnf("cluster %s/%s: skipping config change check", cluster.Namespace, cluster.Name)
+			log.Log.Info(fmt.Sprintf("cluster %s/%s: skipping config change check", cluster.Namespace, cluster.Name), "error", err)
 			continue
 		}
 		secret, err := i.secretsCache.Get(kubeConfigNS, cluster.Spec.KubeConfigSecret)
@@ -154,7 +154,7 @@ func (i *importHandler) onConfig(cfg *config.Config) error {
 			return fmt.Errorf("cluster %s/%s: could not check for config changes: %w", cluster.Namespace, cluster.Name, err)
 		}
 		if err := i.checkForConfigChange(cfg, cluster, secret); err != nil {
-			logrus.WithError(err).Warnf("cluster %s/%s: could not check for config changes", cluster.Namespace, cluster.Name)
+			log.Log.Info(fmt.Sprintf("cluster %s/%s: could not check for config changes", cluster.Namespace, cluster.Name), "error", err)
 			continue
 		}
 	}
@@ -284,7 +284,7 @@ func (i *importHandler) OnChange(key string, cluster *fleet.Cluster) (_ *fleet.C
 
 	// NOTE(mm): why is this not done in importCluster?
 	if cluster.Spec.ClientID == "" {
-		logrus.Debugf("Cluster import for '%s/%s'. Agent found, updating ClientID", cluster.Namespace, cluster.Name)
+		log.Log.V(1).Info(fmt.Sprintf("Cluster import for '%s/%s'. Agent found, updating ClientID", cluster.Namespace, cluster.Name))
 
 		cluster = cluster.DeepCopy()
 		cluster.Spec.ClientID, err = randomtoken.Generate()
@@ -346,15 +346,13 @@ func (i *importHandler) importCluster(cluster *fleet.Cluster, status fleet.Clust
 	if err != nil {
 		return status, err
 	}
-
-	logrus.Debugf("Cluster import for '%s/%s'. Getting kubeconfig from secret in namespace %s", cluster.Namespace, cluster.Name, kubeConfigSecretNamespace)
+	log.Log.V(1).Info(fmt.Sprintf("Cluster import for '%s/%s'. Getting kubeconfig from secret in namespace %s", cluster.Namespace, cluster.Name, kubeConfigSecretNamespace))
 
 	secret, err := i.secretsCache.Get(kubeConfigSecretNamespace, cluster.Spec.KubeConfigSecret)
 	if err != nil {
 		return status, err
 	}
-
-	logrus.Debugf("Cluster import for '%s/%s'. Setting up agent with kubeconfig from secret '%s/%s'", cluster.Namespace, cluster.Name, kubeConfigSecretNamespace, cluster.Spec.KubeConfigSecret)
+	log.Log.V(1).Info(fmt.Sprintf("Cluster import for '%s/%s'. Setting up agent with kubeconfig from secret '%s/%s'", cluster.Namespace, cluster.Name, kubeConfigSecretNamespace, cluster.Spec.KubeConfigSecret))
 	var (
 		cfg          = config.Get()
 		apiServerURL = string(secret.Data[config.APIServerURLKey])
@@ -364,11 +362,11 @@ func (i *importHandler) importCluster(cluster *fleet.Cluster, status fleet.Clust
 	if apiServerURL == "" {
 		if len(cfg.APIServerURL) == 0 {
 			// Current config cannot be deployed, so remove the "config changed" mark
-			logrus.Warnf("cannot import cluster '%s/%s', missing apiServerURL in fleet config for cluster auto registration", cluster.Namespace, cluster.Name)
+			log.Log.Info(fmt.Sprintf("cannot import cluster '%s/%s', missing apiServerURL in fleet config for cluster auto registration", cluster.Namespace, cluster.Name))
 			status.AgentConfigChanged = false
 			return status, nil
 		}
-		logrus.Debugf("Cluster import for '%s/%s'. Using apiServerURL from fleet-controller config", cluster.Namespace, cluster.Name)
+		log.Log.V(1).Info(fmt.Sprintf("Cluster import for '%s/%s'. Using apiServerURL from fleet-controller config", cluster.Namespace, cluster.Name))
 		apiServerURL = cfg.APIServerURL
 	}
 
@@ -388,7 +386,7 @@ func (i *importHandler) importCluster(cluster *fleet.Cluster, status fleet.Clust
 	}
 
 	if err := connection.SmokeTestKubeClientConnection(kc); err != nil {
-		logrus.Errorf("Cluster import for '%s/%s'. Smoke test failed: %v", cluster.Namespace, cluster.Name, err)
+		log.Log.Error(nil, fmt.Sprintf("Cluster import for '%s/%s'. Smoke test failed: %v", cluster.Namespace, cluster.Name, err))
 		return status, err
 	}
 
@@ -425,12 +423,12 @@ func (i *importHandler) importCluster(cluster *fleet.Cluster, status fleet.Clust
 			if apierrors.IsAlreadyExists(err) {
 				token, err = i.tokens.Get(cluster.Namespace, tokenName)
 				if err != nil {
-					logrus.Debugf("Failed to get existing ClusterRegistrationToken for cluster %s/%s: %v (requeuing)", cluster.Namespace, cluster.Name, err)
+					log.Log.V(1).Info(fmt.Sprintf("Failed to get existing ClusterRegistrationToken for cluster %s/%s: %v (requeuing)", cluster.Namespace, cluster.Name, err))
 					i.clusters.EnqueueAfter(cluster.Namespace, cluster.Name, durations.TokenClusterEnqueueDelay)
 					return status, err
 				}
 			} else {
-				logrus.Debugf("Failed to create ClusterRegistrationToken for cluster %s/%s: %v (requeuing)", cluster.Namespace, cluster.Name, err)
+				log.Log.V(1).Info(fmt.Sprintf("Failed to create ClusterRegistrationToken for cluster %s/%s: %v (requeuing)", cluster.Namespace, cluster.Name, err))
 				i.clusters.EnqueueAfter(cluster.Namespace, cluster.Name, durations.TokenClusterEnqueueDelay)
 				return status, err
 			}
@@ -518,10 +516,10 @@ func (i *importHandler) importCluster(cluster *fleet.Cluster, status fleet.Clust
 	}
 
 	if err := apply.ApplyObjects(objs...); err != nil {
-		logrus.Errorf("Failed cluster import for '%s/%s'. Cannot create agent deployment", cluster.Namespace, cluster.Name)
+		log.Log.Error(nil, fmt.Sprintf("Failed cluster import for '%s/%s'. Cannot create agent deployment", cluster.Namespace, cluster.Name))
 		return status, err
 	}
-	logrus.Infof("Cluster import for '%s/%s'. Deployed new agent", cluster.Namespace, cluster.Name)
+	log.Log.Info(fmt.Sprintf("Cluster import for '%s/%s'. Deployed new agent", cluster.Namespace, cluster.Name))
 
 	if err := i.cleanupLeftoverDefaultNamespace(kc); err != nil {
 		return status, err
@@ -580,10 +578,9 @@ func (i *importHandler) teardownLocalAgent(cluster *fleet.Cluster) error {
 		return err
 	}
 	if !isLocal {
-		logrus.Warnf(
-			"Cluster import for '%s/%s'. Refusing to remove agent: localAgentDisabled is set but the cluster reached through its kubeconfig is not the management cluster",
-			cluster.Namespace, cluster.Name,
-		)
+		log.Log.Info(fmt.Sprintf("Cluster import for '%s/%s'. Refusing to remove agent: localAgentDisabled is set but the cluster reached through its kubeconfig is not the management cluster",
+			cluster.Namespace, cluster.Name))
+
 		return nil
 	}
 
@@ -609,8 +606,7 @@ func (i *importHandler) teardownLocalAgent(cluster *fleet.Cluster) error {
 	if err := i.cleanupLeftoverDefaultNamespace(kc); err != nil {
 		return err
 	}
-
-	logrus.Infof("Cluster import for '%s/%s'. Removed local agent (localAgentDisabled=true)", cluster.Namespace, cluster.Name)
+	log.Log.Info(fmt.Sprintf("Cluster import for '%s/%s'. Removed local agent (localAgentDisabled=true)", cluster.Namespace, cluster.Name))
 	return nil
 }
 
@@ -682,7 +678,7 @@ func (i *importHandler) cleanupLeftoverDefaultNamespace(kc kubernetes.Interface)
 	// Clean up the leftover agent if the default namespace still exists.
 	_, err := kc.CoreV1().Namespaces().Get(i.ctx, config.DefaultNamespace, metav1.GetOptions{})
 	if err == nil {
-		logrus.Infof("System namespace (%s) does not equal default namespace (%s), checking for leftover objects...", i.systemNamespace, config.DefaultNamespace)
+		log.Log.Info(fmt.Sprintf("System namespace (%s) does not equal default namespace (%s), checking for leftover objects...", i.systemNamespace, config.DefaultNamespace))
 		if err := i.deleteAgentResources(kc, config.DefaultNamespace); err != nil {
 			return err
 		}
@@ -756,7 +752,7 @@ func (i *importHandler) checkForConfigChange(cfg *config.Config, cluster *fleet.
 	if err != nil {
 		if errors.Is(err, errUnavailableAPIServerURL) {
 			// skip the rest of checks
-			logrus.WithError(err).Warnf("cluster %s/%s: could not check for config changes", cluster.Namespace, cluster.Name)
+			log.Log.Info(fmt.Sprintf("cluster %s/%s: could not check for config changes", cluster.Namespace, cluster.Name), "error", err)
 			return nil
 		}
 		return err
@@ -768,8 +764,7 @@ func (i *importHandler) checkForConfigChange(cfg *config.Config, cluster *fleet.
 	if !hasConfigChanged {
 		return nil
 	}
-
-	logrus.Infof("API server config changed, trigger cluster import for cluster %s/%s", cluster.Namespace, cluster.Name)
+	log.Log.Info(fmt.Sprintf("API server config changed, trigger cluster import for cluster %s/%s", cluster.Namespace, cluster.Name))
 	c := cluster.DeepCopy()
 	c.Status.AgentConfigChanged = true
 	_, err = i.clusters.UpdateStatus(c)

--- a/internal/cmd/controller/agentmanagement/controllers/clusterregistration/controller.go
+++ b/internal/cmd/controller/agentmanagement/controllers/clusterregistration/controller.go
@@ -10,8 +10,6 @@ import (
 	"maps"
 	"time"
 
-	"github.com/sirupsen/logrus"
-
 	"github.com/rancher/fleet/internal/cmd/controller/agentmanagement/controllers/resources"
 	secretutil "github.com/rancher/fleet/internal/cmd/controller/agentmanagement/secret"
 	"github.com/rancher/fleet/internal/config"
@@ -20,6 +18,7 @@ import (
 	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
 	"github.com/rancher/fleet/pkg/durations"
 	fleetcontrollers "github.com/rancher/fleet/pkg/generated/controllers/fleet.cattle.io/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/rancher/wrangler/v3/pkg/apply"
 	corecontrollers "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
@@ -131,8 +130,8 @@ func (h *handler) OnCluster(key string, cluster *fleet.Cluster) (*fleet.Cluster,
 	}
 	for _, cr := range crs {
 		if !cr.Status.Granted {
-			logrus.Infof("Namespace assigned to cluster '%s/%s' enqueues cluster registration '%s/%s'", cluster.Namespace, cluster.Name,
-				cr.Namespace, cr.Name)
+			log.Log.Info(fmt.Sprintf("Namespace assigned to cluster '%s/%s' enqueues cluster registration '%s/%s'", cluster.Namespace, cluster.Name,
+				cr.Namespace, cr.Name))
 			h.clusterRegistration.Enqueue(cr.Namespace, cr.Name)
 		}
 	}
@@ -147,7 +146,7 @@ func (h *handler) OnSecretChange(key string, secret *v1.Secret) (*v1.Secret, err
 	}
 
 	if time.Since(secret.CreationTimestamp.Time) > deleteSecretAfter {
-		logrus.Infof("Deleting expired registration secret %s/%s", secret.Namespace, secret.Name)
+		log.Log.Info(fmt.Sprintf("Deleting expired registration secret %s/%s", secret.Namespace, secret.Name))
 		return secret, h.secrets.Delete(secret.Namespace, secret.Name, nil)
 	}
 
@@ -233,8 +232,8 @@ func (h *handler) OnChange(request *fleet.ClusterRegistration, status fleet.Clus
 		return nil, status, fmt.Errorf("failed to authorize cluster, cannot get service account token: %w", err)
 	} else if secret == nil {
 		status.ClusterName = cluster.Name
-		logrus.Infof("Cluster registration request '%s/%s', cluster '%s/%s' not granted, waiting for service account token",
-			request.Namespace, request.Name, cluster.Namespace, cluster.Name)
+		log.Log.Info(fmt.Sprintf("Cluster registration request '%s/%s', cluster '%s/%s' not granted, waiting for service account token",
+			request.Namespace, request.Name, cluster.Namespace, cluster.Name))
 		return nil, status, nil
 	}
 
@@ -242,7 +241,7 @@ func (h *handler) OnChange(request *fleet.ClusterRegistration, status fleet.Clus
 	crlist, _ := h.clusterRegistration.List(request.Namespace, metav1.ListOptions{})
 	for _, creg := range crlist.Items {
 		if shouldDelete(creg, *request) {
-			logrus.Debugf("Deleting old clusterregistration '%s/%s', now at '%s'", creg.Namespace, creg.Name, request.Name)
+			log.Log.V(1).Info(fmt.Sprintf("Deleting old clusterregistration '%s/%s', now at '%s'", creg.Namespace, creg.Name, request.Name))
 			if err := h.clusterRegistration.Delete(creg.Namespace, creg.Name, nil); err != nil && !apierrors.IsNotFound(err) {
 				return nil, status, err
 			}
@@ -252,8 +251,7 @@ func (h *handler) OnChange(request *fleet.ClusterRegistration, status fleet.Clus
 	// request is granted, create the registration secret and roles
 	status.ClusterName = cluster.Name
 	status.Granted = true
-
-	logrus.Infof("Cluster registration request '%s/%s' granted, creating cluster, request service account, registration secret", request.Namespace, request.Name)
+	log.Log.Info(fmt.Sprintf("Cluster registration request '%s/%s' granted, creating cluster, request service account, registration secret", request.Namespace, request.Name))
 
 	objs := []runtime.Object{
 		// the registration secret c-clientID-clientRandom
@@ -409,16 +407,16 @@ func (h *handler) OnChange(request *fleet.ClusterRegistration, status fleet.Clus
 		// that token's SA scoped read access to the credential secret.
 		tokenName := request.Labels[fleet.RegistrationTokenLabel]
 		if tokenName == "" {
-			logrus.Warnf("ClusterRegistration '%s/%s' has no %s label; cannot grant credential secret access for agent-initiated registration",
-				request.Namespace, request.Name, fleet.RegistrationTokenLabel)
+			log.Log.Info(fmt.Sprintf("ClusterRegistration '%s/%s' has no %s label; cannot grant credential secret access for agent-initiated registration",
+				request.Namespace, request.Name, fleet.RegistrationTokenLabel))
 		} else {
 			agentToken, tokenErr := h.tokenCache.Get(request.Namespace, tokenName)
 			if tokenErr != nil && !apierrors.IsNotFound(tokenErr) {
 				return nil, status, fmt.Errorf("looking up registration token %s/%s: %w", request.Namespace, tokenName, tokenErr)
 			}
 			if apierrors.IsNotFound(tokenErr) {
-				logrus.Warnf("ClusterRegistration '%s/%s': registration token %s/%s not found (may have expired), skipping credential secret access grant",
-					request.Namespace, request.Name, request.Namespace, tokenName)
+				log.Log.Info(fmt.Sprintf("ClusterRegistration '%s/%s': registration token %s/%s not found (may have expired), skipping credential secret access grant",
+					request.Namespace, request.Name, request.Namespace, tokenName))
 				return objs, status, nil
 			}
 			agentSAName := names.SafeConcatName(tokenName, string(agentToken.UID))
@@ -517,7 +515,7 @@ func (h *handler) createOrGetCluster(request *fleet.ClusterRegistration) (*fleet
 		return h.clusters.Get(request.Namespace, clusterName, metav1.GetOptions{})
 	}
 	if err == nil {
-		logrus.Infof("Created cluster %s/%s", request.Namespace, clusterName)
+		log.Log.Info(fmt.Sprintf("Created cluster %s/%s", request.Namespace, clusterName))
 	}
 	return cluster, err
 }

--- a/internal/cmd/controller/agentmanagement/controllers/clusterregistrationtoken/handler.go
+++ b/internal/cmd/controller/agentmanagement/controllers/clusterregistrationtoken/handler.go
@@ -8,8 +8,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/sirupsen/logrus"
-
 	secretutil "github.com/rancher/fleet/internal/cmd/controller/agentmanagement/secret"
 	"github.com/rancher/fleet/internal/config"
 	"github.com/rancher/fleet/internal/names"
@@ -25,6 +23,7 @@ import (
 	apierror "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	yaml "sigs.k8s.io/yaml"
 )
 
@@ -73,11 +72,11 @@ func Register(ctx context.Context,
 
 func (h *handler) OnChange(token *fleet.ClusterRegistrationToken, status fleet.ClusterRegistrationTokenStatus) ([]runtime.Object, fleet.ClusterRegistrationTokenStatus, error) {
 	if h.enforceTTL && (token.Spec.TTL == nil || token.Spec.TTL.Duration <= 0) {
-		logrus.Warnf("ClusterRegistrationToken '%s/%s' has no TTL, deleting", token.Namespace, token.Name)
+		log.Log.Info(fmt.Sprintf("ClusterRegistrationToken '%s/%s' has no TTL, deleting", token.Namespace, token.Name))
 		if err := h.clusterRegistrationTokens.Delete(token.Namespace, token.Name, nil); err != nil && !apierror.IsNotFound(err) {
 			return nil, status, fmt.Errorf("deleting ClusterRegistrationToken %s/%s with no TTL: %w", token.Namespace, token.Name, err)
 		}
-		logrus.Warnf("ClusterRegistrationToken %s/%s rejected: TTL is required", token.Namespace, token.Name)
+		log.Log.Info(fmt.Sprintf("ClusterRegistrationToken %s/%s rejected: TTL is required", token.Namespace, token.Name))
 
 		return nil, status, nil
 	}
@@ -87,8 +86,7 @@ func (h *handler) OnChange(token *fleet.ClusterRegistrationToken, status fleet.C
 			return nil, status, nil //nolint:nilerr // intentionally ignoring error to avoid retry loops on deletion failures
 		}
 	}
-
-	logrus.Debugf("Cluster registration token '%s/%s', creating import service account, roles and secret", token.Namespace, token.Name)
+	log.Log.V(1).Info(fmt.Sprintf("Cluster registration token '%s/%s', creating import service account, roles and secret", token.Namespace, token.Name))
 
 	var (
 		saName  = names.SafeConcatName(token.Name, string(token.UID))
@@ -98,7 +96,7 @@ func (h *handler) OnChange(token *fleet.ClusterRegistrationToken, status fleet.C
 	sa, err := h.serviceAccountCache.Get(token.Namespace, saName)
 	switch {
 	case apierror.IsNotFound(err):
-		logrus.Infof("ClusterRegistrationToken SA does not exist %v", saName)
+		log.Log.Info(fmt.Sprintf("ClusterRegistrationToken SA does not exist %v", saName))
 		// secret doesn't exist
 	case err != nil:
 		return nil, status, err
@@ -118,7 +116,7 @@ func (h *handler) OnChange(token *fleet.ClusterRegistrationToken, status fleet.C
 		}
 
 		if string(secretCreated.Data["token"]) == "" {
-			logrus.Debugf("ClusterRegistrationToken SA does not have a secret %s/%s", token.Namespace, saName)
+			log.Log.V(1).Info(fmt.Sprintf("ClusterRegistrationToken SA does not have a secret %s/%s", token.Namespace, saName))
 
 			secretReloaded, err := h.secretsCache.Get(token.Namespace, secretCreated.Name)
 			if err != nil {

--- a/internal/cmd/controller/agentmanagement/controllers/controllers.go
+++ b/internal/cmd/controller/agentmanagement/controllers/controllers.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"context"
+	"log"
 
 	"github.com/rancher/fleet/internal/cmd/controller/agentmanagement/controllers/bootstrap"
 	"github.com/rancher/fleet/internal/cmd/controller/agentmanagement/controllers/cluster"
@@ -27,8 +28,6 @@ import (
 	"github.com/rancher/wrangler/v3/pkg/generated/controllers/rbac"
 	rbaccontrollers "github.com/rancher/wrangler/v3/pkg/generated/controllers/rbac/v1"
 	"github.com/rancher/wrangler/v3/pkg/start"
-
-	"github.com/sirupsen/logrus"
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -146,7 +145,7 @@ func Register(ctx context.Context, appCtx *AppContext, systemNamespace string, d
 		appCtx.Bundle())
 
 	if err := appCtx.Start(ctx); err != nil {
-		logrus.Fatal(err)
+		log.Fatal(err)
 	}
 
 	return nil

--- a/internal/cmd/controller/agentmanagement/controllers/manageagent/manageagent.go
+++ b/internal/cmd/controller/agentmanagement/controllers/manageagent/manageagent.go
@@ -302,7 +302,7 @@ func (h *handler) OnNamespace(key string, namespace *corev1.Namespace) (*corev1.
 		log.Log.Info(fmt.Sprintf("Update agent bundle for cluster %s/%s", cluster.Namespace, cluster.Name))
 		bundleObjs, err := h.newAgentBundle(namespace.Name, cluster)
 		if err != nil {
-			log.Log.Error(nil, fmt.Sprintf("Failed to update agent bundle for cluster %s/%s", cluster.Namespace, cluster.Name))
+			log.Log.Error(err, fmt.Sprintf("Failed to update agent bundle for cluster %s/%s", cluster.Namespace, cluster.Name))
 			return nil, err
 		}
 		objs = append(objs, bundleObjs...)

--- a/internal/cmd/controller/agentmanagement/controllers/manageagent/manageagent.go
+++ b/internal/cmd/controller/agentmanagement/controllers/manageagent/manageagent.go
@@ -14,8 +14,6 @@ import (
 	"fmt"
 	"sort"
 
-	"github.com/sirupsen/logrus"
-
 	"github.com/rancher/fleet/internal/cmd"
 	"github.com/rancher/fleet/internal/cmd/controller/agentmanagement/agent"
 	"github.com/rancher/fleet/internal/cmd/controller/agentmanagement/scheduling"
@@ -24,6 +22,7 @@ import (
 	"github.com/rancher/fleet/internal/names"
 	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
 	fleetcontrollers "github.com/rancher/fleet/pkg/generated/controllers/fleet.cattle.io/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/rancher/wrangler/v3/pkg/apply"
 	corecontrollers "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
@@ -123,8 +122,7 @@ func (h *handler) onClusterStatusChange(cluster *fleet.Cluster, status fleet.Clu
 	if SkipCluster(cluster) || LocalAgentDisabled(cluster) {
 		return status, nil
 	}
-
-	logrus.Debugf("Reconciling agent settings for cluster %s/%s", cluster.Namespace, cluster.Name)
+	log.Log.V(1).Info(fmt.Sprintf("Reconciling agent settings for cluster %s/%s", cluster.Namespace, cluster.Name))
 
 	status, vars, err := h.reconcileAgentEnvVars(cluster, status)
 	if err != nil {
@@ -301,10 +299,10 @@ func (h *handler) OnNamespace(key string, namespace *corev1.Namespace) (*corev1.
 		if SkipCluster(cluster) || LocalAgentDisabled(cluster) {
 			continue
 		}
-		logrus.Infof("Update agent bundle for cluster %s/%s", cluster.Namespace, cluster.Name)
+		log.Log.Info(fmt.Sprintf("Update agent bundle for cluster %s/%s", cluster.Namespace, cluster.Name))
 		bundleObjs, err := h.newAgentBundle(namespace.Name, cluster)
 		if err != nil {
-			logrus.Errorf("Failed to update agent bundle for cluster %s/%s", cluster.Namespace, cluster.Name)
+			log.Log.Error(nil, fmt.Sprintf("Failed to update agent bundle for cluster %s/%s", cluster.Namespace, cluster.Name))
 			return nil, err
 		}
 		objs = append(objs, bundleObjs...)

--- a/internal/cmd/controller/agentmanagement/scheduling/scheduling.go
+++ b/internal/cmd/controller/agentmanagement/scheduling/scheduling.go
@@ -3,9 +3,8 @@ package scheduling
 import (
 	"fmt"
 
-	"github.com/sirupsen/logrus"
-
 	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	policyv1 "k8s.io/api/policy/v1"
 	schedulingv1 "k8s.io/api/scheduling/v1"
@@ -39,7 +38,7 @@ func PodDisruptionBudget(agentNamespace string, pdbs *fleet.PodDisruptionBudgetS
 
 	switch {
 	case pdbs.MaxUnavailable == "" && pdbs.MinAvailable == "":
-		logrus.Warnf("Neither MaxUnavailable nor MinAvailable is set, defaulting to 0 for MaxUnavailable")
+		log.Log.Info("Neither MaxUnavailable nor MinAvailable is set, defaulting to 0 for MaxUnavailable")
 		pdbSpec.MaxUnavailable = &intstr.IntOrString{IntVal: 0}
 	case pdbs.MaxUnavailable != "" && (pdbs.MinAvailable == "" || pdbs.MinAvailable == "0"):
 		mu := intstr.Parse(pdbs.MaxUnavailable)

--- a/internal/cmd/controller/agentmanagement/secret/util.go
+++ b/internal/cmd/controller/agentmanagement/secret/util.go
@@ -6,12 +6,11 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/sirupsen/logrus"
-
 	"github.com/rancher/fleet/internal/config"
 	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
 	"github.com/rancher/fleet/pkg/durations"
 	corecontrollers "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -55,7 +54,7 @@ func GetServiceAccountTokenSecret(sa *corev1.ServiceAccount, secretsController c
 
 func createServiceAccountTokenSecret(sa *corev1.ServiceAccount, secretsController corecontrollers.SecretController) (*corev1.Secret, error) {
 	// create the secret for the serviceAccount
-	logrus.Debugf("creating ServiceAccountTokenSecret for sa %v", sa.Name)
+	log.Log.V(1).Info(fmt.Sprintf("creating ServiceAccountTokenSecret for sa %v", sa.Name))
 	name := sa.Name + "-token"
 	sc := corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -82,15 +81,15 @@ func createServiceAccountTokenSecret(sa *corev1.ServiceAccount, secretsControlle
 		}
 		secret, err = secretsController.Get(sa.Namespace, name, metav1.GetOptions{})
 		if err != nil {
-			logrus.Debugf("secret %v already exists, error getting it", name)
+			log.Log.V(1).Info(fmt.Sprintf("secret %v already exists, error getting it", name))
 			return nil, fmt.Errorf("error getting secret: %w", err)
 		}
 	}
 	// Kubernetes auto populates the secret token after it is created, for which we should wait
-	logrus.Infof("Waiting for service account token key to be populated for secret %s/%s", secret.Namespace, secret.Name)
+	log.Log.Info(fmt.Sprintf("Waiting for service account token key to be populated for secret %s/%s", secret.Namespace, secret.Name))
 	if _, ok := secret.Data[corev1.ServiceAccountTokenKey]; !ok {
 		for {
-			logrus.Debugf("wait for svc account secret to be populated with token %s", secret.Name)
+			log.Log.V(1).Info("wait for svc account secret to be populated with token " + secret.Name)
 			time.Sleep(durations.ServiceTokenSleep)
 			secret, err = secretsController.Get(sa.Namespace, name, metav1.GetOptions{})
 			if err != nil {

--- a/internal/cmd/controller/agentmanagement/start.go
+++ b/internal/cmd/controller/agentmanagement/start.go
@@ -2,14 +2,13 @@ package agentmanagement
 
 import (
 	"context"
+	"log"
 
 	"github.com/rancher/fleet/internal/cmd/controller/agentmanagement/controllers"
 
 	"github.com/rancher/wrangler/v3/pkg/kubeconfig"
 	"github.com/rancher/wrangler/v3/pkg/leader"
 	"github.com/rancher/wrangler/v3/pkg/schemes"
-
-	"github.com/sirupsen/logrus"
 
 	v1 "k8s.io/api/apps/v1"
 	policyv1 "k8s.io/api/policy/v1"
@@ -49,13 +48,13 @@ func start(ctx context.Context, kubeConfig, namespace string, disableBootstrap b
 	leader.RunOrDie(ctx, namespace, "fleet-agentmanagement-lock", k8s, func(ctx context.Context) {
 		appCtx, err := controllers.NewAppContext(clientConfig)
 		if err != nil {
-			logrus.Fatal(err)
+			log.Fatal(err)
 		}
 		if err := controllers.Register(ctx, appCtx, namespace, disableBootstrap, enforceTTL); err != nil {
-			logrus.Fatal(err)
+			log.Fatal(err)
 		}
 		if err := appCtx.Start(ctx); err != nil {
-			logrus.Fatal(err)
+			log.Fatal(err)
 		}
 	})
 

--- a/internal/cmd/controller/cleanup/controllers/cleanup/controller.go
+++ b/internal/cmd/controller/cleanup/controllers/cleanup/controller.go
@@ -3,10 +3,11 @@ package cleanup
 
 import (
 	"context"
+	"fmt"
 
 	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
 	fleetcontrollers "github.com/rancher/fleet/pkg/generated/controllers/fleet.cattle.io/v1alpha1"
-	"github.com/sirupsen/logrus"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/rancher/wrangler/v3/pkg/apply"
 	corecontrollers "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
@@ -114,8 +115,7 @@ func (h *handler) cleanupNamespace(key string, obj *corev1.Namespace) (*corev1.N
 	if !apierrors.IsNotFound(err) {
 		return obj, err
 	}
-
-	logrus.Infof("Cleaning up fleet-managed namespace %q, cluster not found", obj.Name)
+	log.Log.Info(fmt.Sprintf("Cleaning up fleet-managed namespace %q, cluster not found", obj.Name))
 	return obj, h.namespaces.Delete(key, nil)
 }
 

--- a/internal/cmd/controller/cleanup/controllers/controllers.go
+++ b/internal/cmd/controller/cleanup/controllers/controllers.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"context"
+	"log"
 
 	"github.com/rancher/fleet/internal/cmd/controller/cleanup/controllers/cleanup"
 	"github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
@@ -18,8 +19,6 @@ import (
 	"github.com/rancher/wrangler/v3/pkg/generated/controllers/rbac"
 	rbaccontrollers "github.com/rancher/wrangler/v3/pkg/generated/controllers/rbac/v1"
 	"github.com/rancher/wrangler/v3/pkg/start"
-
-	"github.com/sirupsen/logrus"
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -71,7 +70,7 @@ func Register(ctx context.Context, appCtx *AppContext) error {
 	)
 
 	if err := appCtx.Start(ctx); err != nil {
-		logrus.Fatal(err)
+		log.Fatal(err)
 	}
 
 	return nil

--- a/internal/cmd/controller/cleanup/start.go
+++ b/internal/cmd/controller/cleanup/start.go
@@ -2,8 +2,7 @@ package cleanup
 
 import (
 	"context"
-
-	"github.com/sirupsen/logrus"
+	"log"
 
 	"github.com/rancher/fleet/internal/cmd/controller/cleanup/controllers"
 	"github.com/rancher/wrangler/v3/pkg/kubeconfig"
@@ -31,10 +30,10 @@ func start(ctx context.Context, kubeConfig, namespace string) error {
 	leader.RunOrDie(ctx, namespace, "fleet-cleanup-lock", k8s, func(ctx context.Context) {
 		appCtx, err := controllers.NewAppContext(clientConfig)
 		if err != nil {
-			logrus.Fatal(err)
+			log.Fatal(err)
 		}
 		if err := controllers.Register(ctx, appCtx); err != nil {
-			logrus.Fatal(err)
+			log.Fatal(err)
 		}
 	})
 

--- a/internal/cmd/debug.go
+++ b/internal/cmd/debug.go
@@ -6,7 +6,6 @@ import (
 	"flag"
 	"fmt"
 
-	"github.com/sirupsen/logrus"
 	"go.uber.org/zap/zapcore"
 
 	"k8s.io/klog/v2"
@@ -22,7 +21,6 @@ func (c *DebugConfig) SetupDebug() error {
 	logging := flag.NewFlagSet("", flag.PanicOnError)
 	klog.InitFlags(logging)
 	if c.Debug {
-		logrus.SetLevel(logrus.DebugLevel)
 		if err := logging.Parse([]string{
 			fmt.Sprintf("-v=%d", c.DebugLevel),
 		}); err != nil {

--- a/internal/cmd/options.go
+++ b/internal/cmd/options.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/sirupsen/logrus"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 type LeaderElectionOptions struct {
@@ -71,7 +71,7 @@ func NewLeaderElectionOptionsWithPrefix(prefix string) (LeaderElectionOptions, e
 func ParseEnvAgentReplicaCount() int32 {
 	replicas, err := parseEnvInt32("FLEET_AGENT_REPLICA_COUNT")
 	if err != nil {
-		logrus.Warn("FLEET_AGENT_REPLICA_COUNT not set, defaulting to 1")
+		log.Log.Info("FLEET_AGENT_REPLICA_COUNT not set, defaulting to 1", "error", err)
 		return 1
 	}
 	return replicas

--- a/internal/config/overrides.go
+++ b/internal/config/overrides.go
@@ -1,9 +1,10 @@
 package config
 
 import (
+	"fmt"
 	"os"
 
-	"github.com/sirupsen/logrus"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 const (
@@ -23,20 +24,20 @@ func BypassSystemCAStore() func() {
 	certDirBkp := os.Getenv(envVarSSLCertDir)
 
 	if err := os.Setenv(envVarSSLCertFile, "/dev/null"); err != nil {
-		logrus.Errorf("failed to set env var %s: %s", envVarSSLCertFile, err.Error())
+		log.Log.Error(nil, fmt.Sprintf("failed to set env var %s: %s", envVarSSLCertFile, err.Error()))
 	}
 
 	if err := os.Setenv(envVarSSLCertDir, "/dev/null"); err != nil {
-		logrus.Errorf("failed to set env var %s: %s", envVarSSLCertDir, err.Error())
+		log.Log.Error(nil, fmt.Sprintf("failed to set env var %s: %s", envVarSSLCertDir, err.Error()))
 	}
 
 	return func() {
 		if err := os.Setenv(envVarSSLCertFile, certFileBkp); err != nil {
-			logrus.Errorf("failed to restore env var %s: %s", envVarSSLCertFile, err.Error())
+			log.Log.Error(nil, fmt.Sprintf("failed to restore env var %s: %s", envVarSSLCertFile, err.Error()))
 		}
 
 		if err := os.Setenv(envVarSSLCertDir, certDirBkp); err != nil {
-			logrus.Errorf("failed to restore env var %s: %s", envVarSSLCertDir, err.Error())
+			log.Log.Error(nil, fmt.Sprintf("failed to restore env var %s: %s", envVarSSLCertDir, err.Error()))
 		}
 	}
 }

--- a/internal/config/overrides.go
+++ b/internal/config/overrides.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"fmt"
 	"os"
 
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -24,20 +23,20 @@ func BypassSystemCAStore() func() {
 	certDirBkp := os.Getenv(envVarSSLCertDir)
 
 	if err := os.Setenv(envVarSSLCertFile, "/dev/null"); err != nil {
-		log.Log.Error(nil, fmt.Sprintf("failed to set env var %s: %s", envVarSSLCertFile, err.Error()))
+		log.Log.Error(err, "failed to set env var", "name", envVarSSLCertFile)
 	}
 
 	if err := os.Setenv(envVarSSLCertDir, "/dev/null"); err != nil {
-		log.Log.Error(nil, fmt.Sprintf("failed to set env var %s: %s", envVarSSLCertDir, err.Error()))
+		log.Log.Error(err, "failed to set env var", "name", envVarSSLCertDir)
 	}
 
 	return func() {
 		if err := os.Setenv(envVarSSLCertFile, certFileBkp); err != nil {
-			log.Log.Error(nil, fmt.Sprintf("failed to restore env var %s: %s", envVarSSLCertFile, err.Error()))
+			log.Log.Error(err, "failed to restore env var", "name", envVarSSLCertFile)
 		}
 
 		if err := os.Setenv(envVarSSLCertDir, certDirBkp); err != nil {
-			log.Log.Error(nil, fmt.Sprintf("failed to restore env var %s: %s", envVarSSLCertDir, err.Error()))
+			log.Log.Error(err, "failed to restore env var", "name", envVarSSLCertDir)
 		}
 	}
 }

--- a/internal/names/name.go
+++ b/internal/names/name.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 
 	"github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
-	"github.com/sirupsen/logrus"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 var (
@@ -93,13 +93,13 @@ func HelmReleaseName(str string) string {
 	if helmReleaseName.MatchString(str) && dnsLabelSafe.MatchString(str) {
 		short := Limit(str, v1alpha1.MaxHelmReleaseNameLen)
 		if short != str {
-			logrus.Debugf("shorten bundle name %v to %v", str, short)
+			log.Log.V(1).Info(fmt.Sprintf("shorten bundle name %v to %v", str, short))
 		}
 		return short
 	}
 
 	// if the string ends up empty or otherwise invalid, fall back to just
 	// a checksum of the original input
-	logrus.Debugf("couldn't derive a valid bundle name, using checksum instead for '%s'", str)
+	log.Log.V(1).Info(fmt.Sprintf("couldn't derive a valid bundle name, using checksum instead for '%s'", str))
 	return Hex(bak, 24)
 }

--- a/internal/ocistorage/ociwrapper.go
+++ b/internal/ocistorage/ociwrapper.go
@@ -17,13 +17,13 @@ import (
 
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/sirupsen/logrus"
 	"oras.land/oras-go/v2"
 	"oras.land/oras-go/v2/content"
 	"oras.land/oras-go/v2/content/memory"
 	"oras.land/oras-go/v2/registry/remote"
 	"oras.land/oras-go/v2/registry/remote/auth"
 	"oras.land/oras-go/v2/registry/remote/retry"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/rancher/fleet/internal/manifest"
 	fleetgit "github.com/rancher/fleet/pkg/git"
@@ -86,7 +86,7 @@ func getHTTPClient(insecureSkipTLS bool, caBundle []byte) *http.Client {
 		proxyBytes := []byte(proxyCAPEM)
 		tmpPool := x509.NewCertPool()
 		if !tmpPool.AppendCertsFromPEM(proxyBytes) {
-			logrus.Warnf("%s is set but contains no valid PEM certificates; ignoring proxy CA bundle", fleetgit.ProxyCABundleEnvVar)
+			log.Log.Info(fleetgit.ProxyCABundleEnvVar + " is set but contains no valid PEM certificates; ignoring proxy CA bundle")
 		} else {
 			if len(caBundle) > 0 && caBundle[len(caBundle)-1] != '\n' {
 				caBundle = append(caBundle, '\n')
@@ -120,7 +120,7 @@ func getHTTPClient(insecureSkipTLS bool, caBundle []byte) *http.Client {
 			pool = x509.NewCertPool()
 		}
 		if !pool.AppendCertsFromPEM(caBundle) {
-			logrus.Warnf("CA bundle contains no valid PEM certificates; proceeding with system cert pool only")
+			log.Log.Info("CA bundle contains no valid PEM certificates; proceeding with system cert pool only")
 		}
 		transport.TLSClientConfig.RootCAs = pool
 		transport.TLSClientConfig.MinVersion = tls.VersionTLS12


### PR DESCRIPTION
Replace Fleet logging calls with controller-runtime logr and standard library logging while retaining transitive module dependencies required by upstream packages.

Refers #3554 