### PR TITLE
Allow pod-security namespace labels through Policy

### DIFF
--- a/charts/fleet-crd/templates/crds.yaml
+++ b/charts/fleet-crd/templates/crds.yaml
@@ -239,6 +239,25 @@ spec:
                   description: Options are the deployment options, that are currently
                     applied.
                   properties:
+                    allowPodSecurityNamespaceLabels:
+                      description: 'AllowPodSecurityNamespaceLabels controls whether
+                        NamespaceLabels with the
+
+                        `pod-security.kubernetes.io/` prefix are applied to the target
+                        namespace.
+
+                        When nil or false, those labels are dropped by the agent.
+                        It is set by the
+
+                        controller from the Policy objects of the bundle''s namespace
+                        and any value
+
+                        coming from fleet.yaml or a Bundle is discarded, so opting
+                        in is a cluster
+
+                        administrator decision.'
+                      nullable: true
+                      type: boolean
                     allowedTargetNamespaceSelector:
                       description: 'AllowedTargetNamespaceSelector restricts deployments
                         to namespaces matching this selector.
@@ -726,6 +745,25 @@ spec:
 
                     the next deployment.'
                   properties:
+                    allowPodSecurityNamespaceLabels:
+                      description: 'AllowPodSecurityNamespaceLabels controls whether
+                        NamespaceLabels with the
+
+                        `pod-security.kubernetes.io/` prefix are applied to the target
+                        namespace.
+
+                        When nil or false, those labels are dropped by the agent.
+                        It is set by the
+
+                        controller from the Policy objects of the bundle''s namespace
+                        and any value
+
+                        coming from fleet.yaml or a Bundle is discarded, so opting
+                        in is a cluster
+
+                        administrator decision.'
+                      nullable: true
+                      type: boolean
                     allowedTargetNamespaceSelector:
                       description: 'AllowedTargetNamespaceSelector restricts deployments
                         to namespaces matching this selector.
@@ -1694,6 +1732,25 @@ spec:
               type: object
             spec:
               properties:
+                allowPodSecurityNamespaceLabels:
+                  description: 'AllowPodSecurityNamespaceLabels controls whether NamespaceLabels
+                    with the
+
+                    `pod-security.kubernetes.io/` prefix are applied to the target
+                    namespace.
+
+                    When nil or false, those labels are dropped by the agent. It is
+                    set by the
+
+                    controller from the Policy objects of the bundle''s namespace
+                    and any value
+
+                    coming from fleet.yaml or a Bundle is discarded, so opting in
+                    is a cluster
+
+                    administrator decision.'
+                  nullable: true
+                  type: boolean
                 allowedTargetNamespaceSelector:
                   description: 'AllowedTargetNamespaceSelector restricts deployments
                     to namespaces matching this selector.
@@ -2699,6 +2756,25 @@ spec:
 
                       BundleDeploymentOptions from customizations into this struct.'
                     properties:
+                      allowPodSecurityNamespaceLabels:
+                        description: 'AllowPodSecurityNamespaceLabels controls whether
+                          NamespaceLabels with the
+
+                          `pod-security.kubernetes.io/` prefix are applied to the
+                          target namespace.
+
+                          When nil or false, those labels are dropped by the agent.
+                          It is set by the
+
+                          controller from the Policy objects of the bundle''s namespace
+                          and any value
+
+                          coming from fleet.yaml or a Bundle is discarded, so opting
+                          in is a cluster
+
+                          administrator decision.'
+                        nullable: true
+                        type: boolean
                       allowedTargetNamespaceSelector:
                         description: 'AllowedTargetNamespaceSelector restricts deployments
                           to namespaces matching this selector.
@@ -8035,6 +8111,25 @@ spec:
               type: object
             spec:
               properties:
+                allowPodSecurityNamespaceLabels:
+                  description: 'AllowPodSecurityNamespaceLabels controls whether NamespaceLabels
+                    with the
+
+                    `pod-security.kubernetes.io/` prefix are applied to the target
+                    namespace.
+
+                    When nil or false, those labels are dropped by the agent. It is
+                    set by the
+
+                    controller from the Policy objects of the bundle''s namespace
+                    and any value
+
+                    coming from fleet.yaml or a Bundle is discarded, so opting in
+                    is a cluster
+
+                    administrator decision.'
+                  nullable: true
+                  type: boolean
                 allowedTargetNamespaceSelector:
                   description: 'AllowedTargetNamespaceSelector restricts deployments
                     to namespaces matching this selector.
