### PR TITLE
[v0.15] fix(policy): introduce CreateNamespace option

### DIFF
--- a/charts/fleet-crd/templates/crds.yaml
+++ b/charts/fleet-crd/templates/crds.yaml
@@ -304,6 +304,27 @@ spec:
                             in the helm history.
                           type: boolean
                       type: object
+                    createNamespace:
+                      description: 'CreateNamespace controls whether Fleet creates
+                        the target namespace on
+
+                        downstream clusters during Helm installs. When nil, the default
+                        behavior
+
+                        is to create the namespace (backward-compatible). Set to false
+                        by the
+
+                        controller when Policy requires a ServiceAccount and does
+                        not explicitly
+
+                        allow namespace creation. This does not affect namespaceLabels/
+
+                        namespaceAnnotations patching, which is always attempted (when
+                        set) as
+
+                        the deployment''s ServiceAccount and gated by downstream RBAC.'
+                      nullable: true
+                      type: boolean
                     defaultNamespace:
                       description: 'DefaultNamespace is the namespace to use for resources
                         that do not
@@ -770,6 +791,27 @@ spec:
                             in the helm history.
                           type: boolean
                       type: object
+                    createNamespace:
+                      description: 'CreateNamespace controls whether Fleet creates
+                        the target namespace on
+
+                        downstream clusters during Helm installs. When nil, the default
+                        behavior
+
+                        is to create the namespace (backward-compatible). Set to false
+                        by the
+
+                        controller when Policy requires a ServiceAccount and does
+                        not explicitly
+
+                        allow namespace creation. This does not affect namespaceLabels/
+
+                        namespaceAnnotations patching, which is always attempted (when
+                        set) as
+
+                        the deployment''s ServiceAccount and gated by downstream RBAC.'
+                      nullable: true
+                      type: boolean
                     defaultNamespace:
                       description: 'DefaultNamespace is the namespace to use for resources
                         that do not
@@ -1722,6 +1764,27 @@ spec:
                         in the helm history.
                       type: boolean
                   type: object
+                createNamespace:
+                  description: 'CreateNamespace controls whether Fleet creates the
+                    target namespace on
+
+                    downstream clusters during Helm installs. When nil, the default
+                    behavior
+
+                    is to create the namespace (backward-compatible). Set to false
+                    by the
+
+                    controller when Policy requires a ServiceAccount and does not
+                    explicitly
+
+                    allow namespace creation. This does not affect namespaceLabels/
+
+                    namespaceAnnotations patching, which is always attempted (when
+                    set) as
+
+                    the deployment''s ServiceAccount and gated by downstream RBAC.'
+                  nullable: true
+                  type: boolean
                 defaultNamespace:
                   description: 'DefaultNamespace is the namespace to use for resources
                     that do not
@@ -2803,6 +2866,28 @@ spec:
                               in the helm history.
                             type: boolean
                         type: object
+                      createNamespace:
+                        description: 'CreateNamespace controls whether Fleet creates
+                          the target namespace on
+
+                          downstream clusters during Helm installs. When nil, the
+                          default behavior
+
+                          is to create the namespace (backward-compatible). Set to
+                          false by the
+
+                          controller when Policy requires a ServiceAccount and does
+                          not explicitly
+
+                          allow namespace creation. This does not affect namespaceLabels/
+
+                          namespaceAnnotations patching, which is always attempted
+                          (when set) as
+
+                          the deployment''s ServiceAccount and gated by downstream
+                          RBAC.'
+                        nullable: true
+                        type: boolean
                       defaultNamespace:
                         description: 'DefaultNamespace is the namespace to use for
                           resources that do not
@@ -7930,6 +8015,27 @@ spec:
                         in the helm history.
                       type: boolean
                   type: object
+                createNamespace:
+                  description: 'CreateNamespace controls whether Fleet creates the
+                    target namespace on
+
+                    downstream clusters during Helm installs. When nil, the default
+                    behavior
+
+                    is to create the namespace (backward-compatible). Set to false
+                    by the
+
+                    controller when Policy requires a ServiceAccount and does not
+                    explicitly
+
+                    allow namespace creation. This does not affect namespaceLabels/
+
+                    namespaceAnnotations patching, which is always attempted (when
+                    set) as
+
+                    the deployment''s ServiceAccount and gated by downstream RBAC.'
+                  nullable: true
+                  type: boolean
                 defaultNamespace:
                   description: 'DefaultNamespace is the namespace to use for resources
                     that do not
