### PR TITLE
Confirm deletion upstream before uninstalling releases

### DIFF
--- a/integrationtests/agent/bundle_deployment_stale_cache_test.go
+++ b/integrationtests/agent/bundle_deployment_stale_cache_test.go
@@ -26,8 +26,8 @@ func helmReleaseSecrets(namespace string) []corev1.Secret {
 	return list.Items
 }
 
-// The agent used to delete the resources it manages whenever its cached 
-// client reported a BundleDeployment as NotFound, 
+// The agent used to delete the resources it manages whenever its cached
+// client reported a BundleDeployment as NotFound,
 // even though the BundleDeployment still existed upstream.
 //
 // The agent reads BundleDeployments through the manager's cache

--- a/integrationtests/agent/bundle_deployment_stale_cache_test.go
+++ b/integrationtests/agent/bundle_deployment_stale_cache_test.go
@@ -1,0 +1,165 @@
+package agent_test
+
+import (
+	"context"
+	"strconv"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
+)
+
+// helmReleaseSecrets returns the helm release storage secrets living in the
+// given namespace.
+func helmReleaseSecrets(namespace string) []corev1.Secret {
+	list := &corev1.SecretList{}
+	err := k8sClient.List(ctx, list, client.InNamespace(namespace), client.MatchingLabels{"owner": "helm"})
+	Expect(err).ToNot(HaveOccurred())
+
+	return list.Items
+}
+
+// The agent used to delete the resources it manages whenever its cached 
+// client reported a BundleDeployment as NotFound, 
+// even though the BundleDeployment still existed upstream.
+//
+// The agent reads BundleDeployments through the manager's cache
+// (mgr.GetClient()). controller-runtime's CacheReader.Get returns a plain
+// NotFound whenever the object is missing from the local informer store, and
+// makes no distinction between "the object was deleted" and "our store is
+// empty or behind". The fix is to confirm with a live read
+// (mgr.GetAPIReader()) before uninstalling anything.
+//
+// hideBundleDeployment() reproduces the stale cache exactly: the API server
+// keeps the BundleDeployment, only the agent's cached view of it disappears.
+var _ = Describe("BundleDeployment reported as NotFound by a stale agent cache", Ordered, func() {
+	var (
+		namespace string
+		name      string
+		env       *specEnv
+		pokes     int
+	)
+
+	createBundleDeployment := func(name string) {
+		bd := v1alpha1.BundleDeployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: clusterNS,
+			},
+			Spec: v1alpha1.BundleDeploymentSpec{
+				DeploymentID: "v1",
+				Options: v1alpha1.BundleDeploymentOptions{
+					DefaultNamespace: namespace,
+				},
+			},
+		}
+
+		Expect(k8sClient.Create(context.TODO(), &bd)).ToNot(HaveOccurred())
+	}
+
+	// triggerReconcile wakes up the agent for this BundleDeployment without
+	// changing anything about it. A label change is enough to pass the
+	// controller's event filter. In a real cluster the wake-up comes for free:
+	// emptying the informer store makes the informer emit a delete event.
+	triggerReconcile := func(name string) {
+		bd := &v1alpha1.BundleDeployment{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: clusterNS, Name: name}, bd)).ToNot(HaveOccurred())
+
+		if bd.Labels == nil {
+			bd.Labels = map[string]string{}
+		}
+		pokes++
+		bd.Labels["poke"] = strconv.Itoa(pokes)
+
+		Expect(k8sClient.Update(ctx, bd)).ToNot(HaveOccurred())
+	}
+
+	When("the BundleDeployment is missing from the cache but still exists upstream", func() {
+		BeforeAll(func() {
+			name = "stale-cache-keeps-resources"
+			namespace = createNamespace()
+			env = &specEnv{namespace: namespace}
+
+			createBundleDeployment(name)
+			DeferCleanup(func() {
+				unhideBundleDeployment(clusterNS, name)
+				Expect(k8sClient.Delete(context.TODO(), &v1alpha1.BundleDeployment{
+					ObjectMeta: metav1.ObjectMeta{Namespace: clusterNS, Name: name},
+				})).ToNot(HaveOccurred())
+			})
+		})
+
+		It("keeps the deployed resources", func() {
+			By("Deploying the bundle's resources")
+			Eventually(env.isBundleDeploymentReadyAndNotModified).WithArguments(name).Should(BeTrue())
+			_, err := env.getConfigMap("cm-test")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(helmReleaseSecrets(namespace)).ToNot(BeEmpty())
+
+			By("Making the BundleDeployment invisible to the agent's cache only")
+			hideBundleDeployment(clusterNS, name)
+
+			By("Checking that the BundleDeployment is still there for anyone reading the API server")
+			bd := &v1alpha1.BundleDeployment{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: clusterNS, Name: name}, bd)).ToNot(HaveOccurred())
+
+			By("Waking up the agent")
+			triggerReconcile(name)
+
+			By("Observing that the agent left the resources alone")
+			// The window has to outlast a reconcile on a loaded CI runner:
+			// a shorter one could close before the agent gets to delete
+			// anything, and pass with the bug present.
+			Consistently(func() error {
+				_, err := env.getConfigMap("cm-test")
+				return err
+			}).WithTimeout(10*time.Second).WithPolling(250*time.Millisecond).
+				Should(Succeed(), "cm-test was deleted, see rancher/fleet#5406")
+
+			_, err = env.getService("svc-test")
+			Expect(err).ToNot(HaveOccurred(), "svc-test was deleted, see rancher/fleet#5406")
+
+			By("Checking that the helm release was left alone too")
+			Expect(helmReleaseSecrets(namespace)).ToNot(BeEmpty())
+		})
+	})
+
+	When("the BundleDeployment is really deleted", func() {
+		BeforeAll(func() {
+			name = "deleted-bundledeployment"
+			namespace = createNamespace()
+			env = &specEnv{namespace: namespace}
+
+			createBundleDeployment(name)
+		})
+
+		It("still deletes the deployed resources", func() {
+			By("Deploying the bundle's resources")
+			Eventually(env.isBundleDeploymentReadyAndNotModified).WithArguments(name).Should(BeTrue())
+			_, err := env.getConfigMap("cm-test")
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Deleting the BundleDeployment for real")
+			Expect(k8sClient.Delete(context.TODO(), &v1alpha1.BundleDeployment{
+				ObjectMeta: metav1.ObjectMeta{Namespace: clusterNS, Name: name},
+			})).ToNot(HaveOccurred())
+
+			By("Observing that the agent uninstalled the release")
+			Eventually(func() bool {
+				_, err := env.getConfigMap("cm-test")
+				return err != nil
+			}).Should(BeTrue(), "cm-test survived a genuine deletion")
+
+			Eventually(func() bool {
+				return len(helmReleaseSecrets(namespace)) == 0
+			}).Should(BeTrue(), "the helm release survived a genuine deletion")
+		})
+	})
+})

