### PR TITLE
Drop reserved labels during agent-initiated cluster registration

### DIFF
--- a/internal/cmd/agent/register/register.go
+++ b/internal/cmd/agent/register/register.go
@@ -185,7 +185,7 @@ func runRegistration(ctx context.Context, k8s coreInterface, namespace string) (
 	if cfg.Labels == nil {
 		cfg.Labels = map[string]string{}
 	}
-	cfg.Labels["fleet.cattle.io/created-by-agent-pod"] = os.Getenv("HOSTNAME")
+	cfg.Labels[fleet.CreatedByAgentPodLabel] = os.Getenv("HOSTNAME")
 
 	tokenName := string(values(secret.Data)[TokenName])
 	log.Log.Info(fmt.Sprintf("Creating clusterregistration with id '%s' for new token", clientID))

--- a/internal/cmd/controller/agentmanagement/controllers/clusterregistration/controller.go
+++ b/internal/cmd/controller/agentmanagement/controllers/clusterregistration/controller.go
@@ -7,7 +7,7 @@ package clusterregistration
 import (
 	"context"
 	"fmt"
-	"maps"
+	"strings"
 	"time"
 
 	"github.com/rancher/fleet/internal/cmd/controller/agentmanagement/controllers/resources"
@@ -497,7 +497,7 @@ func (h *handler) createOrGetCluster(request *fleet.ClusterRegistration) (*fleet
 	// and managed clusters would already exist
 	labels := map[string]string{}
 	if !config.Get().IgnoreClusterRegistrationLabels {
-		maps.Copy(labels, request.Spec.ClusterLabels)
+		labels = sanitizeClusterLabels(request)
 	}
 	labels[fleet.ClusterAnnotation] = clusterName
 
@@ -518,6 +518,37 @@ func (h *handler) createOrGetCluster(request *fleet.ClusterRegistration) (*fleet
 		log.Log.Info(fmt.Sprintf("Created cluster %s/%s", request.Namespace, clusterName))
 	}
 	return cluster, err
+}
+
+// sanitizeClusterLabels copies the agent-supplied ClusterLabels while dropping
+// any key a downstream agent must not be able to assert. Keys under the
+// reserved management.cattle.io/ and fleet.cattle.io/ prefixes are Rancher- and
+// Fleet-managed and are trusted for cluster targeting.
+func sanitizeClusterLabels(request *fleet.ClusterRegistration) map[string]string {
+	labels := make(map[string]string, len(request.Spec.ClusterLabels))
+	for k, v := range request.Spec.ClusterLabels {
+		if isReservedLabel(k) {
+			log.Log.Info(fmt.Sprintf("ClusterRegistration %s/%s attempted to set reserved label %q; ignoring it",
+				request.Namespace, request.Name, k))
+			continue
+		}
+		labels[k] = v
+	}
+	return labels
+}
+
+// isReservedLabel reports whether key falls under a reserved, controller-managed
+// label prefix that an agent may not assert. These namespaces are managed by
+// Rancher and Fleet respectively and are trusted for cluster targeting (e.g.
+// management.cattle.io/cluster-display-name is consumed by clusterName
+// selectors); letting an agent set them would allow a registrant to spoof
+// another cluster's identity and attract its BundleDeployments. The debugging
+// label fleet.cattle.io/created-by-agent-pod is explicitly allowed.
+func isReservedLabel(key string) bool {
+	if key == fleet.CreatedByAgentPodLabel {
+		return false
+	}
+	return strings.HasPrefix(key, fleet.ManagementLabelPrefix) || strings.HasPrefix(key, fleet.FleetLabelPrefix)
 }
 
 func (h *handler) authorizeCluster(sa *v1.ServiceAccount, cluster *fleet.Cluster, req *fleet.ClusterRegistration) (*v1.Secret, error) {

--- a/internal/cmd/controller/agentmanagement/controllers/clusterregistration/controller.go
+++ b/internal/cmd/controller/agentmanagement/controllers/clusterregistration/controller.go
@@ -528,7 +528,7 @@ func sanitizeClusterLabels(request *fleet.ClusterRegistration) map[string]string
 	labels := make(map[string]string, len(request.Spec.ClusterLabels))
 	for k, v := range request.Spec.ClusterLabels {
 		if isReservedLabel(k) {
-			log.Log.Info(fmt.Sprintf("ClusterRegistration %s/%s attempted to set reserved label %q; ignoring it",
+			log.Log.Info(fmt.Sprintf("ClusterRegistration %s/%s attempted to set reserved label %q; ignoring that label",
 				request.Namespace, request.Name, k))
 			continue
 		}

--- a/internal/cmd/controller/agentmanagement/controllers/clusterregistration/sanitize_test.go
+++ b/internal/cmd/controller/agentmanagement/controllers/clusterregistration/sanitize_test.go
@@ -1,0 +1,164 @@
+package clusterregistration
+
+import (
+	"github.com/rancher/wrangler/v3/pkg/generic/fake"
+	"go.uber.org/mock/gomock"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/rancher/fleet/internal/names"
+	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("sanitizeClusterLabels", func() {
+	var request *fleet.ClusterRegistration
+
+	BeforeEach(func() {
+		request = &fleet.ClusterRegistration{}
+		request.Namespace = "fleet-default"
+		request.Name = "request-abc"
+	})
+
+	It("drops the spoofable management.cattle.io/cluster-display-name label", func() {
+		request.Spec.ClusterLabels = map[string]string{
+			"management.cattle.io/cluster-display-name": "not-allowed",
+			"env": "prod",
+		}
+
+		labels := sanitizeClusterLabels(request)
+
+		Expect(labels).ToNot(HaveKey("management.cattle.io/cluster-display-name"))
+		// Non-reserved operational labels are preserved.
+		Expect(labels).To(HaveKeyWithValue("env", "prod"))
+	})
+
+	It("drops arbitrary reserved management.cattle.io/* and fleet.cattle.io/* labels", func() {
+		request.Spec.ClusterLabels = map[string]string{
+			"management.cattle.io/anything": "x",
+			"fleet.cattle.io/cluster":       "not-allowed",
+			"team":                          "payments",
+		}
+
+		labels := sanitizeClusterLabels(request)
+
+		Expect(labels).ToNot(HaveKey("management.cattle.io/anything"))
+		Expect(labels).ToNot(HaveKey("fleet.cattle.io/cluster"))
+		Expect(labels).To(HaveKeyWithValue("team", "payments"))
+	})
+
+	It("preserves the allow-listed fleet.cattle.io/created-by-agent-pod debug label", func() {
+		request.Spec.ClusterLabels = map[string]string{
+			"fleet.cattle.io/created-by-agent-pod": "agent-pod-xyz",
+		}
+
+		labels := sanitizeClusterLabels(request)
+
+		Expect(labels).To(HaveKeyWithValue("fleet.cattle.io/created-by-agent-pod", "agent-pod-xyz"))
+	})
+
+	It("returns an empty, non-nil map when there are no labels", func() {
+		labels := sanitizeClusterLabels(request)
+
+		Expect(labels).ToNot(BeNil())
+		Expect(labels).To(BeEmpty())
+	})
+})
+
+var _ = Describe("isReservedLabel", func() {
+	DescribeTable("classifying label keys",
+		func(key string, reserved bool) {
+			Expect(isReservedLabel(key)).To(Equal(reserved))
+		},
+		Entry("management.cattle.io display name is reserved", "management.cattle.io/cluster-display-name", true),
+		Entry("any management.cattle.io key is reserved", "management.cattle.io/foo", true),
+		Entry("any fleet.cattle.io key is reserved", "fleet.cattle.io/cluster", true),
+		Entry("created-by-agent-pod is allow-listed", "fleet.cattle.io/created-by-agent-pod", false),
+		Entry("plain operational label is not reserved", "env", false),
+		Entry("unrelated vendor label is not reserved", "example.com/team", false),
+	)
+})
+
+var _ = Describe("createOrGetCluster label sanitization", func() {
+	var (
+		request      *fleet.ClusterRegistration
+		clusterCache *fake.MockCacheInterface[*fleet.Cluster]
+		clusters     *fake.MockClientInterface[*fleet.Cluster, *fleet.ClusterList]
+		h            *handler
+
+		// The Cluster the handler passed to Create, captured for assertions.
+		created  *fleet.Cluster
+		notFound = apierrors.NewNotFound(schema.GroupResource{}, "")
+	)
+
+	BeforeEach(func() {
+		ctrl := gomock.NewController(GinkgoT())
+		clusterCache = fake.NewMockCacheInterface[*fleet.Cluster](ctrl)
+		clusters = fake.NewMockClientInterface[*fleet.Cluster, *fleet.ClusterList](ctrl)
+		h = &handler{clusterCache: clusterCache, clusters: clusters}
+		created = nil
+
+		request = &fleet.ClusterRegistration{
+			ObjectMeta: metav1.ObjectMeta{Name: "request-abc", Namespace: "fleet-default"},
+			Spec:       fleet.ClusterRegistrationSpec{ClientID: "chosen-id"},
+		}
+
+		// No cluster exists for this ClientID, and none under the derived name,
+		// so registration takes the create-new branch that trusts agent labels.
+		clusterCache.EXPECT().GetByIndex(gomock.Any(), gomock.Any()).Return(nil, nil)
+		clusterCache.EXPECT().Get(gomock.Any(), gomock.Any()).Return(nil, notFound)
+
+		clusters.EXPECT().Create(gomock.Any()).DoAndReturn(
+			func(c *fleet.Cluster) (*fleet.Cluster, error) {
+				created = c
+				return c, nil
+			},
+		)
+	})
+
+	It("does not persist a spoofed display-name label onto the new Cluster", func() {
+		request.Spec.ClusterLabels = map[string]string{
+			"management.cattle.io/cluster-display-name": "now-allowed",
+			"env":  "prod",
+			"team": "payments",
+		}
+
+		_, err := h.createOrGetCluster(request)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(created).ToNot(BeNil())
+		Expect(created.Labels).ToNot(HaveKey("management.cattle.io/cluster-display-name"))
+		// Legitimate targeting labels still reach the Cluster.
+		Expect(created.Labels).To(HaveKeyWithValue("env", "prod"))
+		Expect(created.Labels).To(HaveKeyWithValue("team", "payments"))
+	})
+
+	It("overwrites an agent-injected fleet.cattle.io/cluster label with the trusted cluster name", func() {
+		request.Spec.ClusterLabels = map[string]string{
+			fleet.ClusterAnnotation: "some-other-cluster",
+		}
+
+		_, err := h.createOrGetCluster(request)
+		Expect(err).ToNot(HaveOccurred())
+
+		expected := names.SafeConcatName("cluster", names.KeyHash(request.Spec.ClientID))
+		Expect(created.Name).To(Equal(expected))
+		Expect(created.Labels).To(HaveKeyWithValue(fleet.ClusterAnnotation, expected))
+	})
+
+	It("keeps the allow-listed created-by-agent-pod label on the new Cluster", func() {
+		request.Spec.ClusterLabels = map[string]string{
+			fleet.CreatedByAgentPodLabel: "agent-pod-xyz",
+			"fleet.cattle.io/spoofed":    "nope",
+		}
+
+		_, err := h.createOrGetCluster(request)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(created.Labels).To(HaveKeyWithValue(fleet.CreatedByAgentPodLabel, "agent-pod-xyz"))
+		Expect(created.Labels).ToNot(HaveKey("fleet.cattle.io/spoofed"))
+	})
+})

--- a/internal/cmd/controller/target/builder.go
+++ b/internal/cmd/controller/target/builder.go
@@ -271,7 +271,7 @@ func preprocessHelmValues(logger logr.Logger, opts *fleet.BundleDeploymentOption
 	clusterAnnotations := yaml.CleanAnnotationsForExport(cluster.Annotations)
 
 	for k, v := range cluster.Labels {
-		if strings.HasPrefix(k, "fleet.cattle.io/") || strings.HasPrefix(k, "management.cattle.io/") {
+		if strings.HasPrefix(k, fleet.FleetLabelPrefix) || strings.HasPrefix(k, fleet.ManagementLabelPrefix) {
 			clusterLabels[k] = v
 		}
 	}

--- a/pkg/apis/fleet.cattle.io/v1alpha1/labels.go
+++ b/pkg/apis/fleet.cattle.io/v1alpha1/labels.go
@@ -1,0 +1,21 @@
+package v1alpha1
+
+const (
+	// FleetLabelPrefix is the reserved label namespace managed by Fleet
+	// (equal to SchemeGroupVersion.Group + "/"). Labels under it are trusted
+	// for internal bookkeeping and targeting; a downstream agent must not be
+	// able to assert them during agent-initiated registration.
+	FleetLabelPrefix = "fleet.cattle.io/"
+
+	// ManagementLabelPrefix is the reserved label namespace managed by Rancher
+	// (management.cattle.io). Labels under it - e.g.
+	// management.cattle.io/cluster-display-name, consumed by clusterName
+	// selectors - are trusted and must not be agent-assertable.
+	ManagementLabelPrefix = "management.cattle.io/"
+
+	// CreatedByAgentPodLabel is set by the agent on its own registration to
+	// record the agent pod that created it, for debugging. Informational only;
+	// never used for targeting or authorization. It is the one FleetLabelPrefix
+	// label an agent is allowed to assert.
+	CreatedByAgentPodLabel = "fleet.cattle.io/created-by-agent-pod"
+)


### PR DESCRIPTION
Drops Fleet and Rancher specific labels when running and agent initiated registration
