### PR TITLE
Fix automerge for release branch dependency updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -22,6 +22,23 @@
       ],
       "extends": [
         "github>rancher/renovate-config//rancher-2.15#main"
+      ],
+      "packageRules": [
+        {
+          "matchJsonata": [
+            "$not($exists(vulnerabilityFixVersion) or $exists(isVulnerabilityAlert))"
+          ],
+          "matchUpdateTypes": ["patch", "minor"],
+          "automerge": true
+        },
+        {
+          "matchDepTypes": ["!devDependencies", "!dev-dependencies", "!test"],
+          "matchJsonata": [
+            "$exists(vulnerabilityFixVersion) or $exists(isVulnerabilityAlert)"
+          ],
+          "matchUpdateTypes": ["patch", "minor"],
+          "automerge": true
+        }
       ]
     },
     {
@@ -30,6 +47,23 @@
       ],
       "extends": [
         "github>rancher/renovate-config//rancher-2.14#main"
+      ],
+      "packageRules": [
+        {
+          "matchJsonata": [
+            "$not($exists(vulnerabilityFixVersion) or $exists(isVulnerabilityAlert))"
+          ],
+          "matchUpdateTypes": ["patch", "minor"],
+          "automerge": true
+        },
+        {
+          "matchDepTypes": ["!devDependencies", "!dev-dependencies", "!test"],
+          "matchJsonata": [
+            "$exists(vulnerabilityFixVersion) or $exists(isVulnerabilityAlert)"
+          ],
+          "matchUpdateTypes": ["patch", "minor"],
+          "automerge": true
+        }
       ]
     },
     {
@@ -38,6 +72,23 @@
       ],
       "extends": [
         "github>rancher/renovate-config//rancher-2.13#main"
+      ],
+      "packageRules": [
+        {
+          "matchJsonata": [
+            "$not($exists(vulnerabilityFixVersion) or $exists(isVulnerabilityAlert))"
+          ],
+          "matchUpdateTypes": ["patch", "minor"],
+          "automerge": true
+        },
+        {
+          "matchDepTypes": ["!devDependencies", "!dev-dependencies", "!test"],
+          "matchJsonata": [
+            "$exists(vulnerabilityFixVersion) or $exists(isVulnerabilityAlert)"
+          ],
+          "matchUpdateTypes": ["patch", "minor"],
+          "automerge": true
+        }
       ]
     },
     {
@@ -46,6 +97,23 @@
       ],
       "extends": [
         "github>rancher/renovate-config//rancher-2.12#main"
+      ],
+      "packageRules": [
+        {
+          "matchJsonata": [
+            "$not($exists(vulnerabilityFixVersion) or $exists(isVulnerabilityAlert))"
+          ],
+          "matchUpdateTypes": ["patch", "minor"],
+          "automerge": true
+        },
+        {
+          "matchDepTypes": ["!devDependencies", "!dev-dependencies", "!test"],
+          "matchJsonata": [
+            "$exists(vulnerabilityFixVersion) or $exists(isVulnerabilityAlert)"
+          ],
+          "matchUpdateTypes": ["patch", "minor"],
+          "automerge": true
+        }
       ]
     },
     {
@@ -54,6 +122,23 @@
       ],
       "extends": [
         "github>rancher/renovate-config//rancher-2.11#main"
+      ],
+      "packageRules": [
+        {
+          "matchJsonata": [
+            "$not($exists(vulnerabilityFixVersion) or $exists(isVulnerabilityAlert))"
+          ],
+          "matchUpdateTypes": ["patch", "minor"],
+          "automerge": true
+        },
+        {
+          "matchDepTypes": ["!devDependencies", "!dev-dependencies", "!test"],
+          "matchJsonata": [
+            "$exists(vulnerabilityFixVersion) or $exists(isVulnerabilityAlert)"
+          ],
+          "matchUpdateTypes": ["patch", "minor"],
+          "automerge": true
+        }
       ]
     },
     {


### PR DESCRIPTION
Release branch package rules use extends with matchBaseBranches to pull in the rancher-2.1x presets, which nest those presets packageRules (including their automerge:false rules) under the matching branch condition. Renovate flattens nested packageRules by appending them to the end of the resolved list, so they were evaluated after, and therefore overrode, the automerge:true rules defined later in this file. Add explicit automerge rules inside each release branch block so they are flattened together with, and win over, the inherited automerge:false rules.