### PR TITLE
Add WaitingForDependency bundle state

### DIFF
--- a/charts/fleet-crd/templates/crds.yaml
+++ b/charts/fleet-crd/templates/crds.yaml
@@ -100,7 +100,11 @@ spec:
                           If the dependency is in one of these states, it will not
                           block the deployment of the dependent bundle.
 
-                          Valid Values should match the StateRank keys.
+                          Valid Values should match the StateRank keys, except for
+                          WaitingForDependency, which is rejected:
+
+                          it would unblock this bundle exactly when its dependency
+                          became blocked on a dependency of its own.
 
                           If not specified, default to ["Ready"]: only fully ready
                           dependencies are accepted
@@ -1829,7 +1833,11 @@ spec:
                           If the dependency is in one of these states, it will not
                           block the deployment of the dependent bundle.
 
-                          Valid Values should match the StateRank keys.
+                          Valid Values should match the StateRank keys, except for
+                          WaitingForDependency, which is rejected:
+
+                          it would unblock this bundle exactly when its dependency
+                          became blocked on a dependency of its own.
 
                           If not specified, default to ["Ready"]: only fully ready
                           dependencies are accepted
@@ -3648,6 +3656,15 @@ spec:
 
                               to be deployed.'
                             type: integer
+                          waitingForDependency:
+                            description: 'WaitingForDependency is the number of bundle
+                              deployments which are
+
+                              not deployed because at least one of the bundles they
+                              depend on has
+
+                              not reached an accepted state.'
+                            type: integer
                         type: object
                       unavailable:
                         description: Unavailable is the number of unavailable clusters
@@ -3869,6 +3886,15 @@ spec:
                         waiting
 
                         to be deployed.'
+                      type: integer
+                    waitingForDependency:
+                      description: 'WaitingForDependency is the number of bundle deployments
+                        which are
+
+                        not deployed because at least one of the bundles they depend
+                        on has
+
+                        not reached an accepted state.'
                       type: integer
                   type: object
                 unavailable:
@@ -4308,6 +4334,15 @@ spec:
                         waiting
 
                         to be deployed.'
+                      type: integer
+                    waitingForDependency:
+                      description: 'WaitingForDependency is the number of bundle deployments
+                        which are
+
+                        not deployed because at least one of the bundles they depend
+                        on has
+
+                        not reached an accepted state.'
                       type: integer
                   type: object
               type: object
@@ -6831,6 +6866,15 @@ spec:
 
                         to be deployed.'
                       type: integer
+                    waitingForDependency:
+                      description: 'WaitingForDependency is the number of bundle deployments
+                        which are
+
+                        not deployed because at least one of the bundles they depend
+                        on has
+
+                        not reached an accepted state.'
+                      type: integer
                   type: object
               type: object
           type: object
@@ -7954,6 +7998,15 @@ spec:
 
                         to be deployed.'
                       type: integer
+                    waitingForDependency:
+                      description: 'WaitingForDependency is the number of bundle deployments
+                        which are
+
+                        not deployed because at least one of the bundles they depend
+                        on has
+
+                        not reached an accepted state.'
+                      type: integer
                   type: object
                 updateGeneration:
                   description: Update generation is the force update generation if
@@ -8175,7 +8228,11 @@ spec:
                           If the dependency is in one of these states, it will not
                           block the deployment of the dependent bundle.
 
-                          Valid Values should match the StateRank keys.
+                          Valid Values should match the StateRank keys, except for
+                          WaitingForDependency, which is rejected:
+
+                          it would unblock this bundle exactly when its dependency
+                          became blocked on a dependency of its own.
 
                           If not specified, default to ["Ready"]: only fully ready
                           dependencies are accepted
@@ -10181,6 +10238,15 @@ spec:
                         waiting
 
                         to be deployed.'
+                      type: integer
+                    waitingForDependency:
+                      description: 'WaitingForDependency is the number of bundle deployments
+                        which are
+
+                        not deployed because at least one of the bundles they depend
+                        on has
+
+                        not reached an accepted state.'
                       type: integer
                   type: object
                 version:

--- a/e2e/assets/multi-cluster/bundle-depends-on-unaccepted-state.yaml
+++ b/e2e/assets/multi-cluster/bundle-depends-on-unaccepted-state.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: fleet.cattle.io/v1alpha1
+kind: Bundle
+metadata:
+  labels:
+    role: leaf-unaccepted-state
+  name: {{.Name}}
+  namespace: {{.ClusterRegistrationNamespace}}
+spec:
+  defaultNamespace: {{.ProjectNamespace}}
+  dependsOn:
+  # The dependency is Modified, which is not in this list, so this bundle
+  # stays blocked.
+  - selector:
+      matchLabels:
+        role: root-modified
+    acceptedStates:
+    - Ready
+  resources:
+  - content: |
+      kind: ConfigMap
+      apiVersion: v1
+      metadata:
+        name: dependent-node-blocked
+      data:
+        value: dependent-node-blocked
+    name: cm.yaml
+  targets:
+  - clusterSelector: {}

--- a/e2e/multi-cluster/depends_on_test.go
+++ b/e2e/multi-cluster/depends_on_test.go
@@ -226,6 +226,35 @@ var _ = Describe("Bundle Depends On", func() {
 				}
 				return out
 			}, duration, interval).Should(Equal(string(fleet.WaitingForDependency)))
