### PR TITLE
Validate diff.comparePatches fields early

### DIFF
--- a/charts/fleet-crd/templates/crds.yaml
+++ b/charts/fleet-crd/templates/crds.yaml
@@ -388,7 +388,7 @@ spec:
                                   applies, which is
 
                                   laxer than RFC 6901: "~0" and "~1" are read as "~"
-                                  and "/", and any other
+                                  and "/", respectively, and any other
 
                                   "~" sequence is left as written.'
                                 items:
@@ -928,7 +928,7 @@ spec:
                                   applies, which is
 
                                   laxer than RFC 6901: "~0" and "~1" are read as "~"
-                                  and "/", and any other
+                                  and "/", respectively, and any other
 
                                   "~" sequence is left as written.'
                                 items:
@@ -2043,7 +2043,7 @@ spec:
                               applies, which is
 
                               laxer than RFC 6901: "~0" and "~1" are read as "~" and
-                              "/", and any other
+                              "/", respectively, and any other
 
                               "~" sequence is left as written.'
                             items:
@@ -3149,7 +3149,7 @@ spec:
                                     applies, which is
 
                                     laxer than RFC 6901: "~0" and "~1" are read as
-                                    "~" and "/", and any other
+                                    "~" and "/", respectively, and any other
 
                                     "~" sequence is left as written.'
                                   items:
@@ -8495,7 +8495,7 @@ spec:
                               applies, which is
 
                               laxer than RFC 6901: "~0" and "~1" are read as "~" and
-                              "/", and any other
+                              "/", respectively, and any other
 
                               "~" sequence is left as written.'
                             items:
@@ -9633,7 +9633,7 @@ spec:
                                     applies, which is
 
                                     laxer than RFC 6901: "~0" and "~1" are read as
-                                    "~" and "/", and any other
+                                    "~" and "/", respectively, and any other
 
                                     "~" sequence is left as written.'
                                   items:

--- a/charts/fleet-crd/templates/crds.yaml
+++ b/charts/fleet-crd/templates/crds.yaml
@@ -378,13 +378,19 @@ spec:
                                 description: 'JSONPointers ignore diffs at the given
                                   JSON pointers, e.g. /spec/replicas.
 
-                                  Each entry must be a non-empty RFC 6901 pointer
-                                  starting with a slash; a
+                                  Each entry must be a non-empty pointer starting
+                                  with a slash; a
 
                                   Kubernetes-style field path such as spec.replicas
                                   addresses nothing and is
 
-                                  rejected.'
+                                  rejected. Escaping is the one the JSON patch library
+                                  applies, which is
+
+                                  laxer than RFC 6901: "~0" and "~1" are read as "~"
+                                  and "/", and any other
+
+                                  "~" sequence is left as written.'
                                 items:
                                   type: string
                                 nullable: true
@@ -446,16 +452,19 @@ spec:
                                       description: 'Path is the JSON pointer the operation
                                         applies to, e.g. /spec/replicas.
 
-                                        It must be a non-empty RFC 6901 pointer starting
-                                        with a slash; a
+                                        It must be a non-empty pointer starting with
+                                        a slash; a Kubernetes-style
 
-                                        Kubernetes-style field path such as spec.replicas
-                                        addresses nothing and is
+                                        field path such as spec.replicas addresses
+                                        nothing and is rejected. It is
 
-                                        rejected. Required unless Op is "ignore",
-                                        which drops the whole resource
+                                        escaped like a JSONPointers entry, which is
+                                        laxer than RFC 6901. Required
 
-                                        from the comparison and never reads the path.'
+                                        unless Op is "ignore", which drops the whole
+                                        resource from the comparison
+
+                                        and never reads the path.'
                                       nullable: true
                                       type: string
                                     value:
@@ -909,13 +918,19 @@ spec:
                                 description: 'JSONPointers ignore diffs at the given
                                   JSON pointers, e.g. /spec/replicas.
 
-                                  Each entry must be a non-empty RFC 6901 pointer
-                                  starting with a slash; a
+                                  Each entry must be a non-empty pointer starting
+                                  with a slash; a
 
                                   Kubernetes-style field path such as spec.replicas
                                   addresses nothing and is
 
-                                  rejected.'
+                                  rejected. Escaping is the one the JSON patch library
+                                  applies, which is
+
+                                  laxer than RFC 6901: "~0" and "~1" are read as "~"
+                                  and "/", and any other
+
+                                  "~" sequence is left as written.'
                                 items:
                                   type: string
                                 nullable: true
@@ -977,16 +992,19 @@ spec:
                                       description: 'Path is the JSON pointer the operation
                                         applies to, e.g. /spec/replicas.
 
-                                        It must be a non-empty RFC 6901 pointer starting
-                                        with a slash; a
+                                        It must be a non-empty pointer starting with
+                                        a slash; a Kubernetes-style
 
-                                        Kubernetes-style field path such as spec.replicas
-                                        addresses nothing and is
+                                        field path such as spec.replicas addresses
+                                        nothing and is rejected. It is
 
-                                        rejected. Required unless Op is "ignore",
-                                        which drops the whole resource
+                                        escaped like a JSONPointers entry, which is
+                                        laxer than RFC 6901. Required
 
-                                        from the comparison and never reads the path.'
+                                        unless Op is "ignore", which drops the whole
+                                        resource from the comparison
+
+                                        and never reads the path.'
                                       nullable: true
                                       type: string
                                     value:
@@ -2015,13 +2033,19 @@ spec:
                             description: 'JSONPointers ignore diffs at the given JSON
                               pointers, e.g. /spec/replicas.
 
-                              Each entry must be a non-empty RFC 6901 pointer starting
-                              with a slash; a
+                              Each entry must be a non-empty pointer starting with
+                              a slash; a
 
                               Kubernetes-style field path such as spec.replicas addresses
                               nothing and is
 
-                              rejected.'
+                              rejected. Escaping is the one the JSON patch library
+                              applies, which is
+
+                              laxer than RFC 6901: "~0" and "~1" are read as "~" and
+                              "/", and any other
+
+                              "~" sequence is left as written.'
                             items:
                               type: string
                             nullable: true
@@ -2082,16 +2106,19 @@ spec:
                                   description: 'Path is the JSON pointer the operation
                                     applies to, e.g. /spec/replicas.
 
-                                    It must be a non-empty RFC 6901 pointer starting
-                                    with a slash; a
+                                    It must be a non-empty pointer starting with a
+                                    slash; a Kubernetes-style
 
-                                    Kubernetes-style field path such as spec.replicas
-                                    addresses nothing and is
+                                    field path such as spec.replicas addresses nothing
+                                    and is rejected. It is
 
-                                    rejected. Required unless Op is "ignore", which
-                                    drops the whole resource
+                                    escaped like a JSONPointers entry, which is laxer
+                                    than RFC 6901. Required
 
-                                    from the comparison and never reads the path.'
+                                    unless Op is "ignore", which drops the whole resource
+                                    from the comparison
+
+                                    and never reads the path.'
                                   nullable: true
                                   type: string
                                 value:
@@ -3112,13 +3139,19 @@ spec:
                                   description: 'JSONPointers ignore diffs at the given
                                     JSON pointers, e.g. /spec/replicas.
 
-                                    Each entry must be a non-empty RFC 6901 pointer
-                                    starting with a slash; a
+                                    Each entry must be a non-empty pointer starting
+                                    with a slash; a
 
                                     Kubernetes-style field path such as spec.replicas
                                     addresses nothing and is
 
-                                    rejected.'
+                                    rejected. Escaping is the one the JSON patch library
+                                    applies, which is
+
+                                    laxer than RFC 6901: "~0" and "~1" are read as
+                                    "~" and "/", and any other
+
+                                    "~" sequence is left as written.'
                                   items:
                                     type: string
                                   nullable: true
@@ -3182,17 +3215,19 @@ spec:
                                         description: 'Path is the JSON pointer the
                                           operation applies to, e.g. /spec/replicas.
 
-                                          It must be a non-empty RFC 6901 pointer
-                                          starting with a slash; a
+                                          It must be a non-empty pointer starting
+                                          with a slash; a Kubernetes-style
 
-                                          Kubernetes-style field path such as spec.replicas
-                                          addresses nothing and is
+                                          field path such as spec.replicas addresses
+                                          nothing and is rejected. It is
 
-                                          rejected. Required unless Op is "ignore",
-                                          which drops the whole resource
+                                          escaped like a JSONPointers entry, which
+                                          is laxer than RFC 6901. Required
 
-                                          from the comparison and never reads the
-                                          path.'
+                                          unless Op is "ignore", which drops the whole
+                                          resource from the comparison
+
+                                          and never reads the path.'
                                         nullable: true
                                         type: string
                                       value:
@@ -8450,13 +8485,19 @@ spec:
                             description: 'JSONPointers ignore diffs at the given JSON
                               pointers, e.g. /spec/replicas.
 
-                              Each entry must be a non-empty RFC 6901 pointer starting
-                              with a slash; a
+                              Each entry must be a non-empty pointer starting with
+                              a slash; a
 
                               Kubernetes-style field path such as spec.replicas addresses
                               nothing and is
 
-                              rejected.'
+                              rejected. Escaping is the one the JSON patch library
+                              applies, which is
+
+                              laxer than RFC 6901: "~0" and "~1" are read as "~" and
+                              "/", and any other
+
+                              "~" sequence is left as written.'
                             items:
                               type: string
                             nullable: true
@@ -8517,16 +8558,19 @@ spec:
                                   description: 'Path is the JSON pointer the operation
                                     applies to, e.g. /spec/replicas.
 
-                                    It must be a non-empty RFC 6901 pointer starting
-                                    with a slash; a
+                                    It must be a non-empty pointer starting with a
+                                    slash; a Kubernetes-style
 
-                                    Kubernetes-style field path such as spec.replicas
-                                    addresses nothing and is
+                                    field path such as spec.replicas addresses nothing
+                                    and is rejected. It is
 
-                                    rejected. Required unless Op is "ignore", which
-                                    drops the whole resource
+                                    escaped like a JSONPointers entry, which is laxer
+                                    than RFC 6901. Required
 
-                                    from the comparison and never reads the path.'
+                                    unless Op is "ignore", which drops the whole resource
+                                    from the comparison
+
+                                    and never reads the path.'
                                   nullable: true
                                   type: string
                                 value:
@@ -9579,13 +9623,19 @@ spec:
                                   description: 'JSONPointers ignore diffs at the given
                                     JSON pointers, e.g. /spec/replicas.
 
-                                    Each entry must be a non-empty RFC 6901 pointer
-                                    starting with a slash; a
+                                    Each entry must be a non-empty pointer starting
+                                    with a slash; a
 
                                     Kubernetes-style field path such as spec.replicas
                                     addresses nothing and is
 
-                                    rejected.'
+                                    rejected. Escaping is the one the JSON patch library
+                                    applies, which is
+
+                                    laxer than RFC 6901: "~0" and "~1" are read as
+                                    "~" and "/", and any other
+
+                                    "~" sequence is left as written.'
                                   items:
                                     type: string
                                   nullable: true
@@ -9649,17 +9699,19 @@ spec:
                                         description: 'Path is the JSON pointer the
                                           operation applies to, e.g. /spec/replicas.
 
-                                          It must be a non-empty RFC 6901 pointer
-                                          starting with a slash; a
+                                          It must be a non-empty pointer starting
+                                          with a slash; a Kubernetes-style
 
-                                          Kubernetes-style field path such as spec.replicas
-                                          addresses nothing and is
+                                          field path such as spec.replicas addresses
+                                          nothing and is rejected. It is
 
-                                          rejected. Required unless Op is "ignore",
-                                          which drops the whole resource
+                                          escaped like a JSONPointers entry, which
+                                          is laxer than RFC 6901. Required
 
-                                          from the comparison and never reads the
-                                          path.'
+                                          unless Op is "ignore", which drops the whole
+                                          resource from the comparison
+
+                                          and never reads the path.'
                                         nullable: true
                                         type: string
                                       value:

--- a/charts/fleet-crd/templates/crds.yaml
+++ b/charts/fleet-crd/templates/crds.yaml
@@ -375,8 +375,16 @@ spec:
                                 nullable: true
                                 type: string
                               jsonPointers:
-                                description: JSONPointers ignore diffs at a certain
-                                  JSON path.
+                                description: 'JSONPointers ignore diffs at the given
+                                  JSON pointers, e.g. /spec/replicas.
+
+                                  Each entry must be a non-empty RFC 6901 pointer
+                                  starting with a slash; a
+
+                                  Kubernetes-style field path such as spec.replicas
+                                  addresses nothing and is
+
+                                  rejected.'
                                 items:
                                   type: string
                                 nullable: true
@@ -386,7 +394,14 @@ spec:
                                 nullable: true
                                 type: string
                               name:
-                                description: Name is the name of the resource to match.
+                                description: 'Name is the name of the resource to
+                                  match. Resources are matched by exact
+
+                                  name first and, when the name does not match exactly,
+                                  by matching it as a
+
+                                  regular expression, so it must always be a valid
+                                  Go regular expression.'
                                 nullable: true
                                 type: string
                               namespace:
@@ -406,12 +421,41 @@ spec:
                                     checks for modifications.'
                                   properties:
                                     op:
-                                      description: Op is usually "remove" or "ignore"
+                                      description: 'Op is the operation to perform
+                                        on the matched resource. It must be one of
+
+                                        the JSON Patch operations "add", "remove",
+                                        "replace" and "test", or
+
+                                        Fleet''s own "ignore", which removes the entire
+                                        resource from checks for
+
+                                        modifications. The JSON Patch operations "copy"
+                                        and "move" are not
+
+                                        supported, because an Operation has no "from"
+                                        field to encode them with.
+
+                                        Any other value, including an empty one, makes
+                                        the whole patch fail to
+
+                                        apply.'
                                       nullable: true
                                       type: string
                                     path:
-                                      description: Path is the JSON path to remove.
-                                        Not needed if Op is "ignore".
+                                      description: 'Path is the JSON pointer the operation
+                                        applies to, e.g. /spec/replicas.
+
+                                        It must be a non-empty RFC 6901 pointer starting
+                                        with a slash; a
+
+                                        Kubernetes-style field path such as spec.replicas
+                                        addresses nothing and is
+
+                                        rejected. Required unless Op is "ignore",
+                                        which drops the whole resource
+
+                                        from the comparison and never reads the path.'
                                       nullable: true
                                       type: string
                                     value:
@@ -862,8 +906,16 @@ spec:
                                 nullable: true
                                 type: string
                               jsonPointers:
-                                description: JSONPointers ignore diffs at a certain
-                                  JSON path.
+                                description: 'JSONPointers ignore diffs at the given
+                                  JSON pointers, e.g. /spec/replicas.
+
+                                  Each entry must be a non-empty RFC 6901 pointer
+                                  starting with a slash; a
+
+                                  Kubernetes-style field path such as spec.replicas
+                                  addresses nothing and is
+
+                                  rejected.'
                                 items:
                                   type: string
                                 nullable: true
@@ -873,7 +925,14 @@ spec:
                                 nullable: true
                                 type: string
                               name:
-                                description: Name is the name of the resource to match.
+                                description: 'Name is the name of the resource to
+                                  match. Resources are matched by exact
+
+                                  name first and, when the name does not match exactly,
+                                  by matching it as a
+
+                                  regular expression, so it must always be a valid
+                                  Go regular expression.'
                                 nullable: true
                                 type: string
                               namespace:
@@ -893,12 +952,41 @@ spec:
                                     checks for modifications.'
                                   properties:
                                     op:
-                                      description: Op is usually "remove" or "ignore"
+                                      description: 'Op is the operation to perform
+                                        on the matched resource. It must be one of
+
+                                        the JSON Patch operations "add", "remove",
+                                        "replace" and "test", or
+
+                                        Fleet''s own "ignore", which removes the entire
+                                        resource from checks for
+
+                                        modifications. The JSON Patch operations "copy"
+                                        and "move" are not
+
+                                        supported, because an Operation has no "from"
+                                        field to encode them with.
+
+                                        Any other value, including an empty one, makes
+                                        the whole patch fail to
+
+                                        apply.'
                                       nullable: true
                                       type: string
                                     path:
-                                      description: Path is the JSON path to remove.
-                                        Not needed if Op is "ignore".
+                                      description: 'Path is the JSON pointer the operation
+                                        applies to, e.g. /spec/replicas.
+
+                                        It must be a non-empty RFC 6901 pointer starting
+                                        with a slash; a
+
+                                        Kubernetes-style field path such as spec.replicas
+                                        addresses nothing and is
+
+                                        rejected. Required unless Op is "ignore",
+                                        which drops the whole resource
+
+                                        from the comparison and never reads the path.'
                                       nullable: true
                                       type: string
                                     value:
@@ -1924,8 +2012,16 @@ spec:
                             nullable: true
                             type: string
                           jsonPointers:
-                            description: JSONPointers ignore diffs at a certain JSON
-                              path.
+                            description: 'JSONPointers ignore diffs at the given JSON
+                              pointers, e.g. /spec/replicas.
+
+                              Each entry must be a non-empty RFC 6901 pointer starting
+                              with a slash; a
+
+                              Kubernetes-style field path such as spec.replicas addresses
+                              nothing and is
+
+                              rejected.'
                             items:
                               type: string
                             nullable: true
@@ -1935,7 +2031,14 @@ spec:
                             nullable: true
                             type: string
                           name:
-                            description: Name is the name of the resource to match.
+                            description: 'Name is the name of the resource to match.
+                              Resources are matched by exact
+
+                              name first and, when the name does not match exactly,
+                              by matching it as a
+
+                              regular expression, so it must always be a valid Go
+                              regular expression.'
                             nullable: true
                             type: string
                           namespace:
@@ -1954,12 +2057,41 @@ spec:
                                 for modifications.'
                               properties:
                                 op:
-                                  description: Op is usually "remove" or "ignore"
+                                  description: 'Op is the operation to perform on
+                                    the matched resource. It must be one of
+
+                                    the JSON Patch operations "add", "remove", "replace"
+                                    and "test", or
+
+                                    Fleet''s own "ignore", which removes the entire
+                                    resource from checks for
+
+                                    modifications. The JSON Patch operations "copy"
+                                    and "move" are not
+
+                                    supported, because an Operation has no "from"
+                                    field to encode them with.
+
+                                    Any other value, including an empty one, makes
+                                    the whole patch fail to
+
+                                    apply.'
                                   nullable: true
                                   type: string
                                 path:
-                                  description: Path is the JSON path to remove. Not
-                                    needed if Op is "ignore".
+                                  description: 'Path is the JSON pointer the operation
+                                    applies to, e.g. /spec/replicas.
+
+                                    It must be a non-empty RFC 6901 pointer starting
+                                    with a slash; a
+
+                                    Kubernetes-style field path such as spec.replicas
+                                    addresses nothing and is
+
+                                    rejected. Required unless Op is "ignore", which
+                                    drops the whole resource
+
+                                    from the comparison and never reads the path.'
                                   nullable: true
                                   type: string
                                 value:
@@ -2977,8 +3109,16 @@ spec:
                                   nullable: true
                                   type: string
                                 jsonPointers:
-                                  description: JSONPointers ignore diffs at a certain
-                                    JSON path.
+                                  description: 'JSONPointers ignore diffs at the given
+                                    JSON pointers, e.g. /spec/replicas.
+
+                                    Each entry must be a non-empty RFC 6901 pointer
+                                    starting with a slash; a
+
+                                    Kubernetes-style field path such as spec.replicas
+                                    addresses nothing and is
+
+                                    rejected.'
                                   items:
                                     type: string
                                   nullable: true
@@ -2989,8 +3129,14 @@ spec:
                                   nullable: true
                                   type: string
                                 name:
-                                  description: Name is the name of the resource to
-                                    match.
+                                  description: 'Name is the name of the resource to
+                                    match. Resources are matched by exact
+
+                                    name first and, when the name does not match exactly,
+                                    by matching it as a
+
+                                    regular expression, so it must always be a valid
+                                    Go regular expression.'
                                   nullable: true
                                   type: string
                                 namespace:
@@ -3010,12 +3156,43 @@ spec:
                                       checks for modifications.'
                                     properties:
                                       op:
-                                        description: Op is usually "remove" or "ignore"
+                                        description: 'Op is the operation to perform
+                                          on the matched resource. It must be one
+                                          of
+
+                                          the JSON Patch operations "add", "remove",
+                                          "replace" and "test", or
+
+                                          Fleet''s own "ignore", which removes the
+                                          entire resource from checks for
+
+                                          modifications. The JSON Patch operations
+                                          "copy" and "move" are not
+
+                                          supported, because an Operation has no "from"
+                                          field to encode them with.
+
+                                          Any other value, including an empty one,
+                                          makes the whole patch fail to
+
+                                          apply.'
                                         nullable: true
                                         type: string
                                       path:
-                                        description: Path is the JSON path to remove.
-                                          Not needed if Op is "ignore".
+                                        description: 'Path is the JSON pointer the
+                                          operation applies to, e.g. /spec/replicas.
+
+                                          It must be a non-empty RFC 6901 pointer
+                                          starting with a slash; a
+
+                                          Kubernetes-style field path such as spec.replicas
+                                          addresses nothing and is
+
+                                          rejected. Required unless Op is "ignore",
+                                          which drops the whole resource
+
+                                          from the comparison and never reads the
+                                          path.'
                                         nullable: true
                                         type: string
                                       value:
@@ -8270,8 +8447,16 @@ spec:
                             nullable: true
                             type: string
                           jsonPointers:
-                            description: JSONPointers ignore diffs at a certain JSON
-                              path.
+                            description: 'JSONPointers ignore diffs at the given JSON
+                              pointers, e.g. /spec/replicas.
+
+                              Each entry must be a non-empty RFC 6901 pointer starting
+                              with a slash; a
+
+                              Kubernetes-style field path such as spec.replicas addresses
+                              nothing and is
+
+                              rejected.'
                             items:
                               type: string
                             nullable: true
@@ -8281,7 +8466,14 @@ spec:
                             nullable: true
                             type: string
                           name:
-                            description: Name is the name of the resource to match.
+                            description: 'Name is the name of the resource to match.
+                              Resources are matched by exact
+
+                              name first and, when the name does not match exactly,
+                              by matching it as a
+
+                              regular expression, so it must always be a valid Go
+                              regular expression.'
                             nullable: true
                             type: string
                           namespace:
@@ -8300,12 +8492,41 @@ spec:
                                 for modifications.'
                               properties:
                                 op:
-                                  description: Op is usually "remove" or "ignore"
+                                  description: 'Op is the operation to perform on
+                                    the matched resource. It must be one of
+
+                                    the JSON Patch operations "add", "remove", "replace"
+                                    and "test", or
+
+                                    Fleet''s own "ignore", which removes the entire
+                                    resource from checks for
+
+                                    modifications. The JSON Patch operations "copy"
+                                    and "move" are not
+
+                                    supported, because an Operation has no "from"
+                                    field to encode them with.
+
+                                    Any other value, including an empty one, makes
+                                    the whole patch fail to
+
+                                    apply.'
                                   nullable: true
                                   type: string
                                 path:
-                                  description: Path is the JSON path to remove. Not
-                                    needed if Op is "ignore".
+                                  description: 'Path is the JSON pointer the operation
+                                    applies to, e.g. /spec/replicas.
+
+                                    It must be a non-empty RFC 6901 pointer starting
+                                    with a slash; a
+
+                                    Kubernetes-style field path such as spec.replicas
+                                    addresses nothing and is
+
+                                    rejected. Required unless Op is "ignore", which
+                                    drops the whole resource
+
+                                    from the comparison and never reads the path.'
                                   nullable: true
                                   type: string
                                 value:
@@ -9355,8 +9576,16 @@ spec:
                                   nullable: true
                                   type: string
                                 jsonPointers:
-                                  description: JSONPointers ignore diffs at a certain
-                                    JSON path.
+                                  description: 'JSONPointers ignore diffs at the given
+                                    JSON pointers, e.g. /spec/replicas.
+
+                                    Each entry must be a non-empty RFC 6901 pointer
+                                    starting with a slash; a
+
+                                    Kubernetes-style field path such as spec.replicas
+                                    addresses nothing and is
+
+                                    rejected.'
                                   items:
                                     type: string
                                   nullable: true
@@ -9367,8 +9596,14 @@ spec:
                                   nullable: true
                                   type: string
                                 name:
-                                  description: Name is the name of the resource to
-                                    match.
+                                  description: 'Name is the name of the resource to
+                                    match. Resources are matched by exact
+
+                                    name first and, when the name does not match exactly,
+                                    by matching it as a
+
+                                    regular expression, so it must always be a valid
+                                    Go regular expression.'
                                   nullable: true
                                   type: string
                                 namespace:
@@ -9388,12 +9623,43 @@ spec:
                                       checks for modifications.'
                                     properties:
                                       op:
-                                        description: Op is usually "remove" or "ignore"
+                                        description: 'Op is the operation to perform
+                                          on the matched resource. It must be one
+                                          of
+
+                                          the JSON Patch operations "add", "remove",
+                                          "replace" and "test", or
+
+                                          Fleet''s own "ignore", which removes the
+                                          entire resource from checks for
+
+                                          modifications. The JSON Patch operations
+                                          "copy" and "move" are not
+
+                                          supported, because an Operation has no "from"
+                                          field to encode them with.
+
+                                          Any other value, including an empty one,
+                                          makes the whole patch fail to
+
+                                          apply.'
                                         nullable: true
                                         type: string
                                       path:
-                                        description: Path is the JSON path to remove.
-                                          Not needed if Op is "ignore".
+                                        description: 'Path is the JSON pointer the
+                                          operation applies to, e.g. /spec/replicas.
+
+                                          It must be a non-empty RFC 6901 pointer
+                                          starting with a slash; a
+
+                                          Kubernetes-style field path such as spec.replicas
+                                          addresses nothing and is
+
+                                          rejected. Required unless Op is "ignore",
+                                          which drops the whole resource
+
+                                          from the comparison and never reads the
+                                          path.'
                                         nullable: true
                                         type: string
                                       value:

--- a/integrationtests/cli/apply/apply_test.go
+++ b/integrationtests/cli/apply/apply_test.go
@@ -967,3 +967,347 @@ var _ = Describe("Fleet apply with dependsOn and acceptedStates", func() {
 		})
 	})
 })
+
+// bundleConfigMap is a resource to give a generated bundle something to deploy.
+const bundleConfigMap = `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-config
+data:
+  key: value
+`
+
+// writeBundleDir writes fleetYAML and a ConfigMap into a fresh temporary
+// directory and returns its path, so a test can state the fleet.yaml it needs
+// inline instead of adding a near-duplicate directory under assets/.
+func writeBundleDir(fleetYAML string) string {
+	dir := GinkgoT().TempDir()
+
+	Expect(os.WriteFile(path.Join(dir, "fleet.yaml"), []byte(fleetYAML), 0o644)).To(Succeed())
+	Expect(os.WriteFile(path.Join(dir, "configmap.yaml"), []byte(bundleConfigMap), 0o644)).To(Succeed())
+
+	// fleet apply needs a relative path, see globDirs in internal/cmd/cli/apply
+	pwd, err := os.Getwd()
+	Expect(err).NotTo(HaveOccurred())
+	rel, err := filepath.Rel(pwd, dir)
+	Expect(err).NotTo(HaveOccurred())
+
+	return rel
+}
+
+var _ = Describe("Fleet apply with diff comparePatches", func() {
+	var (
+		dirs    []string
+		name    string
+		options apply.Options
+	)
+
+	When("fleet.yaml contains comparePatches names which are valid regular expressions", func() {
+		BeforeEach(func() {
+			name = "comparepatch-name-valid"
+			dirs = []string{writeBundleDir(`defaultNamespace: test-comparepatch
+diff:
+  comparePatches:
+  - apiVersion: v1
+    kind: Service
+    name: app.v1-alpha.svc
+    operations:
+    - op: ignore
+targetCustomizations:
+- name: dev
+  clusterSelector: {}
+  diff:
+    comparePatches:
+    - apiVersion: v1
+      kind: Service
+      name: ".*serv.*"
+      operations:
+      - op: ignore
+targets:
+- clusterSelector: {}
+`)}
+		})
+
+		It("creates a Bundle keeping both the literal and the regex name", func() {
+			err := fleetApply(name, dirs, options)
+			Expect(err).NotTo(HaveOccurred())
+
+			bundle, err := cli.GetBundleFromOutput(buf)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(bundle.Spec.Diff).NotTo(BeNil())
+			Expect(bundle.Spec.Diff.ComparePatches).To(HaveLen(1))
+			Expect(bundle.Spec.Diff.ComparePatches[0].Name).To(Equal("app.v1-alpha.svc"))
+
+			target, _, found := sliceFind(bundle.Spec.Targets, func(t v1alpha1.BundleTarget) bool {
+				return t.Diff != nil
+			})
+			Expect(found).To(BeTrue())
+			Expect(target.Diff.ComparePatches).To(HaveLen(1))
+			Expect(target.Diff.ComparePatches[0].Name).To(Equal(".*serv.*"))
+		})
+	})
+
+	When("fleet.yaml contains a comparePatches name which is not a valid regular expression", func() {
+		BeforeEach(func() {
+			name = "comparepatch-name-invalid"
+			dirs = []string{writeBundleDir(`defaultNamespace: test-comparepatch
+targetCustomizations:
+- name: dev
+  clusterSelector: {}
+  diff:
+    comparePatches:
+    - apiVersion: v1
+      kind: Service
+      name: "foo["
+      operations:
+      - op: ignore
+targets:
+- clusterSelector: {}
+`)}
+		})
+
+		It("returns an error naming the field path and the offending value", func() {
+			err := fleetApply(name, dirs, options)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("targetCustomizations[0].diff.comparePatches[0].name"))
+			Expect(err.Error()).To(ContainSubstring("invalid regular expression"))
+			Expect(err.Error()).To(ContainSubstring(`"foo["`))
+		})
+	})
+
+	When("fleet.yaml contains supported comparePatches operations", func() {
+		BeforeEach(func() {
+			name = "comparepatch-op-valid"
+			dirs = []string{writeBundleDir(`defaultNamespace: test-comparepatch
+diff:
+  comparePatches:
+  - apiVersion: v1
+    kind: Service
+    name: my-svc
+    operations:
+    - op: remove
+      path: /spec/clusterIP
+    - op: replace
+      path: /spec/type
+      value: ClusterIP
+targetCustomizations:
+- name: dev
+  clusterSelector: {}
+  diff:
+    comparePatches:
+    - apiVersion: v1
+      kind: Service
+      name: my-svc
+      operations:
+      - op: ignore
+targets:
+- clusterSelector: {}
+`)}
+		})
+
+		It("creates a Bundle keeping every operation", func() {
+			err := fleetApply(name, dirs, options)
+			Expect(err).NotTo(HaveOccurred())
+
+			bundle, err := cli.GetBundleFromOutput(buf)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(bundle.Spec.Diff).NotTo(BeNil())
+			Expect(bundle.Spec.Diff.ComparePatches).To(HaveLen(1))
+			Expect(bundle.Spec.Diff.ComparePatches[0].Operations).To(HaveLen(2))
+			Expect(bundle.Spec.Diff.ComparePatches[0].Operations[0].Op).To(Equal("remove"))
+			Expect(bundle.Spec.Diff.ComparePatches[0].Operations[1].Op).To(Equal("replace"))
+
+			target, _, found := sliceFind(bundle.Spec.Targets, func(t v1alpha1.BundleTarget) bool {
+				return t.Diff != nil
+			})
+			Expect(found).To(BeTrue())
+			Expect(target.Diff.ComparePatches).To(HaveLen(1))
+			Expect(target.Diff.ComparePatches[0].Operations).To(HaveLen(1))
+			Expect(target.Diff.ComparePatches[0].Operations[0].Op).To(Equal("ignore"))
+		})
+	})
+
+	When("fleet.yaml contains a comparePatches operation which Fleet cannot apply", func() {
+		BeforeEach(func() {
+			name = "comparepatch-op-invalid"
+			dirs = []string{writeBundleDir(`defaultNamespace: test-comparepatch
+targetCustomizations:
+- name: dev
+  clusterSelector: {}
+  diff:
+    comparePatches:
+    - apiVersion: v1
+      kind: Service
+      name: my-svc
+      operations:
+      - op: remove
+        path: /spec/clusterIP
+      - op: ignroe
+targets:
+- clusterSelector: {}
+`)}
+		})
+
+		It("returns an error naming the field path and the offending value", func() {
+			err := fleetApply(name, dirs, options)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("targetCustomizations[0].diff.comparePatches[0].operations[1].op"))
+			Expect(err.Error()).To(ContainSubstring(`unsupported operation "ignroe"`))
+			Expect(err.Error()).To(ContainSubstring("add, ignore, remove, replace, test"))
+		})
+	})
+
+	When("fleet.yaml contains a comparePatches operation without an op", func() {
+		BeforeEach(func() {
+			name = "comparepatch-op-empty"
+			dirs = []string{writeBundleDir(`defaultNamespace: test-comparepatch
+diff:
+  comparePatches:
+  - apiVersion: v1
+    kind: Service
+    name: my-svc
+    operations:
+    - path: /spec/clusterIP
+targets:
+- clusterSelector: {}
+`)}
+		})
+
+		It("returns an error, as an operation without an op never applies", func() {
+			err := fleetApply(name, dirs, options)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("diff.comparePatches[0].operations[0].op"))
+			Expect(err.Error()).To(ContainSubstring(`unsupported operation ""`))
+		})
+	})
+
+	When("fleet.yaml contains comparePatches paths and jsonPointers which resolve", func() {
+		BeforeEach(func() {
+			name = "comparepatch-pointer-valid"
+			dirs = []string{writeBundleDir(`defaultNamespace: test-comparepatch
+diff:
+  comparePatches:
+  - apiVersion: v1
+    kind: Service
+    name: my-svc
+    jsonPointers:
+    - /spec/clusterIP
+    - /spec/a~0b
+    operations:
+    - op: remove
+      path: /spec/externalIPs/0
+    - op: ignore
+targetCustomizations:
+- name: dev
+  clusterSelector: {}
+  diff:
+    comparePatches:
+    - apiVersion: v1
+      kind: Service
+      name: my-svc
+      jsonPointers:
+      - /metadata/labels
+targets:
+- clusterSelector: {}
+`)}
+		})
+
+		It("creates a Bundle keeping every pointer, including the escaped one", func() {
+			err := fleetApply(name, dirs, options)
+			Expect(err).NotTo(HaveOccurred())
+
+			bundle, err := cli.GetBundleFromOutput(buf)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(bundle.Spec.Diff).NotTo(BeNil())
+			Expect(bundle.Spec.Diff.ComparePatches).To(HaveLen(1))
+			Expect(bundle.Spec.Diff.ComparePatches[0].JsonPointers).To(Equal([]string{"/spec/clusterIP", "/spec/a~0b"}))
+			Expect(bundle.Spec.Diff.ComparePatches[0].Operations).To(HaveLen(2))
+			Expect(bundle.Spec.Diff.ComparePatches[0].Operations[0].Path).To(Equal("/spec/externalIPs/0"))
+
+			target, _, found := sliceFind(bundle.Spec.Targets, func(t v1alpha1.BundleTarget) bool {
+				return t.Diff != nil
+			})
+			Expect(found).To(BeTrue())
+			Expect(target.Diff.ComparePatches[0].JsonPointers).To(Equal([]string{"/metadata/labels"}))
+		})
+	})
+
+	When("fleet.yaml contains a comparePatches operation path which is not a JSON pointer", func() {
+		BeforeEach(func() {
+			name = "comparepatch-path-invalid"
+			dirs = []string{writeBundleDir(`defaultNamespace: test-comparepatch
+targetCustomizations:
+- name: dev
+  clusterSelector: {}
+  diff:
+    comparePatches:
+    - apiVersion: v1
+      kind: Service
+      name: my-svc
+      operations:
+      - op: remove
+        path: spec.clusterIP
+targets:
+- clusterSelector: {}
+`)}
+		})
+
+		It("returns an error naming the field path and suggesting the pointer", func() {
+			err := fleetApply(name, dirs, options)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("targetCustomizations[0].diff.comparePatches[0].operations[0].path"))
+			Expect(err.Error()).To(ContainSubstring(`invalid JSON pointer "spec.clusterIP"`))
+			Expect(err.Error()).To(ContainSubstring(`e.g. "/spec/clusterIP"`))
+		})
+	})
+
+	When("fleet.yaml contains a comparePatches operation without a path", func() {
+		BeforeEach(func() {
+			name = "comparepatch-path-empty"
+			dirs = []string{writeBundleDir(`defaultNamespace: test-comparepatch
+diff:
+  comparePatches:
+  - apiVersion: v1
+    kind: Service
+    name: my-svc
+    operations:
+    - op: remove
+targets:
+- clusterSelector: {}
+`)}
+		})
+
+		It("returns an error, as an operation without a path never applies", func() {
+			err := fleetApply(name, dirs, options)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("diff.comparePatches[0].operations[0].path"))
+			Expect(err.Error()).To(ContainSubstring(`invalid JSON pointer "": must not be empty`))
+		})
+	})
+
+	When("fleet.yaml contains a comparePatches jsonPointer which is not a JSON pointer", func() {
+		BeforeEach(func() {
+			name = "comparepatch-jsonpointer-invalid"
+			dirs = []string{writeBundleDir(`defaultNamespace: test-comparepatch
+diff:
+  comparePatches:
+  - apiVersion: v1
+    kind: Service
+    name: my-svc
+    jsonPointers:
+    - /spec/clusterIP
+    - spec.replicas
+targets:
+- clusterSelector: {}
+`)}
+		})
+
+		It("returns an error naming the offending entry, not the first one", func() {
+			err := fleetApply(name, dirs, options)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("diff.comparePatches[0].jsonPointers[1]"))
+			Expect(err.Error()).To(ContainSubstring(`invalid JSON pointer "spec.replicas"`))
+			Expect(err.Error()).To(ContainSubstring(`e.g. "/spec/replicas"`))
+		})
+	})
+})

--- a/integrationtests/cli/apply/apply_test.go
+++ b/integrationtests/cli/apply/apply_test.go
@@ -1142,7 +1142,7 @@ targetCustomizations:
       operations:
       - op: remove
         path: /spec/clusterIP
