### PR TITLE
Don't require a kubeconfig for fleet apply --output

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -78,6 +78,7 @@ require (
 	github.com/rancher/wrangler/v3 v3.7.1
 	github.com/reugn/go-quartz v0.15.2
 	github.com/spf13/cobra v1.10.2
+	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.12.1
 	github.com/testcontainers/testcontainers-go v0.44.0
 	github.com/ulikunitz/xz v0.5.16
@@ -233,7 +234,6 @@ require (
 	github.com/sirupsen/logrus v1.9.4 // indirect
 	github.com/skeema/knownhosts v1.3.1 // indirect
 	github.com/spf13/cast v1.7.0 // indirect
-	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/tetratelabs/wabin v0.0.0-20230304001439-f6f874872834 // indirect
 	github.com/tetratelabs/wazero v1.12.0 // indirect
 	github.com/tklauser/go-sysconf v0.4.0 // indirect

--- a/internal/cmd/cli/apply.go
+++ b/internal/cmd/cli/apply.go
@@ -3,14 +3,12 @@ package cli
 import (
 	"bytes"
 	"errors"
-	"flag"
 	"fmt"
 	"os"
 
 	gogit "github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/spf13/cobra"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -39,9 +37,8 @@ func NewApply() *cobra.Command {
 		Short: "Create bundles from directories, and output them or apply them on a cluster",
 	})
 
-	fs := flag.NewFlagSet("", flag.ExitOnError)
-	ctrl.RegisterFlags(fs)
-	cmd.Flags().AddGoFlagSet(fs)
+	registerKubeconfigFlags(cmd)
+
 	return cmd
 }
 
@@ -170,20 +167,37 @@ func (a *Apply) run(cmd *cobra.Command, args []string) error {
 	}
 
 	ctx := cmd.Context()
-	cfg := ctrl.GetConfigOrDie()
-	client, err := client.New(cfg, client.Options{Scheme: scheme})
-	if err != nil {
-		return err
-	}
-	recorder, err := getEventRecorder(cfg, "fleet-apply")
-	if err != nil {
-		return err
+
+	// When an output is set the bundles are rendered locally and the cluster
+	// is never contacted: CreateBundles and CreateBundlesDriven skip pruning
+	// and writeBundle returns right after printing, so the client and the
+	// recorder are left nil. Building a client here unconditionally made
+	// `fleet apply --output` fail with an empty kubeconfig, even though it has
+	// nothing to talk to a cluster about.
+	//
+	// The condition is on opts.Output, the very field the apply package
+	// branches on, so this gate cannot drift from the one used there.
+	var c client.Client
+	var recorder record.EventRecorder
+	if opts.Output == nil {
+		cfg, err := getKubeconfig()
+		if err != nil {
+			return fmt.Errorf("%w (use --output to render bundles without a cluster)", err)
+		}
+		c, err = client.New(cfg, client.Options{Scheme: scheme})
+		if err != nil {
+			return err
+		}
+		recorder, err = getEventRecorder(cfg, "fleet-apply")
+		if err != nil {
+			return err
+		}
 	}
 
 	if opts.DrivenScan {
-		return apply.CreateBundlesDriven(ctx, client, recorder, name, args, opts)
+		return apply.CreateBundlesDriven(ctx, c, recorder, name, args, opts)
 	}
-	return apply.CreateBundles(ctx, client, recorder, name, args, opts)
+	return apply.CreateBundles(ctx, c, recorder, name, args, opts)
 }
 
 // addAuthToOpts adds auth if provided as arguments. It will look first for HelmCredentialsByPathFile. If HelmCredentialsByPathFile

--- a/internal/cmd/cli/apply/output_test.go
+++ b/internal/cmd/cli/apply/output_test.go
@@ -36,7 +36,7 @@ func TestCreateBundlesWithOutputNeverUsesClient(t *testing.T) {
 				create = CreateBundlesDriven
 			}
 
-			err := create(context.Background(), nil, nil, "repo", []string{"some"}, opts)
+			err := create(context.Background(), nil, nil, "test-bundle", []string{"some"}, opts)
 			if err != nil {
 				t.Fatalf("expected no error, got %v", err)
 			}

--- a/internal/cmd/cli/apply/output_test.go
+++ b/internal/cmd/cli/apply/output_test.go
@@ -1,0 +1,65 @@
+package apply
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	// Registers the fleet GVKs with the wrangler scheme used by printToOutput,
+	// the same way cmd/fleetcli does.
+	_ "github.com/rancher/fleet/pkg/generated/controllers/fleet.cattle.io"
+)
+
+// TestCreateBundlesWithOutputNeverUsesClient is the invariant the CLI relies
+// on when it skips building a client: with Options.Output set, neither the
+// client nor the recorder is touched, so passing nil for both has to be safe.
+func TestCreateBundlesWithOutputNeverUsesClient(t *testing.T) {
+	// globDirs strips leading slashes, so base dirs have to be relative to the
+	// working directory.
+	t.Chdir(t.TempDir())
+	writeConfigMap(t, "some")
+
+	for name, opts := range map[string]Options{
+		"scan":        {Namespace: "fleet-local"},
+		"driven scan": {Namespace: "fleet-local", DrivenScan: true, DrivenScanSeparator: ":"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			buf := &bytes.Buffer{}
+			opts := opts
+			opts.Output = buf
+
+			create := CreateBundles
+			if opts.DrivenScan {
+				create = CreateBundlesDriven
+			}
+
+			err := create(context.Background(), nil, nil, "repo", []string{"some"}, opts)
+			if err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+			if !strings.Contains(buf.String(), "kind: Bundle") {
+				t.Errorf("expected a Bundle in the output, got %q", buf.String())
+			}
+		})
+	}
+}
+
+func writeConfigMap(t *testing.T, dir string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("failed to create %s: %v", dir, err)
+	}
+	content := `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test
+data:
+  key: value
+`
+	if err := os.WriteFile(filepath.Join(dir, "configmap.yaml"), []byte(content), 0o600); err != nil {
+		t.Fatalf("failed to write configmap: %v", err)
+	}
+}

