### PR TITLE
Remove getHostByName from template function map

### DIFF
--- a/internal/cmd/controller/target/builder.go
+++ b/internal/cmd/controller/target/builder.go
@@ -328,6 +328,9 @@ func tplFuncMap() template.FuncMap {
 	delete(f, "expandenv")
 	delete(f, "include")
 	delete(f, "tpl")
+	// getHostByName performs a live DNS lookup (net.LookupHost). Sprig
+	// classifies it as non-hermetic, so it is not available in templates.
+	delete(f, "getHostByName")
 
 	return f
 }

--- a/internal/cmd/controller/target/target_test.go
+++ b/internal/cmd/controller/target/target_test.go
@@ -395,6 +395,14 @@ func TestProcessTemplateValues(t *testing.T) {
 	}
 }
 
+func TestTplFuncMap_ExcludesGetHostByName(t *testing.T) {
+	f := tplFuncMap()
+
+	if _, ok := f["getHostByName"]; ok {
+		t.Fatal("getHostByName must be excluded from the template function map")
+	}
+}
+
 const clusterYamlWithTemplateValues = `apiVersion: fleet.cattle.io/v1alpha1
 kind: Cluster
 metadata:


### PR DESCRIPTION
Keep template execution limited to deterministic functions.

Refers https://github.com/rancher/fleet/security/advisories/GHSA-x9m6-xcjr-hpjp