-      - op: ignroe
+      - op: bogus
 targets:
 - clusterSelector: {}
 `)}
@@ -1152,7 +1152,7 @@ targets:
 			err := fleetApply(name, dirs, options)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("targetCustomizations[0].diff.comparePatches[0].operations[1].op"))
-			Expect(err.Error()).To(ContainSubstring(`unsupported operation "ignroe"`))
+			Expect(err.Error()).To(ContainSubstring(`unsupported operation "bogus"`))
 			Expect(err.Error()).To(ContainSubstring("add, ignore, remove, replace, test"))
 		})
 	})

--- a/internal/bundlereader/validate_fleetyaml.go
+++ b/internal/bundlereader/validate_fleetyaml.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"sort"
 
+	"github.com/rancher/fleet/internal/validation"
 	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
 )
 
@@ -13,6 +14,38 @@ func validateFleetYAML(fy *fleet.FleetYAML) error {
 	// Validate DependsOn entries at the bundle level
 	for i, dep := range fy.DependsOn {
 		if err := validateBundleRef(i, dep); err != nil {
+			return err
+		}
+	}
+
+	// Rules shared with HelmOp, which reaches the same options through its own
+	// embedded BundleSpec. They live in internal/validation so both entry points
+	// enforce one copy of each rule; see validation.ForEachBundleSpecOptions.
+	for _, check := range validation.BundleDeploymentOptionChecks {
+		if err := forEachOptions(fy, check); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// forEachOptions calls fn for every BundleDeploymentOptions reachable from
+// fleet.yaml, with the field path prefix which identifies it to the user.
+//
+// BundleDeploymentOptions is embedded in three places, and validateFleetYAML runs
+// before targetCustomizations are merged into targets, so all three have to be
+// walked explicitly.
+func forEachOptions(fy *fleet.FleetYAML, fn func(path string, opts *fleet.BundleDeploymentOptions) error) error {
+	// The bundle-level options and the targets are the two sites a HelmOp has as
+	// well, so they are walked by the shared helper rather than a second time here.
+	if err := validation.ForEachBundleSpecOptions("", &fy.BundleSpec, fn); err != nil {
+		return err
+	}
+
+	for i := range fy.TargetCustomizations {
+		path := fmt.Sprintf("targetCustomizations[%d].", i)
+		if err := fn(path, &fy.TargetCustomizations[i].BundleDeploymentOptions); err != nil {
 			return err
 		}
 	}

--- a/internal/bundlereader/validate_fleetyaml_test.go
+++ b/internal/bundlereader/validate_fleetyaml_test.go
@@ -484,9 +484,9 @@ func TestValidateFleetYAML_InvalidComparePatchOperations(t *testing.T) {
 		expectedError string
 	}{
 		{
-			name:          "typo",
-			diff:          diffWithPatchOps("ignroe"),
-			expectedError: `diff.comparePatches[0].operations[0].op: unsupported operation "ignroe", valid values are: add, ignore, remove, replace, test`,
+			name:          "unknown op",
+			diff:          diffWithPatchOps("bogus"),
+			expectedError: `diff.comparePatches[0].operations[0].op: unsupported operation "bogus", valid values are: add, ignore, remove, replace, test`,
 		},
 		{
 			name:          "trailing space",
@@ -508,8 +508,8 @@ func TestValidateFleetYAML_InvalidComparePatchOperations(t *testing.T) {
 		},
 		{
 			name:          "second operation is the offending one",
-			diff:          diffWithPatchOps("remove", "ignroe"),
-			expectedError: `diff.comparePatches[0].operations[1].op: unsupported operation "ignroe"`,
+			diff:          diffWithPatchOps("remove", "bogus"),
+			expectedError: `diff.comparePatches[0].operations[1].op: unsupported operation "bogus"`,
 		},
 		{
 			// json-patch implements "copy" and "move", but fleet.Operation has no
@@ -559,11 +559,11 @@ func TestValidateFleetYAML_ComparePatchOperationOptionSites(t *testing.T) {
 			fy: &fleet.FleetYAML{
 				BundleSpec: fleet.BundleSpec{
 					BundleDeploymentOptions: fleet.BundleDeploymentOptions{
-						Diff: diffWithPatchOps("ignroe"),
+						Diff: diffWithPatchOps("bogus"),
 					},
 				},
 			},
-			expectedError: `diff.comparePatches[0].operations[0].op: unsupported operation "ignroe"`,
+			expectedError: `diff.comparePatches[0].operations[0].op: unsupported operation "bogus"`,
 		},
 		{
 			name: "targets",
@@ -623,7 +623,7 @@ func TestValidateFleetYAML_ComparePatchOperationIndex(t *testing.T) {
 					ComparePatches: []fleet.ComparePatch{
 						{Name: "first", Operations: []fleet.Operation{{Op: "ignore"}}},
 						{Name: "second", Operations: []fleet.Operation{{Op: "remove", Path: "/spec/replicas"}}},
-						{Name: "third", Operations: []fleet.Operation{{Op: "remove"}, {Op: "ignroe"}}},
+						{Name: "third", Operations: []fleet.Operation{{Op: "remove"}, {Op: "bogus"}}},
 					},
 				},
 			},
@@ -635,7 +635,7 @@ func TestValidateFleetYAML_ComparePatchOperationIndex(t *testing.T) {
 		t.Fatal("validateFleetYAML() expected an error, got nil")
 	}
 
-	expected := `diff.comparePatches[2].operations[1].op: unsupported operation "ignroe"`
+	expected := `diff.comparePatches[2].operations[1].op: unsupported operation "bogus"`
 	if !strings.Contains(err.Error(), expected) {
 		t.Errorf("validateFleetYAML() error = %q, expected to contain %q", err.Error(), expected)
 	}

--- a/internal/bundlereader/validate_fleetyaml_test.go
+++ b/internal/bundlereader/validate_fleetyaml_test.go
@@ -198,3 +198,828 @@ func TestValidBundleStatesList_SortedByRank(t *testing.T) {
 		}
 	}
 }
+
+func diffWithPatchName(name string) *fleet.DiffOptions {
+	return &fleet.DiffOptions{
+		ComparePatches: []fleet.ComparePatch{
+			{
+				APIVersion: "v1",
+				Kind:       "Service",
+				Name:       name,
+				Operations: []fleet.Operation{{Op: "ignore"}},
+			},
+		},
+	}
+}
+
+func TestValidateFleetYAML_ValidComparePatchNames(t *testing.T) {
+	tests := []struct {
+		name      string
+		patchName string
+	}{
+		{name: "unset name", patchName: ""},
+		{name: "literal name", patchName: "my-app"},
+		{name: "literal name with dots and dashes", patchName: "app.v1-alpha.svc"},
+		{name: "regular expression", patchName: ".*serv.*"},
+		{name: "anchored regular expression", patchName: "^my-app-[0-9]+$"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fy := &fleet.FleetYAML{
+				BundleSpec: fleet.BundleSpec{
+					BundleDeploymentOptions: fleet.BundleDeploymentOptions{
+						Diff: diffWithPatchName(tt.patchName),
+					},
+				},
+			}
+
+			if err := validateFleetYAML(fy); err != nil {
+				t.Errorf("validateFleetYAML() unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateFleetYAML_InvalidComparePatchNames(t *testing.T) {
+	tests := []struct {
+		name          string
+		patchName     string
+		expectedError string
+	}{
+		{
+			name:          "unclosed character class",
+			patchName:     "foo[",
+			expectedError: `diff.comparePatches[0].name: invalid regular expression "foo[": error parsing regexp: missing closing ]`,
+		},
+		{
+			name:          "unclosed group",
+			patchName:     "a(b",
+			expectedError: `diff.comparePatches[0].name: invalid regular expression "a(b": error parsing regexp: missing closing )`,
+		},
+		{
+			name:          "leading repetition operator",
+			patchName:     "*x",
+			expectedError: `diff.comparePatches[0].name: invalid regular expression "*x": error parsing regexp: missing argument to repetition operator`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fy := &fleet.FleetYAML{
+				BundleSpec: fleet.BundleSpec{
+					BundleDeploymentOptions: fleet.BundleDeploymentOptions{
+						Diff: diffWithPatchName(tt.patchName),
+					},
+				},
+			}
+
+			err := validateFleetYAML(fy)
+			if err == nil {
+				t.Errorf("validateFleetYAML() expected error containing %q, got nil", tt.expectedError)
+				return
+			}
+			if !strings.Contains(err.Error(), tt.expectedError) {
+				t.Errorf("validateFleetYAML() error = %q, expected to contain %q", err.Error(), tt.expectedError)
+			}
+		})
+	}
+}
+
+// TestValidateFleetYAML_ComparePatchNameWithoutIgnoreOp pins the deliberate choice
+// that the rule holds for every comparePatch, not only for patches carrying an
+// "ignore" operation: the name of a patch which is only ever matched exactly must
+// still compile as a regular expression.
+func TestValidateFleetYAML_ComparePatchNameWithoutIgnoreOp(t *testing.T) {
+	tests := []struct {
+		name  string
+		patch fleet.ComparePatch
+	}{
+		{
+			name: "jsonPointers, no operations",
+			patch: fleet.ComparePatch{
+				APIVersion:   "v1",
+				Kind:         "Service",
+				Name:         "foo[",
+				JsonPointers: []string{"/spec/clusterIP"},
+			},
+		},
+		{
+			name: "remove operation",
+			patch: fleet.ComparePatch{
+				APIVersion: "v1",
+				Kind:       "Service",
+				Name:       "foo[",
+				Operations: []fleet.Operation{{Op: "remove", Path: "/spec/clusterIP"}},
+			},
+		},
+	}
+
+	expectedError := `diff.comparePatches[0].name: invalid regular expression "foo["`
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fy := &fleet.FleetYAML{
+				BundleSpec: fleet.BundleSpec{
+					BundleDeploymentOptions: fleet.BundleDeploymentOptions{
+						Diff: &fleet.DiffOptions{ComparePatches: []fleet.ComparePatch{tt.patch}},
+					},
+				},
+			}
+
+			err := validateFleetYAML(fy)
+			if err == nil {
+				t.Errorf("validateFleetYAML() expected error containing %q, got nil", expectedError)
+				return
+			}
+			if !strings.Contains(err.Error(), expectedError) {
+				t.Errorf("validateFleetYAML() error = %q, expected to contain %q", err.Error(), expectedError)
+			}
+		})
+	}
+}
+
+// TestValidateFleetYAML_ComparePatchNameOptionSites makes sure every
+// BundleDeploymentOptions reachable from fleet.yaml is walked, and that the error
+// names the site it came from.
+func TestValidateFleetYAML_ComparePatchNameOptionSites(t *testing.T) {
+	tests := []struct {
+		name          string
+		fy            *fleet.FleetYAML
+		expectedError string
+	}{
+		{
+			name: "bundle level",
+			fy: &fleet.FleetYAML{
+				BundleSpec: fleet.BundleSpec{
+					BundleDeploymentOptions: fleet.BundleDeploymentOptions{
+						Diff: diffWithPatchName("foo["),
+					},
+				},
+			},
+			expectedError: `diff.comparePatches[0].name: invalid regular expression "foo["`,
+		},
+		{
+			name: "targets",
+			fy: &fleet.FleetYAML{
+				BundleSpec: fleet.BundleSpec{
+					Targets: []fleet.BundleTarget{
+						{Name: "first"},
+						{
+							Name: "second",
+							BundleDeploymentOptions: fleet.BundleDeploymentOptions{
+								Diff: diffWithPatchName("a(b"),
+							},
+						},
+					},
+				},
+			},
+			expectedError: `targets[1].diff.comparePatches[0].name: invalid regular expression "a(b"`,
+		},
+		{
+			name: "targetCustomizations",
+			fy: &fleet.FleetYAML{
+				TargetCustomizations: []fleet.BundleTarget{
+					{Name: "first"},
+					{
+						Name: "second",
+						BundleDeploymentOptions: fleet.BundleDeploymentOptions{
+							Diff: diffWithPatchName("*x"),
+						},
+					},
+				},
+			},
+			expectedError: `targetCustomizations[1].diff.comparePatches[0].name: invalid regular expression "*x"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateFleetYAML(tt.fy)
+			if err == nil {
+				t.Errorf("validateFleetYAML() expected error containing %q, got nil", tt.expectedError)
+				return
+			}
+			if !strings.Contains(err.Error(), tt.expectedError) {
+				t.Errorf("validateFleetYAML() error = %q, expected to contain %q", err.Error(), tt.expectedError)
+			}
+		})
+	}
+}
+
+// TestValidateFleetYAML_ComparePatchNameIndex checks that the reported index is the
+// index of the offending patch, not of the first one.
+func TestValidateFleetYAML_ComparePatchNameIndex(t *testing.T) {
+	fy := &fleet.FleetYAML{
+		BundleSpec: fleet.BundleSpec{
+			BundleDeploymentOptions: fleet.BundleDeploymentOptions{
+				Diff: &fleet.DiffOptions{
+					ComparePatches: []fleet.ComparePatch{
+						{Name: "my-app"},
+						{Name: ".*serv.*"},
+						{Name: "foo["},
+					},
+				},
+			},
+		},
+	}
+
+	err := validateFleetYAML(fy)
+	if err == nil {
+		t.Fatal("validateFleetYAML() expected error, got nil")
+	}
+	expectedError := `diff.comparePatches[2].name: invalid regular expression "foo["`
+	if !strings.Contains(err.Error(), expectedError) {
+		t.Errorf("validateFleetYAML() error = %q, expected to contain %q", err.Error(), expectedError)
+	}
+}
+
+// diffWithPatchOps builds a diff with a single comparePatch carrying the given
+// operations, so the tests below only state the op values they are about.
+func diffWithPatchOps(ops ...string) *fleet.DiffOptions {
+	patch := fleet.ComparePatch{Name: "my-app"}
+	for _, op := range ops {
+		patch.Operations = append(patch.Operations, fleet.Operation{Op: op, Path: "/spec/replicas"})
+	}
+
+	return &fleet.DiffOptions{ComparePatches: []fleet.ComparePatch{patch}}
+}
+
+func TestValidateFleetYAML_ValidComparePatchOperations(t *testing.T) {
+	tests := []struct {
+		name string
+		diff *fleet.DiffOptions
+	}{
+		{name: "no diff at all", diff: nil},
+		{name: "patch without operations", diff: diffWithPatchOps()},
+		{name: "ignore", diff: diffWithPatchOps("ignore")},
+		{name: "remove", diff: diffWithPatchOps("remove")},
+		{name: "add", diff: diffWithPatchOps("add")},
+		{name: "replace", diff: diffWithPatchOps("replace")},
+		{name: "test", diff: diffWithPatchOps("test")},
+		{name: "several operations in one patch", diff: diffWithPatchOps("remove", "replace", "test")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fy := &fleet.FleetYAML{
+				BundleSpec: fleet.BundleSpec{
+					BundleDeploymentOptions: fleet.BundleDeploymentOptions{
+						Diff: tt.diff,
+					},
+				},
+			}
+
+			if err := validateFleetYAML(fy); err != nil {
+				t.Errorf("validateFleetYAML() unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateFleetYAML_InvalidComparePatchOperations(t *testing.T) {
+	tests := []struct {
+		name          string
+		diff          *fleet.DiffOptions
+		expectedError string
+	}{
+		{
+			name:          "typo",
+			diff:          diffWithPatchOps("ignroe"),
+			expectedError: `diff.comparePatches[0].operations[0].op: unsupported operation "ignroe", valid values are: add, ignore, remove, replace, test`,
+		},
+		{
+			name:          "trailing space",
+			diff:          diffWithPatchOps("remove "),
+			expectedError: `diff.comparePatches[0].operations[0].op: unsupported operation "remove "`,
+		},
+		{
+			name:          "wrong case",
+			diff:          diffWithPatchOps("Remove"),
+			expectedError: `diff.comparePatches[0].operations[0].op: unsupported operation "Remove"`,
+		},
+		{
+			// An operation with a path but no op reads as a no-op and is not one:
+			// it makes the whole patch fail. Rejecting it is a deliberate
+			// tightening over what fleet apply accepted before.
+			name:          "empty op",
+			diff:          diffWithPatchOps(""),
+			expectedError: `diff.comparePatches[0].operations[0].op: unsupported operation ""`,
+		},
+		{
+			name:          "second operation is the offending one",
+			diff:          diffWithPatchOps("remove", "ignroe"),
+			expectedError: `diff.comparePatches[0].operations[1].op: unsupported operation "ignroe"`,
+		},
+		{
+			// json-patch implements "copy" and "move", but fleet.Operation has no
+			// "from" field, so neither can ever be encoded in a form json-patch
+			// accepts: both always fail with "missing from field".
+			name:          "copy, which Fleet cannot encode",
+			diff:          diffWithPatchOps("copy"),
+			expectedError: `diff.comparePatches[0].operations[0].op: unsupported operation "copy"`,
+		},
+		{
+			name:          "move, which Fleet cannot encode",
+			diff:          diffWithPatchOps("move"),
+			expectedError: `diff.comparePatches[0].operations[0].op: unsupported operation "move"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fy := &fleet.FleetYAML{
+				BundleSpec: fleet.BundleSpec{
+					BundleDeploymentOptions: fleet.BundleDeploymentOptions{
+						Diff: tt.diff,
+					},
+				},
+			}
+
+			err := validateFleetYAML(fy)
+			if err == nil {
+				t.Errorf("validateFleetYAML() expected error containing %q, got nil", tt.expectedError)
+				return
+			}
+			if !strings.Contains(err.Error(), tt.expectedError) {
+				t.Errorf("validateFleetYAML() error = %q, expected to contain %q", err.Error(), tt.expectedError)
+			}
+		})
+	}
+}
+
+func TestValidateFleetYAML_ComparePatchOperationOptionSites(t *testing.T) {
+	tests := []struct {
+		name          string
+		fy            *fleet.FleetYAML
+		expectedError string
+	}{
+		{
+			name: "bundle level",
+			fy: &fleet.FleetYAML{
+				BundleSpec: fleet.BundleSpec{
+					BundleDeploymentOptions: fleet.BundleDeploymentOptions{
+						Diff: diffWithPatchOps("ignroe"),
+					},
+				},
+			},
+			expectedError: `diff.comparePatches[0].operations[0].op: unsupported operation "ignroe"`,
+		},
+		{
+			name: "targets",
+			fy: &fleet.FleetYAML{
+				BundleSpec: fleet.BundleSpec{
+					Targets: []fleet.BundleTarget{
+						{Name: "first"},
+						{
+							Name: "second",
+							BundleDeploymentOptions: fleet.BundleDeploymentOptions{
+								Diff: diffWithPatchOps("remove", "delete"),
+							},
+						},
+					},
+				},
+			},
+			expectedError: `targets[1].diff.comparePatches[0].operations[1].op: unsupported operation "delete"`,
+		},
+		{
+			name: "targetCustomizations",
+			fy: &fleet.FleetYAML{
+				TargetCustomizations: []fleet.BundleTarget{
+					{Name: "first"},
+					{
+						Name: "second",
+						BundleDeploymentOptions: fleet.BundleDeploymentOptions{
+							Diff: diffWithPatchOps(""),
+						},
+					},
+				},
+			},
+			expectedError: `targetCustomizations[1].diff.comparePatches[0].operations[0].op: unsupported operation ""`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateFleetYAML(tt.fy)
+			if err == nil {
+				t.Errorf("validateFleetYAML() expected error containing %q, got nil", tt.expectedError)
+				return
+			}
+			if !strings.Contains(err.Error(), tt.expectedError) {
+				t.Errorf("validateFleetYAML() error = %q, expected to contain %q", err.Error(), tt.expectedError)
+			}
+		})
+	}
+}
+
+// TestValidateFleetYAML_ComparePatchOperationIndex checks that the reported index
+// is the index of the offending patch, not of the first one.
+func TestValidateFleetYAML_ComparePatchOperationIndex(t *testing.T) {
+	fy := &fleet.FleetYAML{
+		BundleSpec: fleet.BundleSpec{
+			BundleDeploymentOptions: fleet.BundleDeploymentOptions{
+				Diff: &fleet.DiffOptions{
+					ComparePatches: []fleet.ComparePatch{
+						{Name: "first", Operations: []fleet.Operation{{Op: "ignore"}}},
+						{Name: "second", Operations: []fleet.Operation{{Op: "remove", Path: "/spec/replicas"}}},
+						{Name: "third", Operations: []fleet.Operation{{Op: "remove"}, {Op: "ignroe"}}},
+					},
+				},
+			},
+		},
+	}
+
+	err := validateFleetYAML(fy)
+	if err == nil {
+		t.Fatal("validateFleetYAML() expected an error, got nil")
+	}
+
+	expected := `diff.comparePatches[2].operations[1].op: unsupported operation "ignroe"`
+	if !strings.Contains(err.Error(), expected) {
+		t.Errorf("validateFleetYAML() error = %q, expected to contain %q", err.Error(), expected)
+	}
+}
+
+// diffWithPatchPaths builds a diff with one comparePatch whose operations use the
+// given paths, all with a "remove" op so that the path rule is what decides.
+func diffWithPatchPaths(paths ...string) *fleet.DiffOptions {
+	patch := fleet.ComparePatch{Name: "my-app"}
+	for _, p := range paths {
+		patch.Operations = append(patch.Operations, fleet.Operation{Op: "remove", Path: p})
+	}
+
+	return &fleet.DiffOptions{ComparePatches: []fleet.ComparePatch{patch}}
+}
+
+// diffWithJSONPointers builds a diff with one comparePatch carrying the given
+// jsonPointers and no operations.
+func diffWithJSONPointers(pointers ...string) *fleet.DiffOptions {
+	return &fleet.DiffOptions{
+		ComparePatches: []fleet.ComparePatch{{Name: "my-app", JsonPointers: pointers}},
+	}
+}
+
+func TestValidateFleetYAML_ValidComparePatchOperationPaths(t *testing.T) {
+	tests := []struct {
+		name string
+		diff *fleet.DiffOptions
+	}{
+		{name: "no diff at all", diff: nil},
+		{name: "patch without operations", diff: diffWithPatchPaths()},
+		{name: "simple pointer", diff: diffWithPatchPaths("/spec/replicas")},
+		{name: "root child", diff: diffWithPatchPaths("/metadata")},
+		{name: "array index", diff: diffWithPatchPaths("/spec/containers/0/image")},
+		{name: "several operations", diff: diffWithPatchPaths("/spec/a", "/spec/b")},
+		{
+			// json-patch rewrites ~0 and ~1 and leaves any other ~ sequence
+			// literal, so these address real keys and must keep working.
+			name: "escaped tilde and slash",
+			diff: diffWithPatchPaths("/spec/a~0b", "/spec/c~1d"),
+		},
+		{
+			name: "tilde which is not an RFC 6901 escape",
+			diff: diffWithPatchPaths("/spec/a~2b", "/spec/trailing~"),
+		},
+		{
+			// A path which does not resolve on the live object is a runtime
+			// concern, not a syntax one, and stays accepted.
+			name: "pointer to a field which may not exist",
+			diff: diffWithPatchPaths("/spec/doesNotExist"),
+		},
+		{
+			// "ignore" drops the whole resource and never reads the path, so
+			// whatever is written there cannot break anything.
+			name: "ignore operation without a path",
+			diff: &fleet.DiffOptions{
+				ComparePatches: []fleet.ComparePatch{{
+					Name:       "my-app",
+					Operations: []fleet.Operation{{Op: "ignore"}},
+				}},
+			},
+		},
+		{
+			name: "ignore operation with a malformed path",
+			diff: &fleet.DiffOptions{
+				ComparePatches: []fleet.ComparePatch{{
+					Name:       "my-app",
+					Operations: []fleet.Operation{{Op: "ignore", Path: "spec.replicas"}},
+				}},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fy := &fleet.FleetYAML{
+				BundleSpec: fleet.BundleSpec{
+					BundleDeploymentOptions: fleet.BundleDeploymentOptions{
+						Diff: tt.diff,
+					},
+				},
+			}
+
+			if err := validateFleetYAML(fy); err != nil {
+				t.Errorf("validateFleetYAML() unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateFleetYAML_InvalidComparePatchOperationPaths(t *testing.T) {
+	tests := []struct {
+		name          string
+		diff          *fleet.DiffOptions
+		expectedError string
+	}{
+		{
+			// The common mistake: a Kubernetes field path instead of a pointer.
+			name:          "dotted field path",
+			diff:          diffWithPatchPaths("spec.replicas"),
+			expectedError: `diff.comparePatches[0].operations[0].path: invalid JSON pointer "spec.replicas": must start with "/", e.g. "/spec/replicas"`,
+		},
+		{
+			name:          "single segment without a slash",
+			diff:          diffWithPatchPaths("spec"),
+			expectedError: `diff.comparePatches[0].operations[0].path: invalid JSON pointer "spec": must start with "/", e.g. "/spec"`,
+		},
+		{
+			// Path is marshalled with omitempty, so an empty one reaches
+			// json-patch as a missing "path" field and always fails.
+			name:          "empty path",
+			diff:          diffWithPatchPaths(""),
+			expectedError: `diff.comparePatches[0].operations[0].path: invalid JSON pointer "": must not be empty`,
+		},
+		{
+			name:          "second operation is the offending one",
+			diff:          diffWithPatchPaths("/spec/replicas", "spec.template"),
+			expectedError: `diff.comparePatches[0].operations[1].path: invalid JSON pointer "spec.template": must start with "/", e.g. "/spec/template"`,
+		},
+		{
+			name: "non-ignore operation other than remove",
+			diff: &fleet.DiffOptions{
+				ComparePatches: []fleet.ComparePatch{{
+					Name:       "my-app",
+					Operations: []fleet.Operation{{Op: "replace", Path: "spec.type", Value: "ClusterIP"}},
+				}},
+			},
+			expectedError: `diff.comparePatches[0].operations[0].path: invalid JSON pointer "spec.type"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fy := &fleet.FleetYAML{
+				BundleSpec: fleet.BundleSpec{
+					BundleDeploymentOptions: fleet.BundleDeploymentOptions{
+						Diff: tt.diff,
+					},
+				},
+			}
+
+			err := validateFleetYAML(fy)
+			if err == nil {
+				t.Errorf("validateFleetYAML() expected error containing %q, got nil", tt.expectedError)
+				return
+			}
+			if !strings.Contains(err.Error(), tt.expectedError) {
+				t.Errorf("validateFleetYAML() error = %q, expected to contain %q", err.Error(), tt.expectedError)
+			}
+		})
+	}
+}
+
+func TestValidateFleetYAML_ComparePatchOperationPathOptionSites(t *testing.T) {
+	tests := []struct {
+		name          string
+		fy            *fleet.FleetYAML
+		expectedError string
+	}{
+		{
+			name: "bundle level",
+			fy: &fleet.FleetYAML{
+				BundleSpec: fleet.BundleSpec{
+					BundleDeploymentOptions: fleet.BundleDeploymentOptions{
+						Diff: diffWithPatchPaths("spec.replicas"),
+					},
+				},
+			},
+			expectedError: `diff.comparePatches[0].operations[0].path: invalid JSON pointer "spec.replicas"`,
+		},
+		{
+			name: "targets",
+			fy: &fleet.FleetYAML{
+				BundleSpec: fleet.BundleSpec{
+					Targets: []fleet.BundleTarget{
+						{Name: "first"},
+						{
+							Name: "second",
+							BundleDeploymentOptions: fleet.BundleDeploymentOptions{
+								Diff: diffWithPatchPaths("/spec/ok", "spec.bad"),
+							},
+						},
+					},
+				},
+			},
+			expectedError: `targets[1].diff.comparePatches[0].operations[1].path: invalid JSON pointer "spec.bad"`,
+		},
+		{
+			name: "targetCustomizations",
+			fy: &fleet.FleetYAML{
+				TargetCustomizations: []fleet.BundleTarget{
+					{Name: "first"},
+					{
+						Name: "second",
+						BundleDeploymentOptions: fleet.BundleDeploymentOptions{
+							Diff: diffWithPatchPaths(""),
+						},
+					},
+				},
+			},
+			expectedError: `targetCustomizations[1].diff.comparePatches[0].operations[0].path: invalid JSON pointer ""`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateFleetYAML(tt.fy)
+			if err == nil {
+				t.Errorf("validateFleetYAML() expected error containing %q, got nil", tt.expectedError)
+				return
+			}
+			if !strings.Contains(err.Error(), tt.expectedError) {
+				t.Errorf("validateFleetYAML() error = %q, expected to contain %q", err.Error(), tt.expectedError)
+			}
+		})
+	}
+}
+
+func TestValidateFleetYAML_ValidComparePatchJSONPointers(t *testing.T) {
+	tests := []struct {
+		name string
+		diff *fleet.DiffOptions
+	}{
+		{name: "no diff at all", diff: nil},
+		{name: "patch without pointers", diff: diffWithJSONPointers()},
+		{name: "simple pointer", diff: diffWithJSONPointers("/spec/replicas")},
+		{name: "several pointers", diff: diffWithJSONPointers("/spec/replicas", "/metadata/labels")},
+		{name: "array index", diff: diffWithJSONPointers("/spec/containers/0/image")},
+		{name: "escaped tilde and slash", diff: diffWithJSONPointers("/spec/a~0b", "/spec/c~1d")},
+		{name: "tilde which is not an RFC 6901 escape", diff: diffWithJSONPointers("/spec/a~2b")},
+		{name: "pointer to a field which may not exist", diff: diffWithJSONPointers("/spec/doesNotExist")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fy := &fleet.FleetYAML{
+				BundleSpec: fleet.BundleSpec{
+					BundleDeploymentOptions: fleet.BundleDeploymentOptions{
+						Diff: tt.diff,
+					},
+				},
+			}
+
+			if err := validateFleetYAML(fy); err != nil {
+				t.Errorf("validateFleetYAML() unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateFleetYAML_InvalidComparePatchJSONPointers(t *testing.T) {
+	tests := []struct {
+		name          string
+		diff          *fleet.DiffOptions
+		expectedError string
+	}{
+		{
+			name:          "dotted field path",
+			diff:          diffWithJSONPointers("spec.replicas"),
+			expectedError: `diff.comparePatches[0].jsonPointers[0]: invalid JSON pointer "spec.replicas": must start with "/", e.g. "/spec/replicas"`,
+		},
+		{
+			name:          "empty pointer",
+			diff:          diffWithJSONPointers(""),
+			expectedError: `diff.comparePatches[0].jsonPointers[0]: invalid JSON pointer "": must not be empty`,
+		},
+		{
+			name:          "second pointer is the offending one",
+			diff:          diffWithJSONPointers("/spec/replicas", "spec.template"),
+			expectedError: `diff.comparePatches[0].jsonPointers[1]: invalid JSON pointer "spec.template"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fy := &fleet.FleetYAML{
+				BundleSpec: fleet.BundleSpec{
+					BundleDeploymentOptions: fleet.BundleDeploymentOptions{
+						Diff: tt.diff,
+					},
+				},
+			}
+
+			err := validateFleetYAML(fy)
+			if err == nil {
+				t.Errorf("validateFleetYAML() expected error containing %q, got nil", tt.expectedError)
+				return
+			}
+			if !strings.Contains(err.Error(), tt.expectedError) {
+				t.Errorf("validateFleetYAML() error = %q, expected to contain %q", err.Error(), tt.expectedError)
+			}
+		})
+	}
+}
+
+func TestValidateFleetYAML_ComparePatchJSONPointerOptionSites(t *testing.T) {
+	tests := []struct {
+		name          string
+		fy            *fleet.FleetYAML
+		expectedError string
+	}{
+		{
+			name: "bundle level",
+			fy: &fleet.FleetYAML{
+				BundleSpec: fleet.BundleSpec{
+					BundleDeploymentOptions: fleet.BundleDeploymentOptions{
+						Diff: diffWithJSONPointers("spec.replicas"),
+					},
+				},
+			},
+			expectedError: `diff.comparePatches[0].jsonPointers[0]: invalid JSON pointer "spec.replicas"`,
+		},
+		{
+			name: "targets",
+			fy: &fleet.FleetYAML{
+				BundleSpec: fleet.BundleSpec{
+					Targets: []fleet.BundleTarget{
+						{Name: "first"},
+						{
+							Name: "second",
+							BundleDeploymentOptions: fleet.BundleDeploymentOptions{
+								Diff: diffWithJSONPointers("/spec/ok", "spec.bad"),
+							},
+						},
+					},
+				},
+			},
+			expectedError: `targets[1].diff.comparePatches[0].jsonPointers[1]: invalid JSON pointer "spec.bad"`,
+		},
+		{
+			name: "targetCustomizations",
+			fy: &fleet.FleetYAML{
+				TargetCustomizations: []fleet.BundleTarget{
+					{Name: "first"},
+					{
+						Name: "second",
+						BundleDeploymentOptions: fleet.BundleDeploymentOptions{
+							Diff: diffWithJSONPointers(""),
+						},
+					},
+				},
+			},
+			expectedError: `targetCustomizations[1].diff.comparePatches[0].jsonPointers[0]: invalid JSON pointer ""`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateFleetYAML(tt.fy)
+			if err == nil {
+				t.Errorf("validateFleetYAML() expected error containing %q, got nil", tt.expectedError)
+				return
+			}
+			if !strings.Contains(err.Error(), tt.expectedError) {
+				t.Errorf("validateFleetYAML() error = %q, expected to contain %q", err.Error(), tt.expectedError)
+			}
+		})
+	}
+}
+
+// TestValidateFleetYAML_ComparePatchPointerIndex checks that the reported index is
+// the index of the offending patch, not of the first one.
+func TestValidateFleetYAML_ComparePatchPointerIndex(t *testing.T) {
+	fy := &fleet.FleetYAML{
+		BundleSpec: fleet.BundleSpec{
+			BundleDeploymentOptions: fleet.BundleDeploymentOptions{
+				Diff: &fleet.DiffOptions{
+					ComparePatches: []fleet.ComparePatch{
+						{Name: "first", Operations: []fleet.Operation{{Op: "ignore"}}},
+						{Name: "second", JsonPointers: []string{"/spec/replicas"}},
+						{Name: "third", JsonPointers: []string{"/ok", "not-a-pointer"}},
+					},
+				},
+			},
+		},
+	}
+
+	err := validateFleetYAML(fy)
+	if err == nil {
+		t.Fatal("validateFleetYAML() expected an error, got nil")
+	}
+
+	expected := `diff.comparePatches[2].jsonPointers[1]: invalid JSON pointer "not-a-pointer"`
+	if !strings.Contains(err.Error(), expected) {
+		t.Errorf("validateFleetYAML() error = %q, expected to contain %q", err.Error(), expected)
+	}
+}

--- a/internal/cmd/agent/deployer/desiredset/diff.go
+++ b/internal/cmd/agent/deployer/desiredset/diff.go
@@ -16,6 +16,7 @@ import (
 	"github.com/rancher/fleet/internal/cmd/agent/deployer/merr"
 	"github.com/rancher/fleet/internal/cmd/agent/deployer/normalizers"
 	"github.com/rancher/fleet/internal/cmd/agent/deployer/objectset"
+	"github.com/rancher/fleet/internal/validation"
 	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -30,7 +31,7 @@ func Diff(logger logr.Logger, plan Plan, bd *fleet.BundleDeployment, ns string, 
 	desired := objectset.NewObjectSet(objs...).ObjectsByGVK()
 	live := objectset.NewObjectSet(plan.Objects...).ObjectsByGVK()
 
-	norms, err := newNormalizers(live, bd)
+	norms, err := newNormalizers(logger, live, bd)
 	if err != nil {
 		return plan, err
 	}
@@ -58,9 +59,11 @@ func Diff(logger logr.Logger, plan Plan, bd *fleet.BundleDeployment, ns string, 
 
 				re, err := regexp.Compile(key.Name)
 				if err != nil {
-					// XXX: enable detection of such issues earlier, for instance through CLI validating
-					// fleet.yaml syntax; see fleet#4533.
-					logger.V(1).Error(
+					// fleet apply rejects a name which does not compile (see
+					// validation.ValidateComparePatchNames), but BundleDeployments
+					// created by an older Fleet version, or from a HelmOp, still reach
+					// this point, hence the check and the error log.
+					logger.Error(
 						err,
 						"Cannot compile bundle diff ignore regex, will discard it",
 						"namespace", key.Namespace,
@@ -181,7 +184,7 @@ func Diff(logger logr.Logger, plan Plan, bd *fleet.BundleDeployment, ns string, 
 //   - normalizers.NewIgnoreNormalizer (patch.JsonPointers)
 //   - normalizers.NewKnownTypesNormalizer (rollout.argoproj.io)
 //   - patch.Operations
-func newNormalizers(live objectset.ObjectByGVK, bd *fleet.BundleDeployment) (diff.Normalizer, error) {
+func newNormalizers(logger logr.Logger, live objectset.ObjectByGVK, bd *fleet.BundleDeployment) (diff.Normalizer, error) {
 	var ignore []resource.ResourceIgnoreDifferences
 	jsonPatchNorm := &normalizers.JSONPatchNormalizer{}
 
@@ -191,26 +194,94 @@ func newNormalizers(live objectset.ObjectByGVK, bd *fleet.BundleDeployment) (dif
 			if err != nil {
 				return nil, err
 			}
+
+			pointers := make([]string, 0, len(patch.JsonPointers))
+			for _, pointer := range patch.JsonPointers {
+				if !validation.IsJSONPointer(pointer) {
+					// fleet apply rejects a malformed pointer (see
+					// validation.ValidateComparePatchJSONPointers), but BundleDeployments created
+					// by an older Fleet version, or from a HelmOp, still reach this point.
+					// Dropping the entry here makes the failure visible: the normalizer
+					// only logs it at V(1) info level, which the agent's default
+					// verbosity filters out entirely. The user-visible diff is unchanged
+					// either way — a pointer which resolves to nothing is a no-op, and a
+					// two-segment slashless one such as "x/status", which json-patch does
+					// resolve to a root key (see validation.IsJSONPointer), is normalized
+					// out of the live, desired and original objects alike.
+					logger.Error(
+						validation.InvalidJSONPointerError(pointer),
+						"Cannot ignore bundle diff JSON pointer, will discard it",
+						"namespace", patch.Namespace,
+						"name", patch.Name,
+						"gvk", groupVersion.WithKind(patch.Kind).String(),
+					)
+					continue
+				}
+
+				pointers = append(pointers, pointer)
+			}
+
 			ignore = append(ignore, resource.ResourceIgnoreDifferences{
 				Namespace:    patch.Namespace,
 				Name:         patch.Name,
 				Kind:         patch.Kind,
 				Group:        groupVersion.Group,
-				JSONPointers: patch.JsonPointers,
+				JSONPointers: pointers,
 			})
 
 			for _, op := range patch.Operations {
+				// "ignore" is Fleet's own operation, applied in Diff; it never
+				// becomes a JSON patch.
+				if op.Op == fleet.IgnoreOp {
+					continue
+				}
+
+				gvk := schema.FromAPIVersionAndKind(patch.APIVersion, patch.Kind)
+
+				if !validation.IsSupportedPatchOp(op.Op) {
+					// fleet apply rejects an unsupported operation (see
+					// validation.ValidateComparePatchOperations), but BundleDeployments
+					// created by an older Fleet version, or from a HelmOp, still reach this
+					// point. Dropping the operation here keeps the other patches for the
+					// same resource working: json-patch fails on an unknown operation at
+					// apply time, and JSONPatchNormalizer then discards every patch it holds
+					// for that object, not just this one.
+					logger.Error(
+						validation.UnsupportedPatchOpError(op.Op),
+						"Cannot apply bundle diff patch operation, will discard it",
+						"namespace", patch.Namespace,
+						"name", patch.Name,
+						"gvk", gvk.String(),
+					)
+					continue
+				}
+
+				if !validation.IsJSONPointer(op.Path) {
+					// fleet apply rejects a malformed path (see
+					// validation.ValidateComparePatchOperationPaths), but BundleDeployments created
+					// by an older Fleet version, or from a HelmOp, still reach this point.
+					// Dropping the operation here keeps the other patches for the same
+					// resource working: json-patch fails to resolve such a path at apply
+					// time, and JSONPatchNormalizer then discards every patch it holds for
+					// that object, not just this one. A path json-patch does resolve, but
+					// not to what the user wrote, is dropped here as well, before it can
+					// silently rewrite the wrong field.
+					logger.Error(
+						validation.InvalidJSONPointerError(op.Path),
+						"Cannot apply bundle diff patch operation, will discard it",
+						"namespace", patch.Namespace,
+						"name", patch.Name,
+						"gvk", gvk.String(),
+					)
+					continue
+				}
+
 				// compile each operation by itself so that one failing operation doesn't block the others
 				patchData, err := json.Marshal([]any{op})
 				if err != nil {
 					return nil, err
 				}
 
-				if op.Op == fleet.IgnoreOp {
-					continue
-				}
-
-				gvk := schema.FromAPIVersionAndKind(patch.APIVersion, patch.Kind)
 				key := objectset.ObjectKey{
 					Name:      patch.Name,
 					Namespace: patch.Namespace,

--- a/internal/cmd/agent/deployer/desiredset/normalizers_internal_test.go
+++ b/internal/cmd/agent/deployer/desiredset/normalizers_internal_test.go
@@ -33,7 +33,7 @@ func TestNewNormalizers_DropsUnsupportedOperation(t *testing.T) {
 							Name:       "my-svc",
 							Operations: []fleet.Operation{
 								{Op: "remove", Path: "/spec/clusterIP"},
-								{Op: "ignroe"},
+								{Op: "bogus"},
 							},
 						},
 					},

--- a/internal/cmd/agent/deployer/desiredset/normalizers_internal_test.go
+++ b/internal/cmd/agent/deployer/desiredset/normalizers_internal_test.go
@@ -1,0 +1,232 @@
+package desiredset
+
+import (
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/go-logr/logr/funcr"
+
+	"github.com/rancher/fleet/internal/cmd/agent/deployer/objectset"
+	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// TestNewNormalizers_DropsUnsupportedOperation pins the drop newNormalizers does
+// for an operation validation.IsSupportedPatchOp rejects. Without it the bad
+// operation is marshalled into a JSON patch of its own, json-patch fails to apply
+// it, and JSONPatchNormalizer's applyPatches returns nil for the whole object —
+// discarding the good operation next to it as well. So the assertion is that the
+// good operation still takes effect: /spec/clusterIP is really gone.
+func TestNewNormalizers_DropsUnsupportedOperation(t *testing.T) {
+	bd := &fleet.BundleDeployment{
+		Spec: fleet.BundleDeploymentSpec{
+			Options: fleet.BundleDeploymentOptions{
+				Diff: &fleet.DiffOptions{
+					ComparePatches: []fleet.ComparePatch{
+						{
+							APIVersion: "v1",
+							Kind:       "Service",
+							Namespace:  "test-ns",
+							Name:       "my-svc",
+							Operations: []fleet.Operation{
+								{Op: "remove", Path: "/spec/clusterIP"},
+								{Op: "ignroe"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	svc := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "v1",
+			"kind":       "Service",
+			"metadata": map[string]any{
+				"name":      "my-svc",
+				"namespace": "test-ns",
+			},
+			"spec": map[string]any{
+				"clusterIP": "10.43.0.1",
+				"type":      "ClusterIP",
+			},
+		},
+	}
+
+	live := objectset.ObjectByGVK{}
+
+	norm, err := newNormalizers(logr.Discard(), live, bd)
+	if err != nil {
+		t.Fatalf("newNormalizers() unexpected error: %v", err)
+	}
+
+	if err := norm.Normalize(svc); err != nil {
+		t.Fatalf("Normalize() unexpected error: %v", err)
+	}
+
+	if _, found, err := unstructured.NestedString(svc.Object, "spec", "clusterIP"); err != nil {
+		t.Fatalf("reading spec.clusterIP: %v", err)
+	} else if found {
+		t.Error("spec.clusterIP is still set: the unsupported operation next to it discarded the whole patch")
+	}
+
+	// The rest of the object has to survive, so that the check above cannot pass
+	// just because normalization wiped everything.
+	if svcType, found, err := unstructured.NestedString(svc.Object, "spec", "type"); err != nil {
+		t.Fatalf("reading spec.type: %v", err)
+	} else if !found || svcType != "ClusterIP" {
+		t.Errorf("spec.type = %q (found %v), want %q: normalization dropped more than the patched field", svcType, found, "ClusterIP")
+	}
+}
+
+// TestNewNormalizers_DropsInvalidOperationPath pins the drop newNormalizers does
+// for an operation path validation.IsJSONPointer rejects. Without it the bad
+// operation is marshalled into a JSON patch of its own, json-patch fails to
+// resolve the path, and JSONPatchNormalizer's applyPatches returns nil for the
+// whole object — discarding the good operation next to it as well. So the
+// assertion is that the good operation still takes effect: /spec/clusterIP is
+// really gone.
+func TestNewNormalizers_DropsInvalidOperationPath(t *testing.T) {
+	bd := &fleet.BundleDeployment{
+		Spec: fleet.BundleDeploymentSpec{
+			Options: fleet.BundleDeploymentOptions{
+				Diff: &fleet.DiffOptions{
+					ComparePatches: []fleet.ComparePatch{
+						{
+							APIVersion: "v1",
+							Kind:       "Service",
+							Namespace:  "test-ns",
+							Name:       "my-svc",
+							Operations: []fleet.Operation{
+								{Op: "remove", Path: "/spec/clusterIP"},
+								{Op: "remove", Path: "spec.type"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	svc := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "v1",
+			"kind":       "Service",
+			"metadata": map[string]any{
+				"name":      "my-svc",
+				"namespace": "test-ns",
+			},
+			"spec": map[string]any{
+				"clusterIP": "10.43.0.1",
+				"type":      "ClusterIP",
+			},
+		},
+	}
+
+	live := objectset.ObjectByGVK{}
+
+	norm, err := newNormalizers(logr.Discard(), live, bd)
+	if err != nil {
+		t.Fatalf("newNormalizers() unexpected error: %v", err)
+	}
+
+	if err := norm.Normalize(svc); err != nil {
+		t.Fatalf("Normalize() unexpected error: %v", err)
+	}
+
+	if _, found, err := unstructured.NestedString(svc.Object, "spec", "clusterIP"); err != nil {
+		t.Fatalf("reading spec.clusterIP: %v", err)
+	} else if found {
+		t.Error("spec.clusterIP is still set: the unusable path next to it discarded the whole patch")
+	}
+
+	// The field the unusable path aimed at has to survive: dropping the operation
+	// must not turn into applying it.
+	if svcType, found, err := unstructured.NestedString(svc.Object, "spec", "type"); err != nil {
+		t.Fatalf("reading spec.type: %v", err)
+	} else if !found || svcType != "ClusterIP" {
+		t.Errorf("spec.type = %q (found %v), want %q: normalization dropped more than the patched field", svcType, found, "ClusterIP")
+	}
+}
+
+// TestNewNormalizers_DropsInvalidJSONPointer pins the drop newNormalizers does for
+// a jsonPointers entry validation.IsJSONPointer rejects, before the entry reaches
+// the vendored ignore normalizer. The user-visible diff is the same either way —
+// that normalizer fails each pointer on its own and carries on, and a pointer it
+// does resolve to the wrong place is normalized out of live, desired and original
+// alike — so what this pins is the *visibility*: it reports the failure at V(1) info
+// level, which the agent's default verbosity filters out entirely, and the drop
+// exists so the same failure is reported as an error instead. The valid pointer
+// next to it still has to take effect.
+func TestNewNormalizers_DropsInvalidJSONPointer(t *testing.T) {
+	var logged []string
+	logger := funcr.New(func(prefix, args string) { logged = append(logged, args) }, funcr.Options{})
+
+	bd := &fleet.BundleDeployment{
+		Spec: fleet.BundleDeploymentSpec{
+			Options: fleet.BundleDeploymentOptions{
+				Diff: &fleet.DiffOptions{
+					ComparePatches: []fleet.ComparePatch{
+						{
+							APIVersion:   "v1",
+							Kind:         "Service",
+							Namespace:    "test-ns",
+							Name:         "my-svc",
+							JsonPointers: []string{"spec.type", "/spec/clusterIP"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	svc := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "v1",
+			"kind":       "Service",
+			"metadata": map[string]any{
+				"name":      "my-svc",
+				"namespace": "test-ns",
+			},
+			"spec": map[string]any{
+				"clusterIP": "10.43.0.1",
+				"type":      "ClusterIP",
+			},
+		},
+	}
+
+	live := objectset.ObjectByGVK{}
+
+	norm, err := newNormalizers(logger, live, bd)
+	if err != nil {
+		t.Fatalf("newNormalizers() unexpected error: %v", err)
+	}
+
+	if err := norm.Normalize(svc); err != nil {
+		t.Fatalf("Normalize() unexpected error: %v", err)
+	}
+
+	if _, found, err := unstructured.NestedString(svc.Object, "spec", "clusterIP"); err != nil {
+		t.Fatalf("reading spec.clusterIP: %v", err)
+	} else if found {
+		t.Error("spec.clusterIP is still set: the unusable pointer next to it took the valid one down")
+	}
+
+	if svcType, found, err := unstructured.NestedString(svc.Object, "spec", "type"); err != nil {
+		t.Fatalf("reading spec.type: %v", err)
+	} else if !found || svcType != "ClusterIP" {
+		t.Errorf("spec.type = %q (found %v), want %q: normalization dropped more than the ignored field", svcType, found, "ClusterIP")
+	}
+
+	// The whole point of dropping the entry here rather than leaving it to the
+	// vendored normalizer: the user has to be told.
+	if !slices.ContainsFunc(logged, func(line string) bool {
+		return strings.Contains(line, "invalid JSON pointer") && strings.Contains(line, "spec.type")
+	}) {
+		t.Errorf("the unusable pointer was discarded without being logged as an error; logged: %v", logged)
+	}
+}

--- a/internal/cmd/agent/deployer/desiredset/normalizers_test.go
+++ b/internal/cmd/agent/deployer/desiredset/normalizers_test.go
@@ -12,11 +12,11 @@ import (
 	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
 )
 
-// rejectedPatchOps are values which must never be accepted: typos, wrong case
-// and stray whitespace, plus the two JSON Patch operations Fleet cannot encode.
+// rejectedPatchOps are values which must never be accepted: unknown names, wrong
+// case and stray whitespace, plus the two JSON Patch operations Fleet cannot encode.
 // json-patch implements "copy" and "move", but fleet.Operation has no "from"
 // field, so neither can ever be handed to it in a form it accepts.
-var rejectedPatchOps = []string{"", "Remove", "remove ", "ignroe", "delete", "copy", "move"}
+var rejectedPatchOps = []string{"", "Remove", "remove ", "bogus", "delete", "copy", "move"}
 
 // TestNormalizers_AgreesWithValidation pins validation.IsSupportedPatchOp, which
 // fleet apply rejects a comparePatch operation with, to what the agent can really

--- a/internal/cmd/agent/deployer/desiredset/normalizers_test.go
+++ b/internal/cmd/agent/deployer/desiredset/normalizers_test.go
@@ -1,0 +1,281 @@
+package desiredset_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"slices"
+	"testing"
+
+	jsonpatch "github.com/evanphx/json-patch"
+
+	"github.com/rancher/fleet/internal/validation"
+	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
+)
+
+// rejectedPatchOps are values which must never be accepted: typos, wrong case
+// and stray whitespace, plus the two JSON Patch operations Fleet cannot encode.
+// json-patch implements "copy" and "move", but fleet.Operation has no "from"
+// field, so neither can ever be handed to it in a form it accepts.
+var rejectedPatchOps = []string{"", "Remove", "remove ", "ignroe", "delete", "copy", "move"}
+
+// TestNormalizers_AgreesWithValidation pins validation.IsSupportedPatchOp, which
+// fleet apply rejects a comparePatch operation with, to what the agent can really
+// apply. It drives the accepted half from validation.SupportedPatchOps, so adding
+// an operation to the predicate which the agent cannot apply fails here, and it
+// goes through the same fleet.Operation marshalling newNormalizers does, so an
+// operation which json-patch implements but fleet.Operation cannot express — one
+// needing a "from" — counts as unsupported, the way it really behaves.
+func TestNormalizers_AgreesWithValidation(t *testing.T) {
+	for _, op := range validation.SupportedPatchOps() {
+		t.Run(fmt.Sprintf("accepted op %q", op), func(t *testing.T) {
+			if slices.Contains(rejectedPatchOps, op) {
+				t.Fatalf("IsSupportedPatchOp(%q) = true, but it is listed as an operation which must be rejected", op)
+			}
+
+			if op == fleet.IgnoreOp {
+				// "ignore" is Fleet's own extension: Diff handles it and it never
+				// reaches json-patch, which is why it has to be accepted here and
+				// is expected to be unknown to the library.
+				if err := applyAsJSONPatch(t, op); err == nil {
+					t.Errorf("json-patch now applies %q; Diff intercepts it before json-patch sees it, revisit that", op)
+				}
+				return
+			}
+
+			if err := applyAsJSONPatch(t, op); err != nil {
+				t.Errorf(
+					"IsSupportedPatchOp(%q) = true, but the agent cannot apply it: %v",
+					op, err,
+				)
+			}
+		})
+	}
+
+	for _, op := range rejectedPatchOps {
+		t.Run(fmt.Sprintf("rejected op %q", op), func(t *testing.T) {
+			if validation.IsSupportedPatchOp(op) {
+				t.Errorf("IsSupportedPatchOp(%q) = true, but the agent cannot apply it", op)
+			}
+
+			if err := applyAsJSONPatch(t, op); err == nil {
+				t.Errorf("json-patch applied %q; it is rejected by the validator, so the two disagree", op)
+			}
+		})
+	}
+}
+
+// applyAsJSONPatch runs op through the agent's path: it marshals a real
+// fleet.Operation exactly as newNormalizers does, then decodes and applies the
+// result the way JSONPatchNormalizer does. It returns the error the agent would
+// hit, or nil if the operation applies.
+func applyAsJSONPatch(t *testing.T, op string) error {
+	t.Helper()
+
+	// Every field fleet.Operation has is set, so that a supported operation
+	// applies cleanly to the document below: "test" compares /a against its
+	// actual value.
+	patchData, err := json.Marshal([]any{fleet.Operation{Op: op, Path: "/a", Value: "b"}})
+	if err != nil {
+		t.Fatalf("marshalling an operation %q: %v", op, err)
+	}
+
+	patch, err := jsonpatch.DecodePatch(patchData)
+	if err != nil {
+		return err
+	}
+
+	_, err = patch.Apply([]byte(`{"a":"b"}`))
+
+	return err
+}
+
+// acceptedJSONPointers are pointers validation.IsJSONPointer must keep accepting,
+// each with a document it addresses and what removing that pointer has to leave
+// behind. The document is the point: it pins that json-patch resolves the pointer
+// to the key the user wrote, not merely that the patch applies without an error.
+var acceptedJSONPointers = []struct {
+	pointer string
+	doc     string
+	want    string
+}{
+	{
+		pointer: "/spec/replicas",
+		doc:     `{"spec":{"replicas":3,"paused":true}}`,
+		want:    `{"spec":{"paused":true}}`,
+	},
+	{
+		// A single segment addresses a top-level key.
+		pointer: "/status",
+		doc:     `{"spec":{},"status":{"phase":"Running"}}`,
+		want:    `{"spec":{}}`,
+	},
+	{
+		// "~1" is the RFC 6901 escape for "/", so this is one annotation key
+		// containing a slash, not four segments.
+		pointer: "/metadata/annotations/deployment.kubernetes.io~1revision",
+		doc:     `{"metadata":{"annotations":{"deployment.kubernetes.io/revision":"1","other":"x"}}}`,
+		want:    `{"metadata":{"annotations":{"other":"x"}}}`,
+	},
+	{
+		// "~0" is the escape for "~".
+		pointer: "/spec/a~0b",
+		doc:     `{"spec":{"a~b":1,"keep":2}}`,
+		want:    `{"spec":{"keep":2}}`,
+	},
+	{
+		// json-patch rewrites only "~0" and "~1" and leaves any other "~" sequence
+		// literal, so this addresses a key really named "a~2b". A stricter RFC 6901
+		// check would reject it and break configurations which work today.
+		pointer: "/spec/a~2b",
+		doc:     `{"spec":{"a~2b":1,"keep":2}}`,
+		want:    `{"spec":{"keep":2}}`,
+	},
+	{
+		pointer: "/spec/trailing~",
+		doc:     `{"spec":{"trailing~":1,"keep":2}}`,
+		want:    `{"spec":{"keep":2}}`,
+	},
+}
+
+// rejectedJSONPointers are values which must never be accepted, each with a
+// document and the result the user was aiming for. "intended" is what the pointer
+// would have produced had it addressed what the user wrote; the assertion is that
+// json-patch does not produce it — it either fails outright, or, for a value with
+// two segments and no leading slash, quietly hits something else.
+var rejectedJSONPointers = []struct {
+	pointer  string
+	doc      string
+	intended string
+}{
+	{
+		// RFC 6901 reads "" as the whole document; Fleet rejects it because it
+		// reaches json-patch as a missing path instead.
+		pointer:  "",
+		doc:      `{"spec":{"replicas":3}}`,
+		intended: `{}`,
+	},
+	{
+		// The common mistake: a Kubernetes-style field path.
+		pointer:  "spec.replicas",
+		doc:      `{"spec":{"replicas":3}}`,
+		intended: `{"spec":{}}`,
+	},
+	{
+		pointer:  "spec",
+		doc:      `{"spec":{},"status":{}}`,
+		intended: `{"status":{}}`,
+	},
+	{
+		// The dangerous one. json-patch splits on "/" and walks
+		// split[1:len(split)-1], which is empty here, so this addresses "kind" at
+		// the root of the document and really does rewrite the resource's kind
+		// rather than the metadata.kind the user aimed at.
+		pointer:  "metadata/kind",
+		doc:      `{"kind":"Service","metadata":{"kind":"Pod"}}`,
+		intended: `{"kind":"Service","metadata":{}}`,
+	},
+}
+
+// TestNormalizers_AgreesWithJSONPointerValidation pins validation.IsJSONPointer,
+// which fleet apply rejects a comparePatch path and a jsonPointers entry with, to
+// what the agent can really address. Both consumers are driven: the fleet.Operation
+// marshalling newNormalizers does for an operation path, and the
+// map[string]string{"op": "remove", "path": …} the ignore normalizer builds for a
+// jsonPointers entry (internal/normalizers/diff_normalizer.go:51). A pointer the
+// predicate accepts has to resolve to the key the user wrote in both; one it
+// rejects must not.
+func TestNormalizers_AgreesWithJSONPointerValidation(t *testing.T) {
+	for _, tc := range acceptedJSONPointers {
+		t.Run(fmt.Sprintf("accepted pointer %q", tc.pointer), func(t *testing.T) {
+			if !validation.IsJSONPointer(tc.pointer) {
+				t.Fatalf("IsJSONPointer(%q) = false, but the agent can address it", tc.pointer)
+			}
+
+			for shape, remove := range removeByPointer {
+				got, err := remove(t, tc.pointer, tc.doc)
+				if err != nil {
+					t.Errorf(
+						"IsJSONPointer(%q) = true, but the agent cannot address it as %s: %v",
+						tc.pointer, shape, err,
+					)
+					continue
+				}
+
+				if !jsonpatch.Equal(got, []byte(tc.want)) {
+					t.Errorf(
+						"removing %q as %s from %s gave %s, want %s: the pointer does not address what the user wrote",
+						tc.pointer, shape, tc.doc, got, tc.want,
+					)
+				}
+			}
+		})
+	}
+
+	for _, tc := range rejectedJSONPointers {
+		t.Run(fmt.Sprintf("rejected pointer %q", tc.pointer), func(t *testing.T) {
+			if validation.IsJSONPointer(tc.pointer) {
+				t.Errorf("IsJSONPointer(%q) = true, but the agent cannot address it", tc.pointer)
+			}
+
+			for shape, remove := range removeByPointer {
+				got, err := remove(t, tc.pointer, tc.doc)
+				if err != nil {
+					continue // failing outright is the expected outcome
+				}
+
+				if jsonpatch.Equal(got, []byte(tc.intended)) {
+					t.Errorf(
+						"removing %q as %s from %s gave %s, which is what the user meant; it is rejected by the validator, so the two disagree",
+						tc.pointer, shape, tc.doc, got,
+					)
+				}
+			}
+		})
+	}
+}
+
+// removeByPointer holds the two ways a comparePatch pointer reaches json-patch,
+// so every case is driven through both.
+var removeByPointer = map[string]func(t *testing.T, pointer, doc string) ([]byte, error){
+	"an operation path":    removeViaOperation,
+	"a jsonPointers entry": removeViaIgnoreNormalizer,
+}
+
+// removeViaOperation marshals a real fleet.Operation exactly as newNormalizers
+// does for a comparePatch operation, then applies it the way JSONPatchNormalizer
+// does.
+func removeViaOperation(t *testing.T, pointer, doc string) ([]byte, error) {
+	t.Helper()
+
+	patchData, err := json.Marshal([]any{fleet.Operation{Op: "remove", Path: pointer}})
+	if err != nil {
+		t.Fatalf("marshalling an operation for pointer %q: %v", pointer, err)
+	}
+
+	return applyRemove(patchData, doc)
+}
+
+// removeViaIgnoreNormalizer builds the patch the vendored ignore normalizer builds
+// for a jsonPointers entry at
+// internal/cmd/agent/deployer/internal/normalizers/diff_normalizer.go:51. The shape
+// differs from an operation's: map[string]string has no omitempty, so an empty
+// pointer arrives as an empty path rather than as a missing one.
+func removeViaIgnoreNormalizer(t *testing.T, pointer, doc string) ([]byte, error) {
+	t.Helper()
+
+	patchData, err := json.Marshal([]map[string]string{{"op": "remove", "path": pointer}})
+	if err != nil {
+		t.Fatalf("marshalling an ignore patch for pointer %q: %v", pointer, err)
+	}
+
+	return applyRemove(patchData, doc)
+}
+
+func applyRemove(patchData []byte, doc string) ([]byte, error) {
+	patch, err := jsonpatch.DecodePatch(patchData)
+	if err != nil {
+		return nil, err
+	}
+
+	return patch.Apply([]byte(doc))
+}

--- a/internal/cmd/controller/helmops/reconciler/helmop_controller.go
+++ b/internal/cmd/controller/helmops/reconciler/helmop_controller.go
@@ -35,6 +35,7 @@ import (
 	"github.com/rancher/fleet/internal/cmd/controller/finalize"
 	ctrlquartz "github.com/rancher/fleet/internal/cmd/controller/quartz"
 	"github.com/rancher/fleet/internal/metrics"
+	"github.com/rancher/fleet/internal/validation"
 	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
 	"github.com/rancher/fleet/pkg/cert"
 	"github.com/rancher/fleet/pkg/durations"
@@ -588,6 +589,9 @@ func jobKey(h fleet.HelmOp) *quartz.JobKey {
 // * tarball URL in Chart, empty Repo, empty Version
 // * OCI reference in the Repo field, empty Chart, optional Version
 // * non-empty Repo URL, non-empty Chart name, optional Version
+//
+// It then hands the BundleSpec a HelmOp embeds to validateBundleSpec, so the
+// options a HelmOp shares with a fleet.yaml are checked here as well.
 func validate(h fleet.HelmOp) error {
 	if h.Spec.Helm == nil {
 		return errors.New("helm options are empty in the HelmOp's spec")
@@ -617,6 +621,25 @@ func validate(h fleet.HelmOp) error {
 
 		if len(h.Spec.Helm.Repo) == 0 {
 			return fail("non-tarball chart with an empty repo field")
+		}
+	}
+
+	return validateBundleSpec(&h.Spec.BundleSpec)
+}
+
+// validateBundleSpec runs the rules which apply to the BundleSpec a HelmOp embeds.
+// A HelmOp reaches the same BundleDeploymentOptions a fleet.yaml does, but never
+// goes through bundlereader.validateFleetYAML, so without this the values would
+// only fail on the agent, silently. The rules themselves live in
+// internal/validation so that both entry points enforce one copy of each.
+//
+// Paths are reported from the HelmOp spec, e.g.
+// "spec.targets[0].diff.comparePatches[1].name", because that is where the user
+// wrote the value; the message reaches them on the Accepted condition.
+func validateBundleSpec(spec *fleet.BundleSpec) error {
+	for _, check := range validation.BundleDeploymentOptionChecks {
+		if err := validation.ForEachBundleSpecOptions("spec.", spec, check); err != nil {
+			return err
 		}
 	}
 

--- a/internal/cmd/controller/helmops/reconciler/helmop_controller_test.go
+++ b/internal/cmd/controller/helmops/reconciler/helmop_controller_test.go
@@ -253,6 +253,137 @@ func TestReconcile_Validate(t *testing.T) {
 			},
 			err: "non-tarball chart with an empty repo field",
 		},
+		{
+			// A HelmOp reaches the same diff.comparePatches a fleet.yaml does, but
+			// never goes through bundlereader.validateFleetYAML, so these two cases
+			// pin that the shared rules run here too.
+			name: "error if a comparePatch name is not a valid regular expression",
+			helmop: fleet.HelmOp{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "helmop",
+					Namespace: "default",
+				},
+				Spec: fleet.HelmOpSpec{
+					BundleSpec: fleet.BundleSpec{
+						BundleDeploymentOptions: fleet.BundleDeploymentOptions{
+							Helm: &fleet.HelmOptions{
+								Chart: "chart",
+								Repo:  "https://foo.bar",
+							},
+							Diff: &fleet.DiffOptions{
+								ComparePatches: []fleet.ComparePatch{
+									{Name: "foo["},
+								},
+							},
+						},
+					},
+				},
+			},
+			err: `spec.diff.comparePatches[0].name: invalid regular expression "foo["`,
+		},
+		{
+			name: "error if a comparePatch operation is not supported",
+			helmop: fleet.HelmOp{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "helmop",
+					Namespace: "default",
+				},
+				Spec: fleet.HelmOpSpec{
+					BundleSpec: fleet.BundleSpec{
+						BundleDeploymentOptions: fleet.BundleDeploymentOptions{
+							Helm: &fleet.HelmOptions{
+								Chart: "chart",
+								Repo:  "https://foo.bar",
+							},
+						},
+						Targets: []fleet.BundleTarget{
+							{
+								Name: "dev",
+								BundleDeploymentOptions: fleet.BundleDeploymentOptions{
+									Diff: &fleet.DiffOptions{
+										ComparePatches: []fleet.ComparePatch{
+											{
+												Name: "my-svc",
+												Operations: []fleet.Operation{
+													{Op: "remove", Path: "/spec/clusterIP"},
+													{Op: "ignroe"},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			err: `spec.targets[0].diff.comparePatches[0].operations[1].op: unsupported operation "ignroe"`,
+		},
+		{
+			name: "error if a comparePatch operation path is not a JSON pointer",
+			helmop: fleet.HelmOp{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "helmop",
+					Namespace: "default",
+				},
+				Spec: fleet.HelmOpSpec{
+					BundleSpec: fleet.BundleSpec{
+						BundleDeploymentOptions: fleet.BundleDeploymentOptions{
+							Helm: &fleet.HelmOptions{
+								Chart: "chart",
+								Repo:  "https://foo.bar",
+							},
+							Diff: &fleet.DiffOptions{
+								ComparePatches: []fleet.ComparePatch{
+									{
+										Name: "my-svc",
+										Operations: []fleet.Operation{
+											{Op: "remove", Path: "spec.clusterIP"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			err: `spec.diff.comparePatches[0].operations[0].path: invalid JSON pointer "spec.clusterIP"`,
+		},
+		{
+			name: "error if a comparePatch jsonPointer is not a JSON pointer",
+			helmop: fleet.HelmOp{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "helmop",
+					Namespace: "default",
+				},
+				Spec: fleet.HelmOpSpec{
+					BundleSpec: fleet.BundleSpec{
+						BundleDeploymentOptions: fleet.BundleDeploymentOptions{
+							Helm: &fleet.HelmOptions{
+								Chart: "chart",
+								Repo:  "https://foo.bar",
+							},
+						},
+						Targets: []fleet.BundleTarget{
+							{
+								Name: "dev",
+								BundleDeploymentOptions: fleet.BundleDeploymentOptions{
+									Diff: &fleet.DiffOptions{
+										ComparePatches: []fleet.ComparePatch{
+											{
+												Name:         "my-svc",
+												JsonPointers: []string{"spec.replicas"},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			err: `spec.targets[0].diff.comparePatches[0].jsonPointers[0]: invalid JSON pointer "spec.replicas"`,
+		},
 	}
 
 	for _, c := range cases {
@@ -1353,4 +1484,199 @@ func expectCABundleLookup(client *mocks.MockK8sClient) {
 	).AnyTimes().DoAndReturn(func(_ context.Context, _ types.NamespacedName, _ *corev1.Secret, _ ...any) error {
 		return k8serrors.NewNotFound(schema.GroupResource{}, "tls-ca-additional")
 	})
+}
+
+// TestValidateBundleSpec covers the rules a HelmOp shares with fleet.yaml through
+// its embedded BundleSpec. A HelmOp never passes through
+// bundlereader.validateFleetYAML, so without these the values would only fail on
+// the agent, where the failure is logged and swallowed.
+func TestValidateBundleSpec(t *testing.T) {
+	diffWith := func(patches ...fleet.ComparePatch) fleet.BundleDeploymentOptions {
+		return fleet.BundleDeploymentOptions{
+			Diff: &fleet.DiffOptions{ComparePatches: patches},
+		}
+	}
+
+	cases := []struct {
+		name string
+		spec fleet.BundleSpec
+		err  string
+	}{
+		{
+			name: "no diff options at all",
+			spec: fleet.BundleSpec{},
+		},
+		{
+			name: "valid name and operations",
+			spec: fleet.BundleSpec{
+				BundleDeploymentOptions: diffWith(fleet.ComparePatch{
+					Name: ".*serv.*",
+					Operations: []fleet.Operation{
+						{Op: "remove", Path: "/spec/clusterIP"},
+						{Op: "ignore"},
+					},
+				}),
+			},
+		},
+		{
+			name: "valid options on a target",
+			spec: fleet.BundleSpec{
+				Targets: []fleet.BundleTarget{
+					{Name: "dev", BundleDeploymentOptions: diffWith(fleet.ComparePatch{Name: "my-svc"})},
+				},
+			},
+		},
+		{
+			name: "invalid name at the spec level",
+			spec: fleet.BundleSpec{
+				BundleDeploymentOptions: diffWith(fleet.ComparePatch{Name: "a(b"}),
+			},
+			err: `spec.diff.comparePatches[0].name: invalid regular expression "a(b"`,
+		},
+		{
+			name: "invalid operation at the spec level",
+			spec: fleet.BundleSpec{
+				BundleDeploymentOptions: diffWith(fleet.ComparePatch{
+					Name:       "my-svc",
+					Operations: []fleet.Operation{{Op: "ignroe"}},
+				}),
+			},
+			err: `spec.diff.comparePatches[0].operations[0].op: unsupported operation "ignroe", valid values are: add, ignore, remove, replace, test`,
+		},
+		{
+			// The second target, so a walk which only looked at the first would
+			// still be caught.
+			name: "invalid name on the second target",
+			spec: fleet.BundleSpec{
+				Targets: []fleet.BundleTarget{
+					{Name: "first"},
+					{Name: "second", BundleDeploymentOptions: diffWith(fleet.ComparePatch{Name: "*x"})},
+				},
+			},
+			err: `spec.targets[1].diff.comparePatches[0].name: invalid regular expression "*x"`,
+		},
+		{
+			name: "invalid operation on a target",
+			spec: fleet.BundleSpec{
+				Targets: []fleet.BundleTarget{
+					{
+						Name: "dev",
+						BundleDeploymentOptions: diffWith(fleet.ComparePatch{
+							Name:       "my-svc",
+							Operations: []fleet.Operation{{Op: "copy", Path: "/spec/foo"}},
+						}),
+					},
+				},
+			},
+			err: `spec.targets[0].diff.comparePatches[0].operations[0].op: unsupported operation "copy"`,
+		},
+		{
+			name: "an operation without an op",
+			spec: fleet.BundleSpec{
+				BundleDeploymentOptions: diffWith(fleet.ComparePatch{
+					Name:       "my-svc",
+					Operations: []fleet.Operation{{Path: "/spec/clusterIP"}},
+				}),
+			},
+			err: `spec.diff.comparePatches[0].operations[0].op: unsupported operation ""`,
+		},
+		{
+			name: "valid jsonPointers and operation paths",
+			spec: fleet.BundleSpec{
+				BundleDeploymentOptions: diffWith(fleet.ComparePatch{
+					Name:         "my-svc",
+					JsonPointers: []string{"/spec/clusterIP", "/spec/a~0b"},
+					Operations: []fleet.Operation{
+						{Op: "remove", Path: "/spec/externalIPs/0"},
+						{Op: "ignore", Path: "ignored, and never read"},
+					},
+				}),
+			},
+		},
+		{
+			name: "operation path which is not a JSON pointer",
+			spec: fleet.BundleSpec{
+				BundleDeploymentOptions: diffWith(fleet.ComparePatch{
+					Name:       "my-svc",
+					Operations: []fleet.Operation{{Op: "remove", Path: "spec.clusterIP"}},
+				}),
+			},
+			err: `spec.diff.comparePatches[0].operations[0].path: invalid JSON pointer "spec.clusterIP": must start with "/", e.g. "/spec/clusterIP"`,
+		},
+		{
+			name: "operation without a path",
+			spec: fleet.BundleSpec{
+				BundleDeploymentOptions: diffWith(fleet.ComparePatch{
+					Name:       "my-svc",
+					Operations: []fleet.Operation{{Op: "remove"}},
+				}),
+			},
+			err: `spec.diff.comparePatches[0].operations[0].path: invalid JSON pointer "": must not be empty`,
+		},
+		{
+			// The second target, so a walk which only looked at the first would
+			// still be caught.
+			name: "operation path on the second target",
+			spec: fleet.BundleSpec{
+				Targets: []fleet.BundleTarget{
+					{Name: "first"},
+					{
+						Name: "second",
+						BundleDeploymentOptions: diffWith(fleet.ComparePatch{
+							Name:       "my-svc",
+							Operations: []fleet.Operation{{Op: "remove", Path: "spec.clusterIP"}},
+						}),
+					},
+				},
+			},
+			err: `spec.targets[1].diff.comparePatches[0].operations[0].path: invalid JSON pointer "spec.clusterIP"`,
+		},
+		{
+			name: "jsonPointer which is not a JSON pointer",
+			spec: fleet.BundleSpec{
+				BundleDeploymentOptions: diffWith(fleet.ComparePatch{
+					Name:         "my-svc",
+					JsonPointers: []string{"/spec/ok", "spec.clusterIP"},
+				}),
+			},
+			err: `spec.diff.comparePatches[0].jsonPointers[1]: invalid JSON pointer "spec.clusterIP"`,
+		},
+		{
+			name: "jsonPointer on the second target",
+			spec: fleet.BundleSpec{
+				Targets: []fleet.BundleTarget{
+					{Name: "first"},
+					{
+						Name: "second",
+						BundleDeploymentOptions: diffWith(fleet.ComparePatch{
+							Name:         "my-svc",
+							JsonPointers: []string{""},
+						}),
+					},
+				},
+			},
+			err: `spec.targets[1].diff.comparePatches[0].jsonPointers[0]: invalid JSON pointer "": must not be empty`,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := validateBundleSpec(&c.spec)
+
+			if c.err == "" {
+				if err != nil {
+					t.Errorf("validateBundleSpec() unexpected error: %v", err)
+				}
+				return
+			}
+
+			if err == nil {
+				t.Errorf("validateBundleSpec() expected error containing %q, got nil", c.err)
+				return
+			}
+			if !strings.Contains(err.Error(), c.err) {
+				t.Errorf("validateBundleSpec() error = %q, expected to contain %q", err.Error(), c.err)
+			}
+		})
+	}
 }

--- a/internal/cmd/controller/helmops/reconciler/helmop_controller_test.go
+++ b/internal/cmd/controller/helmops/reconciler/helmop_controller_test.go
@@ -1489,7 +1489,7 @@ func expectCABundleLookup(client *mocks.MockK8sClient) {
 // TestValidateBundleSpec covers the rules a HelmOp shares with fleet.yaml through
 // its embedded BundleSpec. A HelmOp never passes through
 // bundlereader.validateFleetYAML, so without these the values would only fail on
-// the agent, where the failure is logged and swallowed.
+// the agent, where the failure is logged and not surfaced to the user.
 func TestValidateBundleSpec(t *testing.T) {
 	diffWith := func(patches ...fleet.ComparePatch) fleet.BundleDeploymentOptions {
 		return fleet.BundleDeploymentOptions{

--- a/internal/cmd/controller/helmops/reconciler/helmop_controller_test.go
+++ b/internal/cmd/controller/helmops/reconciler/helmop_controller_test.go
@@ -306,7 +306,7 @@ func TestReconcile_Validate(t *testing.T) {
 												Name: "my-svc",
 												Operations: []fleet.Operation{
 													{Op: "remove", Path: "/spec/clusterIP"},
-													{Op: "ignroe"},
+													{Op: "bogus"},
 												},
 											},
 										},
@@ -317,7 +317,7 @@ func TestReconcile_Validate(t *testing.T) {
 					},
 				},
 			},
-			err: `spec.targets[0].diff.comparePatches[0].operations[1].op: unsupported operation "ignroe"`,
+			err: `spec.targets[0].diff.comparePatches[0].operations[1].op: unsupported operation "bogus"`,
 		},
 		{
 			name: "error if a comparePatch operation path is not a JSON pointer",
@@ -1538,10 +1538,10 @@ func TestValidateBundleSpec(t *testing.T) {
 			spec: fleet.BundleSpec{
 				BundleDeploymentOptions: diffWith(fleet.ComparePatch{
 					Name:       "my-svc",
-					Operations: []fleet.Operation{{Op: "ignroe"}},
+					Operations: []fleet.Operation{{Op: "bogus"}},
 				}),
 			},
-			err: `spec.diff.comparePatches[0].operations[0].op: unsupported operation "ignroe", valid values are: add, ignore, remove, replace, test`,
+			err: `spec.diff.comparePatches[0].operations[0].op: unsupported operation "bogus", valid values are: add, ignore, remove, replace, test`,
 		},
 		{
 			// The second target, so a walk which only looked at the first would

--- a/internal/validation/comparepatches.go
+++ b/internal/validation/comparepatches.go
@@ -53,7 +53,7 @@ var BundleDeploymentOptionChecks = []func(path string, opts *fleet.BundleDeploym
 // ValidateComparePatchNames checks that every diff.comparePatches[].name in opts compiles
 // as a regular expression. The agent matches a patch by exact name first and falls
 // back to matching the name as a regex, so a name which does not compile is dead
-// config: it is dropped by the agent instead of being reported to the user.
+// config: without this validation, it would fail to compile on the agent and have no effect.
 func ValidateComparePatchNames(path string, opts *fleet.BundleDeploymentOptions) error {
 	if opts.Diff == nil {
 		return nil

--- a/internal/validation/comparepatches.go
+++ b/internal/validation/comparepatches.go
@@ -1,0 +1,247 @@
+package validation
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+
+	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
+)
+
+// ForEachBundleSpecOptions calls fn for every BundleDeploymentOptions reachable
+// from a BundleSpec — the spec's own options and those of each target — with the
+// field path prefix which identifies it to the user, below the given prefix.
+//
+// BundleSpec is what fleet.yaml and a HelmOp have in common, so a rule walked
+// with this function is checked identically on both. Note that
+// TargetCustomizations are *not* part of BundleSpec: a fleet.yaml has that third
+// site and has to walk it itself (see bundlereader.forEachOptions).
+func ForEachBundleSpecOptions(
+	prefix string,
+	spec *fleet.BundleSpec,
+	fn func(path string, opts *fleet.BundleDeploymentOptions) error,
+) error {
+	if err := fn(prefix, &spec.BundleDeploymentOptions); err != nil {
+		return err
+	}
+
+	for i := range spec.Targets {
+		if err := fn(fmt.Sprintf("%stargets[%d].", prefix, i), &spec.Targets[i].BundleDeploymentOptions); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// BundleDeploymentOptionChecks are the rules which apply to a
+// BundleDeploymentOptions whichever entry point it was written at. Both
+// bundlereader.validateFleetYAML and the HelmOp reconciler's validateBundleSpec
+// range over this one list, so a rule added here cannot end up enforced on
+// fleet.yaml but not on a HelmOp, or the other way round.
+//
+// Each entry takes the field path prefix identifying the options to the user, so
+// the caller decides how paths are reported (see ForEachBundleSpecOptions).
+var BundleDeploymentOptionChecks = []func(path string, opts *fleet.BundleDeploymentOptions) error{
+	ValidateComparePatchNames,
+	ValidateComparePatchOperations,
+	ValidateComparePatchOperationPaths,
+	ValidateComparePatchJSONPointers,
+}
+
+// ValidateComparePatchNames checks that every diff.comparePatches[].name in opts compiles
+// as a regular expression. The agent matches a patch by exact name first and falls
+// back to matching the name as a regex, so a name which does not compile is dead
+// config: it is dropped by the agent instead of being reported to the user.
+func ValidateComparePatchNames(path string, opts *fleet.BundleDeploymentOptions) error {
+	if opts.Diff == nil {
+		return nil
+	}
+
+	for i, patch := range opts.Diff.ComparePatches {
+		// An empty name means "match every name" (see desiredset.diff).
+		if patch.Name == "" {
+			continue
+		}
+
+		if _, err := regexp.Compile(patch.Name); err != nil {
+			return fmt.Errorf(
+				"%sdiff.comparePatches[%d].name: invalid regular expression %q: %w",
+				path, i, patch.Name, err,
+			)
+		}
+	}
+
+	return nil
+}
+
+// ValidateComparePatchOperations checks that every diff.comparePatches[].operations[].op
+// in opts names an operation Fleet can apply. Anything else is dead config: the
+// agent marshals the operation into a JSON patch which json-patch then refuses to
+// apply, and that failure is only logged, so the patch does nothing. An empty op
+// is rejected too; it fails in exactly the same way rather than being the no-op it
+// looks like.
+func ValidateComparePatchOperations(path string, opts *fleet.BundleDeploymentOptions) error {
+	if opts.Diff == nil {
+		return nil
+	}
+
+	for i, patch := range opts.Diff.ComparePatches {
+		for j, op := range patch.Operations {
+			if IsSupportedPatchOp(op.Op) {
+				continue
+			}
+
+			return fmt.Errorf(
+				"%sdiff.comparePatches[%d].operations[%d].op: %w",
+				path, i, j, UnsupportedPatchOpError(op.Op),
+			)
+		}
+	}
+
+	return nil
+}
+
+// ValidateComparePatchOperationPaths checks that every diff.comparePatches[].operations[].path
+// in opts is a JSON pointer the agent can address. Anything else is dead config, in one
+// of two ways: usually the agent marshals the operation into a JSON patch whose path
+// json-patch fails to resolve, and because that failure only reaches a log line the
+// patch silently does nothing — taking the other operations held for the same resource
+// with it. Occasionally it is worse than that, because json-patch resolves the path to
+// something the user did not write: see IsJSONPointer for the two-segment case.
+//
+// An "ignore" operation is skipped: it removes the whole resource from the diff and
+// its path is never read (see desiredset.Diff).
+func ValidateComparePatchOperationPaths(path string, opts *fleet.BundleDeploymentOptions) error {
+	if opts.Diff == nil {
+		return nil
+	}
+
+	for i, patch := range opts.Diff.ComparePatches {
+		for j, op := range patch.Operations {
+			if op.Op == fleet.IgnoreOp {
+				continue
+			}
+
+			if err := checkJSONPointer(op.Path); err != nil {
+				return fmt.Errorf(
+					"%sdiff.comparePatches[%d].operations[%d].path: %w",
+					path, i, j, err,
+				)
+			}
+		}
+	}
+
+	return nil
+}
+
+// ValidateComparePatchJSONPointers checks that every entry of every
+// diff.comparePatches[].jsonPointers in opts is a JSON pointer the agent can
+// address. A malformed entry is dead config, and the most invisible kind Fleet
+// has: the ignore normalizer logs the failure at V(1) info level, which is
+// filtered out at the agent's default verbosity, so nothing is reported at all
+// and the field the user asked to ignore keeps showing up as drift. An entry
+// which json-patch does resolve, but not to what the user wrote, reports nothing
+// either and ignores the wrong field: see IsJSONPointer for the two-segment case.
+func ValidateComparePatchJSONPointers(path string, opts *fleet.BundleDeploymentOptions) error {
+	if opts.Diff == nil {
+		return nil
+	}
+
+	for i, patch := range opts.Diff.ComparePatches {
+		for j, pointer := range patch.JsonPointers {
+			if err := checkJSONPointer(pointer); err != nil {
+				return fmt.Errorf(
+					"%sdiff.comparePatches[%d].jsonPointers[%d]: %w",
+					path, i, j, err,
+				)
+			}
+		}
+	}
+
+	return nil
+}
+
+// IsJSONPointer reports whether value can be used as a JSON pointer by a diff
+// comparePatch — as an operation path or as a jsonPointers entry, which end up in
+// the same json-patch call. A pointer has to be non-empty and start with "/".
+//
+// The rule is deliberately only what json-patch cannot resolve to what the user
+// wrote. It is not a full RFC 6901 check, because json-patch is laxer than the RFC
+// in a way real configurations depend on — it rewrites "~0" and "~1" and leaves any
+// other "~" sequence alone, so "/spec/a~2b" legitimately addresses a key named
+// "a~2b" and must keep working.
+//
+// The missing leading slash is not merely a pointer which fails to resolve. Whether
+// it fails depends on how many segments it has, because json-patch splits the path
+// on "/" and then walks split[1:len(split)-1]: "spec.replicas" has one segment and
+// addresses nothing, but "metadata/kind" has two, leaves nothing to walk, and so
+// addresses the key "kind" at the *root* of the document — a patch on it really does
+// rewrite the resource's kind, silently and nowhere near where the user aimed it.
+//
+// The empty pointer is rejected even though RFC 6901 gives it a meaning (the whole
+// document): Operation.Path is marshalled with omitempty, so an empty path reaches
+// json-patch as a missing "path" field and always fails with "operation missing
+// path field".
+func IsJSONPointer(value string) bool {
+	return strings.HasPrefix(value, "/")
+}
+
+// InvalidJSONPointerError returns the error reported for a diff comparePatch
+// pointer IsJSONPointer rejects. It lives here so that the validator and the
+// agent, which both have to explain the same rejection, cannot word it
+// differently.
+func InvalidJSONPointerError(value string) error {
+	if value == "" {
+		return errors.New(`invalid JSON pointer "": must not be empty, e.g. "/spec/replicas"`)
+	}
+
+	// A Kubernetes-style field path is the common mistake, so the hint spells out
+	// the pointer the user probably meant — where that can be done without
+	// inventing one, and the fixed hint otherwise.
+	hint := "/spec/replicas"
+	if converted, ok := dottedFieldPathHint(value); ok {
+		hint = converted
+	}
+
+	return fmt.Errorf("invalid JSON pointer %q: must start with %q, e.g. %q", value, "/", hint)
+}
+
+// dottedFieldPathHint converts a Kubernetes-style field path such as
+// "spec.replicas" into the JSON pointer it was probably meant to be, reporting
+// false where converting the dots would produce something wrong or misleading.
+//
+// A wrong hint is worse here than no hint: this message is written to be copied,
+// and a value copied out of it that Fleet then accepts but the agent cannot use
+// recreates the silent failure the check exists to prevent.
+func dottedFieldPathHint(value string) (string, bool) {
+	// A "/" or a "~" means at least one dot belongs to a key rather than being a
+	// separator: "metadata.annotations.deployment.kubernetes.io/revision" is a
+	// single annotation, whose pointer is
+	// "/metadata/annotations/deployment.kubernetes.io~1revision", not one segment
+	// per dot.
+	if strings.ContainsAny(value, "/~") {
+		return "", false
+	}
+
+	// A leading, trailing or doubled dot converts to an empty segment, which is
+	// how a hint ends up worse than useless: ".spec.replicas" would suggest
+	// "//spec/replicas", and that *passes* IsJSONPointer, so a user who copies it
+	// gets a value fleet apply accepts and the agent then fails on silently.
+	if strings.HasPrefix(value, ".") || strings.HasSuffix(value, ".") || strings.Contains(value, "..") {
+		return "", false
+	}
+
+	return "/" + strings.ReplaceAll(value, ".", "/"), true
+}
+
+// checkJSONPointer reports why value cannot be used as a JSON pointer, or nil if
+// it can.
+func checkJSONPointer(value string) error {
+	if IsJSONPointer(value) {
+		return nil
+	}
+
+	return InvalidJSONPointerError(value)
+}

--- a/internal/validation/comparepatches_test.go
+++ b/internal/validation/comparepatches_test.go
@@ -1,6 +1,7 @@
 package validation
 
 import (
+	"strings"
 	"testing"
 
 	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
@@ -103,9 +104,148 @@ func TestInvalidJSONPointerError(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			if got := InvalidJSONPointerError(c.value).Error(); got != c.want {
-				t.Errorf("InvalidJSONPointerError(%q) = %q, want %q", c.value, got, c.want)
-			}
+			assertErrorExact(t, InvalidJSONPointerError(c.value), c.want)
+		})
+	}
+}
+
+func TestComparePatchNames(t *testing.T) {
+	cases := []struct {
+		name string
+		path string
+		opts *fleet.BundleDeploymentOptions
+		want string // empty means no error
+	}{
+		{
+			name: "no diff options",
+			opts: &fleet.BundleDeploymentOptions{},
+		},
+		{
+			name: "no compare patches",
+			opts: &fleet.BundleDeploymentOptions{Diff: &fleet.DiffOptions{}},
+		},
+		{
+			name: "valid regex names",
+			opts: withPatches(
+				fleet.ComparePatch{Name: "my-service"},
+				fleet.ComparePatch{Name: ".*-svc$"},
+				fleet.ComparePatch{Name: "prefix-.*"},
+			),
+		},
+		{
+			name: "empty name matches everything",
+			opts: withPatches(fleet.ComparePatch{Name: ""}),
+		},
+		{
+			name: "invalid regex - unclosed bracket",
+			opts: withPatches(fleet.ComparePatch{Name: "foo["}),
+			want: `diff.comparePatches[0].name: invalid regular expression "foo["`,
+		},
+		{
+			name: "invalid regex - unclosed paren",
+			opts: withPatches(fleet.ComparePatch{Name: "a(b"}),
+			want: `diff.comparePatches[0].name: invalid regular expression "a(b"`,
+		},
+		{
+			name: "invalid regex - invalid repetition",
+			opts: withPatches(fleet.ComparePatch{Name: "*x"}),
+			want: `diff.comparePatches[0].name: invalid regular expression "*x"`,
+		},
+		{
+			name: "indices identify the offending patch",
+			path: "targets[1].",
+			opts: withPatches(
+				fleet.ComparePatch{Name: "valid"},
+				fleet.ComparePatch{Name: "also-valid"},
+				fleet.ComparePatch{Name: "(?P<invalid)"},
+			),
+			want: `targets[1].diff.comparePatches[2].name: invalid regular expression "(?P<invalid)"`,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			assertError(t, ValidateComparePatchNames(c.path, c.opts), c.want)
+		})
+	}
+}
+
+func TestComparePatchOperations(t *testing.T) {
+	cases := []struct {
+		name string
+		path string
+		opts *fleet.BundleDeploymentOptions
+		want string // empty means no error
+	}{
+		{
+			name: "no diff options",
+			opts: &fleet.BundleDeploymentOptions{},
+		},
+		{
+			name: "no compare patches",
+			opts: &fleet.BundleDeploymentOptions{Diff: &fleet.DiffOptions{}},
+		},
+		{
+			name: "valid operations",
+			opts: withPatches(fleet.ComparePatch{
+				Operations: []fleet.Operation{
+					{Op: "add", Path: "/spec/foo", Value: "bar"},
+					{Op: "remove", Path: "/spec/clusterIP"},
+					{Op: "replace", Path: "/spec/type", Value: "NodePort"},
+					{Op: "test", Path: "/spec/replicas", Value: "3"},
+					{Op: fleet.IgnoreOp},
+				},
+			}),
+		},
+		{
+			name: "empty op is rejected",
+			opts: withPatches(fleet.ComparePatch{
+				Operations: []fleet.Operation{{Op: "", Path: "/spec/replicas"}},
+			}),
+			want: `diff.comparePatches[0].operations[0].op: unsupported operation ""`,
+		},
+		{
+			name: "copy operation is not supported",
+			opts: withPatches(fleet.ComparePatch{
+				Operations: []fleet.Operation{{Op: "copy", Path: "/spec/foo"}},
+			}),
+			want: `diff.comparePatches[0].operations[0].op: unsupported operation "copy"`,
+		},
+		{
+			name: "move operation is not supported",
+			opts: withPatches(fleet.ComparePatch{
+				Operations: []fleet.Operation{{Op: "move", Path: "/spec/foo"}},
+			}),
+			want: `diff.comparePatches[0].operations[0].op: unsupported operation "move"`,
+		},
+		{
+			name: "bogus operation",
+			opts: withPatches(fleet.ComparePatch{
+				Operations: []fleet.Operation{{Op: "bogus", Path: "/spec/foo"}},
+			}),
+			want: `diff.comparePatches[0].operations[0].op: unsupported operation "bogus"`,
+		},
+		{
+			name: "indices identify the offending operation",
+			path: "targetCustomizations[0].",
+			opts: withPatches(
+				fleet.ComparePatch{
+					Operations: []fleet.Operation{{Op: "remove", Path: "/spec/ok"}},
+				},
+				fleet.ComparePatch{
+					Operations: []fleet.Operation{
+						{Op: "remove", Path: "/spec/clusterIP"},
+						{Op: "invalid"},
+					},
+				},
+			),
+			want: `targetCustomizations[0].diff.comparePatches[1].operations[1].op: unsupported operation "invalid"`,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			assertError(t, ValidateComparePatchOperations(c.path, c.opts), c.want)
 		})
 	}
 }
@@ -263,6 +403,19 @@ func withPatches(patches ...fleet.ComparePatch) *fleet.BundleDeploymentOptions {
 }
 
 func assertError(t *testing.T, err error, want string) {
+	t.Helper()
+
+	switch {
+	case want == "" && err != nil:
+		t.Errorf("unexpected error: %v", err)
+	case want != "" && err == nil:
+		t.Errorf("expected error containing %q, got none", want)
+	case want != "" && !strings.Contains(err.Error(), want):
+		t.Errorf("error = %q, want to contain %q", err.Error(), want)
+	}
+}
+
+func assertErrorExact(t *testing.T, err error, want string) {
 	t.Helper()
 
 	switch {

--- a/internal/validation/comparepatches_test.go
+++ b/internal/validation/comparepatches_test.go
@@ -1,0 +1,276 @@
+package validation
+
+import (
+	"testing"
+
+	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
+)
+
+func TestIsJSONPointer(t *testing.T) {
+	cases := []struct {
+		value string
+		want  bool
+	}{
+		{value: "/spec/replicas", want: true},
+		{value: "/status", want: true},
+		{value: "/", want: true}, // addresses the key "" — odd, but json-patch resolves it
+		{value: "/metadata/annotations/deployment.kubernetes.io~1revision", want: true},
+		{value: "/spec/a~0b", want: true},
+		// json-patch leaves any "~" sequence other than "~0" and "~1" literal, so
+		// these address keys really named "a~2b" and "trailing~". A stricter RFC 6901
+		// check would reject them and break configurations which work today.
+		{value: "/spec/a~2b", want: true},
+		{value: "/spec/trailing~", want: true},
+
+		{value: "", want: false},
+		{value: "spec", want: false},
+		{value: "spec.replicas", want: false},
+		{value: "metadata/kind", want: false},
+		{value: " /spec/replicas", want: false},
+	}
+
+	for _, c := range cases {
+		t.Run(c.value, func(t *testing.T) {
+			if got := IsJSONPointer(c.value); got != c.want {
+				t.Errorf("IsJSONPointer(%q) = %v, want %v", c.value, got, c.want)
+			}
+		})
+	}
+}
+
+func TestInvalidJSONPointerError(t *testing.T) {
+	cases := []struct {
+		name  string
+		value string
+		want  string
+	}{
+		{
+			name:  "empty",
+			value: "",
+			want:  `invalid JSON pointer "": must not be empty, e.g. "/spec/replicas"`,
+		},
+		{
+			name:  "kubernetes field path",
+			value: "spec.replicas",
+			want:  `invalid JSON pointer "spec.replicas": must start with "/", e.g. "/spec/replicas"`,
+		},
+		{
+			name:  "single segment",
+			value: "spec",
+			want:  `invalid JSON pointer "spec": must start with "/", e.g. "/spec"`,
+		},
+		{
+			// The hint may only convert dots where doing so really produces the
+			// pointer the user meant. Here it does not: the key is one annotation
+			// name, so the pointer is
+			// "/metadata/annotations/deployment.kubernetes.io~1revision" and a hint of
+			// "/metadata/annotations/deployment/kubernetes/io/revision" would be wrong
+			// in a message whose entire purpose is to be copied.
+			name:  "key containing a slash and dots",
+			value: "metadata.annotations.deployment.kubernetes.io/revision",
+			want:  `invalid JSON pointer "metadata.annotations.deployment.kubernetes.io/revision": must start with "/", e.g. "/spec/replicas"`,
+		},
+		{
+			name:  "key containing a tilde",
+			value: "spec.a~2b",
+			want:  `invalid JSON pointer "spec.a~2b": must start with "/", e.g. "/spec/replicas"`,
+		},
+		{
+			// A leading dot would convert to an empty first segment, giving the hint
+			// "//spec/replicas" — which IsJSONPointer accepts, so a user copying it
+			// would get a value fleet apply lets through and the agent then fails on
+			// silently. The fixed hint is the only safe answer.
+			name:  "leading dot",
+			value: ".spec.replicas",
+			want:  `invalid JSON pointer ".spec.replicas": must start with "/", e.g. "/spec/replicas"`,
+		},
+		{
+			name:  "trailing dot",
+			value: "spec.replicas.",
+			want:  `invalid JSON pointer "spec.replicas.": must start with "/", e.g. "/spec/replicas"`,
+		},
+		{
+			name:  "doubled dot",
+			value: "spec..replicas",
+			want:  `invalid JSON pointer "spec..replicas": must start with "/", e.g. "/spec/replicas"`,
+		},
+		{
+			name:  "two segments addressing the document root",
+			value: "metadata/kind",
+			want:  `invalid JSON pointer "metadata/kind": must start with "/", e.g. "/spec/replicas"`,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := InvalidJSONPointerError(c.value).Error(); got != c.want {
+				t.Errorf("InvalidJSONPointerError(%q) = %q, want %q", c.value, got, c.want)
+			}
+		})
+	}
+}
+
+func TestComparePatchOperationPaths(t *testing.T) {
+	cases := []struct {
+		name string
+		path string
+		opts *fleet.BundleDeploymentOptions
+		want string // empty means no error
+	}{
+		{
+			name: "no diff options",
+			opts: &fleet.BundleDeploymentOptions{},
+		},
+		{
+			name: "no compare patches",
+			opts: &fleet.BundleDeploymentOptions{Diff: &fleet.DiffOptions{}},
+		},
+		{
+			name: "valid paths",
+			opts: withPatches(fleet.ComparePatch{
+				Operations: []fleet.Operation{
+					{Op: "remove", Path: "/spec/clusterIP"},
+					{Op: "replace", Path: "/spec/a~2b", Value: "x"},
+				},
+			}),
+		},
+		{
+			// An "ignore" operation drops the whole resource from the diff and its
+			// path is never read, so whatever is in it cannot break anything.
+			name: "ignore operation with an unusable path",
+			opts: withPatches(fleet.ComparePatch{
+				Operations: []fleet.Operation{
+					{Op: fleet.IgnoreOp, Path: "spec.replicas"},
+					{Op: fleet.IgnoreOp},
+				},
+			}),
+		},
+		{
+			name: "kubernetes field path",
+			opts: withPatches(fleet.ComparePatch{
+				Operations: []fleet.Operation{{Op: "remove", Path: "spec.replicas"}},
+			}),
+			want: `diff.comparePatches[0].operations[0].path: invalid JSON pointer "spec.replicas": must start with "/", e.g. "/spec/replicas"`,
+		},
+		{
+			name: "empty path",
+			opts: withPatches(fleet.ComparePatch{
+				Operations: []fleet.Operation{{Op: "remove"}},
+			}),
+			want: `diff.comparePatches[0].operations[0].path: invalid JSON pointer "": must not be empty, e.g. "/spec/replicas"`,
+		},
+		{
+			// Two segments without a leading slash resolve, but to the root of the
+			// document rather than to what the user wrote, so they are rejected too.
+			name: "two segments addressing the document root",
+			opts: withPatches(fleet.ComparePatch{
+				Operations: []fleet.Operation{{Op: "replace", Path: "metadata/kind", Value: "Pod"}},
+			}),
+			want: `diff.comparePatches[0].operations[0].path: invalid JSON pointer "metadata/kind": must start with "/", e.g. "/spec/replicas"`,
+		},
+		{
+			name: "indices identify the offending operation",
+			path: "targets[2].",
+			opts: withPatches(
+				fleet.ComparePatch{
+					Operations: []fleet.Operation{{Op: "remove", Path: "/spec/clusterIP"}},
+				},
+				fleet.ComparePatch{
+					Operations: []fleet.Operation{
+						{Op: "remove", Path: "/spec/ok"},
+						{Op: "remove", Path: "spec.bad"},
+					},
+				},
+			),
+			want: `targets[2].diff.comparePatches[1].operations[1].path: invalid JSON pointer "spec.bad": must start with "/", e.g. "/spec/bad"`,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			assertError(t, ValidateComparePatchOperationPaths(c.path, c.opts), c.want)
+		})
+	}
+}
+
+func TestComparePatchJSONPointers(t *testing.T) {
+	cases := []struct {
+		name string
+		path string
+		opts *fleet.BundleDeploymentOptions
+		want string // empty means no error
+	}{
+		{
+			name: "no diff options",
+			opts: &fleet.BundleDeploymentOptions{},
+		},
+		{
+			name: "no compare patches",
+			opts: &fleet.BundleDeploymentOptions{Diff: &fleet.DiffOptions{}},
+		},
+		{
+			name: "valid pointers",
+			opts: withPatches(fleet.ComparePatch{
+				JsonPointers: []string{
+					"/spec/replicas",
+					"/metadata/annotations/deployment.kubernetes.io~1revision",
+					"/spec/trailing~",
+				},
+			}),
+		},
+		{
+			// Unlike an operation path, a jsonPointers entry is never skipped: it
+			// does not belong to an operation, so there is no "ignore" to skip it for.
+			name: "checked next to an ignore operation",
+			opts: withPatches(fleet.ComparePatch{
+				Operations:   []fleet.Operation{{Op: fleet.IgnoreOp}},
+				JsonPointers: []string{"spec.replicas"},
+			}),
+			want: `diff.comparePatches[0].jsonPointers[0]: invalid JSON pointer "spec.replicas": must start with "/", e.g. "/spec/replicas"`,
+		},
+		{
+			name: "empty pointer",
+			opts: withPatches(fleet.ComparePatch{JsonPointers: []string{""}}),
+			want: `diff.comparePatches[0].jsonPointers[0]: invalid JSON pointer "": must not be empty, e.g. "/spec/replicas"`,
+		},
+		{
+			name: "two segments addressing the document root",
+			opts: withPatches(fleet.ComparePatch{JsonPointers: []string{"metadata/kind"}}),
+			want: `diff.comparePatches[0].jsonPointers[0]: invalid JSON pointer "metadata/kind": must start with "/", e.g. "/spec/replicas"`,
+		},
+		{
+			name: "indices identify the offending pointer",
+			path: "targetCustomizations[1].",
+			opts: withPatches(
+				fleet.ComparePatch{JsonPointers: []string{"/spec/replicas"}},
+				fleet.ComparePatch{JsonPointers: []string{"/spec/ok", "spec.bad"}},
+			),
+			want: `targetCustomizations[1].diff.comparePatches[1].jsonPointers[1]: invalid JSON pointer "spec.bad": must start with "/", e.g. "/spec/bad"`,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			assertError(t, ValidateComparePatchJSONPointers(c.path, c.opts), c.want)
+		})
+	}
+}
+
+func withPatches(patches ...fleet.ComparePatch) *fleet.BundleDeploymentOptions {
+	return &fleet.BundleDeploymentOptions{
+		Diff: &fleet.DiffOptions{ComparePatches: patches},
+	}
+}
+
+func assertError(t *testing.T, err error, want string) {
+	t.Helper()
+
+	switch {
+	case want == "" && err != nil:
+		t.Errorf("unexpected error: %v", err)
+	case want != "" && err == nil:
+		t.Errorf("expected error %q, got none", want)
+	case want != "" && err.Error() != want:
+		t.Errorf("error = %q, want %q", err.Error(), want)
+	}
+}

--- a/internal/validation/patchop.go
+++ b/internal/validation/patchop.go
@@ -1,0 +1,56 @@
+// Package validation holds the predicates which the fleet.yaml validation run by
+// `fleet apply` and the agent code consuming those values have to agree on. A
+// rule which lives in one place cannot drift apart between the two.
+//
+// It must stay a leaf package: a rule kept here has no fleet-internal
+// dependencies beyond pkg/apis, so both the validator and the agent can import
+// it freely, whatever else either of them already pulls in.
+package validation
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+
+	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
+)
+
+// supportedPatchOps lists the operations a diff.comparePatches operation may
+// use: Fleet's own "ignore", which the agent handles itself, plus the RFC 6902
+// operations which github.com/evanphx/json-patch can apply to what Fleet is able
+// to give it.
+//
+// "copy" and "move" are deliberately absent even though json-patch implements
+// both: fleet.Operation has no "from" field, so a copy or a move can never be
+// encoded in a form json-patch accepts. It always fails with "missing from
+// field", which makes both of them dead config by any route.
+//
+// Kept sorted, because SupportedPatchOps feeds error messages.
+var supportedPatchOps = []string{
+	"add",
+	fleet.IgnoreOp,
+	"remove",
+	"replace",
+	"test",
+}
+
+// IsSupportedPatchOp reports whether op is an operation Fleet can apply as part
+// of a diff comparePatch. The empty string is not one: an operation without an
+// op is not a no-op, it makes the patch fail.
+func IsSupportedPatchOp(op string) bool {
+	return slices.Contains(supportedPatchOps, op)
+}
+
+// SupportedPatchOps returns the operations accepted by IsSupportedPatchOp,
+// sorted, for use in error messages.
+func SupportedPatchOps() []string {
+	return slices.Clone(supportedPatchOps)
+}
+
+// UnsupportedPatchOpError returns the error reported for a diff comparePatch
+// operation IsSupportedPatchOp rejects. It lives here so that the validator and
+// the agent, which both have to explain the same rejection, cannot word it
+// differently or list different operations.
+func UnsupportedPatchOpError(op string) error {
+	return fmt.Errorf("unsupported operation %q, valid values are: %s", op, strings.Join(supportedPatchOps, ", "))
+}

--- a/pkg/apis/fleet.cattle.io/v1alpha1/bundledeployment_types.go
+++ b/pkg/apis/fleet.cattle.io/v1alpha1/bundledeployment_types.go
@@ -169,13 +169,18 @@ type ComparePatch struct {
 	// Kind is the kind of the resource to match.
 	// +nullable
 	Kind string `json:"kind,omitempty"`
-	// Name is the name of the resource to match.
+	// Name is the name of the resource to match. Resources are matched by exact
+	// name first and, when the name does not match exactly, by matching it as a
+	// regular expression, so it must always be a valid Go regular expression.
 	// +nullable
 	Name string `json:"name,omitempty"`
 	// Namespace is the namespace of the resource to match.
 	// +nullable
 	Namespace string `json:"namespace,omitempty"`
-	// JSONPointers ignore diffs at a certain JSON path.
+	// JSONPointers ignore diffs at the given JSON pointers, e.g. /spec/replicas.
+	// Each entry must be a non-empty RFC 6901 pointer starting with a slash; a
+	// Kubernetes-style field path such as spec.replicas addresses nothing and is
+	// rejected.
 	// +nullable
 	JsonPointers []string `json:"jsonPointers,omitempty"`
 	// Operations remove a JSON path from the resource.
@@ -187,10 +192,20 @@ type ComparePatch struct {
 // * "remove" to remove a specific path in a resource
 // * "ignore" to remove the entire resource from checks for modifications.
 type Operation struct {
-	// Op is usually "remove" or "ignore"
+	// Op is the operation to perform on the matched resource. It must be one of
+	// the JSON Patch operations "add", "remove", "replace" and "test", or
+	// Fleet's own "ignore", which removes the entire resource from checks for
+	// modifications. The JSON Patch operations "copy" and "move" are not
+	// supported, because an Operation has no "from" field to encode them with.
+	// Any other value, including an empty one, makes the whole patch fail to
+	// apply.
 	// +nullable
-	Op string `json:"op,omitempty"`
-	// Path is the JSON path to remove. Not needed if Op is "ignore".
+	Op string `json:"op,omitempty" jsonschema:"enum=add,enum=ignore,enum=remove,enum=replace,enum=test"`
+	// Path is the JSON pointer the operation applies to, e.g. /spec/replicas.
+	// It must be a non-empty RFC 6901 pointer starting with a slash; a
+	// Kubernetes-style field path such as spec.replicas addresses nothing and is
+	// rejected. Required unless Op is "ignore", which drops the whole resource
+	// from the comparison and never reads the path.
 	// +nullable
 	Path string `json:"path,omitempty"`
 	// Value is usually empty.

--- a/pkg/apis/fleet.cattle.io/v1alpha1/bundledeployment_types.go
+++ b/pkg/apis/fleet.cattle.io/v1alpha1/bundledeployment_types.go
@@ -181,7 +181,7 @@ type ComparePatch struct {
 	// Each entry must be a non-empty pointer starting with a slash; a
 	// Kubernetes-style field path such as spec.replicas addresses nothing and is
 	// rejected. Escaping is the one the JSON patch library applies, which is
-	// laxer than RFC 6901: "~0" and "~1" are read as "~" and "/", and any other
+	// laxer than RFC 6901: "~0" and "~1" are read as "~" and "/", respectively, and any other
 	// "~" sequence is left as written.
 	// +nullable
 	JsonPointers []string `json:"jsonPointers,omitempty"`

--- a/pkg/apis/fleet.cattle.io/v1alpha1/bundledeployment_types.go
+++ b/pkg/apis/fleet.cattle.io/v1alpha1/bundledeployment_types.go
@@ -178,9 +178,11 @@ type ComparePatch struct {
 	// +nullable
 	Namespace string `json:"namespace,omitempty"`
 	// JSONPointers ignore diffs at the given JSON pointers, e.g. /spec/replicas.
-	// Each entry must be a non-empty RFC 6901 pointer starting with a slash; a
+	// Each entry must be a non-empty pointer starting with a slash; a
 	// Kubernetes-style field path such as spec.replicas addresses nothing and is
-	// rejected.
+	// rejected. Escaping is the one the JSON patch library applies, which is
+	// laxer than RFC 6901: "~0" and "~1" are read as "~" and "/", and any other
+	// "~" sequence is left as written.
 	// +nullable
 	JsonPointers []string `json:"jsonPointers,omitempty"`
 	// Operations remove a JSON path from the resource.
@@ -202,10 +204,11 @@ type Operation struct {
 	// +nullable
 	Op string `json:"op,omitempty" jsonschema:"enum=add,enum=ignore,enum=remove,enum=replace,enum=test"`
 	// Path is the JSON pointer the operation applies to, e.g. /spec/replicas.
-	// It must be a non-empty RFC 6901 pointer starting with a slash; a
-	// Kubernetes-style field path such as spec.replicas addresses nothing and is
-	// rejected. Required unless Op is "ignore", which drops the whole resource
-	// from the comparison and never reads the path.
+	// It must be a non-empty pointer starting with a slash; a Kubernetes-style
+	// field path such as spec.replicas addresses nothing and is rejected. It is
+	// escaped like a JSONPointers entry, which is laxer than RFC 6901. Required
+	// unless Op is "ignore", which drops the whole resource from the comparison
+	// and never reads the path.
 	// +nullable
 	Path string `json:"path,omitempty"`
 	// Value is usually empty.

--- a/schemas/fleet.yaml.json
+++ b/schemas/fleet.yaml.json
@@ -165,7 +165,7 @@
             "type": "string"
           },
           "type": "array",
-          "description": "JSONPointers ignore diffs at the given JSON pointers, e.g. /spec/replicas.\nEach entry must be a non-empty pointer starting with a slash; a\nKubernetes-style field path such as spec.replicas addresses nothing and is\nrejected. Escaping is the one the JSON patch library applies, which is\nlaxer than RFC 6901: \"~0\" and \"~1\" are read as \"~\" and \"/\", and any other\n\"~\" sequence is left as written."
+          "description": "JSONPointers ignore diffs at the given JSON pointers, e.g. /spec/replicas.\nEach entry must be a non-empty pointer starting with a slash; a\nKubernetes-style field path such as spec.replicas addresses nothing and is\nrejected. Escaping is the one the JSON patch library applies, which is\nlaxer than RFC 6901: \"~0\" and \"~1\" are read as \"~\" and \"/\", respectively, and any other\n\"~\" sequence is left as written."
         },
         "operations": {
           "items": {

--- a/schemas/fleet.yaml.json
+++ b/schemas/fleet.yaml.json
@@ -154,7 +154,7 @@
         },
         "name": {
           "type": "string",
-          "description": "Name is the name of the resource to match."
+          "description": "Name is the name of the resource to match. Resources are matched by exact\nname first and, when the name does not match exactly, by matching it as a\nregular expression, so it must always be a valid Go regular expression."
         },
         "namespace": {
           "type": "string",
@@ -165,7 +165,7 @@
             "type": "string"
           },
           "type": "array",
-          "description": "JSONPointers ignore diffs at a certain JSON path."
+          "description": "JSONPointers ignore diffs at the given JSON pointers, e.g. /spec/replicas.\nEach entry must be a non-empty RFC 6901 pointer starting with a slash; a\nKubernetes-style field path such as spec.replicas addresses nothing and is\nrejected."
         },
         "operations": {
           "items": {
@@ -495,11 +495,18 @@
       "properties": {
         "op": {
           "type": "string",
-          "description": "Op is usually \"remove\" or \"ignore\""
+          "enum": [
+            "add",
+            "ignore",
+            "remove",
+            "replace",
+            "test"
+          ],
+          "description": "Op is the operation to perform on the matched resource. It must be one of\nthe JSON Patch operations \"add\", \"remove\", \"replace\" and \"test\", or\nFleet's own \"ignore\", which removes the entire resource from checks for\nmodifications. The JSON Patch operations \"copy\" and \"move\" are not\nsupported, because an Operation has no \"from\" field to encode them with.\nAny other value, including an empty one, makes the whole patch fail to\napply."
         },
         "path": {
           "type": "string",
-          "description": "Path is the JSON path to remove. Not needed if Op is \"ignore\"."
+          "description": "Path is the JSON pointer the operation applies to, e.g. /spec/replicas.\nIt must be a non-empty RFC 6901 pointer starting with a slash; a\nKubernetes-style field path such as spec.replicas addresses nothing and is\nrejected. Required unless Op is \"ignore\", which drops the whole resource\nfrom the comparison and never reads the path."
         },
         "value": {
           "type": "string",

--- a/schemas/fleet.yaml.json
+++ b/schemas/fleet.yaml.json
@@ -165,7 +165,7 @@
             "type": "string"
           },
           "type": "array",
-          "description": "JSONPointers ignore diffs at the given JSON pointers, e.g. /spec/replicas.\nEach entry must be a non-empty RFC 6901 pointer starting with a slash; a\nKubernetes-style field path such as spec.replicas addresses nothing and is\nrejected."
+          "description": "JSONPointers ignore diffs at the given JSON pointers, e.g. /spec/replicas.\nEach entry must be a non-empty pointer starting with a slash; a\nKubernetes-style field path such as spec.replicas addresses nothing and is\nrejected. Escaping is the one the JSON patch library applies, which is\nlaxer than RFC 6901: \"~0\" and \"~1\" are read as \"~\" and \"/\", and any other\n\"~\" sequence is left as written."
         },
         "operations": {
           "items": {
@@ -506,7 +506,7 @@
         },
         "path": {
           "type": "string",
-          "description": "Path is the JSON pointer the operation applies to, e.g. /spec/replicas.\nIt must be a non-empty RFC 6901 pointer starting with a slash; a\nKubernetes-style field path such as spec.replicas addresses nothing and is\nrejected. Required unless Op is \"ignore\", which drops the whole resource\nfrom the comparison and never reads the path."
+          "description": "Path is the JSON pointer the operation applies to, e.g. /spec/replicas.\nIt must be a non-empty pointer starting with a slash; a Kubernetes-style\nfield path such as spec.replicas addresses nothing and is rejected. It is\nescaped like a JSONPointers entry, which is laxer than RFC 6901. Required\nunless Op is \"ignore\", which drops the whole resource from the comparison\nand never reads the path."
         },
         "value": {
           "type": "string",


### PR DESCRIPTION
Bad values in `diff.comparePatches` are currently accepted by `fleet apply` and then discarded on the agent, where the failure is either silent or only visible at `-v=1`. This validates four of them up front, so a typo fails at apply time with the offending path and value.

Validated fields:

- `diff.comparePatches[].name` — must be a valid Go regular expression
- `diff.comparePatches[].operations[].op` — one of `add`, `ignore`, `remove`, `replace`, `test` (`copy`/`move` are unsupported: `Operation` has no `from` field to encode them)
- `diff.comparePatches[].operations[].path` — non-empty JSON pointer starting with `/`; skipped for `ignore`, which never reads the path
- `diff.comparePatches[].jsonPointers` — same rule

Refers to: https://github.com/rancher/fleet/issues/4663

## Additional Information

### Checklist

~- [ ] <!-- If applicable,--> I have updated the documentation via a pull request in the [fleet-product-docs](https://github.com/rancher/fleet-product-docs) repository.~