--- a/internal/cmd/cli/apply_offline_test.go
+++ b/internal/cmd/cli/apply_offline_test.go
@@ -1,0 +1,144 @@
+package cli
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	// Registers the fleet GVKs with the wrangler scheme used to render
+	// bundles, the same way cmd/fleetcli does.
+	_ "github.com/rancher/fleet/pkg/generated/controllers/fleet.cattle.io"
+)
+
+// setupOfflineApply prepares a working directory holding a single resource in
+// ./some, and makes any attempt to reach a cluster fail by pointing the
+// kubeconfig at a valid but empty one.
+func setupOfflineApply(t *testing.T) {
+	t.Helper()
+
+	t.Chdir(t.TempDir())
+
+	if err := os.MkdirAll("some", 0o700); err != nil {
+		t.Fatalf("failed to create bundle dir: %v", err)
+	}
+	configMap := `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test
+data:
+  key: value
+`
+	if err := os.WriteFile(filepath.Join("some", "configmap.yaml"), []byte(configMap), 0o600); err != nil {
+		t.Fatalf("failed to write configmap: %v", err)
+	}
+
+	emptyKubeconfig := `apiVersion: v1
+kind: Config
+clusters: []
+contexts: []
+users: []
+preferences: {}
+`
+	path := filepath.Join(t.TempDir(), "kubeconfig-empty.yaml")
+	if err := os.WriteFile(path, []byte(emptyKubeconfig), 0o600); err != nil {
+		t.Fatalf("failed to write kubeconfig: %v", err)
+	}
+
+	t.Setenv("KUBECONFIG", path)
+	setKubeconfigFlag(t, path)
+}
+
+func newApplyForTest() *Apply {
+	a := &Apply{}
+	a.Namespace = "fleet-local"
+	a.BundleCreationMaxConcurrency = 4
+	// Set so that the git repository containing the test is not scanned.
+	a.Commit = "0000000000000000000000000000000000000000"
+
+	return a
+}
+
+func testCommand() *cobra.Command {
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+
+	return cmd
+}
+
+// TestApplyOutputWithoutCluster is a regression test for #5426: with --output,
+// bundles are rendered locally, so a reachable cluster must not be required.
+func TestApplyOutputWithoutCluster(t *testing.T) {
+	for name, output := range map[string]string{
+		"file":   "bundle.yaml",
+		"stdout": "-",
+	} {
+		t.Run(name, func(t *testing.T) {
+			setupOfflineApply(t)
+
+			a := newApplyForTest()
+			a.Output = output
+
+			if err := a.Run(testCommand(), []string{"repo", "some"}); err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+
+			if output == "-" {
+				// Nothing to assert on beyond the command succeeding: the
+				// bundle went to the process' stdout.
+				return
+			}
+
+			b, err := os.ReadFile(output)
+			if err != nil {
+				t.Fatalf("expected %s to be written: %v", output, err)
+			}
+			if !strings.Contains(string(b), "kind: Bundle") {
+				t.Errorf("expected a Bundle in %s, got %q", output, string(b))
+			}
+		})
+	}
+}
+
+// TestApplyDrivenScanOutputWithoutCluster covers the same regression for
+// --driven-scan, which goes through CreateBundlesDriven.
+func TestApplyDrivenScanOutputWithoutCluster(t *testing.T) {
+	setupOfflineApply(t)
+
+	a := newApplyForTest()
+	a.Output = "bundle.yaml"
+	a.DrivenScan = true
+	a.DrivenScanSeparator = ":"
+
+	if err := a.Run(testCommand(), []string{"repo", "some"}); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	b, err := os.ReadFile("bundle.yaml")
+	if err != nil {
+		t.Fatalf("expected bundle.yaml to be written: %v", err)
+	}
+	if !strings.Contains(string(b), "kind: Bundle") {
+		t.Errorf("expected a Bundle in bundle.yaml, got %q", string(b))
+	}
+}
+
+// TestApplyWithoutOutputRequiresKubeconfig makes sure the offline path is not
+// taken when bundles are meant to be created on a cluster, and that the
+// failure is reported instead of exiting silently.
+func TestApplyWithoutOutputRequiresKubeconfig(t *testing.T) {
+	setupOfflineApply(t)
+
+	a := newApplyForTest()
+
+	err := a.Run(testCommand(), []string{"repo", "some"})
+	if err == nil {
+		t.Fatal("expected an error, got none")
+	}
+	if !strings.Contains(err.Error(), "kubeconfig") {
+		t.Errorf("expected the error to mention the kubeconfig, got %v", err)
+	}
+}