@@ -9072,6 +9167,25 @@ spec:
 
                       BundleDeploymentOptions from customizations into this struct.'
                     properties:
+                      allowPodSecurityNamespaceLabels:
+                        description: 'AllowPodSecurityNamespaceLabels controls whether
+                          NamespaceLabels with the
+
+                          `pod-security.kubernetes.io/` prefix are applied to the
+                          target namespace.
+
+                          When nil or false, those labels are dropped by the agent.
+                          It is set by the
+
+                          controller from the Policy objects of the bundle''s namespace
+                          and any value
+
+                          coming from fleet.yaml or a Bundle is discarded, so opting
+                          in is a cluster
+
+                          administrator decision.'
+                        nullable: true
+                        type: boolean
                       allowedTargetNamespaceSelector:
                         description: 'AllowedTargetNamespaceSelector restricts deployments
                           to namespaces matching this selector.
@@ -10462,6 +10576,22 @@ spec:
                 through other means (ValidatingAdmissionPolicy, Kyverno, etc.) can
 
                 set this to true.'
+              type: boolean
+            allowPodSecurityNamespaceLabels:
+              description: 'AllowPodSecurityNamespaceLabels, when true, allows namespaceLabels
+                with
+
+                the `pod-security.kubernetes.io/` prefix to be applied to the target
+
+                namespace on downstream clusters. By default (false) those labels
+                are
+
+                dropped, so Pod Security Standards set by cluster administrators cannot
+
+                be weakened through fleet.yaml. Set this to true in workspaces where
+                the
+
+                Git contents are trusted to manage Pod Security Standards.'
               type: boolean
             allowedServiceAccounts:
               description: 'AllowedServiceAccounts lists service accounts that may

--- a/integrationtests/controller/bundle/bundle_namespace_labels_test.go
+++ b/integrationtests/controller/bundle/bundle_namespace_labels_test.go
@@ -1,0 +1,102 @@
+package bundle
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/rancher/fleet/integrationtests/utils"
+	"github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("Bundle namespace labels", func() {
+	var bundleName string
+
+	// createBundle creates a bundle targeting the single cluster of the test
+	// namespace, with pod-security namespaceLabels and an attempt to opt into
+	// applying them from the bundle itself.
+	createBundle := func() {
+		allow := true
+		bundle := &v1alpha1.Bundle{
+			ObjectMeta: metav1.ObjectMeta{Name: bundleName, Namespace: namespace},
+			Spec: v1alpha1.BundleSpec{
+				BundleDeploymentOptions: v1alpha1.BundleDeploymentOptions{
+					AllowPodSecurityNamespaceLabels: &allow,
+					NamespaceLabels: map[string]string{
+						"pod-security.kubernetes.io/enforce": "privileged",
+					},
+				},
+				Targets: []v1alpha1.BundleTarget{{Name: "cluster", ClusterName: "cluster"}},
+			},
+		}
+		Expect(k8sClient.Create(ctx, bundle)).ToNot(HaveOccurred())
+
+		DeferCleanup(func() {
+			Expect(k8sClient.Delete(ctx, bundle)).ToNot(HaveOccurred())
+			cleanupBundleDeployments(bundleName, namespace)
+		})
+	}
+
+	bundleDeploymentOptions := func(g Gomega) v1alpha1.BundleDeploymentOptions {
+		list := &v1alpha1.BundleDeploymentList{}
+		g.Expect(k8sClient.List(ctx, list, client.MatchingLabels{
+			"fleet.cattle.io/bundle-name":      bundleName,
+			"fleet.cattle.io/bundle-namespace": namespace,
+		})).To(Succeed())
+		g.Expect(list.Items).To(HaveLen(1))
+		return list.Items[0].Spec.Options
+	}
+
+	BeforeEach(func() {
+		var err error
+		namespace, err = utils.NewNamespaceName()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(k8sClient.Create(ctx, &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: namespace},
+		})).ToNot(HaveOccurred())
+
+		bundleName = "namespace-labels"
+
+		_, err = utils.CreateCluster(ctx, k8sClient, "cluster", namespace, nil, namespace)
+		Expect(err).ToNot(HaveOccurred())
+
+		DeferCleanup(func() {
+			Expect(k8sClient.Delete(ctx, &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{Name: namespace},
+			})).ToNot(HaveOccurred())
+		})
+	})
+
+	When("no Policy allows pod-security namespace labels", func() {
+		It("does not opt the BundleDeployment into applying them", func() {
+			createBundle()
+
+			Eventually(func(g Gomega) {
+				opts := bundleDeploymentOptions(g)
+				g.Expect(opts.NamespaceLabels).To(
+					HaveKeyWithValue("pod-security.kubernetes.io/enforce", "privileged"))
+				g.Expect(opts.AllowPodSecurityNamespaceLabels).To(BeNil())
+			}).Should(Succeed())
+		})
+	})
+
+	When("a Policy allows pod-security namespace labels", func() {
+		It("opts the BundleDeployment into applying them", func() {
+			Expect(k8sClient.Create(ctx, &v1alpha1.Policy{
+				ObjectMeta:                      metav1.ObjectMeta{Name: "policy", Namespace: namespace},
+				AllowPodSecurityNamespaceLabels: true,
+			})).ToNot(HaveOccurred())
+
+			createBundle()
+
+			Eventually(func(g Gomega) {
+				opts := bundleDeploymentOptions(g)
+				g.Expect(opts.AllowPodSecurityNamespaceLabels).ToNot(BeNil())
+				g.Expect(*opts.AllowPodSecurityNamespaceLabels).To(BeTrue())
+			}).Should(Succeed())
+		})
+	})
+})