@@ -9035,6 +9141,28 @@ spec:
                               in the helm history.
                             type: boolean
                         type: object
+                      createNamespace:
+                        description: 'CreateNamespace controls whether Fleet creates
+                          the target namespace on
+
+                          downstream clusters during Helm installs. When nil, the
+                          default behavior
+
+                          is to create the namespace (backward-compatible). Set to
+                          false by the
+
+                          controller when Policy requires a ServiceAccount and does
+                          not explicitly
+
+                          allow namespace creation. This does not affect namespaceLabels/
+
+                          namespaceAnnotations patching, which is always attempted
+                          (when set) as
+
+                          the deployment''s ServiceAccount and gated by downstream
+                          RBAC.'
+                        nullable: true
+                        type: boolean
                       defaultNamespace:
                         description: 'DefaultNamespace is the namespace to use for
                           resources that do not
@@ -10160,6 +10288,22 @@ spec:
             \ in the same namespace are aggregated with OR/union\nsemantics, sorted\
             \ by name for determinism."
           properties:
+            allowNamespaceCreation:
+              description: 'AllowNamespaceCreation, when true, allows Fleet to create
+                namespaces on
+
+                downstream clusters during Helm installs. By default (false), when
+
+                RequireServiceAccount is true, namespace creation is disabled so that
+
+                tenant ServiceAccounts are not forced to hold the cluster-scoped
+
+                namespaces.create verb. Operators who have secured namespace creation
+
+                through other means (ValidatingAdmissionPolicy, Kyverno, etc.) can
+
+                set this to true.'
+              type: boolean
             allowedServiceAccounts:
               description: 'AllowedServiceAccounts lists service accounts that may
                 be used.

