### PR TITLE
Compute `rancher/charts` base branch for testing Fleet in Rancher

### DIFF
--- a/.github/workflows/e2e-test-fleet-in-rancher.yml
+++ b/.github/workflows/e2e-test-fleet-in-rancher.yml
@@ -13,9 +13,8 @@ on:
         default: "fleetrepoci/charts"
         type: string
       charts_branch:
-        description: Branch from which to source Fleet charts
-        required: true
-        default: "dev-v2.14"
+        description: Branch from which to source Fleet charts; if empty, will be computed from the latest Rancher minor release.
+        required: false
         type: string
   push:
     tags: [ 'v*' ]

--- a/.github/workflows/release-against-test-charts.yml
+++ b/.github/workflows/release-against-test-charts.yml
@@ -3,9 +3,8 @@ on:
   workflow_dispatch:
     inputs:
       charts_base_branch:
-        description: "Use the following rancher/charts branch as a base (e.g. dev-v2.7)"
+        description: "Use the following rancher/charts branch as a base (e.g. dev-v2.15)"
         required: false
-        default: "dev-v2.14"
         type: string
       charts_repo:
         description: "Push to the following Rancher charts repo (which must exist)"
@@ -19,9 +18,8 @@ on:
     # Variables to set when calling this reusable workflow
     inputs:
       charts_base_branch:
-        description: "Use the following rancher/charts branch as a base (e.g. dev-v2.7)"
+        description: "Use the following rancher/charts branch as a base (e.g. dev-v2.15)"
         required: false
-        default: "dev-v2.14"
         type: string
       charts_repo:
         description: "Push to the following Rancher charts repo (which must exist)"
@@ -60,7 +58,14 @@ jobs:
           INPUT_CHARTS_BASE_BRANCH: ${{ inputs.charts_base_branch }}
           INPUT_CHARTS_REPO: ${{ inputs.charts_repo }}
         run: |
-          charts_base_branch="${INPUT_CHARTS_BASE_BRANCH:-dev-v2.14}"
+          charts_base_branch="${INPUT_CHARTS_BASE_BRANCH}"
+
+          if [ -z "$charts_base_branch" ]; then
+            helm repo add rancher-latest https://releases.rancher.com/server-charts/latest
+            latest_rancher_minor_chart="$(helm search repo rancher-latest/rancher --fail-on-no-result --devel -o=json | jq '.[0]["app_version"]' | grep -oE 'v[0-9]+\.[0-9]+')"
+            charts_base_branch="dev-$latest_rancher_minor_chart"
+          fi
+
           charts_repo="${INPUT_CHARTS_REPO:-fleetrepoci/charts}"
 
           echo "charts_base_branch=$charts_base_branch" >> "$GITHUB_OUTPUT"

--- a/dev/README.md
+++ b/dev/README.md
@@ -326,14 +326,14 @@ including all the necessary tools to run both single and multi-cluster tests of
 fleet.
 
 ```Dockerfile
-FROM ubuntu:22.04
+FROM ubuntu:26.04
 
 ARG BUILDARCH=amd64
-ARG NVM_VERSION=v0.39.7
-ARG NODE_VERSION=20
+ARG NVM_VERSION=v0.40.7
+ARG NODE_VERSION=24.19.0
 
 RUN apt update && apt upgrade -y
-RUN apt install -y wget curl git jq zstd
+RUN apt install -y wget curl git jq zstd make file
 
 WORKDIR /tmp
 


### PR DESCRIPTION
## Brief context

The `Test Fleet in Rancher` CI workflow aims to test a given Fleet commit against the latest Rancher release.
It does so by building a custom Fleet chart, to be embedded into Rancher at `helm install` time. For the time being, this requires cloning `rancher/charts`.

Whenever a new Rancher minor is released, the default value for `rancher/charts` would need to be updated; otherwise, Rancher would fail to install, as it would be looking for versions of component charts which could not be resolved in a custom `rancher/charts` branch based on an older dev branch.

## New approach

Instead of hard-coding the base `rancher/charts` branch, the workflow computes it as `dev-<latest Rancher minor available in charts repo>`, where the charts repository in question is `https://releases.rancher.com/server-charts/latest`.

This new behaviour applies to empty (default) base branch names; should a user still need to manually call the workflow with a specific dev branch, that would still be possible — although the Rancher CLI and a few other tools, such as `kubectl`, are still installed with hard-coded versions.

This allows the Rancher provisioning tests to [run again](https://github.com/rancher/fleet/actions/runs/32868203834/job/97870190031). Making them pass is beyond the scope of this patch.

¹ as is the case at the time of writing: `rancher/charts` branch `dev-v2.16` exists, but no Rancher v2.16 charts is available.

## Considered alternative

Checking the latest available Rancher minor based on `dev-` branches in the `rancher/charts` repo has been pondered. However, that approach would be vulnerable to an edge case¹ where a new `dev-` branch exists in `rancher/charts` with no corresponding chart the aforementioned Helm repository. That would prevent successful installation of Rancher components against an older chart, creating the opposite issue to the one this patch aims to resolve.

## Additional Information

### Checklist

~- [ ] <!-- If applicable,--> I have updated the documentation via a pull request in the [fleet-product-docs](https://github.com/rancher/fleet-product-docs) repository.~
