### PR TITLE
Keep k3d test clusters from garbage-collecting local images

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -90,6 +90,7 @@ jobs:
           k3d cluster create upstream --wait \
             --agents 1 \
             --image docker.io/rancher/k3s:${{ env.SETUP_K3S_VERSION }} \
+            --k3s-arg "--kubelet-arg=image-gc-high-threshold=100@all" \
             --k3s-arg "--cluster-init@server:0"
 
       - name: Import Images Into k3d

--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -118,6 +118,7 @@ jobs:
               --agents 1 \
               --network "nw01" \
               --image docker.io/rancher/k3s:${{matrix.k3s.version}} \
+              --k3s-arg "--kubelet-arg=image-gc-high-threshold=100@all" \
               --k3s-arg "--cluster-init@server:0"; then
               echo "Cluster created successfully"
               break

--- a/.github/workflows/e2e-fleet-upgrade-ci.yml
+++ b/.github/workflows/e2e-fleet-upgrade-ci.yml
@@ -82,6 +82,7 @@ jobs:
             --agents 1 \
             --network "nw01" \
             --image docker.io/rancher/k3s:${{matrix.k3s.version}} \
+            --k3s-arg "--kubelet-arg=image-gc-high-threshold=100@all" \
             --k3s-arg "--cluster-init@server:0"
       -
         name: Deploy Latest Release

--- a/.github/workflows/e2e-multicluster-ci.yml
+++ b/.github/workflows/e2e-multicluster-ci.yml
@@ -87,6 +87,7 @@ jobs:
             -p "443:443@agent:0:direct" \
             --api-port 6443 \
             --agents 1 \
+            --k3s-arg "--kubelet-arg=image-gc-high-threshold=100@all" \
             --network "nw01"
       -
         name: Provision k3d Downstream Cluster for agent-initiated registration
@@ -96,6 +97,7 @@ jobs:
             -p "444:443@agent:0:direct" \
             --api-port 6644 \
             --agents 1 \
+            --k3s-arg "--kubelet-arg=image-gc-high-threshold=100@all" \
             --network "nw01"
       -
         name: Provision k3d Downstream Cluster for manager-initiated registration
@@ -105,6 +107,7 @@ jobs:
             -p "445:443@agent:0:direct" \
             --api-port 6645 \
             --agents 1 \
+            --k3s-arg "--kubelet-arg=image-gc-high-threshold=100@all" \
             --network "nw01"
       -
         name: Import Images Into k3d

--- a/.github/workflows/e2e-nightly-ci.yml
+++ b/.github/workflows/e2e-nightly-ci.yml
@@ -119,6 +119,7 @@ jobs:
             --agents 1 \
             --network "nw01" \
             --image "docker.io/rancher/k3s:${K3S_VERSION}" \
+            --k3s-arg "--kubelet-arg=image-gc-high-threshold=100@all" \
             --k3s-arg "--cluster-init@server:0"
       -
         name: Import Images Into k3d

--- a/.github/workflows/e2e-rancher-upgrade-fleet-to-head-ci.yml
+++ b/.github/workflows/e2e-rancher-upgrade-fleet-to-head-ci.yml
@@ -164,6 +164,7 @@ jobs:
             --agents 1 \
             --k3s-arg '--kubelet-arg=eviction-hard=imagefs.available<1%,nodefs.available<1%@agent:*' \
             --k3s-arg '--kubelet-arg=eviction-minimum-reclaim=imagefs.available=1%,nodefs.available=1%@agent:*' \
+            --k3s-arg "--kubelet-arg=image-gc-high-threshold=100@all" \
             --network "nw01" \
             --image docker.io/rancher/k3s:${{ env.SETUP_K3S_VERSION }} \
             --k3s-arg "--cluster-init@server:0"
@@ -177,6 +178,7 @@ jobs:
             --agents 1 \
             --k3s-arg '--kubelet-arg=eviction-hard=imagefs.available<1%,nodefs.available<1%@agent:*' \
             --k3s-arg '--kubelet-arg=eviction-minimum-reclaim=imagefs.available=1%,nodefs.available=1%@agent:*' \
+            --k3s-arg "--kubelet-arg=image-gc-high-threshold=100@all" \
             --network "nw01" \
             --image docker.io/rancher/k3s:${{ env.SETUP_K3S_VERSION }} \
             --k3s-arg "--cluster-init@server:0"

--- a/.github/workflows/e2e-rancher-upgrade-fleet.yml
+++ b/.github/workflows/e2e-rancher-upgrade-fleet.yml
@@ -129,6 +129,7 @@ jobs:
             --agents 1 \
             --k3s-arg '--kubelet-arg=eviction-hard=imagefs.available<1%,nodefs.available<1%@agent:*' \
             --k3s-arg '--kubelet-arg=eviction-minimum-reclaim=imagefs.available=1%,nodefs.available=1%@agent:*' \