+
+			By("restoring the ConfigMap, which makes the dependency acceptable again")
+			_, err = k.Namespace(namespace).Run(
+				"patch", "configmap", "root-will-be-modified",
+				"--type=merge", "-p", `{"data":{"value":"original"}}`,
+			)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("waiting for the required bundle to be ready again")
+			Eventually(func() string {
+				out, err := k.Namespace(env.Namespace).Get("bundle", required, "-o=jsonpath={.status.display}")
+				if err != nil {
+					return ""
+				}
+				var d fleet.BundleDisplay
+				_ = json.Unmarshal([]byte(out), &d)
+				return d.ReadyClusters
+			}, 2*time.Minute, interval).Should(Equal("1/1"))
+
+			By("verifying the dependent bundle leaves WaitingForDependency and deploys")
+			Eventually(func() string {
+				out, err := k.Namespace(env.Namespace).Get("bundle", dependsOn, "-o=jsonpath={.status.display}")
+				if err != nil {
+					return ""
+				}
+				var d fleet.BundleDisplay
+				_ = json.Unmarshal([]byte(out), &d)
+				return d.ReadyClusters
+			}, 5*time.Minute, interval).Should(Equal("1/1"))
 		})
 	})
 })

--- a/e2e/multi-cluster/depends_on_test.go
+++ b/e2e/multi-cluster/depends_on_test.go
@@ -162,4 +162,70 @@ var _ = Describe("Bundle Depends On", func() {
 			}, 5*time.Minute, interval).Should(Equal("1/1"))
 		})
 	})
+
+	When("bundle depends on a bundle which is not in an accepted state", func() {
+		BeforeEach(func() {
+			required = "required-unaccepted"
+			dependsOn = "depends-on-unaccepted-state"
+			namespace = testenv.NewNamespaceName("bnm-unaccepted", r)
+		})
+
+		It("reports WaitingForDependency, not ErrApplied", func() {
+			By("deploying the required bundle first")
+			err := testenv.ApplyTemplate(k.Namespace(env.Namespace), testenv.AssetPath("multi-cluster/bundle-cm-modified.yaml"),
+				TemplateData{required, env.Namespace, namespace})
+			Expect(err).ToNot(HaveOccurred())
+
+			By("waiting for ConfigMap to be deployed")
+			Eventually(func() error {
+				_, err := k.Namespace(namespace).Get("configmap", "root-will-be-modified")
+				return err
+			}, 2*time.Minute, interval).Should(Succeed())
+
+			By("modifying the deployed ConfigMap to trigger drift")
+			_, err = k.Namespace(namespace).Run(
+				"patch", "configmap", "root-will-be-modified",
+				"--type=merge", "-p", `{"data":{"value":"modified-externally"}}`,
+			)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("waiting for required bundle to enter Modified state")
+			Eventually(func() string {
+				out, err := k.Namespace(env.Namespace).Get("bundle", required, "-o=jsonpath={.status.display.state}")
+				if err != nil {
+					return ""
+				}
+				return out
+			}, 2*time.Minute, interval).Should(Equal("Modified"))
+
+			By("deploying a dependent bundle which only accepts Ready")
+			err = testenv.ApplyTemplate(k.Namespace(env.Namespace), testenv.AssetPath("multi-cluster/bundle-depends-on-unaccepted-state.yaml"),
+				TemplateData{dependsOn, env.Namespace, namespace})
+			Expect(err).ToNot(HaveOccurred())
+
+			By("waiting for the dependent bundle to report WaitingForDependency")
+			Eventually(func() []fleet.NonReadyResource {
+				out, err := k.Namespace(env.Namespace).Get("bundle", dependsOn, "-o=jsonpath={.status.summary}")
+				if err != nil {
+					return []fleet.NonReadyResource{}
+				}
+				var sum fleet.BundleSummary
+				_ = json.Unmarshal([]byte(out), &sum)
+				return sum.NonReadyResources
+			}, 2*time.Minute, interval).Should(ContainElement(fleet.NonReadyResource{
+				State:   fleet.WaitingForDependency,
+				Message: "waiting for dependent bundle(s) to reach an accepted state: " + required + " (state: Modified, accepted: Ready)",
+				Name:    "fleet-local/local",
+			}))
+
+			By("keeping that state instead of falling back to ErrApplied")
+			Consistently(func() string {
+				out, err := k.Namespace(env.Namespace).Get("bundle", dependsOn, "-o=jsonpath={.status.summary.nonReadyResources[0].bundleState}")
+				if err != nil {
+					return ""
+				}
+				return out
+			}, duration, interval).Should(Equal(string(fleet.WaitingForDependency)))
+		})
+	})
 })

--- a/internal/bundlereader/validate_fleetyaml.go
+++ b/internal/bundlereader/validate_fleetyaml.go
@@ -39,8 +39,21 @@ func validateBundleRef(index int, dep fleet.BundleRef) error {
 	return nil
 }
 
-// isValidBundleState checks if a BundleState is valid by checking against StateRank
+// statesRejectedAsAccepted lists states which are ranked in StateRank, but which
+// must not be used as an acceptedState. WaitingForDependency describes a bundle
+// which is itself blocked on one of its own dependencies, so accepting it would
+// unblock the dependent bundle precisely when its dependency stopped making
+// progress, which defeats the point of declaring the dependency.
+var statesRejectedAsAccepted = map[fleet.BundleState]struct{}{
+	fleet.WaitingForDependency: {},
+}
+
+// isValidBundleState checks if a BundleState may be used as an acceptedState. A
+// state is valid if it is ranked in StateRank and is not rejected explicitly.
 func isValidBundleState(state fleet.BundleState) bool {
+	if _, rejected := statesRejectedAsAccepted[state]; rejected {
+		return false
+	}
 	_, exists := fleet.StateRank[state]
 	return exists
 }