--- a/integrationtests/agent/suite_test.go
+++ b/integrationtests/agent/suite_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"sync"
 	"testing"
 	"time"
 
@@ -13,8 +14,10 @@ import (
 	"github.com/rancher/wrangler/v3/pkg/genericcondition"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/discovery"
@@ -138,9 +141,14 @@ var _ = AfterSuite(func() {
 // in the test Fleet namespace, using configuration from the provided manager.
 // Resources are provided by the lookup parameter.
 func newReconciler(ctx context.Context, mgr manager.Manager, lookup *lookup, driftChan chan event.TypedGenericEvent[*v1alpha1.BundleDeployment]) *controller.BundleDeploymentReconciler {
-	upstreamClient := mgr.GetClient()
+	cachedClient := mgr.GetClient()
 	// re-use client, since this is a single cluster test
-	localClient := upstreamClient
+	localClient := cachedClient
+
+	// The agent reads BundleDeployments through the manager's cache. Wrapping
+	// it lets a test make a single BundleDeployment invisible to the agent,
+	// the way a stale informer store does, while the API server still has it.
+	upstreamClient := &staleCacheClient{Client: cachedClient}
 
 	systemNamespace := "cattle-fleet-system"
 	fleetNamespace := clusterNS
@@ -197,6 +205,7 @@ func newReconciler(ctx context.Context, mgr manager.Manager, lookup *lookup, dri
 	// Build the clean up
 	cleanup := cleanup.New(
 		upstreamClient,
+		mgr.GetAPIReader(),
 		mapper,
 		localDynamic,
 		helmDeployer,
@@ -207,6 +216,7 @@ func newReconciler(ctx context.Context, mgr manager.Manager, lookup *lookup, dri
 
 	return &controller.BundleDeploymentReconciler{
 		Client: upstreamClient,
+		Reader: mgr.GetAPIReader(),
 
 		Scheme:      mgr.GetScheme(),
 		LocalClient: localClient,
@@ -221,6 +231,42 @@ func newReconciler(ctx context.Context, mgr manager.Manager, lookup *lookup, dri
 		AgentScope: agentScope,
 		Workers:    50,
 	}
+}
+
+// hiddenBundleDeployments holds the keys of BundleDeployments that
+// staleCacheClient must pretend not to know about, as "namespace/name".
+var hiddenBundleDeployments sync.Map
+
+// hideBundleDeployment makes the agent's cached client report the
+// BundleDeployment as NotFound, without touching the API server. This is what
+// controller-runtime's CacheReader does whenever the object is missing from
+// the local informer store: it returns a plain NotFound, with no check on
+// whether the store is in sync (see pkg/cache/internal/cache_reader.go).
+func hideBundleDeployment(namespace, name string) {
+	hiddenBundleDeployments.Store(namespace+"/"+name, struct{}{})
+}
+
+func unhideBundleDeployment(namespace, name string) {
+	hiddenBundleDeployments.Delete(namespace + "/" + name)
+}
+
+// staleCacheClient is the agent's upstream client, with the ability to
+// simulate a stale cache for individual BundleDeployments.
+type staleCacheClient struct {
+	client.Client
+}
+
+func (c *staleCacheClient) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+	if _, ok := obj.(*v1alpha1.BundleDeployment); ok {
+		if _, hidden := hiddenBundleDeployments.Load(key.String()); hidden {
+			return apierrors.NewNotFound(
+				schema.GroupResource{Group: v1alpha1.SchemeGroupVersion.Group, Resource: "bundledeployments"},
+				key.Name,
+			)
+		}
+	}
+
+	return c.Client.Get(ctx, key, obj, opts...)
 }
 
 // restClientGetter is needed to create the helm deployer. We just need to return the rest.Config for this test.

--- a/internal/cmd/agent/controller/bundledeployment_controller.go
+++ b/internal/cmd/agent/controller/bundledeployment_controller.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/rancher/fleet/internal/cmd/agent/deployer"
@@ -64,6 +65,12 @@ type BundleDeploymentReconciler struct {
 	AgentScope string
 
 	Workers int
+
+	// staleCacheHits counts, per BundleDeployment key, how many reconciles in
+	// a row found the object missing from the agent's cache while it was still
+	// present upstream. Entries are dropped as soon as the cache catches up or
+	// the deletion is confirmed.
+	staleCacheHits sync.Map
 }
 
 var DefaultRetry = wait.Backoff{
@@ -109,6 +116,87 @@ func (r *BundleDeploymentReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Complete(r)
 }
 
+// cleanupMissingBundleDeployment uninstalls the helm releases of a
+// BundleDeployment which the agent's cache no longer holds.
+//
+// The cache answers NotFound both for a BundleDeployment that was really
+// deleted and for one that is merely missing from a stale local store, and
+// there is nothing in the error to tell those apart. Since the cleanup deletes
+// the resources the bundle deployed, it is only safe once the API server has
+// confirmed the object is gone.
+func (r *BundleDeploymentReconciler) cleanupMissingBundleDeployment(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+	key := req.String()
+
+	switch err := r.Reader.Get(ctx, req.NamespacedName, &fleetv1.BundleDeployment{}); {
+	case err == nil:
+		// Wait for the cache to catch up. It usually does within a resync, so
+		// only the first attempt is worth reporting at the default verbosity:
+		// a cache which never recovers would otherwise log forever.
+		hits := r.recordStaleCacheHit(key)
+		if hits == 1 {
+			logger.Info(
+				"BundleDeployment is missing from the agent's cache but still exists upstream, not cleaning up",
+				"key", key,
+			)
+		} else {
+			logger.V(1).Info(
+				"BundleDeployment is still missing from the agent's cache",
+				"key", key,
+				"attempts", hits,
+			)
+		}
+
+		return ctrl.Result{RequeueAfter: staleCacheRequeueAfter(hits)}, nil
+	case !apierrors.IsNotFound(err):
+		// Never delete anything on the strength of a read we could not confirm.
+		return ctrl.Result{}, fmt.Errorf("cannot confirm deletion of bundledeployment %s: %w", key, err)
+	}
+
+	r.forgetStaleCacheHits(key)
+
+	// This actually deletes the helm releases if a bundledeployment is deleted or orphaned
+	logger.V(1).Info("BundleDeployment deleted, cleaning up helm releases")
+	if err := r.Cleanup.CleanupReleases(ctx, key, nil); err != nil {
+		logger.Error(err, "Failed to clean up missing bundledeployment", "key", key)
+	}
+
+	return ctrl.Result{}, nil
+}
+
+// recordStaleCacheHit counts one more reconcile in which key was missing from
+// the cache but present upstream, and returns the new count. Reconciles for a
+// single key never overlap, so the read-modify-write needs no extra locking.
+func (r *BundleDeploymentReconciler) recordStaleCacheHit(key string) int {
+	hits := 1
+	if previous, ok := r.staleCacheHits.Load(key); ok {
+		hits = previous.(int) + 1
+	}
+	r.staleCacheHits.Store(key, hits)
+
+	return hits
+}
+
+// forgetStaleCacheHits drops the stale cache counter for key, either because
+// the cache caught up or because the deletion has been confirmed.
+func (r *BundleDeploymentReconciler) forgetStaleCacheHits(key string) {
+	r.staleCacheHits.Delete(key)
+}
+
+// staleCacheRequeueAfter backs the retry off exponentially, so that a cache
+// which never recovers does not keep polling the API server every few seconds.
+func staleCacheRequeueAfter(hits int) time.Duration {
+	requeue := durations.StaleCacheRequeue
+	for i := 1; i < hits; i++ {
+		requeue *= 2
+		if requeue >= durations.StaleCacheRequeueMax {
+			return durations.StaleCacheRequeueMax
+		}
+	}
+
+	return requeue
+}
+
 //+kubebuilder:rbac:groups=fleet.cattle.io,resources=bundledeployments,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=fleet.cattle.io,resources=bundledeployments/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=fleet.cattle.io,resources=bundledeployments/finalizers,verbs=update
@@ -131,16 +219,11 @@ func (r *BundleDeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	bd := &fleetv1.BundleDeployment{}
 	err := r.Get(ctx, req.NamespacedName, bd)
 	if apierrors.IsNotFound(err) {
-		// This actually deletes the helm releases if a bundledeployment is deleted or orphaned
-		logger.V(1).Info("BundleDeployment deleted, cleaning up helm releases")
-		if err := r.Cleanup.CleanupReleases(ctx, key, nil); err != nil {
-			logger.Error(err, "Failed to clean up missing bundledeployment", "key", key)
-		}
-
-		return ctrl.Result{}, nil
+		return r.cleanupMissingBundleDeployment(ctx, req)
 	} else if err != nil {
 		return ctrl.Result{}, err
 	}
+	r.forgetStaleCacheHits(key)
 	orig := bd.DeepCopy()
 
 	if bd.Spec.Paused {

--- a/internal/cmd/agent/controller/bundledeployment_controller_test.go
+++ b/internal/cmd/agent/controller/bundledeployment_controller_test.go
@@ -29,8 +29,8 @@ func TestStaleCacheRequeueAfter(t *testing.T) {
 }
 
 // TestStaleCacheHits checks that the counter for a BundleDeployment starts at
-// one, grows while its cache entry is missing, and is forgotten once the agent
-// sees the object again.
+// one, grows by one every time a stale cache hit is recorded, and is reset to 0
+// when stale cache hits are forgotten.
 func TestStaleCacheHits(t *testing.T) {
 	r := &BundleDeploymentReconciler{}
 	key := "cluster-ns/bd"

--- a/internal/cmd/agent/controller/bundledeployment_controller_test.go
+++ b/internal/cmd/agent/controller/bundledeployment_controller_test.go
@@ -1,0 +1,54 @@
+package controller
+
+import (
+	"testing"
+	"time"
+
+	"github.com/rancher/fleet/pkg/durations"
+)
+
+// TestStaleCacheRequeueAfter checks that repeated stale cache observations back
+// off, and that the wait stops growing at the cap: a cache which never catches
+// up must not keep the agent polling the API server every few seconds.
+func TestStaleCacheRequeueAfter(t *testing.T) {
+	cases := []struct {
+		hits     int
+		expected time.Duration
+	}{
+		{hits: 1, expected: durations.StaleCacheRequeue},
+		{hits: 2, expected: 2 * durations.StaleCacheRequeue},
+		{hits: 3, expected: 4 * durations.StaleCacheRequeue},
+		{hits: 100, expected: durations.StaleCacheRequeueMax},
+	}
+
+	for _, c := range cases {
+		if got := staleCacheRequeueAfter(c.hits); got != c.expected {
+			t.Errorf("staleCacheRequeueAfter(%d) = %s, expected %s", c.hits, got, c.expected)
+		}
+	}
+}
+
+// TestStaleCacheHits checks that the counter for a BundleDeployment starts at
+// one, grows while its cache entry is missing, and is forgotten once the agent
+// sees the object again.
+func TestStaleCacheHits(t *testing.T) {
+	r := &BundleDeploymentReconciler{}
+	key := "cluster-ns/bd"
+
+	for expected := 1; expected <= 3; expected++ {
+		if got := r.recordStaleCacheHit(key); got != expected {
+			t.Errorf("recordStaleCacheHit() = %d, expected %d", got, expected)
+		}
+	}
+
+	// Another BundleDeployment is counted separately.
+	if got := r.recordStaleCacheHit("cluster-ns/other-bd"); got != 1 {
+		t.Errorf("recordStaleCacheHit() for a second key = %d, expected 1", got)
+	}
+
+	r.forgetStaleCacheHits(key)
+
+	if got := r.recordStaleCacheHit(key); got != 1 {
+		t.Errorf("recordStaleCacheHit() after forgetting = %d, expected 1", got)
+	}
+}

--- a/internal/cmd/agent/deployer/cleanup/cleanup.go
+++ b/internal/cmd/agent/deployer/cleanup/cleanup.go
@@ -34,7 +34,10 @@ type HelmDeployer interface {
 }
 
 type Cleanup struct {
-	client           client.Client
+	client client.Client
+	// reader reads from the upstream cluster without going through the cache,
+	// so that a stale cache cannot make us uninstall a live release.
+	reader           client.Reader
 	fleetNamespace   string
 	defaultNamespace string
 	helmDeployer     HelmDeployer
@@ -49,6 +52,7 @@ type Cleanup struct {
 
 func New(
 	upstream client.Client,
+	upstreamReader client.Reader,
 	mapper meta.RESTMapper,
 	localDynamicClient *dynamic.DynamicClient,
 	deployer HelmDeployer,
@@ -62,6 +66,7 @@ func New(
 
 	return &Cleanup{
 		client:                    upstream,
+		reader:                    upstreamReader,
 		mapper:                    mapper,
 		localDynamicClient:        localDynamicClient,
 		helmDeployer:              deployer,
@@ -126,9 +131,29 @@ func (c *Cleanup) cleanup(ctx context.Context, logger logr.Logger) error {
 	}
 
 	for _, deployed := range deployed {
+		nsn := types.NamespacedName{Namespace: c.fleetNamespace, Name: deployed.BundleID}
 		bundleDeployment := &fleet.BundleDeployment{}
-		err := c.client.Get(ctx, types.NamespacedName{Namespace: c.fleetNamespace, Name: deployed.BundleID}, bundleDeployment)
+		err := c.client.Get(ctx, nsn, bundleDeployment)
 		if apierror.IsNotFound(err) {
+			// The cache answers NotFound both for a BundleDeployment that was
+			// really deleted and for one that is only missing from a stale
+			// local store. Uninstalling deletes live resources, so confirm
+			// with the API server first.
+			liveErr := c.reader.Get(ctx, nsn, bundleDeployment)
+			if liveErr == nil {
+				logger.Info(
+					"Bundle ID is missing from the agent's cache but still exists upstream, not uninstalling",
+					"bundleID", deployed.BundleID,
+					"release", deployed.ReleaseName,
+				)
+
+				continue
+			}
+			if !apierror.IsNotFound(liveErr) {
+				// Never uninstall on the strength of a read we could not confirm.
+				return fmt.Errorf("cannot confirm deletion of bundledeployment %s: %w", nsn, liveErr)
+			}
+
 			// found a helm secret, but no bundle deployment, so uninstall the release
 			logger.Info("Deleting orphan bundle ID, helm uninstall", "bundleID", deployed.BundleID, "release", deployed.ReleaseName)
 			if err := c.helmDeployer.DeleteRelease(ctx, deployed); err != nil {

--- a/internal/cmd/agent/deployer/cleanup/cleanup_test.go
+++ b/internal/cmd/agent/deployer/cleanup/cleanup_test.go
@@ -4,6 +4,7 @@ package cleanup
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -12,6 +13,8 @@ import (
 	"github.com/rancher/fleet/internal/names"
 	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
 	"go.uber.org/mock/gomock"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
@@ -79,7 +82,7 @@ func TestCleanupReleases(t *testing.T) {
 	mockHelmDeployer.EXPECT().DeleteRelease(gomock.Any(), deployedBundles[1]).Return(nil)
 	mockHelmDeployer.EXPECT().DeleteRelease(gomock.Any(), deployedBundles[2]).Return(nil)
 
-	cleanup := New(mockClient, nil, nil, mockHelmDeployer, fleetNS, defaultNS, 1*time.Second)
+	cleanup := New(mockClient, mockClient, nil, nil, mockHelmDeployer, fleetNS, defaultNS, 1*time.Second)
 
 	err := cleanup.cleanup(context.Background(), log.FromContext(context.Background()).WithName("test"))
 
@@ -124,11 +127,122 @@ func TestCleanupReleasesNoExplicitReleaseName(t *testing.T) {
 	mockHelmDeployer.EXPECT().ListDeployments(gomock.Any()).Return(deployedBundles, nil)
 	// DeleteRelease must NOT be called: the release name matches.
 
-	cleanup := New(mockClient, nil, nil, mockHelmDeployer, fleetNS, defaultNS, 1*time.Second)
+	cleanup := New(mockClient, mockClient, nil, nil, mockHelmDeployer, fleetNS, defaultNS, 1*time.Second)
 
 	err := cleanup.cleanup(context.Background(), log.FromContext(context.Background()).WithName("test"))
 
 	if err != nil {
 		t.Errorf("cleanup failed: %v", err)
+	}
+}
+
+// notFound builds the error the cache returns for a BundleDeployment it does
+// not hold, which is the same error the API server returns for one that does
+// not exist. Telling those two apart is the whole point of the specs below.
+func notFound() error {
+	return apierrors.NewNotFound(
+		schema.GroupResource{Group: fleet.SchemeGroupVersion.Group, Resource: "bundledeployments"},
+		"ID1",
+	)
+}
+
+// TestCleanupKeepsReleaseWhenCacheIsStale covers rancher/fleet#5406: a
+// BundleDeployment missing from the agent's cache but still present on the API
+// server must not have its release uninstalled.
+func TestCleanupKeepsReleaseWhenCacheIsStale(t *testing.T) {
+	fleetNS := "foo"
+	defaultNS := "bar"
+
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	deployedBundles := []helmdeployer.DeployedBundle{
+		{BundleID: "ID1", ReleaseName: defaultNS + "/TestRelease1"},
+	}
+	nsn := types.NamespacedName{Namespace: fleetNS, Name: "ID1"}
+
+	// The cache has lost the object...
+	cache := mocks.NewMockK8sClient(mockCtrl)
+	cache.EXPECT().Get(gomock.Any(), nsn, gomock.Any()).Return(notFound())
+
+	// ...but the API server still has it.
+	reader := mocks.NewMockK8sClient(mockCtrl)
+	reader.EXPECT().Get(gomock.Any(), nsn, gomock.Any()).Return(nil)
+
+	mockHelmDeployer := mocks.NewMockHelmDeployer(mockCtrl)
+	mockHelmDeployer.EXPECT().NewListAction()
+	mockHelmDeployer.EXPECT().ListDeployments(gomock.Any()).Return(deployedBundles, nil)
+	// No DeleteRelease call is expected; gomock fails the test if one happens.
+
+	cleanup := New(cache, reader, nil, nil, mockHelmDeployer, fleetNS, defaultNS, 1*time.Second)
+
+	if err := cleanup.cleanup(context.Background(), log.FromContext(context.Background()).WithName("test")); err != nil {
+		t.Errorf("cleanup failed: %v", err)
+	}
+}
+
+// TestCleanupDeletesReleaseWhenReallyGone makes sure the fix for #5406 did not
+// disable the feature: a BundleDeployment the API server confirms is gone
+// still gets its release uninstalled.
+func TestCleanupDeletesReleaseWhenReallyGone(t *testing.T) {
+	fleetNS := "foo"
+	defaultNS := "bar"
+
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	deployedBundles := []helmdeployer.DeployedBundle{
+		{BundleID: "ID1", ReleaseName: defaultNS + "/TestRelease1"},
+	}
+	nsn := types.NamespacedName{Namespace: fleetNS, Name: "ID1"}
+
+	cache := mocks.NewMockK8sClient(mockCtrl)
+	cache.EXPECT().Get(gomock.Any(), nsn, gomock.Any()).Return(notFound())
+
+	reader := mocks.NewMockK8sClient(mockCtrl)
+	reader.EXPECT().Get(gomock.Any(), nsn, gomock.Any()).Return(notFound())
+
+	mockHelmDeployer := mocks.NewMockHelmDeployer(mockCtrl)
+	mockHelmDeployer.EXPECT().NewListAction()
+	mockHelmDeployer.EXPECT().ListDeployments(gomock.Any()).Return(deployedBundles, nil)
+	mockHelmDeployer.EXPECT().DeleteRelease(gomock.Any(), deployedBundles[0]).Return(nil)
+
+	cleanup := New(cache, reader, nil, nil, mockHelmDeployer, fleetNS, defaultNS, 1*time.Second)
+
+	if err := cleanup.cleanup(context.Background(), log.FromContext(context.Background()).WithName("test")); err != nil {
+		t.Errorf("cleanup failed: %v", err)
+	}
+}
+
+// TestCleanupKeepsReleaseWhenConfirmationFails checks that an unconfirmed read
+// is never treated as a deletion either.
+func TestCleanupKeepsReleaseWhenConfirmationFails(t *testing.T) {
+	fleetNS := "foo"
+	defaultNS := "bar"
+
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	deployedBundles := []helmdeployer.DeployedBundle{
+		{BundleID: "ID1", ReleaseName: defaultNS + "/TestRelease1"},
+	}
+	nsn := types.NamespacedName{Namespace: fleetNS, Name: "ID1"}
+
+	cache := mocks.NewMockK8sClient(mockCtrl)
+	cache.EXPECT().Get(gomock.Any(), nsn, gomock.Any()).Return(notFound())
+
+	reader := mocks.NewMockK8sClient(mockCtrl)
+	reader.EXPECT().Get(gomock.Any(), nsn, gomock.Any()).Return(errors.New("connection refused"))
+
+	mockHelmDeployer := mocks.NewMockHelmDeployer(mockCtrl)
+	mockHelmDeployer.EXPECT().NewListAction()
+	mockHelmDeployer.EXPECT().ListDeployments(gomock.Any()).Return(deployedBundles, nil)
+	// No DeleteRelease call is expected.
+
+	cleanup := New(cache, reader, nil, nil, mockHelmDeployer, fleetNS, defaultNS, 1*time.Second)
+
+	err := cleanup.cleanup(context.Background(), log.FromContext(context.Background()).WithName("test"))
+	if err == nil {
+		t.Error("expected cleanup to report that it could not confirm the deletion")
 	}
 }

--- a/internal/cmd/agent/operator.go
+++ b/internal/cmd/agent/operator.go
@@ -268,6 +268,7 @@ func newReconciler(
 	// Build the clean up, which deletes helm releases
 	cleanup := cleanup.New(
 		upstreamClient,
+		mgr.GetAPIReader(),
 		localClient.RESTMapper(),
 		localDynamic,
 		helmDeployer,

--- a/pkg/durations/durations.go
+++ b/pkg/durations/durations.go
@@ -46,6 +46,15 @@ const (
 	// a reconcile on its own, so the agent requeues at this interval to
 	// converge once the permission is added.
 	NamespacePermissionRequeueInterval = time.Minute * 2
+	// StaleCacheRequeue is how long the Fleet agent waits before looking again
+	// at a BundleDeployment which is missing from its cache but still present
+	// on the API server. It doubles on every further attempt, up to
+	// StaleCacheRequeueMax.
+	StaleCacheRequeue = time.Second * 30
+	// StaleCacheRequeueMax caps the wait between those attempts, so that a
+	// cache which never catches up stops polling the API server every few
+	// seconds.
+	StaleCacheRequeueMax = time.Minute * 10
 )
 
 // Equal reports whether the duration t is equal to u.

--- a/pkg/durations/durations.go
+++ b/pkg/durations/durations.go
@@ -52,8 +52,7 @@ const (
 	// StaleCacheRequeueMax.
 	StaleCacheRequeue = time.Second * 30
 	// StaleCacheRequeueMax caps the wait between those attempts, so that a
-	// cache which never catches up stops polling the API server every few
-	// seconds.
+	// cache which never catches up polls the API server with this periodicity.
 	StaleCacheRequeueMax = time.Minute * 10
 )
 


### PR DESCRIPTION
The agent reads BundleDeployments through the manager's cache. A CacheReader returns a plain NotFound whenever the object is missing from the local informer store, with no way to tell "deleted" apart from "our store is empty or behind". Both the reconciler and the garbage collector took that NotFound as a deletion and uninstalled the helm release, wiping live resources on a stale cache.

Both paths now confirm with a live read (mgr.GetAPIReader()) before uninstalling anything, and treat a read they could not complete as "do not delete" rather than as a deletion. While the cache is behind, the reconciler requeues with an exponential backoff instead of cleaning up.

Refers to: https://github.com/rancher/fleet/issues/5406

## Additional Information

### Checklist

~ [ ] <!-- If applicable,--> I have updated the documentation via a pull request in the [fleet-product-docs](https://github.com/rancher/fleet-product-docs) repository.~