--- a/internal/cmd/cli/apply_offline_test.go
+++ b/internal/cmd/cli/apply_offline_test.go
@@ -82,7 +82,7 @@ func TestApplyOutputWithoutCluster(t *testing.T) {
 			a := newApplyForTest()
 			a.Output = output
 
-			if err := a.Run(testCommand(), []string{"repo", "some"}); err != nil {
+			if err := a.Run(testCommand(), []string{"test-bundle", "some"}); err != nil {
 				t.Fatalf("expected no error, got %v", err)
 			}
 
@@ -113,7 +113,7 @@ func TestApplyDrivenScanOutputWithoutCluster(t *testing.T) {
 	a.DrivenScan = true
 	a.DrivenScanSeparator = ":"
 
-	if err := a.Run(testCommand(), []string{"repo", "some"}); err != nil {
+	if err := a.Run(testCommand(), []string{"test-bundle", "some"}); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
@@ -134,7 +134,7 @@ func TestApplyWithoutOutputRequiresKubeconfig(t *testing.T) {
 
 	a := newApplyForTest()
 
-	err := a.Run(testCommand(), []string{"repo", "some"})
+	err := a.Run(testCommand(), []string{"test-bundle", "some"})
 	if err == nil {
 		t.Fatal("expected an error, got none")
 	}

--- a/internal/cmd/cli/bundlediff.go
+++ b/internal/cmd/cli/bundlediff.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"flag"
 	"fmt"
 	"io"
 	"os"
@@ -68,10 +67,7 @@ Examples:
 	})
 	cmd.SetOut(os.Stdout)
 
-	fs := flag.NewFlagSet("", flag.ExitOnError)
-	zopts.BindFlags(fs)
-	ctrl.RegisterFlags(fs)
-	cmd.Flags().AddGoFlagSet(fs)
+	registerLoggingAndKubeconfigFlags(cmd)
 	return cmd
 }
 
@@ -110,9 +106,9 @@ func (d *BundleDiff) Run(cmd *cobra.Command, args []string) error {
 		return errors.New("cannot specify both --json and --fleet-yaml")
 	}
 
-	cfg, err := ctrl.GetConfig()
+	cfg, err := getKubeconfig()
 	if err != nil {
-		return fmt.Errorf("failed to get k8s config: %w", err)
+		return err
 	}
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&zopts)))