+            --k3s-arg "--kubelet-arg=image-gc-high-threshold=100@all" \
             --network "nw01" \
             --image "docker.io/rancher/k3s:${K3S_VERSION}" \
             --k3s-arg "--cluster-init@server:0"
@@ -144,6 +145,7 @@ jobs:
             --agents 1 \
             --k3s-arg '--kubelet-arg=eviction-hard=imagefs.available<1%,nodefs.available<1%@agent:*' \
             --k3s-arg '--kubelet-arg=eviction-minimum-reclaim=imagefs.available=1%,nodefs.available=1%@agent:*' \
+            --k3s-arg "--kubelet-arg=image-gc-high-threshold=100@all" \
             --network "nw01" \
             --image "docker.io/rancher/k3s:${K3S_VERSION}" \
             --k3s-arg "--cluster-init@server:0"

--- a/.github/workflows/e2e-test-fleet-in-rancher.yml
+++ b/.github/workflows/e2e-test-fleet-in-rancher.yml
@@ -170,6 +170,7 @@ jobs:
             --agents 1 \
             --k3s-arg '--kubelet-arg=eviction-hard=imagefs.available<1%,nodefs.available<1%@agent:*' \
             --k3s-arg '--kubelet-arg=eviction-minimum-reclaim=imagefs.available=1%,nodefs.available=1%@agent:*' \
+            --k3s-arg "--kubelet-arg=image-gc-high-threshold=100@all" \
             --network "nw01" \
             --image docker.io/rancher/k3s:${{ env.SETUP_K3S_VERSION }} \
             --k3s-arg "--cluster-init@server:0"
@@ -184,6 +185,7 @@ jobs:
             --agents 1 \
             --k3s-arg '--kubelet-arg=eviction-hard=imagefs.available<1%,nodefs.available<1%@agent:*' \
             --k3s-arg '--kubelet-arg=eviction-minimum-reclaim=imagefs.available=1%,nodefs.available=1%@agent:*' \
+            --k3s-arg "--kubelet-arg=image-gc-high-threshold=100@all" \
             --network "nw01" \
             --image docker.io/rancher/k3s:${{ env.SETUP_K3S_VERSION }} \
             --k3s-arg "--cluster-init@server:0"

--- a/dev/setup-k3d
+++ b/dev/setup-k3d
@@ -57,4 +57,5 @@ k3d cluster create "$name" \
   -p "$(( 4343 + offs )):4343@server:0" \
   -p "$unique_tls_port:443@server:0" \
   --k3s-arg '--tls-san=k3d-upstream-server-0@server:0' \
+  --k3s-arg '--kubelet-arg=image-gc-high-threshold=100@all' \
   $args

--- a/dev/setup-k3ds-downstream
+++ b/dev/setup-k3ds-downstream
@@ -28,6 +28,7 @@ for i in $(seq 1 "$FLEET_E2E_DS_CLUSTER_COUNT"); do
     -p "$((4080 + (1000 * i))):80@server:0" \
     -p "$((3443 + i)):443@server:0" \
     --k3s-arg "--tls-san=k3d-$name$i-server-0@server:0" \
+    --k3s-arg "--kubelet-arg=image-gc-high-threshold=100@all" \
     $args
 done
 


### PR DESCRIPTION
E2E jobs import rancher/fleet:dev and rancher/fleet-agent:dev straight
into the k3d nodes' containerd and rely on imagePullPolicy IfNotPresent;
there is no registry to pull them from. Tests that scale the fleet-agent
deployment to zero, or restart its pod, leave the agent image
unreferenced, so kubelet's image garbage collection is free to evict it.
The agent then never comes back: it fails with ImagePullBackOff on
docker.io/rancher/fleet-agent:dev, and every spec waiting on a bundle
being applied times out.

Set image-gc-high-threshold to 100 on all nodes of the clusters created
in CI, which effectively disables that garbage collection for the
lifetime of a test run.<!-- Specify the issue ID that this pull request is solving -->


<!-- Make sure that the referenced issue provides steps to reproduce it -->

<!-- Describe the changes introduced by this pull request -->

<!--
  Please provide a unit, integration (`./integrationtests/`) or e2e (`./e2e/`) test if possible.
-->

## Additional Information

### Checklist

- [ ] <!-- If applicable,--> I have updated the documentation via a pull request in the [fleet-product-docs](https://github.com/rancher/fleet-product-docs) repository.
