### PR TITLE
Require Renovate automerge marker

### DIFF
--- a/.github/workflows/auto-approve-bot-prs.yml
+++ b/.github/workflows/auto-approve-bot-prs.yml
@@ -48,7 +48,7 @@ jobs:
           if ! pr_list_json=$(gh pr list --repo "$REPO" --state open \
             --author "$RENOVATE_BOT_USERNAME" \
             --sort created --order asc \
-            --json number,state,autoMergeRequest,headRepository,headRefName,author,createdAt \
+            --json number,state,body,autoMergeRequest,headRepository,headRefName,author,createdAt \
             --jq '.[] | @json'); then
             echo "Failed to get open Renovate PRs from $REPO."
             exit 1
@@ -63,12 +63,16 @@ jobs:
           while IFS= read -r pr_json; do
             pr_number=$(jq -r '.number' <<<"$pr_json")
             head_ref=$(jq -r '.headRefName' <<<"$pr_json")
+            pr_body=$(jq -r '.body // ""' <<<"$pr_json")
 
             if [[ $(jq -r '.state' <<<"$pr_json") != "OPEN" ||
                   $(jq -r '.autoMergeRequest' <<<"$pr_json") == "null" ||
                   $(jq -r '.headRepository.nameWithOwner' <<<"$pr_json") != "$REPO" ||
                   $(jq -r '.author.login' <<<"$pr_json") != "$RENOVATE_BOT_USERNAME" ||
                   "$head_ref" != renovate/* ]]; then
+              continue
+            fi
+            if ! [[ "$pr_body" =~ \*\*[[:space:]]*Automerge[[:space:]]*\*\*[[:space:]]*:[[:space:]]*Enabled[[:space:]]*\.? ]]; then
               continue
             fi
 


### PR DESCRIPTION
Only approve Renovate PRs whose body explicitly enables automerge. Without this it was possible to manually enable Github auto-merge for a Renovate pr and then the pr would have been automatically approved by this action.