--- a/internal/cmd/agent/controller/bundledeployment_controller.go
+++ b/internal/cmd/agent/controller/bundledeployment_controller.go
@@ -229,18 +229,15 @@ func (r *BundleDeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Req
 
 	// helm deploy the bundledeployment
 	if status, err := r.Deployer.DeployBundle(ctx, bd, forceDeploy); err != nil {
+		if handled, res, err := r.requeueIfNamespaceForbidden(ctx, orig, bd, status, err); handled {
+			return res, err
+		}
+
 		// do not use the returned status, instead set the condition and possibly a timestamp
 		bd.Status = setCondition(bd.Status, err, monitor.Cond(fleetv1.BundleDeploymentConditionDeployed))
 
-		// Not-ready dependencies should not be treated as an error.
-		// Instead, a controlled requeue should happen until the conditions are met.
-		var notReadyDependenciesError *deployer.NotReadyDependenciesError
-		if errors.As(err, &notReadyDependenciesError) {
-			if err := r.updateStatus(ctx, orig, bd); err != nil {
-				return ctrl.Result{}, err
-			}
-			logger.V(1).Info("Dependencies not ready, requeuing...", "pending", notReadyDependenciesError.Pending)
-			return ctrl.Result{RequeueAfter: durations.WaitForDependenciesReadyRequeueInterval}, nil
+		if handled, res, err := r.requeueIfDependenciesNotReady(ctx, orig, bd, err); handled {
+			return res, err
 		}
 
 		logger.V(1).Info("Failed to deploy bundle", "status", status, "error", err)
@@ -507,6 +504,47 @@ func (r *BundleDeploymentReconciler) updateStatus(ctx context.Context, orig *fle
 		return nil
 	}
 	return r.Status().Patch(ctx, obj, statusPatch)
+}
+
+// requeueIfNamespaceForbidden handles a denied namespace patch returned by
+// DeployBundle. The Helm release installed, but the requested namespaceLabels/
+// namespaceAnnotations could not be applied, so it is handled as a controlled
+// requeue rather than a failed reconcile so it does not tight-loop: keep
+// Ready/Installed=false from the returned status, mark Deployed (the release is
+// installed), persist, and requeue so the patch converges once the missing
+// namespace RBAC is granted (granting it does not otherwise trigger a
+// reconcile). Returns handled=false when err is not a NamespaceForbiddenError.
+func (r *BundleDeploymentReconciler) requeueIfNamespaceForbidden(ctx context.Context, orig, bd *fleetv1.BundleDeployment, status fleetv1.BundleDeploymentStatus, err error) (bool, ctrl.Result, error) {
+	var namespaceForbiddenError *deployer.NamespaceForbiddenError
+	if !errors.As(err, &namespaceForbiddenError) {
+		return false, ctrl.Result{}, nil
+	}
+
+	bd.Status = setCondition(status, nil, monitor.Cond(fleetv1.BundleDeploymentConditionDeployed))
+	if err := r.updateStatus(ctx, orig, bd); err != nil {
+		return true, ctrl.Result{}, err
+	}
+
+	log.FromContext(ctx).V(1).Info("Namespace patch forbidden, requeuing...", "error", namespaceForbiddenError)
+	return true, ctrl.Result{RequeueAfter: durations.NamespacePermissionRequeueInterval}, nil
+}
+
+// requeueIfDependenciesNotReady handles the case where DeployBundle reports
+// not-ready dependencies. That is not treated as an error; instead a controlled
+// requeue happens until the dependencies' conditions are met. Returns
+// handled=false when err is not a NotReadyDependenciesError.
+func (r *BundleDeploymentReconciler) requeueIfDependenciesNotReady(ctx context.Context, orig, bd *fleetv1.BundleDeployment, err error) (bool, ctrl.Result, error) {
+	var notReadyDependenciesError *deployer.NotReadyDependenciesError
+	if !errors.As(err, &notReadyDependenciesError) {
+		return false, ctrl.Result{}, nil
+	}
+
+	if err := r.updateStatus(ctx, orig, bd); err != nil {
+		return true, ctrl.Result{}, err
+	}
+
+	log.FromContext(ctx).V(1).Info("Dependencies not ready, requeuing...", "pending", notReadyDependenciesError.Pending)
+	return true, ctrl.Result{RequeueAfter: durations.WaitForDependenciesReadyRequeueInterval}, nil
 }
 
 // setCondition sets the condition and updates the timestamp, if the condition changed

--- a/internal/cmd/agent/deployer/deployer.go
+++ b/internal/cmd/agent/deployer/deployer.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -32,6 +33,23 @@ type NotReadyDependenciesError struct {
 func (e *NotReadyDependenciesError) Error() string {
 	return fmt.Sprintf("dependent bundle(s) are not ready: %v", e.Pending)
 }
+
+// NamespaceForbiddenError indicates the deployment's service account is not
+// allowed to mutate the target namespace. The Helm release installed, but the
+// requested namespaceLabels/namespaceAnnotations could not be applied, so the
+// deployment is reported not-ready. It is handled as a controlled requeue
+// rather than a failed reconcile (to avoid tight-looping); the patch converges
+// once the missing namespace RBAC is granted. That grant is not a watched
+// resource and would never re-trigger a reconcile on its own, hence the
+// controlled requeue. It unwraps to the underlying Forbidden error, so
+// apierrors.IsForbidden still reports true.
+type NamespaceForbiddenError struct {
+	err error
+}
+
+func (e *NamespaceForbiddenError) Error() string { return e.err.Error() }
+
+func (e *NamespaceForbiddenError) Unwrap() error { return e.err }
 
 type Deployer struct {
 	client         client.Client
@@ -104,6 +122,16 @@ func (d *Deployer) DeployBundle(
 	status.AppliedDeploymentID = bd.Spec.DeploymentID
 
 	if err := d.setNamespaceLabelsAndAnnotations(ctx, bd, releaseID); err != nil {
+		// A permission error here means the deployment's service account is
+		// not allowed to mutate the target namespace. Record it on the status
+		// and return a typed error so the controller does a controlled requeue
+		// (the missing namespace RBAC is not watched, so granting it would not
+		// otherwise re-trigger a reconcile) rather than tight-looping.
+		if do, newStatus := forbiddenToStatus(err, status); do {
+			newStatus.Release = releaseID
+			newStatus.AppliedDeploymentID = bd.Spec.DeploymentID
+			return newStatus, &NamespaceForbiddenError{err: err}
+		}
 		return fleet.BundleDeploymentStatus{}, err
 	}
 
@@ -192,7 +220,17 @@ func (d *Deployer) setNamespaceLabelsAndAnnotations(ctx context.Context, bd *fle
 		return nil
 	}
 
-	ns, err := d.fetchNamespace(ctx, releaseID)
+	// Patch the namespace as the deployment's service account so that this
+	// operation is gated by the same downstream RBAC as the deployment itself,
+	// rather than by the agent's cluster-admin credentials. When the deployment
+	// resolves to no service account, fall back to the agent client, preserving
+	// the previous behaviour.
+	c, err := d.namespaceClient(ctx, bd)
+	if err != nil {
+		return err
+	}
+
+	ns, err := fetchNamespace(ctx, c, releaseID)
 	if err != nil {
 		return err
 	}
@@ -218,13 +256,39 @@ func (d *Deployer) setNamespaceLabelsAndAnnotations(ctx context.Context, bd *fle
 
 	ns.Labels = desiredLabels
 	ns.Annotations = desiredAnnotations
-	return d.updateNamespace(ctx, ns)
+	return updateNamespace(ctx, c, ns)
+}
+
+// namespaceClient returns the client to use for namespace label/annotation
+// mutations. When the deployment resolves to a service account (pinned, or the
+// "fleet-default" fallback), it returns a client impersonating that account, so
+// the mutation is authorized against the downstream RBAC of the tenant rather
+// than the agent's cluster-admin credentials. Otherwise it returns the agent
+// client, preserving the previous behaviour.
+func (d *Deployer) namespaceClient(ctx context.Context, bd *fleet.BundleDeployment) (client.Client, error) {
+	if bd == nil {
+		return nil, errors.New("bundledeployment is nil")
+	}
+	if d.helm != nil {
+		c, err := d.helm.ImpersonatedClient(ctx, bd.Spec.Options.ServiceAccount)
+		if err != nil {
+			return nil, err
+		}
+		if c != nil {
+			return c, nil
+		}
+	}
+	return d.client, nil
 }
 
 // updateNamespace updates a namespace resource in the cluster.
-func (d *Deployer) updateNamespace(ctx context.Context, ns *corev1.Namespace) error {
-	err := d.client.Update(ctx, ns)
-	if err != nil {
+func updateNamespace(ctx context.Context, c client.Client, ns *corev1.Namespace) error {
+	if err := c.Update(ctx, ns); err != nil {
+		if apierrors.IsForbidden(err) {
+			return fmt.Errorf("the deployment's service account is not allowed to update namespace %q; "+
+				"grant it 'update' on this namespace (scoped via resourceNames) or remove "+
+				"namespaceLabels/namespaceAnnotations: %w", ns.Name, err)
+		}
 		return err
 	}
 
@@ -233,11 +297,15 @@ func (d *Deployer) updateNamespace(ctx context.Context, ns *corev1.Namespace) er
 
 // fetchNamespace gets the namespace matching the release ID. Returns an error if none is found.
 // releaseID is composed of release.Namespace/release.Name/release.Version
-func (d *Deployer) fetchNamespace(ctx context.Context, releaseID string) (*corev1.Namespace, error) {
+func fetchNamespace(ctx context.Context, c client.Client, releaseID string) (*corev1.Namespace, error) {
 	namespace := strings.Split(releaseID, "/")[0]
 	ns := &corev1.Namespace{}
-	err := d.client.Get(ctx, types.NamespacedName{Name: namespace}, ns)
-	if err != nil {
+	if err := c.Get(ctx, types.NamespacedName{Name: namespace}, ns); err != nil {
+		if apierrors.IsForbidden(err) {
+			return nil, fmt.Errorf("the deployment's service account is not allowed to get namespace %q; "+
+				"grant it 'get' on this namespace (scoped via resourceNames) or remove "+
+				"namespaceLabels/namespaceAnnotations: %w", namespace, err)
+		}
 		return nil, err
 	}
 	return ns, nil
@@ -249,6 +317,14 @@ const podSecurityLabelPrefix = "pod-security.kubernetes.io/"
 // the `kubernetes.io/metadata.name` label added by Kubernetes when creating the namespace
 // and any existing `pod-security.kubernetes.io/*` labels. Labels with the
 // `pod-security.kubernetes.io/` prefix in optLabels are ignored.
+//
+// This filtering is intentionally unconditional and independent of the
+// service-account impersonation used for the namespace patch: it must also hold
+// for deployments that run as the agent (no service account pinned), where
+// there is no downstream RBAC gating at all. It is the only safeguard against a
+// bundle escalating pod-security enforcement on its target namespace. To set
+// pod-security labels on a namespace, declare them on the Namespace resource in
+// the bundle instead.
 func addLabelsFromOptions(logger logr.Logger, nsLabels map[string]string, optLabels map[string]string) {
 	for k, v := range optLabels {
 		if strings.HasPrefix(k, podSecurityLabelPrefix) {
@@ -340,6 +416,28 @@ func deployErrToStatus(err error, status fleet.BundleDeploymentStatus) (bool, fl
 	}
 
 	return false, status
+}
+
+// forbiddenToStatus records a namespace permission error as a status condition,
+// mirroring deployErrToStatus. Such errors occur when the deployment's service
+// account is not allowed to mutate the target namespace. The condition surfaces
+// the missing RBAC on the bundle deployment; the caller wraps the error in a
+// NamespaceForbiddenError so the controller does a controlled requeue (at
+// NamespacePermissionRequeueInterval) rather than tight-looping, letting the
+// patch converge once the permission is granted.
+func forbiddenToStatus(err error, status fleet.BundleDeploymentStatus) (bool, fleet.BundleDeploymentStatus) {
+	if !apierrors.IsForbidden(err) {
+		return false, status
+	}
+
+	status.Ready = false
+	status.NonModified = true
+
+	msg := err.Error()
+	condition.Cond(fleet.BundleDeploymentConditionReady).SetError(&status, "", fmt.Errorf("not ready: %s", msg))
+	condition.Cond(fleet.BundleDeploymentConditionInstalled).SetError(&status, "", fmt.Errorf("not installed: %s", msg))
+
+	return true, status
 }
 
 func (d *Deployer) checkDependency(ctx context.Context, bd *fleet.BundleDeployment) error {

--- a/internal/cmd/agent/deployer/deployer_test.go
+++ b/internal/cmd/agent/deployer/deployer_test.go
@@ -2,6 +2,7 @@ package deployer
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/go-logr/logr"
@@ -12,6 +13,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -151,6 +153,129 @@ func TestSetNamespaceLabelsAndAnnotations(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestSetNamespaceLabelsAndAnnotations_CreateNamespaceFalse verifies that
+// disabling Helm namespace creation (CreateNamespace=false) does not prevent
+// Fleet from applying namespaceLabels/namespaceAnnotations to the (already
+// existing) namespace. CreateNamespace only governs creation; mutation is gated
+// by the deployment's service account RBAC, not by this flag.
+func TestSetNamespaceLabelsAndAnnotations_CreateNamespaceFalse(t *testing.T) {
+	createNS := false
+	bd := &fleet.BundleDeployment{Spec: fleet.BundleDeploymentSpec{
+		Options: fleet.BundleDeploymentOptions{
+			CreateNamespace:      &createNS,
+			NamespaceLabels:      map[string]string{"label": "value"},
+			NamespaceAnnotations: map[string]string{"ann": "value"},
+		},
+	}}
+	ns := corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "namespace",
+			Labels: map[string]string{"kubernetes.io/metadata.name": "namespace"},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+
+	updateCalled := false
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(&ns).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Update: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+				updateCalled = true
+				return c.Update(ctx, obj, opts...)
+			},
+		}).
+		Build()
+
+	h := Deployer{client: fakeClient}
+	err := h.setNamespaceLabelsAndAnnotations(context.Background(), bd, "namespace/foo/bar")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !updateCalled {
+		t.Error("namespace UPDATE was not attempted when CreateNamespace is false; mutation must not be gated by CreateNamespace")
+	}
+
+	result := &corev1.Namespace{}
+	if err := fakeClient.Get(context.Background(), types.NamespacedName{Name: "namespace"}, result); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Labels["label"] != "value" {
+		t.Errorf("label: got %q, want %q", result.Labels["label"], "value")
+	}
+	if result.Annotations["ann"] != "value" {
+		t.Errorf("annotation: got %q, want %q", result.Annotations["ann"], "value")
+	}
+}
+
+// TestSetNamespaceLabelsAndAnnotations_ForbiddenSurfaces verifies that a
+// permission error from the namespace client is wrapped such that it is still
+// detectable as a Forbidden error (so the caller can record it as a status
+// condition instead of requeuing forever).
+func TestSetNamespaceLabelsAndAnnotations_ForbiddenSurfaces(t *testing.T) {
+	bd := &fleet.BundleDeployment{Spec: fleet.BundleDeploymentSpec{
+		Options: fleet.BundleDeploymentOptions{
+			NamespaceLabels: map[string]string{"label": "value"},
+		},
+	}}
+	ns := corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "namespace",
+			Labels: map[string]string{"kubernetes.io/metadata.name": "namespace"},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+
+	forbidden := apierrors.NewForbidden(
+		schema.GroupResource{Resource: "namespaces"}, "namespace", errors.New("nope"))
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(&ns).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Update: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+				return forbidden
+			},
+		}).
+		Build()
+
+	h := Deployer{client: fakeClient}
+	err := h.setNamespaceLabelsAndAnnotations(context.Background(), bd, "namespace/foo/bar")
+	if err == nil {
+		t.Fatal("expected a forbidden error, got nil")
+	}
+	if !apierrors.IsForbidden(err) {
+		t.Errorf("expected error to be detectable as Forbidden, got %v", err)
+	}
+
+	if do, status := forbiddenToStatus(err, fleet.BundleDeploymentStatus{}); !do {
+		t.Error("forbiddenToStatus did not record the forbidden error as a status condition")
+	} else if status.Ready {
+		t.Error("expected status.Ready to be false")
+	}
+}
+
+// TestNamespaceForbiddenError verifies that the typed error DeployBundle
+// returns for a denied namespace patch is both detectable via errors.As (so the
+// controller can do a controlled requeue) and still unwraps to a Forbidden
+// error.
+func TestNamespaceForbiddenError(t *testing.T) {
+	forbidden := apierrors.NewForbidden(
+		schema.GroupResource{Resource: "namespaces"}, "namespace", errors.New("nope"))
+	err := error(&NamespaceForbiddenError{err: forbidden})
+
+	var nsErr *NamespaceForbiddenError
+	if !errors.As(err, &nsErr) {
+		t.Errorf("expected error to be detectable as *NamespaceForbiddenError, got %v", err)
+	}
+	if !apierrors.IsForbidden(err) {
+		t.Errorf("expected error to unwrap to a Forbidden error, got %v", err)
 	}
 }
 

--- a/internal/cmd/controller/policyrestrictions/policyrestrictions.go
+++ b/internal/cmd/controller/policyrestrictions/policyrestrictions.go
@@ -15,6 +15,7 @@ import (
 type Merged struct {
 	RequireServiceAccount  bool
 	AllowedServiceAccounts []string
+	AllowNamespaceCreation bool
 
 	// GitRepo-specific
 	GitDefaultServiceAccount    string
@@ -42,6 +43,14 @@ func Aggregate(policies []fleet.Policy) Merged {
 	for _, p := range policies {
 		if p.RequireServiceAccount {
 			m.RequireServiceAccount = true
+		}
+		// AllowNamespaceCreation is aggregated with OR semantics, which here is
+		// least-restrictive: if any Policy in the namespace allows namespace
+		// creation, it is allowed for all deployments in that namespace.
+		// Operators relying on this to keep namespace creation disabled must
+		// ensure no Policy in the namespace sets allowNamespaceCreation: true.
+		if p.AllowNamespaceCreation {
+			m.AllowNamespaceCreation = true
 		}
 		m.AllowedServiceAccounts = append(m.AllowedServiceAccounts, p.AllowedServiceAccounts...)
 

--- a/internal/cmd/controller/target/builder.go
+++ b/internal/cmd/controller/target/builder.go
@@ -13,11 +13,13 @@ import (
 	"github.com/Masterminds/sprig/v3"
 	"github.com/go-logr/logr"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	errutil "github.com/rancher/fleet/internal/cmd/controller/errorutil"
 	"github.com/rancher/fleet/internal/cmd/controller/labelselectors"
 	"github.com/rancher/fleet/internal/cmd/controller/options"
+	"github.com/rancher/fleet/internal/cmd/controller/policyrestrictions"
 	"github.com/rancher/fleet/internal/cmd/controller/target/matcher"
 	"github.com/rancher/fleet/internal/helmvalues"
 	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
@@ -55,6 +57,11 @@ func (m *Manager) Targets(ctx context.Context, bundle *fleet.Bundle, manifestID 
 	namespaceSelector, err := m.getNamespaceSelectorForBundle(ctx, bundle)
 	if err != nil {
 		return nil, false, fmt.Errorf("failed to get namespace selector: %w", err)
+	}
+
+	createNamespace, err := m.getCreateNamespaceForBundle(ctx, bundle)
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to resolve createNamespace from Policy: %w", err)
 	}
 
 	bm, err := matcher.New(bundle)
@@ -98,6 +105,9 @@ func (m *Manager) Targets(ctx context.Context, bundle *fleet.Bundle, manifestID 
 			opts := options.Merge(bundle.Spec.BundleDeploymentOptions, targetOpts)
 			if namespaceSelector != nil {
 				opts.AllowedTargetNamespaceSelector = namespaceSelector
+			}
+			if createNamespace != nil {
+				opts.CreateNamespace = createNamespace
 			}
 
 			err = preprocessHelmValues(logger, &opts, &cluster)
@@ -428,4 +438,30 @@ func (m *Manager) getNamespaceSelectorForBundle(ctx context.Context, bundle *fle
 	}
 
 	return result, nil
+}
+
+// getCreateNamespaceForBundle resolves whether namespace creation should be
+// disabled based on Policy objects in the bundle's namespace. Returns a pointer
+// to false when the aggregated policy requires a ServiceAccount but does not
+// allow namespace creation. Returns nil otherwise (no change to default).
+func (m *Manager) getCreateNamespaceForBundle(ctx context.Context, bundle *fleet.Bundle) (*bool, error) {
+	policies := &fleet.PolicyList{}
+	if err := m.client.List(ctx, policies, client.InNamespace(bundle.Namespace)); err != nil {
+		if apimeta.IsNoMatchError(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to list Policies: %w", err)
+	}
+
+	if len(policies.Items) == 0 {
+		return nil, nil
+	}
+
+	pol := policyrestrictions.Aggregate(policies.Items)
+	if pol.RequireServiceAccount && !pol.AllowNamespaceCreation {
+		v := false
+		return &v, nil
+	}
+
+	return nil, nil
 }

--- a/internal/helmdeployer/impersonate.go
+++ b/internal/helmdeployer/impersonate.go
@@ -11,7 +11,45 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+// ImpersonatedClient returns a controller-runtime client that impersonates the
+// service account resolved for the given deployment, to be used for namespace
+// label/annotation mutations. Performing those mutations as the same identity
+// the deployment runs as ensures they are gated by the same downstream RBAC,
+// rather than by the agent's own (cluster-admin) credentials.
+//
+// Service account resolution is identical to the Helm install path
+// (getServiceAccount): an explicitly pinned account is used as-is, otherwise it
+// falls back to "fleet-default" when present. It returns a nil client only when
+// no service account is resolved at all (none pinned and no "fleet-default"); in
+// that case the deployment runs as the agent itself, and callers should fall
+// back to their own client to preserve the existing behaviour.
+func (h *Helm) ImpersonatedClient(ctx context.Context, serviceAccountName string) (client.Client, error) {
+	saNamespace, saName, err := h.getServiceAccount(ctx, serviceAccountName)
+	if err != nil {
+		return nil, err
+	}
+	if saName == "" {
+		return nil, nil
+	}
+
+	getter, err := newImpersonatingGetter(saNamespace, saName, h.getter)
+	if err != nil {
+		return nil, err
+	}
+	restConfig, err := getter.ToRESTConfig()
+	if err != nil {
+		return nil, err
+	}
+	mapper, err := getter.ToRESTMapper()
+	if err != nil {
+		return nil, err
+	}
+
+	return client.New(restConfig, client.Options{Scheme: h.client.Scheme(), Mapper: mapper})
+}
 
 // getServiceAccount is called with an empty name, unless the user specified a
 // service account in their git repo.

--- a/internal/helmdeployer/install.go
+++ b/internal/helmdeployer/install.go
@@ -236,7 +236,7 @@ func (h *Helm) configureInstallAction(u *action.Install, cfg *action.Configurati
 	u.Replace = true
 	u.RollbackOnFailure = options.Helm.Atomic
 	u.ReleaseName = releaseName
-	u.CreateNamespace = true
+	u.CreateNamespace = options.CreateNamespace == nil || *options.CreateNamespace
 	u.Namespace = namespace
 	u.Timeout = timeout
 	u.DryRunStrategy = h.configureDryRunStrategy(dryRunCfg)

--- a/pkg/apis/fleet.cattle.io/v1alpha1/bundledeployment_types.go
+++ b/pkg/apis/fleet.cattle.io/v1alpha1/bundledeployment_types.go
@@ -86,6 +86,17 @@ type BundleDeploymentOptions struct {
 	// +nullable
 	ServiceAccount string `json:"serviceAccount,omitempty"`
 
+	// CreateNamespace controls whether Fleet creates the target namespace on
+	// downstream clusters during Helm installs. When nil, the default behavior
+	// is to create the namespace (backward-compatible). Set to false by the
+	// controller when Policy requires a ServiceAccount and does not explicitly
+	// allow namespace creation. This does not affect namespaceLabels/
+	// namespaceAnnotations patching, which is always attempted (when set) as
+	// the deployment's ServiceAccount and gated by downstream RBAC.
+	// +optional
+	// +nullable
+	CreateNamespace *bool `json:"createNamespace,omitempty"`
+
 	// ForceSyncGeneration is used to force a redeployment
 	ForceSyncGeneration int64 `json:"forceSyncGeneration,omitempty"`
 

--- a/pkg/apis/fleet.cattle.io/v1alpha1/policy_types.go
+++ b/pkg/apis/fleet.cattle.io/v1alpha1/policy_types.go
@@ -41,6 +41,16 @@ type Policy struct {
 	// +nullable
 	AllowedServiceAccounts []string `json:"allowedServiceAccounts,omitempty"`
 
+	// AllowNamespaceCreation, when true, allows Fleet to create namespaces on
+	// downstream clusters during Helm installs. By default (false), when
+	// RequireServiceAccount is true, namespace creation is disabled so that
+	// tenant ServiceAccounts are not forced to hold the cluster-scoped
+	// namespaces.create verb. Operators who have secured namespace creation
+	// through other means (ValidatingAdmissionPolicy, Kyverno, etc.) can
+	// set this to true.
+	// +optional
+	AllowNamespaceCreation bool `json:"allowNamespaceCreation,omitempty"`
+
 	// GitRepo contains restrictions and defaults applied only by the GitRepo reconciler.
 	// +optional
 	GitRepo *GitRepoPolicySpec `json:"gitRepo,omitempty"`

--- a/pkg/apis/fleet.cattle.io/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/fleet.cattle.io/v1alpha1/zz_generated.deepcopy.go
@@ -194,6 +194,11 @@ func (in *BundleDeploymentOptions) DeepCopyInto(out *BundleDeploymentOptions) {
 		*out = new(HelmOptions)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.CreateNamespace != nil {
+		in, out := &in.CreateNamespace, &out.CreateNamespace
+		*out = new(bool)
+		**out = **in
+	}
 	if in.Diff != nil {
 		in, out := &in.Diff, &out.Diff
 		*out = new(DiffOptions)

--- a/pkg/durations/durations.go
+++ b/pkg/durations/durations.go
@@ -40,6 +40,12 @@ const (
 	HelmOpStatusDelay = time.Second * 5
 	// WaitForDependenciesReadyRequeueInterval is the wait time after the Fleet agent finds a BundleDeployment has non-ready dependencies
 	WaitForDependenciesReadyRequeueInterval = time.Second * 15
+	// NamespacePermissionRequeueInterval is the wait time after the Fleet
+	// agent is denied permission to patch a target namespace's
+	// labels/annotations. Granting the missing namespace RBAC does not trigger
+	// a reconcile on its own, so the agent requeues at this interval to
+	// converge once the permission is added.
+	NamespacePermissionRequeueInterval = time.Minute * 2
 )
 
 // Equal reports whether the duration t is equal to u.


### PR DESCRIPTION
to, by default, disable the need for helm to create namespaces if a serviceAccount is required by Policy. This ensures tenant ServiceAccounts are not forced to hold the cluster-scoped namespaces.create verb, which cannot be scoped to a single tenant boundary.

When requireServiceAccount is true on an aggregated Policy and allowNamespaceCreation is not explicitly set, the controller stamps CreateNamespace=false on BundleDeploymentOptions. This only disables Helm's namespace creation on install; it does not affect namespaceLabels/namespaceAnnotations patching, which is still attempted (when set) as the deployment's ServiceAccount and gated by downstream RBAC.

Operators who have secured namespace creation through other means (ValidatingAdmissionPolicy, Kyverno, etc.) can re-enable it by setting allowNamespaceCreation: true on the Policy.

Refers to #5658