@@ -51,6 +64,9 @@ func isValidBundleState(state fleet.BundleState) bool {
 func validBundleStatesList() []fleet.BundleState {
 	states := make([]fleet.BundleState, 0, len(fleet.StateRank))
 	for state := range fleet.StateRank {
+		if !isValidBundleState(state) {
+			continue
+		}
 		states = append(states, state)
 	}
 	sort.Slice(states, func(i, j int) bool {

--- a/internal/bundlereader/validate_fleetyaml_test.go
+++ b/internal/bundlereader/validate_fleetyaml_test.go
@@ -78,6 +78,11 @@ func TestValidateFleetYAML_InvalidAcceptedStates(t *testing.T) {
 			states:        []fleet.BundleState{""},
 			expectedError: `dependsOn[0].acceptedStates[0]: invalid state ""`,
 		},
+		{
+			name:          "WaitingForDependency is ranked, but rejected as an accepted state",
+			states:        []fleet.BundleState{fleet.Ready, fleet.WaitingForDependency},
+			expectedError: `dependsOn[0].acceptedStates[1]: invalid state "WaitingForDependency"`,
+		},
 	}
 
 	for _, tt := range tests {
@@ -171,6 +176,10 @@ func TestIsValidBundleState(t *testing.T) {
 		"READY",
 		"",
 		"Foo",
+		// Ranked in StateRank, but rejected as an acceptedState: it would
+		// unblock the dependent bundle as soon as the dependency became
+		// blocked itself.
+		fleet.WaitingForDependency,
 	}
 
 	for _, state := range invalidStates {
@@ -183,9 +192,17 @@ func TestIsValidBundleState(t *testing.T) {
 func TestValidBundleStatesList_SortedByRank(t *testing.T) {
 	states := validBundleStatesList()
 
-	// Verify all states from StateRank are present
-	if len(states) != len(fleet.StateRank) {
-		t.Errorf("validBundleStatesList() returned %d states, expected %d", len(states), len(fleet.StateRank))
+	// Verify all states from StateRank are present, minus the ones rejected
+	// as acceptedStates
+	if want := len(fleet.StateRank) - len(statesRejectedAsAccepted); len(states) != want {
+		t.Errorf("validBundleStatesList() returned %d states, expected %d", len(states), want)
+	}
+
+	// Verify no rejected state leaks into the list suggested to users
+	for _, state := range states {
+		if _, rejected := statesRejectedAsAccepted[state]; rejected {
+			t.Errorf("validBundleStatesList() contains rejected state %q", state)
+		}
 	}
 
 	// Verify states are sorted by rank (ascending)

--- a/internal/cmd/agent/controller/bundledeployment_controller.go
+++ b/internal/cmd/agent/controller/bundledeployment_controller.go
@@ -323,7 +323,7 @@ func (r *BundleDeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		}
 
 		// do not use the returned status, instead set the condition and possibly a timestamp
-		bd.Status = setCondition(bd.Status, err, monitor.Cond(fleetv1.BundleDeploymentConditionDeployed))
+		bd.Status = setConditionWithReason(bd.Status, err, deployedConditionReason(err), monitor.Cond(fleetv1.BundleDeploymentConditionDeployed))
 
 		if handled, res, err := r.requeueIfDependenciesNotReady(ctx, orig, bd, err); handled {
 			return res, err
@@ -640,14 +640,34 @@ func (r *BundleDeploymentReconciler) requeueIfDependenciesNotReady(ctx context.C
 		return true, ctrl.Result{}, err
 	}
 
-	log.FromContext(ctx).V(1).Info("Dependencies not ready, requeuing...", "pending", notReadyDependenciesError.Pending)
+	log.FromContext(ctx).V(1).Info("Dependencies not ready, requeuing...", "pending", notReadyDependenciesError.PendingDescriptions())
 	return true, ctrl.Result{RequeueAfter: durations.WaitForDependenciesReadyRequeueInterval}, nil
 }
 
 // setCondition sets the condition and updates the timestamp, if the condition changed
 func setCondition(newStatus fleetv1.BundleDeploymentStatus, err error, cond monitor.Cond) fleetv1.BundleDeploymentStatus {
-	cond.SetError(&newStatus, "", ignoreConflict(err))
+	return setConditionWithReason(newStatus, err, "", cond)
+}
+
+// setConditionWithReason sets the condition with an explicit reason and updates
+// the timestamp, if the condition changed. An empty reason means "Error" for a
+// non-nil error, and clears the reason otherwise.
+func setConditionWithReason(newStatus fleetv1.BundleDeploymentStatus, err error, reason string, cond monitor.Cond) fleetv1.BundleDeploymentStatus {
+	cond.SetError(&newStatus, reason, ignoreConflict(err))
 	return newStatus
+}
+
+// deployedConditionReason returns the reason to record on the Deployed
+// condition for a failed deployment. Waiting on a dependency gets a dedicated
+// reason, so the bundledeployment is reported as WaitingForDependency instead
+// of the misleading ErrApplied. Any other error keeps the default "Error".
+func deployedConditionReason(err error) string {
+	var notReadyDependenciesError *deployer.NotReadyDependenciesError
+	if errors.As(err, &notReadyDependenciesError) {
+		return fleetv1.BundleDeploymentReasonWaitingForDependency
+	}
+
+	return ""
 }
 
 func ignoreConflict(err error) error {

--- a/internal/cmd/agent/controller/bundledeployment_controller.go
+++ b/internal/cmd/agent/controller/bundledeployment_controller.go
@@ -662,8 +662,7 @@ func setConditionWithReason(newStatus fleetv1.BundleDeploymentStatus, err error,
 // reason, so the bundledeployment is reported as WaitingForDependency instead
 // of the misleading ErrApplied. Any other error keeps the default "Error".
 func deployedConditionReason(err error) string {
-	var notReadyDependenciesError *deployer.NotReadyDependenciesError
-	if errors.As(err, &notReadyDependenciesError) {
+	if _, ok := errors.AsType[*deployer.NotReadyDependenciesError](err); ok {
 		return fleetv1.BundleDeploymentReasonWaitingForDependency
 	}
 

--- a/internal/cmd/agent/deployer/deployer.go
+++ b/internal/cmd/agent/deployer/deployer.go
@@ -43,12 +43,47 @@ var deployErrPattern = regexp.MustCompile(
 		"(chart requires kubeVersion: [0-9A-Za-z\\.\\-<>=]+ which is incompatible with Kubernetes)", // trying to deploy to incompatible Kubernetes
 )
 
+// PendingDependency describes a dependency which is blocking a deployment,
+// together with the state it is in and the states which would unblock it.
+type PendingDependency struct {
+	Name           string
+	State          fleet.BundleState
+	AcceptedStates []fleet.BundleState
+}
+
+func (d PendingDependency) String() string {
+	accepted := effectiveAcceptedStates(d.AcceptedStates)
+
+	states := make([]string, 0, len(accepted))
+	for _, s := range accepted {
+		states = append(states, string(s))
+	}
+
+	return fmt.Sprintf("%s (state: %s, accepted: %s)", d.Name, d.State, strings.Join(states, ", "))
+}
+
+// NotReadyDependenciesError indicates that the bundledeployment is not deployed
+// yet because at least one of the bundles it depends on has not reached an
+// accepted state. This is a temporary condition, not a deployment error: the
+// controller requeues until the dependencies are met.
 type NotReadyDependenciesError struct {
-	Pending []string
+	Pending []PendingDependency
+}
+
+// PendingDescriptions returns one human readable description per blocking
+// dependency. Loggers reflect over a []PendingDependency instead of calling
+// String on its elements, so they should use this rather than Pending.
+func (e *NotReadyDependenciesError) PendingDescriptions() []string {
+	pending := make([]string, 0, len(e.Pending))
+	for _, d := range e.Pending {
+		pending = append(pending, d.String())
+	}
+
+	return pending
 }
 
 func (e *NotReadyDependenciesError) Error() string {
-	return fmt.Sprintf("dependent bundle(s) are not ready: %v", e.Pending)
+	return "waiting for dependent bundle(s) to reach an accepted state: " + strings.Join(e.PendingDescriptions(), "; ")
 }
 
 // NamespaceForbiddenError indicates the deployment's service account is not
@@ -445,7 +480,7 @@ func forbiddenToStatus(err error, status fleet.BundleDeploymentStatus) (bool, fl
 }
 
 func (d *Deployer) checkDependency(ctx context.Context, bd *fleet.BundleDeployment) error {
-	var depBundleList []string
+	var depBundleList []PendingDependency
 	bundleNamespace := bd.Labels[fleet.BundleNamespaceLabel]
 	for _, depend := range bd.Spec.DependsOn {
 		// skip empty BundleRef definitions. Possible if there is a typo in the yaml
@@ -477,8 +512,13 @@ func (d *Deployer) checkDependency(ctx context.Context, bd *fleet.BundleDeployme
 			}
 
 			for _, depBundle := range bds.Items {
-				if !isDependencyReady(depBundle, depend.AcceptedStates) {
-					depBundleList = append(depBundleList, depBundle.Name)
+				state := summary.GetDeploymentState(&depBundle)
+				if !isStateAccepted(state, depend.AcceptedStates) {
+					depBundleList = append(depBundleList, PendingDependency{
+						Name:           depBundle.Name,
+						State:          state,
+						AcceptedStates: depend.AcceptedStates,
+					})
 				}
 
 			}
@@ -492,18 +532,19 @@ func (d *Deployer) checkDependency(ctx context.Context, bd *fleet.BundleDeployme
 	return nil
 }
 
+// effectiveAcceptedStates returns the states which unblock a dependency. An
+// empty or nil list means the default: only Ready is accepted. Both the check
+// and the message reporting a blocked dependency go through here, so they
+// cannot disagree about what the default is.
+func effectiveAcceptedStates(acceptedStates []fleet.BundleState) []fleet.BundleState {
+	if len(acceptedStates) == 0 {
+		return []fleet.BundleState{fleet.Ready}
+	}
+	return acceptedStates
+}
+
 // isStateAccepted checks if currentState is in acceptedStates.
 // If acceptedStates is empty or nil, only Ready is accepted (default behavior).
 func isStateAccepted(currentState fleet.BundleState, acceptedStates []fleet.BundleState) bool {
-	if len(acceptedStates) == 0 {
-		return currentState == fleet.Ready
-	}
-	return slices.Contains(acceptedStates, currentState)
-}
-
-// isDependencyReady checks if a BundleDeployment dependency is in an acceptable state.
-// acceptedStates is a list of states that are considered acceptable for this dependency.
-// If acceptedStates is empty or nil, only the "Ready" state is accepted (default behavior).
-func isDependencyReady(depBundle fleet.BundleDeployment, acceptedStates []fleet.BundleState) bool {
-	return isStateAccepted(summary.GetDeploymentState(&depBundle), acceptedStates)
+	return slices.Contains(effectiveAcceptedStates(acceptedStates), currentState)
 }

--- a/internal/cmd/agent/deployer/deployer_test.go
+++ b/internal/cmd/agent/deployer/deployer_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"reflect"
+	"strings"
 	"testing"
 
 	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
@@ -499,6 +501,96 @@ func TestIsStateAccepted(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			if got := isStateAccepted(tc.state, tc.accepted); got != tc.want {
 				t.Errorf("isStateAccepted(%q, %v) = %v, want %v", tc.state, tc.accepted, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCheckDependency(t *testing.T) {
+	const (
+		bundleNamespace  = "fleet-local"
+		clusterNamespace = "cluster-fleet-local-local-1a2b3c"
+	)
+
+	// notReadyDep is a dependency which has been deployed, but whose
+	// resources are not ready, i.e. it is in the NotReady state.
+	notReadyDep := &fleet.BundleDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "dep",
+			Namespace: clusterNamespace,
+			Labels: map[string]string{
+				fleet.BundleLabel:          "dep",
+				fleet.BundleNamespaceLabel: bundleNamespace,
+			},
+		},
+		Spec:   fleet.BundleDeploymentSpec{DeploymentID: "id1", StagedDeploymentID: "id1"},
+		Status: fleet.BundleDeploymentStatus{AppliedDeploymentID: "id1", Ready: false},
+	}
+
+	tests := map[string]struct {
+		acceptedStates  []fleet.BundleState
+		wantErr         bool
+		wantPending     []PendingDependency
+		wantErrContains string
+	}{
+		"dependency state is not accepted by default": {
+			acceptedStates: nil,
+			wantErr:        true,
+			wantPending: []PendingDependency{
+				{Name: "dep", State: fleet.NotReady},
+			},
+			wantErrContains: "dep (state: NotReady, accepted: Ready)",
+		},
+		"dependency state is not in acceptedStates": {
+			acceptedStates: []fleet.BundleState{fleet.Ready, fleet.Modified},
+			wantErr:        true,
+			wantPending: []PendingDependency{
+				{Name: "dep", State: fleet.NotReady, AcceptedStates: []fleet.BundleState{fleet.Ready, fleet.Modified}},
+			},
+			wantErrContains: "dep (state: NotReady, accepted: Ready, Modified)",
+		},
+		"dependency state is in acceptedStates": {
+			acceptedStates: []fleet.BundleState{fleet.Ready, fleet.NotReady},
+			wantErr:        false,
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	utilruntime.Must(fleet.AddToScheme(scheme))
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			bd := &fleet.BundleDeployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "app",
+					Namespace: clusterNamespace,
+					Labels:    map[string]string{fleet.BundleNamespaceLabel: bundleNamespace},
+				},
+				Spec: fleet.BundleDeploymentSpec{
+					DependsOn: []fleet.BundleRef{{Name: "dep", AcceptedStates: tc.acceptedStates}},
+				},
+			}
+
+			c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(notReadyDep).Build()
+			d := Deployer{upstreamClient: c}
+
+			err := d.checkDependency(context.Background(), bd)
+			if !tc.wantErr {
+				if err != nil {
+					t.Fatalf("expected no error, got %v", err)
+				}
+				return
+			}
+
+			var depErr *NotReadyDependenciesError
+			if !errors.As(err, &depErr) {
+				t.Fatalf("expected a NotReadyDependenciesError, got %T: %v", err, err)
+			}
+			if !reflect.DeepEqual(depErr.Pending, tc.wantPending) {
+				t.Errorf("pending dependencies: got %+v, want %+v", depErr.Pending, tc.wantPending)
+			}
+			if !strings.Contains(err.Error(), tc.wantErrContains) {
+				t.Errorf("error message %q does not contain %q", err.Error(), tc.wantErrContains)
 			}
 		})
 	}

--- a/internal/cmd/controller/summary/summary.go
+++ b/internal/cmd/controller/summary/summary.go
@@ -24,6 +24,8 @@ func IncrementState(summary *fleet.BundleSummary, name string, state fleet.Bundl
 		summary.WaitApplied++
 	case fleet.ErrApplied:
 		summary.ErrApplied++
+	case fleet.WaitingForDependency:
+		summary.WaitingForDependency++
 	case fleet.NotReady:
 		summary.NotReady++
 	case fleet.OutOfSync:
@@ -52,6 +54,7 @@ func Increment(left *fleet.BundleSummary, right fleet.BundleSummary) {
 	left.NotReady += right.NotReady
 	left.WaitApplied += right.WaitApplied
 	left.ErrApplied += right.ErrApplied
+	left.WaitingForDependency += right.WaitingForDependency
 	left.OutOfSync += right.OutOfSync
 	left.Modified += right.Modified
 	left.Ready += right.Ready
@@ -89,7 +92,14 @@ func GetSummaryState(summary fleet.BundleSummary) fleet.BundleState {
 func GetDeploymentState(bundleDeployment *fleet.BundleDeployment) fleet.BundleState {
 	switch {
 	case bundleDeployment.Status.AppliedDeploymentID != bundleDeployment.Spec.DeploymentID:
-		if condition.Cond(fleet.BundleDeploymentConditionDeployed).IsFalse(bundleDeployment) {
+		deployed := condition.Cond(fleet.BundleDeploymentConditionDeployed)
+		if deployed.IsFalse(bundleDeployment) {
+			// The agent blocks on dependencies before deploying. That is
+			// a temporary wait, not a deployment error, and it gets its
+			// own state so users are not sent looking for a failed apply.
+			if deployed.GetReason(bundleDeployment) == fleet.BundleDeploymentReasonWaitingForDependency {
+				return fleet.WaitingForDependency
+			}
 			return fleet.ErrApplied
 		}
 		return fleet.WaitApplied
@@ -154,12 +164,13 @@ func MessageFromDeployment(deployment *fleet.BundleDeployment) string {
 func ReadyMessage(summary fleet.BundleSummary, referencedKind string) string {
 	var messages []string
 	for msg, count := range map[fleet.BundleState]int{
-		fleet.OutOfSync:   summary.OutOfSync,
-		fleet.NotReady:    summary.NotReady,
-		fleet.WaitApplied: summary.WaitApplied,
-		fleet.ErrApplied:  summary.ErrApplied,
-		fleet.Pending:     summary.Pending,
-		fleet.Modified:    summary.Modified,
+		fleet.OutOfSync:            summary.OutOfSync,
+		fleet.NotReady:             summary.NotReady,
+		fleet.WaitApplied:          summary.WaitApplied,
+		fleet.ErrApplied:           summary.ErrApplied,
+		fleet.WaitingForDependency: summary.WaitingForDependency,
+		fleet.Pending:              summary.Pending,
+		fleet.Modified:             summary.Modified,
 	} {
 		if count <= 0 {
 			continue

--- a/internal/cmd/controller/summary/summary_test.go
+++ b/internal/cmd/controller/summary/summary_test.go
@@ -51,14 +51,18 @@ func TestGetSummaryState(t *testing.T) {
 	// Pending:              3,
 	// NotReady:             2,
 	// Ready:                1,
+	//
+	// The winning state is deliberately placed at a different index in each
+	// case below, so that an implementation picking the first or the last
+	// element instead of the highest ranked one fails here.
 	s.NonReadyResources = []fleet.NonReadyResource{
 		{
 			Name:  "test",
-			State: fleet.Pending,
+			State: fleet.WaitApplied,
 		},
 		{
 			Name:  "test",
-			State: fleet.WaitApplied,
+			State: fleet.Pending,
 		},
 	}
 	bundleState = summary.GetSummaryState(s)
@@ -77,6 +81,10 @@ func TestGetSummaryState(t *testing.T) {
 			Name:  "test",
 			State: fleet.WaitingForDependency,
 		},
+		{
+			Name:  "test",
+			State: fleet.NotReady,
+		},
 	}
 	bundleState = summary.GetSummaryState(s)
 	if bundleState != fleet.WaitingForDependency {
@@ -88,16 +96,38 @@ func TestGetSummaryState(t *testing.T) {
 	s.NonReadyResources = []fleet.NonReadyResource{
 		{
 			Name:  "test",
-			State: fleet.WaitingForDependency,
+			State: fleet.ErrApplied,
 		},
 		{
 			Name:  "test",
-			State: fleet.ErrApplied,
+			State: fleet.WaitingForDependency,
 		},
 	}
 	bundleState = summary.GetSummaryState(s)
 	if bundleState != fleet.ErrApplied {
 		t.Errorf("Expected ErrApplied, got %s", bundleState)
+	}
+
+	// The single Modified case above is unavoidably both first and last, so
+	// pin the ranking once more with Modified surrounded by lower ranked
+	// states.
+	s.NonReadyResources = []fleet.NonReadyResource{
+		{
+			Name:  "test",
+			State: fleet.OutOfSync,
+		},
+		{
+			Name:  "test",
+			State: fleet.Modified,
+		},
+		{
+			Name:  "test",
+			State: fleet.Pending,
+		},
+	}
+	bundleState = summary.GetSummaryState(s)
+	if bundleState != fleet.Modified {
+		t.Errorf("Expected Modified, got %s", bundleState)
 	}
 }
 

--- a/internal/cmd/controller/summary/summary_test.go
+++ b/internal/cmd/controller/summary/summary_test.go
@@ -43,13 +43,14 @@ func TestGetSummaryState(t *testing.T) {
 
 	// It is supposed to return the highest priority state if there are multiple
 	// non-ready resources. Rank depends on v1alpha1.StateRank.
-	// ErrApplied:  7,
-	// WaitApplied: 6,
-	// Modified:    5,
-	// OutOfSync:   4,
-	// Pending:     3,
-	// NotReady:    2,
-	// Ready:       1,
+	// ErrApplied:           8,
+	// WaitingForDependency: 7,
+	// WaitApplied:          6,
+	// Modified:             5,
+	// OutOfSync:            4,
+	// Pending:              3,
+	// NotReady:             2,
+	// Ready:                1,
 	s.NonReadyResources = []fleet.NonReadyResource{
 		{
 			Name:  "test",
@@ -63,6 +64,142 @@ func TestGetSummaryState(t *testing.T) {
 	bundleState = summary.GetSummaryState(s)
 	if bundleState != fleet.WaitApplied {
 		t.Errorf("Expected WaitApplied, got %s", bundleState)
+	}
+
+	// WaitingForDependency outranks the generic WaitApplied, because it says
+	// why the deployment is waiting.
+	s.NonReadyResources = []fleet.NonReadyResource{
+		{
+			Name:  "test",
+			State: fleet.WaitApplied,
+		},
+		{
+			Name:  "test",
+			State: fleet.WaitingForDependency,
+		},
+	}
+	bundleState = summary.GetSummaryState(s)
+	if bundleState != fleet.WaitingForDependency {
+		t.Errorf("Expected WaitingForDependency, got %s", bundleState)
+	}
+
+	// An actual deployment error still outranks a dependency wait, so it is
+	// not hidden in summaries covering several clusters.
+	s.NonReadyResources = []fleet.NonReadyResource{
+		{
+			Name:  "test",
+			State: fleet.WaitingForDependency,
+		},
+		{
+			Name:  "test",
+			State: fleet.ErrApplied,
+		},
+	}
+	bundleState = summary.GetSummaryState(s)
+	if bundleState != fleet.ErrApplied {
+		t.Errorf("Expected ErrApplied, got %s", bundleState)
+	}
+}
+
+func TestGetDeploymentState(t *testing.T) {
+	// deployed builds a bundledeployment which has not applied its
+	// deployment ID yet, with the given Deployed condition.
+	notApplied := func(status, reason string) *fleet.BundleDeployment {
+		bd := &fleet.BundleDeployment{}
+		bd.Spec.DeploymentID = "id2"
+		bd.Status.AppliedDeploymentID = "id1"
+		if status != "" {
+			c := condition.Cond(fleet.BundleDeploymentConditionDeployed)
+			c.SetStatus(bd, status)
+			c.Reason(bd, reason)
+		}
+		return bd
+	}
+
+	tests := map[string]struct {
+		bd   *fleet.BundleDeployment
+		want fleet.BundleState
+	}{
+		"waiting on a dependency is not an error": {
+			bd:   notApplied("False", fleet.BundleDeploymentReasonWaitingForDependency),
+			want: fleet.WaitingForDependency,
+		},
+		"a failed deployment is still ErrApplied": {
+			bd:   notApplied("False", "Error"),
+			want: fleet.ErrApplied,
+		},
+		"a failed deployment without a reason is still ErrApplied": {
+			bd:   notApplied("False", ""),
+			want: fleet.ErrApplied,
+		},
+		"no Deployed condition yet": {
+			bd:   notApplied("", ""),
+			want: fleet.WaitApplied,
+		},
+		"Deployed is true, but the deployment ID is not applied yet": {
+			bd:   notApplied("True", ""),
+			want: fleet.WaitApplied,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			if got := summary.GetDeploymentState(tc.bd); got != tc.want {
+				t.Errorf("GetDeploymentState() = %s, want %s", got, tc.want)
+			}
+		})
+	}
+
+	// A stale WaitingForDependency reason must not survive a successful
+	// deployment: once the deployment ID is applied, the state is derived
+	// from the resources.
+	t.Run("reason is ignored once the deployment ID is applied", func(t *testing.T) {
+		bd := notApplied("False", fleet.BundleDeploymentReasonWaitingForDependency)
+		bd.Status.AppliedDeploymentID = bd.Spec.DeploymentID
+		bd.Spec.StagedDeploymentID = bd.Spec.DeploymentID
+		bd.Status.Ready = true
+		bd.Status.NonModified = true
+
+		if got := summary.GetDeploymentState(bd); got != fleet.Ready {
+			t.Errorf("GetDeploymentState() = %s, want Ready", got)
+		}
+	})
+}
+
+func TestReadyMessage_WaitingForDependency(t *testing.T) {
+	s := fleet.BundleSummary{
+		WaitingForDependency: 1,
+		NonReadyResources: []fleet.NonReadyResource{
+			{
+				Name:    "fleet-local/local",
+				State:   fleet.WaitingForDependency,
+				Message: "waiting for dependent bundle(s) to reach an accepted state: dep (state: NotReady, accepted: Ready)",
+			},
+		},
+	}
+
+	msg := summary.ReadyMessage(s, "Cluster")
+	want := "WaitingForDependency(1) [Cluster fleet-local/local: waiting for dependent bundle(s) to reach an accepted state: dep (state: NotReady, accepted: Ready)]"
+	if msg != want {
+		t.Errorf("ReadyMessage() = %q, want %q", msg, want)
+	}
+}
+
+func TestIncrementState_WaitingForDependency(t *testing.T) {
+	s := &fleet.BundleSummary{}
+	summary.IncrementState(s, "bd", fleet.WaitingForDependency, "waiting", nil, nil)
+
+	if s.WaitingForDependency != 1 {
+		t.Errorf("expected WaitingForDependency count 1, got %d", s.WaitingForDependency)
+	}
+	if len(s.NonReadyResources) != 1 || s.NonReadyResources[0].State != fleet.WaitingForDependency {
+		t.Errorf("expected the bundledeployment to be listed as non-ready, got %+v", s.NonReadyResources)
+	}
+
+	other := fleet.BundleSummary{WaitingForDependency: 2}
+	summary.Increment(s, other)
+	if s.WaitingForDependency != 3 {
+		t.Errorf("expected WaitingForDependency count 3 after Increment, got %d", s.WaitingForDependency)
 	}
 }
 

--- a/internal/metrics/bundle_metrics.go
+++ b/internal/metrics/bundle_metrics.go
@@ -43,6 +43,15 @@ var (
 				},
 				bundleLabels,
 			),
+			"waiting_for_dependency": promauto.NewGaugeVec(
+				prometheus.GaugeOpts{
+					Namespace: metricPrefix,
+					Subsystem: bundleSubsystem,
+					Name:      "waiting_for_dependency",
+					Help:      "Number of deployments for a specific bundle waiting for a dependency to reach an accepted state.",
+				},
+				bundleLabels,
+			),
 			"out_of_sync": promauto.NewGaugeVec(
 				prometheus.GaugeOpts{
 					Namespace: metricPrefix,
@@ -124,6 +133,8 @@ func collectBundleMetrics(obj any, metrics map[string]prometheus.Collector) {
 		Set(float64(bundle.Status.Summary.WaitApplied))
 	metrics["err_applied"].(*prometheus.GaugeVec).With(labels).
 		Set(float64(bundle.Status.Summary.ErrApplied))
+	metrics["waiting_for_dependency"].(*prometheus.GaugeVec).With(labels).
+		Set(float64(bundle.Status.Summary.WaitingForDependency))
 	metrics["out_of_sync"].(*prometheus.GaugeVec).With(labels).
 		Set(float64(bundle.Status.Summary.OutOfSync))
 	metrics["modified"].(*prometheus.GaugeVec).With(labels).

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -27,6 +27,7 @@ var (
 		fleet.Modified,
 		fleet.WaitApplied,
 		fleet.ErrApplied,
+		fleet.WaitingForDependency,
 	}
 
 	objMetrics = []prometheus.Collector{}

--- a/pkg/apis/fleet.cattle.io/v1alpha1/bundle_types.go
+++ b/pkg/apis/fleet.cattle.io/v1alpha1/bundle_types.go
@@ -23,6 +23,12 @@ const (
 	// the downstream cluster, but there were some errors when deploying
 	// the Bundle.
 	ErrApplied BundleState = "ErrApplied"
+	// WaitingForDependency: Bundles have been synced from the Fleet
+	// controller and the downstream cluster, but are not deployed yet
+	// because at least one of the bundles they depend on has not reached
+	// an accepted state. Unlike ErrApplied this is not a deployment error:
+	// it resolves on its own once the dependency progresses.
+	WaitingForDependency BundleState = "WaitingForDependency"
 	// OutOfSync: Bundles have been synced from Fleet controller, but
 	// downstream agent hasn't synced the change yet.
 	OutOfSync BundleState = "OutOfSync"
@@ -49,13 +55,14 @@ var (
 	// StateRank ranks the state, e.g. so the highest ranked non-ready
 	// state can be reported in a summary.
 	StateRank = map[BundleState]int{
-		ErrApplied:  7,
-		WaitApplied: 6,
-		Modified:    5,
-		OutOfSync:   4,
-		Pending:     3,
-		NotReady:    2,
-		Ready:       1,
+		ErrApplied:           8,
+		WaitingForDependency: 7,
+		WaitApplied:          6,
+		Modified:             5,
+		OutOfSync:            4,
+		Pending:              3,
+		NotReady:             2,
+		Ready:                1,
 	}
 )
 
@@ -155,7 +162,8 @@ type BundleRef struct {
 	Selector *metav1.LabelSelector `json:"selector,omitempty"`
 	// AcceptedStates is a list of BundleDeployment state that are considered acceptable for this dependency.
 	// If the dependency is in one of these states, it will not block the deployment of the dependent bundle.
-	// Valid Values should match the StateRank keys.
+	// Valid Values should match the StateRank keys, except for WaitingForDependency, which is rejected:
+	// it would unblock this bundle exactly when its dependency became blocked on a dependency of its own.
 	// If not specified, default to ["Ready"]: only fully ready dependencies are accepted
 	// Example: ["Ready", "Modified"] will accept dependencies that are either ready or have drifted from their desired state.
 	// +nullable
@@ -305,6 +313,10 @@ type BundleSummary struct {
 	// from the Fleet controller and the downstream cluster, but with some
 	// errors when deploying the bundle.
 	ErrApplied int `json:"errApplied,omitempty"`
+	// WaitingForDependency is the number of bundle deployments which are
+	// not deployed because at least one of the bundles they depend on has
+	// not reached an accepted state.
+	WaitingForDependency int `json:"waitingForDependency,omitempty"`
 	// OutOfSync is the number of bundle deployments that have been synced
 	// from Fleet controller, but not yet by the downstream agent.
 	OutOfSync int `json:"outOfSync,omitempty"`
@@ -377,6 +389,13 @@ const (
 	// succeeded.
 	BundleDeploymentConditionDeployed  = "Deployed"
 	BundleDeploymentConditionMonitored = "Monitored"
+
+	// BundleDeploymentReasonWaitingForDependency is the reason set on the
+	// Deployed condition when the bundledeployment is not deployed because
+	// one of its dependencies has not reached an accepted state. It
+	// distinguishes that temporary wait from an actual deployment error,
+	// which uses the default "Error" reason.
+	BundleDeploymentReasonWaitingForDependency = "WaitingForDependency"
 )
 
 type BundleStatus struct {

--- a/schemas/fleet.yaml.json
+++ b/schemas/fleet.yaml.json
@@ -28,7 +28,7 @@
             "type": "string"
           },
           "type": "array",
-          "description": "AcceptedStates is a list of BundleDeployment state that are considered acceptable for this dependency.\nIf the dependency is in one of these states, it will not block the deployment of the dependent bundle.\nValid Values should match the StateRank keys.\nIf not specified, default to [\"Ready\"]: only fully ready dependencies are accepted\nExample: [\"Ready\", \"Modified\"] will accept dependencies that are either ready or have drifted from their desired state."
+          "description": "AcceptedStates is a list of BundleDeployment state that are considered acceptable for this dependency.\nIf the dependency is in one of these states, it will not block the deployment of the dependent bundle.\nValid Values should match the StateRank keys, except for WaitingForDependency, which is rejected:\nit would unblock this bundle exactly when its dependency became blocked on a dependency of its own.\nIf not specified, default to [\"Ready\"]: only fully ready dependencies are accepted\nExample: [\"Ready\", \"Modified\"] will accept dependencies that are either ready or have drifted from their desired state."
         }
       },
       "additionalProperties": false,


### PR DESCRIPTION
Introduces a new WaitingForDependency bundle/bundledeployment state so bundles blocked on an unaccepted dependency are reported distinctly from actual deployment errors, instead of surfacing as ErrApplied. Includes CRD, summary, and metrics updates plus e2e coverage.

Refers to: https://github.com/rancher/fleet/issues/4797