--- a/internal/cmd/cli/cleanup.go
+++ b/internal/cmd/cli/cleanup.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"errors"
-	"flag"
 	"fmt"
 	"math"
 	"strconv"
@@ -40,10 +39,7 @@ func NewClusterRegistration() *cobra.Command {
 		SilenceErrors: true,
 	})
 
-	fs := flag.NewFlagSet("", flag.ExitOnError)
-	zopts.BindFlags(fs)
-	ctrl.RegisterFlags(fs)
-	cmd.Flags().AddGoFlagSet(fs)
+	registerLoggingAndKubeconfigFlags(cmd)
 	return cmd
 }
 
@@ -55,10 +51,7 @@ func NewGitjob() *cobra.Command {
 		SilenceErrors: true,
 	})
 
-	fs := flag.NewFlagSet("", flag.ExitOnError)
-	zopts.BindFlags(fs)
-	ctrl.RegisterFlags(fs)
-	cmd.Flags().AddGoFlagSet(fs)
+	registerLoggingAndKubeconfigFlags(cmd)
 	return cmd
 }
 
@@ -132,7 +125,10 @@ func (a *ClusterRegistration) Run(cmd *cobra.Command, args []string) error {
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&zopts)))
 	ctx := log.IntoContext(cmd.Context(), ctrl.Log)
 
-	cfg := ctrl.GetConfigOrDie()
+	cfg, err := getKubeconfig()
+	if err != nil {
+		return err
+	}
 	client, err := client.New(cfg, client.Options{Scheme: scheme})
 	if err != nil {
 		return err
@@ -164,7 +160,10 @@ func (r *Gitjob) Run(cmd *cobra.Command, args []string) error {
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&zopts)))
 	ctx := log.IntoContext(cmd.Context(), ctrl.Log)
 
-	cfg := ctrl.GetConfigOrDie()
+	cfg, err := getKubeconfig()
+	if err != nil {
+		return err
+	}
 	client, err := client.New(cfg, client.Options{Scheme: scheme})
 	if err != nil {
 		return err

--- a/internal/cmd/cli/deploy.go
+++ b/internal/cmd/cli/deploy.go
@@ -36,12 +36,7 @@ func NewDeploy() *cobra.Command {
 	})
 	cmd.SetOut(os.Stdout)
 
-	// add command line flags from zap and controller-runtime, which use
-	// goflags and convert them to pflags
-	fs := flag.NewFlagSet("", flag.ExitOnError)
-	zopts.BindFlags(fs)
-	ctrl.RegisterFlags(fs)
-	cmd.Flags().AddGoFlagSet(fs)
+	registerLoggingAndKubeconfigFlags(cmd)
 	return cmd
 }
 