--- a/internal/cmd/agent/deployer/deployer.go
+++ b/internal/cmd/agent/deployer/deployer.go
@@ -257,7 +257,9 @@ func (d *Deployer) setNamespaceLabelsAndAnnotations(ctx context.Context, bd *fle
 		if desiredLabels == nil {
 			desiredLabels = make(map[string]string)
 		}
-		addLabelsFromOptions(log.FromContext(ctx), desiredLabels, bd.Spec.Options.NamespaceLabels)
+		allowPodSecurity := bd.Spec.Options.AllowPodSecurityNamespaceLabels != nil &&
+			*bd.Spec.Options.AllowPodSecurityNamespaceLabels
+		addLabelsFromOptions(log.FromContext(ctx), desiredLabels, bd.Spec.Options.NamespaceLabels, allowPodSecurity)
 	}
 	desiredAnnotations := maps.Clone(ns.Annotations)
 	if bd.Spec.Options.NamespaceAnnotations != nil {
@@ -332,20 +334,19 @@ const podSecurityLabelPrefix = "pod-security.kubernetes.io/"
 
 // addLabelsFromOptions updates nsLabels to contain labels from optLabels, while preserving
 // the `kubernetes.io/metadata.name` label added by Kubernetes when creating the namespace
-// and any existing `pod-security.kubernetes.io/*` labels. Labels with the
-// `pod-security.kubernetes.io/` prefix in optLabels are ignored.
+// and any existing `pod-security.kubernetes.io/*` labels which optLabels does not declare.
 //
-// This filtering is intentionally unconditional and independent of the
-// service-account impersonation used for the namespace patch: it must also hold
-// for deployments that run as the agent (no service account pinned), where
-// there is no downstream RBAC gating at all. It is the only safeguard against a
-// bundle escalating pod-security enforcement on its target namespace. To set
-// pod-security labels on a namespace, declare them on the Namespace resource in
-// the bundle instead.
-func addLabelsFromOptions(logger logr.Logger, nsLabels map[string]string, optLabels map[string]string) {
+// Labels with the `pod-security.kubernetes.io/` prefix in optLabels are only
+// applied when allowPodSecurity is true. That flag comes from the
+// BundleDeployment options, where the controller sets it from a Policy of the
+// bundle's namespace; it cannot be requested from fleet.yaml. Without it, a
+// bundle could weaken pod-security enforcement on its target namespace, which
+// is not gated by downstream RBAC for deployments running as the agent.
+func addLabelsFromOptions(logger logr.Logger, nsLabels map[string]string, optLabels map[string]string, allowPodSecurity bool) {
 	for k, v := range optLabels {
-		if strings.HasPrefix(k, podSecurityLabelPrefix) {
-			logger.V(1).Info("Ignoring label from options", "label", k)
+		if !allowPodSecurity && strings.HasPrefix(k, podSecurityLabelPrefix) {
+			logger.Info("Ignoring pod-security label from options: no Policy in the bundle's namespace "+
+				"sets allowPodSecurityNamespaceLabels", "label", k)
 			continue
 		}
 		nsLabels[k] = v
@@ -353,7 +354,7 @@ func addLabelsFromOptions(logger logr.Logger, nsLabels map[string]string, optLab
 
 	// Delete labels not defined in the options.
 	// Keep the `kubernetes.io/metadata.name` label as it is added by kubernetes when creating the namespace.
-	// Keep pod-security.kubernetes.io/ labels as they are managed by cluster administrators.
+	// Keep undeclared pod-security.kubernetes.io/ labels as they are managed by cluster administrators.
 	for k := range nsLabels {
 		if strings.HasPrefix(k, podSecurityLabelPrefix) {
 			continue

--- a/internal/cmd/agent/deployer/deployer_test.go
+++ b/internal/cmd/agent/deployer/deployer_test.go
@@ -350,9 +350,10 @@ func TestSetNamespaceLabelsAndAnnotations_NoUpdateWhenAlreadyCorrect(t *testing.
 
 func TestAddLabelsFromOptions_PodSecurityLabelsFiltered(t *testing.T) {
 	tests := map[string]struct {
-		nsLabels       map[string]string
-		optLabels      map[string]string
-		expectedLabels map[string]string
+		nsLabels         map[string]string
+		optLabels        map[string]string
+		allowPodSecurity bool
+		expectedLabels   map[string]string
 	}{
 		"pod-security.kubernetes.io labels in optLabels are not applied to namespace": {
 			nsLabels: map[string]string{"kubernetes.io/metadata.name": "ns"},
@@ -409,11 +410,29 @@ func TestAddLabelsFromOptions_PodSecurityLabelsFiltered(t *testing.T) {
 				"safe-label":                  "value",
 			},
 		},
+		"pod-security.kubernetes.io labels are applied when allowed by Policy": {
+			nsLabels: map[string]string{
+				"kubernetes.io/metadata.name":        "ns",
+				"pod-security.kubernetes.io/enforce": "restricted",
+				"pod-security.kubernetes.io/audit":   "restricted",
+			},
+			optLabels: map[string]string{
+				"pod-security.kubernetes.io/enforce": "privileged",
+				"safe-label":                         "value",
+			},
+			allowPodSecurity: true,
+			expectedLabels: map[string]string{
+				"kubernetes.io/metadata.name":        "ns",
+				"pod-security.kubernetes.io/enforce": "privileged",
+				"pod-security.kubernetes.io/audit":   "restricted",
+				"safe-label":                         "value",
+			},
+		},
 	}
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			addLabelsFromOptions(logr.Discard(), test.nsLabels, test.optLabels)
+			addLabelsFromOptions(logr.Discard(), test.nsLabels, test.optLabels, test.allowPodSecurity)
 
 			if len(test.nsLabels) != len(test.expectedLabels) {
 				t.Errorf("expected %d labels, got %d: %v", len(test.expectedLabels), len(test.nsLabels), test.nsLabels)
@@ -474,6 +493,48 @@ func TestSetNamespaceLabelsAndAnnotations_PodSecurityLabelsPreserved(t *testing.
 	}
 	if result.Labels["app-label"] != "value" {
 		t.Errorf("app-label: got %s, want value", result.Labels["app-label"])
+	}
+}
+
+// TestSetNamespaceLabelsAndAnnotations_PodSecurityLabelsAllowed verifies that
+// pod-security labels from namespaceLabels are applied when the controller
+// resolved a Policy allowing them.
+func TestSetNamespaceLabelsAndAnnotations_PodSecurityLabelsAllowed(t *testing.T) {
+	allow := true
+	bd := &fleet.BundleDeployment{Spec: fleet.BundleDeploymentSpec{
+		Options: fleet.BundleDeploymentOptions{
+			AllowPodSecurityNamespaceLabels: &allow,
+			NamespaceLabels: map[string]string{
+				"pod-security.kubernetes.io/enforce": "privileged",
+			},
+		},
+	}}
+	ns := corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "namespace",
+			Labels: map[string]string{
+				"kubernetes.io/metadata.name":        "namespace",
+				"pod-security.kubernetes.io/enforce": "restricted",
+			},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(&ns).Build()
+	h := Deployer{client: client}
+
+	if err := h.setNamespaceLabelsAndAnnotations(context.Background(), bd, "namespace/foo/bar"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	result := &corev1.Namespace{}
+	if err := client.Get(context.Background(), types.NamespacedName{Name: "namespace"}, result); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Labels["pod-security.kubernetes.io/enforce"] != "privileged" {
+		t.Errorf("pod-security.kubernetes.io/enforce: got %s, want privileged",
+			result.Labels["pod-security.kubernetes.io/enforce"])
 	}
 }
 

--- a/internal/cmd/controller/policyrestrictions/policyrestrictions.go
+++ b/internal/cmd/controller/policyrestrictions/policyrestrictions.go
@@ -13,9 +13,10 @@ import (
 
 // Merged is the aggregated result of one or more Policy objects in a namespace.
 type Merged struct {
-	RequireServiceAccount  bool
-	AllowedServiceAccounts []string
-	AllowNamespaceCreation bool
+	RequireServiceAccount           bool
+	AllowedServiceAccounts          []string
+	AllowNamespaceCreation          bool
+	AllowPodSecurityNamespaceLabels bool
 
 	// GitRepo-specific
 	GitDefaultServiceAccount    string
@@ -52,6 +53,11 @@ func Aggregate(policies []fleet.Policy) Merged {
 		// ensure no Policy in the namespace sets allowNamespaceCreation: true.
 		if p.AllowNamespaceCreation {
 			m.AllowNamespaceCreation = true
+		}
+		// Least-restrictive as well: one Policy allowing pod-security namespace
+		// labels enables them for all deployments in that namespace.
+		if p.AllowPodSecurityNamespaceLabels {
+			m.AllowPodSecurityNamespaceLabels = true
 		}
 		m.AllowedServiceAccounts = append(m.AllowedServiceAccounts, p.AllowedServiceAccounts...)
 

--- a/internal/cmd/controller/target/builder.go
+++ b/internal/cmd/controller/target/builder.go
@@ -64,6 +64,11 @@ func (m *Manager) Targets(ctx context.Context, bundle *fleet.Bundle, manifestID 
 		return nil, false, fmt.Errorf("failed to resolve createNamespace from Policy: %w", err)
 	}
 
+	allowPodSecurityNamespaceLabels, err := m.getAllowPodSecurityNamespaceLabelsForBundle(ctx, bundle)
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to resolve allowPodSecurityNamespaceLabels from Policy: %w", err)
+	}
+
 	bm, err := matcher.New(bundle)
 	if err != nil {
 		return nil, false, err
@@ -149,6 +154,10 @@ func (m *Manager) Targets(ctx context.Context, bundle *fleet.Bundle, manifestID 
 			if createNamespace != nil {
 				opts.CreateNamespace = createNamespace
 			}
+			// Discard any value coming from fleet.yaml or the Bundle: only
+			// Policy objects, which are managed by cluster administrators, may
+			// enable pod-security namespace labels.
+			opts.AllowPodSecurityNamespaceLabels = allowPodSecurityNamespaceLabels
 
 			err = preprocessHelmValues(logger, &opts, &cluster)
 			if err != nil {
@@ -501,4 +510,26 @@ func (m *Manager) getCreateNamespaceForBundle(ctx context.Context, bundle *fleet
 	}
 
 	return nil, nil
+}
+
+// getAllowPodSecurityNamespaceLabelsForBundle resolves whether namespaceLabels
+// with the `pod-security.kubernetes.io/` prefix may be applied to the target
+// namespace, based on Policy objects in the bundle's namespace. Returns a
+// pointer to true when the aggregated policy allows them, nil otherwise, which
+// the agent treats as "filter them out".
+func (m *Manager) getAllowPodSecurityNamespaceLabelsForBundle(ctx context.Context, bundle *fleet.Bundle) (*bool, error) {
+	policies := &fleet.PolicyList{}
+	if err := m.client.List(ctx, policies, client.InNamespace(bundle.Namespace)); err != nil {
+		if apimeta.IsNoMatchError(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to list Policies: %w", err)
+	}
+
+	if !policyrestrictions.Aggregate(policies.Items).AllowPodSecurityNamespaceLabels {
+		return nil, nil
+	}
+
+	v := true
+	return &v, nil
 }

--- a/internal/cmd/controller/target/builder_test.go
+++ b/internal/cmd/controller/target/builder_test.go
@@ -1,0 +1,88 @@
+package target
+
+import (
+	"context"
+	"testing"
+
+	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestGetAllowPodSecurityNamespaceLabelsForBundle(t *testing.T) {
+	tests := map[string]struct {
+		policies []fleet.Policy
+		expected *bool
+	}{
+		"no policy keeps pod-security labels filtered": {
+			expected: nil,
+		},
+		"policy without the option keeps pod-security labels filtered": {
+			policies: []fleet.Policy{{
+				ObjectMeta:            metav1.ObjectMeta{Name: "p1", Namespace: "fleet-default"},
+				RequireServiceAccount: true,
+			}},
+			expected: nil,
+		},
+		"policy allowing pod-security labels opts in": {
+			policies: []fleet.Policy{{
+				ObjectMeta:                      metav1.ObjectMeta{Name: "p1", Namespace: "fleet-default"},
+				AllowPodSecurityNamespaceLabels: true,
+			}},
+			expected: new(true),
+		},
+		"one allowing policy among several opts in": {
+			policies: []fleet.Policy{
+				{
+					ObjectMeta:            metav1.ObjectMeta{Name: "p1", Namespace: "fleet-default"},
+					RequireServiceAccount: true,
+				},
+				{
+					ObjectMeta:                      metav1.ObjectMeta{Name: "p2", Namespace: "fleet-default"},
+					AllowPodSecurityNamespaceLabels: true,
+				},
+			},
+			expected: new(true),
+		},
+		"policy in another namespace is ignored": {
+			policies: []fleet.Policy{{
+				ObjectMeta:                      metav1.ObjectMeta{Name: "p1", Namespace: "fleet-local"},
+				AllowPodSecurityNamespaceLabels: true,
+			}},
+			expected: nil,
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(fleet.AddToScheme(scheme))
+
+	bundle := &fleet.Bundle{ObjectMeta: metav1.ObjectMeta{Name: "bundle", Namespace: "fleet-default"}}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			builder := fake.NewClientBuilder().WithScheme(scheme)
+			for i := range test.policies {
+				builder = builder.WithObjects(&test.policies[i])
+			}
+			m := New(builder.Build(), nil)
+
+			got, err := m.getAllowPodSecurityNamespaceLabelsForBundle(context.Background(), bundle)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			switch {
+			case test.expected == nil && got != nil:
+				t.Errorf("expected nil, got %v", *got)
+			case test.expected != nil && got == nil:
+				t.Errorf("expected %v, got nil", *test.expected)
+			case test.expected != nil && *got != *test.expected:
+				t.Errorf("expected %v, got %v", *test.expected, *got)
+			}
+		})
+	}
+}

--- a/pkg/apis/fleet.cattle.io/v1alpha1/bundledeployment_types.go
+++ b/pkg/apis/fleet.cattle.io/v1alpha1/bundledeployment_types.go
@@ -121,6 +121,16 @@ type BundleDeploymentOptions struct {
 	// +nullable
 	NamespaceLabels map[string]string `json:"namespaceLabels,omitempty"`
 
+	// AllowPodSecurityNamespaceLabels controls whether NamespaceLabels with the
+	// `pod-security.kubernetes.io/` prefix are applied to the target namespace.
+	// When nil or false, those labels are dropped by the agent. It is set by the
+	// controller from the Policy objects of the bundle's namespace and any value
+	// coming from fleet.yaml or a Bundle is discarded, so opting in is a cluster
+	// administrator decision.
+	// +optional
+	// +nullable
+	AllowPodSecurityNamespaceLabels *bool `json:"allowPodSecurityNamespaceLabels,omitempty"`
+
 	// NamespaceAnnotations are annotations that will be appended to the namespace created by Fleet.
 	// +nullable
 	NamespaceAnnotations map[string]string `json:"namespaceAnnotations,omitempty"`

--- a/pkg/apis/fleet.cattle.io/v1alpha1/policy_types.go
+++ b/pkg/apis/fleet.cattle.io/v1alpha1/policy_types.go
@@ -51,6 +51,15 @@ type Policy struct {
 	// +optional
 	AllowNamespaceCreation bool `json:"allowNamespaceCreation,omitempty"`
 
+	// AllowPodSecurityNamespaceLabels, when true, allows namespaceLabels with
+	// the `pod-security.kubernetes.io/` prefix to be applied to the target
+	// namespace on downstream clusters. By default (false) those labels are
+	// dropped, so Pod Security Standards set by cluster administrators cannot
+	// be weakened through fleet.yaml. Set this to true in workspaces where the
+	// Git contents are trusted to manage Pod Security Standards.
+	// +optional
+	AllowPodSecurityNamespaceLabels bool `json:"allowPodSecurityNamespaceLabels,omitempty"`
+
 	// GitRepo contains restrictions and defaults applied only by the GitRepo reconciler.
 	// +optional
 	GitRepo *GitRepoPolicySpec `json:"gitRepo,omitempty"`

--- a/pkg/apis/fleet.cattle.io/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/fleet.cattle.io/v1alpha1/zz_generated.deepcopy.go
@@ -221,6 +221,11 @@ func (in *BundleDeploymentOptions) DeepCopyInto(out *BundleDeploymentOptions) {
 			(*out)[key] = val
 		}
 	}
+	if in.AllowPodSecurityNamespaceLabels != nil {
+		in, out := &in.AllowPodSecurityNamespaceLabels, &out.AllowPodSecurityNamespaceLabels
+		*out = new(bool)
+		**out = **in
+	}
 	if in.NamespaceAnnotations != nil {
 		in, out := &in.NamespaceAnnotations, &out.NamespaceAnnotations
 		*out = make(map[string]string, len(*in))

--- a/schemas/fleet.yaml.json
+++ b/schemas/fleet.yaml.json
@@ -95,6 +95,10 @@
           "type": "object",
           "description": "NamespaceLabels are labels that will be appended to the namespace created by Fleet."
         },
+        "allowPodSecurityNamespaceLabels": {
+          "type": "boolean",
+          "description": "AllowPodSecurityNamespaceLabels controls whether NamespaceLabels with the\n`pod-security.kubernetes.io/` prefix are applied to the target namespace.\nWhen nil or false, those labels are dropped by the agent. It is set by the\ncontroller from the Policy objects of the bundle's namespace and any value\ncoming from fleet.yaml or a Bundle is discarded, so opting in is a cluster\nadministrator decision."
+        },
         "namespaceAnnotations": {
           "additionalProperties": {
             "type": "string"
@@ -736,6 +740,10 @@
       },
       "type": "object",
       "description": "NamespaceLabels are labels that will be appended to the namespace created by Fleet."
+    },
+    "allowPodSecurityNamespaceLabels": {
+      "type": "boolean",
+      "description": "AllowPodSecurityNamespaceLabels controls whether NamespaceLabels with the\n`pod-security.kubernetes.io/` prefix are applied to the target namespace.\nWhen nil or false, those labels are dropped by the agent. It is set by the\ncontroller from the Policy objects of the bundle's namespace and any value\ncoming from fleet.yaml or a Bundle is discarded, so opting in is a cluster\nadministrator decision."
     },
     "namespaceAnnotations": {
       "additionalProperties": {


### PR DESCRIPTION
Namespace labels with the `pod-security.kubernetes.io/` prefix are dropped by the agent, which also blocks operators who use `namespaceLabels` in `fleet.yaml` to set Pod Security Standards on the namespaces Fleet creates.

`Policy.allowPodSecurityNamespaceLabels` re-enables those labels for a workspace. The controller resolves it from the Policy objects of the bundle namespace into `BundleDeployment.spec.options` and discards any value coming from `fleet.yaml` or a Bundle, so opting in stays a cluster administrator decision. Without such a Policy the labels are still filtered, and pod-security labels a bundle does not declare are never removed.

Refers #5550 