### PR TITLE
fix(e2e): use retry to prevent false negative on imagescan_test.go

### DIFF
--- a/e2e/single-cluster/imagescan_test.go
+++ b/e2e/single-cluster/imagescan_test.go
@@ -250,10 +250,21 @@ func tagAndPushImage(baseImage, image, tag string) string {
 	cmd := exec.CommandContext(context.Background(), "docker", "tag", baseImage, imageTag)
 	err := cmd.Run()
 	Expect(err).ToNot(HaveOccurred())
-	// push the image to ttl.sh
-	cmd = exec.CommandContext(context.Background(), "docker", "push", imageTag)
-	err = cmd.Run()
-	Expect(err).ToNot(HaveOccurred())
+	const pushTimeout = 30 * time.Second
+
+	Eventually(func() error {
+		ctx, cancel := context.WithTimeout(context.Background(), pushTimeout)
+		defer cancel()
+
+		// CombinedOutput, so a failing push reports the registry's reason
+		// instead of a bare exit status.
+		out, err := exec.CommandContext(ctx, "docker", "push", imageTag).CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("docker push %s: %s: %w", imageTag, out, err)
+		}
+
+		return nil
+	}, 2*time.Minute, time.Second).Should(Succeed())
 	return imageTag
 }
 


### PR DESCRIPTION
The `e2e/single-cluster` attempts to run a `git pull` and hangs idenfintly. The whole *E2E Infra Tests - Git* then fails before even run any tests. To prevent this we can retry execute a fresh `Cmd` with timeout. The given timeout should provide enough span to retry a few time before actual fail.

```bash
❯ while go test -count=1 -timeout=1h -failfast ./e2e/single-cluster/ -args -ginkgo.trace -ginkgo.label-filter='infra-setup && !helm-registry && !oci-registry'; do :; done
ok      github.com/rancher/fleet/e2e/single-cluster     803.021s
ok      github.com/rancher/fleet/e2e/single-cluster     776.441s
ok      github.com/rancher/fleet/e2e/single-cluster     826.037s
ok      github.com/rancher/fleet/e2e/single-cluster     803.497s
ok      github.com/rancher/fleet/e2e/single-cluster     786.217s
ok      github.com/rancher/fleet/e2e/single-cluster     848.368s
```

## Additional Information

I couldnt really reproduce it local. I run it in a loop 12 times in a row and all pass.
However the logs https://github.com/rancher/fleet/actions/runs/31578176420/job/94054933676?pr=5549
are quite straight forward and a try seems like a way to prevent this as usually also works with a manual restart.

### Checklist

- [ ] Run the tests in an iteration and so far all of them are passing.
