### PR TITLE
Remove logrus codegen

### DIFF
--- a/cmd/codegen/jsonschema/main.go
+++ b/cmd/codegen/jsonschema/main.go
@@ -9,13 +9,13 @@ package main
 
 import (
 	"encoding/json"
+	"log"
 	"os"
 	"path/filepath"
 	"reflect"
 	"strings"
 
 	"github.com/invopop/jsonschema"
-	"github.com/sirupsen/logrus"
 
 	v1alpha1 "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
 
@@ -50,7 +50,7 @@ func main() {
 	// Pull `// ...` doc comments off the structs and turn them into schema
 	// descriptions. This is what gives IDEs inline documentation.
 	if err := r.AddGoComments(moduleBase, apisSrcDir); err != nil {
-		logrus.Fatalf("adding Go comments: %v", err)
+		log.Fatalf("adding Go comments: %v", err)
 	}
 	stripMarkers(r.CommentMap)
 
@@ -58,18 +58,18 @@ func main() {
 
 	data, err := json.MarshalIndent(schema, "", "  ")
 	if err != nil {
-		logrus.Fatalf("marshaling schema: %v", err)
+		log.Fatalf("marshaling schema: %v", err)
 	}
 	data = append(data, '\n')
 
 	if err := os.MkdirAll(filepath.Dir(outputPath), 0o755); err != nil {
-		logrus.Fatalf("creating output directory: %v", err)
+		log.Fatalf("creating output directory: %v", err)
 	}
 	if err := os.WriteFile(outputPath, data, 0o644); err != nil { //nolint:gosec
-		logrus.Fatalf("writing schema: %v", err)
+		log.Fatalf("writing schema: %v", err)
 	}
 
-	logrus.Infof("wrote %s", outputPath)
+	log.Printf("wrote %s", outputPath)
 }
 
 // stripMarkers removes code-generation marker lines from the extracted doc

--- a/dev/LOGGING.md
+++ b/dev/LOGGING.md
@@ -26,8 +26,8 @@ logger.V(1).Info(
 More info [here](https://github.com/kubernetes-sigs/controller-runtime/blob/main/TMP-LOGGING.md) on how
 `controller-runtime` approaches logging.
 
-Fleet has preexisting logging code using [logrus](https://github.com/sirupsen/logrus), which can be ported to
-[zap](https://pkg.go.dev/go.uber.org/zap), for which `controller-runtime` provides helpers.
+Fleet uses the controller-runtime `logr` API for structured logging. Runtime binaries configure it with
+[zap](https://pkg.go.dev/go.uber.org/zap) through controller-runtime's logging helpers.
 
 ## Where to log
 


### PR DESCRIPTION
Prevent `go mod tidy` from restoring `logrus` as a direct dependency.

- Replace `logrus` usage in the JSON schema generator with standard library logging.
- Update logging guidance to document controller-runtime `logr` and zap usage.

`logrus` remains only as an indirect dependency required by Wrangler.