@@ -127,7 +122,10 @@ func (d *Deploy) Run(cmd *cobra.Command, args []string) error {
 		return printRelease(cmd, rel)
 	}
 
-	cfg := ctrl.GetConfigOrDie()
+	cfg, err := getKubeconfig()
+	if err != nil {
+		return err
+	}
 	client, err := client.New(cfg, client.Options{Scheme: scheme})
 	if err != nil {
 		return err

--- a/internal/cmd/cli/dump.go
+++ b/internal/cmd/cli/dump.go
@@ -93,9 +93,9 @@ func (d *Dump) Run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	cfg, err := ctrl.GetConfig()
+	cfg, err := getKubeconfig()
 	if err != nil {
-		return fmt.Errorf("failed to get k8s config: %w", err)
+		return err
 	}
 
 	fmt.Fprintln(os.Stderr, "dump path: ", d.DumpPath)

--- a/internal/cmd/cli/dump.go
+++ b/internal/cmd/cli/dump.go
@@ -27,10 +27,13 @@ fleet dump check
 
 // NewDump returns a subcommand to dump Fleet's state
 func NewDump() *cobra.Command {
-	return command.Command(&Dump{}, cobra.Command{
+	cmd := command.Command(&Dump{}, cobra.Command{
 		Use:   "dump [flags]",
 		Short: "Dump state of upstream Fleet-managed resources into an archive",
 	})
+
+	registerLoggingAndKubeconfigFlags(cmd)
+	return cmd
 }
 
 type Dump struct {

--- a/internal/cmd/cli/kubeconfig.go
+++ b/internal/cmd/cli/kubeconfig.go
@@ -31,9 +31,11 @@ func registerLoggingAndKubeconfigFlags(cmd *cobra.Command) {
 // getKubeconfig.
 //
 // ctrl.RegisterFlags binds --kubeconfig via the stdlib flag package, which has
-// no notion of shorthands. pflag only records a shorthand while adding a flag
-// to a set, in AddFlag, so "k" has to be set on the way in: assigning
-// Shorthand afterwards updates the usage output but leaves -k unparsable.
+// no notion of shorthands, so fs cannot carry "k" itself. pfs is the staging
+// set where it can: pflag only records a shorthand in AddFlag, as the flag
+// enters a set, so setting it on pfs before cmd.Flags().AddFlagSet(pfs) is
+// what registers -k with the command. Assigning Shorthand to a flag already
+// in cmd.Flags() updates the usage output but leaves -k unparsable.
 func addGoFlags(cmd *cobra.Command, fs *flag.FlagSet) {
 	ctrl.RegisterFlags(fs)
 

--- a/internal/cmd/cli/kubeconfig.go
+++ b/internal/cmd/cli/kubeconfig.go
@@ -1,0 +1,60 @@
+package cli
+
+import (
+	"flag"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+// registerKubeconfigFlags adds the controller-runtime flags, --kubeconfig
+// among them, to cmd.
+func registerKubeconfigFlags(cmd *cobra.Command) {
+	addGoFlags(cmd, flag.NewFlagSet("", flag.ExitOnError))
+}
+
+// registerLoggingAndKubeconfigFlags does the same as registerKubeconfigFlags,
+// and also exposes the zap logging flags, for the commands which set up the
+// controller-runtime logger from them.
+func registerLoggingAndKubeconfigFlags(cmd *cobra.Command) {
+	fs := flag.NewFlagSet("", flag.ExitOnError)
+	zopts.BindFlags(fs)
+	addGoFlags(cmd, fs)
+}
+
+// addGoFlags converts fs, together with the controller-runtime flags, to
+// pflags and adds them to cmd. Every subcommand which talks to a cluster has
+// to go through here, so that --kubeconfig reaches the loader used by
+// getKubeconfig.
+//
+// ctrl.RegisterFlags binds --kubeconfig via the stdlib flag package, which has
+// no notion of shorthands. pflag only records a shorthand while adding a flag
+// to a set, in AddFlag, so "k" has to be set on the way in: assigning
+// Shorthand afterwards updates the usage output but leaves -k unparsable.
+func addGoFlags(cmd *cobra.Command, fs *flag.FlagSet) {
+	ctrl.RegisterFlags(fs)
+
+	pfs := pflag.NewFlagSet("", pflag.ExitOnError)
+	pfs.AddGoFlagSet(fs)
+	if f := pfs.Lookup("kubeconfig"); f != nil {
+		f.Shorthand = "k"
+	}
+
+	cmd.Flags().AddFlagSet(pfs)
+}
+
+// getKubeconfig returns the rest config to use, looked up from --kubeconfig,
+// the KUBECONFIG environment variable, the in-cluster config or
+// ~/.kube/config, in that order. Unlike ctrl.GetConfigOrDie it lets the caller
+// report the failure instead of exiting the process.
+func getKubeconfig() (*rest.Config, error) {
+	cfg, err := ctrl.GetConfig()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get kubeconfig: %w", err)
+	}
+
+	return cfg, nil
+}

--- a/internal/cmd/cli/kubeconfig_flag_test.go
+++ b/internal/cmd/cli/kubeconfig_flag_test.go
@@ -18,7 +18,9 @@ func kubeconfigCommands() map[string]func() *cobra.Command {
 		"bundlediff":          NewBundleDiff,
 		"clusterregistration": NewClusterRegistration,
 		"deploy":              NewDeploy,
+		"dump":                NewDump,
 		"gitjob":              NewGitjob,
+		"migrate":             NewMigrateGitRepoHelmURLRegex,
 		"monitor":             NewMonitor,
 		"target":              NewTarget,
 	}

--- a/internal/cmd/cli/kubeconfig_flag_test.go
+++ b/internal/cmd/cli/kubeconfig_flag_test.go
@@ -1,0 +1,148 @@
+package cli
+
+import (
+	"flag"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/cobra"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+// kubeconfigCommands returns every subcommand which registers --kubeconfig, so
+// that the flag is covered wherever it is offered rather than on apply alone.
+func kubeconfigCommands() map[string]func() *cobra.Command {
+	return map[string]func() *cobra.Command{
+		"apply":               NewApply,
+		"bundlediff":          NewBundleDiff,
+		"clusterregistration": NewClusterRegistration,
+		"deploy":              NewDeploy,
+		"gitjob":              NewGitjob,
+		"monitor":             NewMonitor,
+		"target":              NewTarget,
+	}
+}
+
+// writeKubeconfig writes a minimal, valid kubeconfig pointing at a known
+// server and returns its path.
+func writeKubeconfig(t *testing.T, server string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "kubeconfig.yaml")
+	content := `apiVersion: v1
+kind: Config
+clusters:
+- name: test
+  cluster:
+    server: ` + server + `
+contexts:
+- name: test
+  context:
+    cluster: test
+    user: test
+current-context: test
+users:
+- name: test
+  user: {}
+`
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("failed to write kubeconfig: %v", err)
+	}
+	return path
+}
+
+// resetKubeconfigFlag clears the kubeconfig path used by ctrl.GetConfig. That
+// path lives in a controller-runtime package global, shared by every test in
+// this binary, so a test which sets it - by parsing --kubeconfig or otherwise
+// - has to clear it again. Otherwise it leaks into whatever runs next, which
+// under `go test -shuffle` is not the test the author had in mind.
+func resetKubeconfigFlag(t *testing.T) {
+	t.Helper()
+
+	fs := flag.NewFlagSet("", flag.ContinueOnError)
+	ctrl.RegisterFlags(fs) // re-binding resets the global to ""
+	if err := fs.Parse(nil); err != nil {
+		t.Errorf("failed to reset --kubeconfig: %v", err)
+	}
+}
+
+// setKubeconfigFlag points the kubeconfig used by ctrl.GetConfig at path, and
+// restores it afterwards. The flag takes precedence over the in-cluster
+// config, so tests behave the same inside and outside a pod.
+func setKubeconfigFlag(t *testing.T, path string) {
+	t.Helper()
+
+	fs := flag.NewFlagSet("", flag.ContinueOnError)
+	ctrl.RegisterFlags(fs)
+	if err := fs.Parse([]string{"--kubeconfig", path}); err != nil {
+		t.Fatalf("failed to set --kubeconfig: %v", err)
+	}
+
+	t.Cleanup(func() { resetKubeconfigFlag(t) })
+}
+
+// TestKubeconfigFlagIsHonored is a regression test for #5170: the subcommands
+// which talk to a cluster must honor --kubeconfig, i.e. the flag must be wired
+// to the config loader used by ctrl.GetConfig (the one the commands actually
+// use), not to a dead struct field.
+func TestKubeconfigFlagIsHonored(t *testing.T) {
+	const server = "https://example.test:6443"
+
+	for name, newCmd := range kubeconfigCommands() {
+		t.Run(name, func(t *testing.T) {
+			kubeconfig := writeKubeconfig(t, server)
+
+			cmd := newCmd()
+			t.Cleanup(func() { resetKubeconfigFlag(t) })
+
+			// Parsing --kubeconfig must be accepted (not an "unknown flag"
+			// error). ParseFlags merges persistent+local flags as cobra does
+			// at execution time.
+			if err := cmd.ParseFlags([]string{"--kubeconfig", kubeconfig}); err != nil {
+				t.Fatalf("failed to parse --kubeconfig: %v", err)
+			}
+
+			// ...and it must actually reach the config loader the command uses.
+			cfg, err := ctrl.GetConfig()
+			if err != nil {
+				t.Fatalf("ctrl.GetConfig() failed: %v", err)
+			}
+			if cfg.Host != server {
+				t.Errorf("--kubeconfig was not honored: got host %q, want %q", cfg.Host, server)
+			}
+		})
+	}
+}
+
+// TestKubeconfigShorthand makes sure the -k shorthand for --kubeconfig keeps
+// working. The pre-existing FleetClient.Kubeconfig field exposed -k; the fix
+// must not silently drop it.
+//
+// This parses -k rather than reading Flag.Shorthand: pflag records shorthands
+// in a lookup table while the flag is added, so a Shorthand set after the fact
+// shows up in --help while -k is still rejected at parse time.
+func TestKubeconfigShorthand(t *testing.T) {
+	const server = "https://shorthand.test:6443"
+
+	for name, newCmd := range kubeconfigCommands() {
+		t.Run(name, func(t *testing.T) {
+			kubeconfig := writeKubeconfig(t, server)
+
+			cmd := newCmd()
+			t.Cleanup(func() { resetKubeconfigFlag(t) })
+
+			if err := cmd.ParseFlags([]string{"-k", kubeconfig}); err != nil {
+				t.Fatalf("failed to parse -k: %v", err)
+			}
+
+			cfg, err := ctrl.GetConfig()
+			if err != nil {
+				t.Fatalf("ctrl.GetConfig() failed: %v", err)
+			}
+			if cfg.Host != server {
+				t.Errorf("-k was not honored: got host %q, want %q", cfg.Host, server)
+			}
+		})
+	}
+}

--- a/internal/cmd/cli/migrate.go
+++ b/internal/cmd/cli/migrate.go
@@ -58,7 +58,10 @@ func (m *MigrateGitRepoHelmURLRegex) Run(cmd *cobra.Command, _ []string) error {
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&zopts)))
 	ctx := log.IntoContext(cmd.Context(), ctrl.Log)
 
-	cfg := ctrl.GetConfigOrDie()
+	cfg, err := getKubeconfig()
+	if err != nil {
+		return err
+	}
 	cl, err := client.New(cfg, client.Options{Scheme: scheme})
 	if err != nil {
 		return err

--- a/internal/cmd/cli/migrate.go
+++ b/internal/cmd/cli/migrate.go
@@ -28,12 +28,15 @@ func newMigrateCmd() *cobra.Command {
 }
 
 func NewMigrateGitRepoHelmURLRegex() *cobra.Command {
-	return command.Command(&MigrateGitRepoHelmURLRegex{}, cobra.Command{
+	cmd := command.Command(&MigrateGitRepoHelmURLRegex{}, cobra.Command{
 		Use:           "gitrepo-helm-url-regex [flags]",
 		Short:         "Set helmRepoURLRegex on GitRepos that have a Helm secret but no regex",
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	})
+
+	registerLoggingAndKubeconfigFlags(cmd)
+	return cmd
 }
 
 type Migrate struct{}

--- a/internal/cmd/cli/monitor.go
+++ b/internal/cmd/cli/monitor.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"context"
 	"encoding/json"
-	"flag"
 	"fmt"
 	"os"
 	"time"
@@ -226,12 +225,7 @@ Examples:
 	})
 	cmd.SetOut(os.Stdout)
 
-	// add command line flags from zap and controller-runtime, which use
-	// goflags and convert them to pflags
-	fs := flag.NewFlagSet("", flag.ExitOnError)
-	zopts.BindFlags(fs)
-	ctrl.RegisterFlags(fs)
-	cmd.Flags().AddGoFlagSet(fs)
+	registerLoggingAndKubeconfigFlags(cmd)
 	return cmd
 }
 
@@ -239,7 +233,10 @@ func (m *Monitor) Run(cmd *cobra.Command, args []string) error {
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&zopts)))
 	ctx := log.IntoContext(cmd.Context(), ctrl.Log)
 
-	cfg := ctrl.GetConfigOrDie()
+	cfg, err := getKubeconfig()
+	if err != nil {
+		return err
+	}
 	c, err := client.New(cfg, client.Options{Scheme: scheme})
 	if err != nil {
 		return err

--- a/internal/cmd/cli/target.go
+++ b/internal/cmd/cli/target.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"errors"
-	"flag"
 	"os"
 	"reflect"
 
@@ -45,12 +44,7 @@ func NewTarget() *cobra.Command {
 	})
 	cmd.SetOut(os.Stdout)
 
-	// add command line flags from zap and controller-runtime, which use
-	// goflags and convert them to pflags
-	fs := flag.NewFlagSet("", flag.ExitOnError)
-	zopts.BindFlags(fs)
-	ctrl.RegisterFlags(fs)
-	cmd.Flags().AddGoFlagSet(fs)
+	registerLoggingAndKubeconfigFlags(cmd)
 	return cmd
 }
 
@@ -94,7 +88,10 @@ func (t *Target) Run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	cfg := ctrl.GetConfigOrDie()
+	cfg, err := getKubeconfig()
+	if err != nil {
+		return err
+	}
 	client, err := client.New(cfg, client.Options{Scheme: scheme})
 	if err != nil {
 		return err


### PR DESCRIPTION
This PR fixes an issue when calling `fleet apply --ouput` without a valid kubeconfig.

fleet apply --output renders bundles locally and never talks to a cluster, but it built a Kubernetes client before deciding that — so it failed on any machine without a loadable kubeconfig, and failed silently (exit 1, no message), because ctrl.GetConfigOrDie logs through controller-runtime's logger that fleet apply never initializes and then calls os.Exit.

The client and event recorder are now built only when --output is unset, so the offline path never needs a kubeconfig; and every CLI command uses ctrl.GetConfig and returns the error instead of dying, so a genuinely missing kubeconfig now prints a valid message.

Refers to: https://github.com/rancher/fleet/issues/5426

## Additional Information

### Checklist

~- [ ] <!-- If applicable,--> I have updated the documentation via a pull request in the [fleet-product-docs](https://github.com/rancher/fleet-product-docs) repository.~
