### PR TITLE
Merge Wrangler Renovate updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -61,7 +61,7 @@
       "matchFileNames": ["pkg/helmvalues/go.mod"],
       "matchPackageNames": ["github.com/rancher/wrangler/v3"],
       "enabled": true,
-      "groupName": "Helm values dependencies",
+      "groupName": "wrangler-lasso",
       "minimumGroupSize": 1
     },
     {


### PR DESCRIPTION
Use shared `wrangler-lasso` grouping so root and Helm-values updates share one PR.