### PR TITLE
Use main branch for Renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "github>rancher/renovate-config//rancher-main#release"
+    "github>rancher/renovate-config//rancher-main#main"
   ],
   "baseBranchPatterns": [
     "main",
@@ -20,7 +20,7 @@
         "release/v0.16"
       ],
       "extends": [
-        "github>rancher/renovate-config//rancher-2.15#release"
+        "github>rancher/renovate-config//rancher-2.15#main"
       ]
     },
     {
@@ -28,7 +28,7 @@
         "release/v0.15"
       ],
       "extends": [
-        "github>rancher/renovate-config//rancher-2.14#release"
+        "github>rancher/renovate-config//rancher-2.14#main"
       ]
     },
     {
@@ -36,7 +36,7 @@
         "release/v0.14"
       ],
       "extends": [
-        "github>rancher/renovate-config//rancher-2.13#release"
+        "github>rancher/renovate-config//rancher-2.13#main"
       ]
     },
     {
@@ -44,7 +44,7 @@
         "release/v0.13"
       ],
       "extends": [
-        "github>rancher/renovate-config//rancher-2.12#release"
+        "github>rancher/renovate-config//rancher-2.12#main"
       ]
     },
     {
@@ -52,7 +52,7 @@
         "release/v0.12"
       ],
       "extends": [
-        "github>rancher/renovate-config//rancher-2.11#release"
+        "github>rancher/renovate-config//rancher-2.11#main"
       ]
     },
     {


### PR DESCRIPTION
Early adopt renovate-config changes before they move from main to release.