### PR TITLE
Enable automerge for eligible Renovate updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -90,33 +90,6 @@
       "enabled": true,
       "groupName": "Kubernetes dependencies",
       "minimumGroupSize": 2
-    },
-    {
-      "description": "Automerge patch and minor updates",
-      "matchJsonata": [
-        "$not($exists(vulnerabilityFixVersion) or $exists(isVulnerabilityAlert))"
-      ],
-      "matchUpdateTypes": [
-        "patch",
-        "minor"
-      ],
-      "automerge": true
-    },
-    {
-      "description": "Automerge security updates",
-      "matchDepTypes": [
-        "!devDependencies",
-        "!dev-dependencies",
-        "!test"
-      ],
-      "matchJsonata": [
-        "$exists(vulnerabilityFixVersion) or $exists(isVulnerabilityAlert)"
-      ],
-      "matchUpdateTypes": [
-        "patch",
-        "minor"
-      ],
-      "automerge": true
     }
   ]
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -57,6 +57,20 @@
       ]
     },
     {
+      "description": "Activate automerge for eligible updates",
+      "matchBaseBranches": [
+        "main",
+        "release/v0.16",
+        "release/v0.15",
+        "release/v0.14",
+        "release/v0.13",
+        "release/v0.12"
+      ],
+      "extends": [
+        "github>rancher/renovate-config//automerge#main"
+      ]
+    },
+    {
       "description": "Update Wrangler in Helm values module",
       "matchManagers": ["gomod"],
       "matchFileNames": ["pkg/helmvalues/go.mod"],


### PR DESCRIPTION
Apply shared `automerge.json` policy to Fleet main and release branches.

Requires https://github.com/rancher/renovate-config/pull/831