### PR TITLE
Simplify automerge rules

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -86,7 +86,6 @@
         "patch",
         "minor"
       ],
-      "enabled": true,
       "automerge": true
     },
     {
@@ -103,7 +102,6 @@
         "patch",
         "minor"
       ],
-      "enabled": true,
       "automerge": true
     }
   ]

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -11,6 +11,7 @@
     "release/v0.13",
     "release/v0.12"
   ],
+  "prHourlyLimit": 6,
   "ignorePaths": [
     "**/assets/**"
   ],


### PR DESCRIPTION
Configure Renovate to automerge eligible patch and minor updates while preserving release-branch disable rules. Limit PR creation to six per hour to allow all release branches to be update at once.