### PR TITLE
[v0.16] - Fix Schedule race condition and flaky e2e tests (#5436)

### DIFF
--- a/e2e/single-cluster/agent_scheduling_customization_test.go
+++ b/e2e/single-cluster/agent_scheduling_customization_test.go
@@ -8,30 +8,77 @@ import (
 	. "github.com/onsi/gomega"
 	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
 	schedulingv1 "k8s.io/api/scheduling/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	localAgentNamespace   = "cattle-fleet-local-system"
+	agentPriorityClass    = "fleet-agent-priority-class"
+	agentDisruptionBudget = "fleet-agent-pod-disruption-budget"
 )
 
 func ptr[T any](v T) *T {
 	return new(v)
 }
 
-var _ = Describe("Agent Scheduling Customization", func() {
-	var (
-		cluster *fleet.Cluster
-	)
-
-	BeforeEach(func() {
-		var err error
-		cluster = &fleet.Cluster{}
-		err = clientUpstream.Get(context.TODO(), client.ObjectKey{
+// removeAgentSchedulingCustomization clears the customization from the local cluster and
+// waits until the controller has fully reconciled the removal: the status hash is empty
+// and both resources the customization owns are gone. Every spec here shares the same
+// local cluster, so returning before the cleanup lands would leak a PriorityClass or a
+// PDB into whichever spec runs next and make the suite order-dependent.
+func removeAgentSchedulingCustomization() {
+	Eventually(func(g Gomega) {
+		latestCluster := &fleet.Cluster{}
+		err := clientUpstream.Get(context.TODO(), client.ObjectKey{
 			Namespace: env.Namespace,
 			Name:      "local",
-		}, cluster)
-		Expect(err).ToNot(HaveOccurred())
-	})
+		}, latestCluster)
+		g.Expect(err).ToNot(HaveOccurred())
 
+		latestCluster.Spec.AgentSchedulingCustomization = nil
+		// Bump RedeployAgentGeneration to force a prompt agent re-import.
+		// Removing the customization clears the status hash quickly, but the
+		// re-import that prunes the PriorityClass and the PDB is otherwise only
+		// triggered on the controller's periodic resync (~5m). That cadence races
+		// the deletion waits below and makes the specs flaky, so we force the
+		// redeploy here to prune both immediately.
+		latestCluster.Spec.RedeployAgentGeneration++
+		err = clientUpstream.Update(context.TODO(), latestCluster)
+		g.Expect(err).ToNot(HaveOccurred())
+	}).Should(Succeed(), "Should be able to update cluster to remove agentSchedulingCustomization")
+
+	Eventually(func(g Gomega) {
+		latestCluster := &fleet.Cluster{}
+		err := clientUpstream.Get(context.TODO(), client.ObjectKey{
+			Namespace: env.Namespace,
+			Name:      "local",
+		}, latestCluster)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(latestCluster.Status.AgentSchedulingCustomizationHash).To(Equal(""))
+	}).Should(Succeed(), "Should have cleared the AgentSchedulingCustomizationHash")
+
+	Eventually(func(g Gomega) {
+		pc := &schedulingv1.PriorityClass{}
+		err := clientUpstream.Get(context.TODO(), client.ObjectKey{
+			Name: agentPriorityClass,
+		}, pc)
+		g.Expect(errors.IsNotFound(err)).To(BeTrue())
+	}).Should(Succeed(), "PriorityClass should be deleted")
+
+	Eventually(func(g Gomega) {
+		pdb := &policyv1.PodDisruptionBudget{}
+		err := clientUpstream.Get(context.TODO(), client.ObjectKey{
+			Namespace: localAgentNamespace,
+			Name:      agentDisruptionBudget,
+		}, pdb)
+		g.Expect(errors.IsNotFound(err)).To(BeTrue())
+	}).Should(Succeed(), "PodDisruptionBudget should be deleted")
+}
+
+var _ = Describe("Agent Scheduling Customization", func() {
 	When("agentSchedulingCustomization.PriorityClass is configured on the cluster resource", func() {
 		BeforeEach(func() {
 			// Update the cluster with agentSchedulingCustomization
@@ -56,48 +103,14 @@ var _ = Describe("Agent Scheduling Customization", func() {
 			}).Should(Succeed(), "Should be able to update cluster with agentSchedulingCustomization")
 		})
 
-		AfterEach(func() {
-			// Clean up by removing the agentSchedulingCustomization
-			Eventually(func(g Gomega) {
-				// Re-fetch the cluster to get the latest version
-				latestCluster := &fleet.Cluster{}
-				err := clientUpstream.Get(context.TODO(), client.ObjectKey{
-					Namespace: env.Namespace,
-					Name:      "local",
-				}, latestCluster)
-				g.Expect(err).ToNot(HaveOccurred())
-
-				latestCluster.Spec.AgentSchedulingCustomization = nil
-				err = clientUpstream.Update(context.TODO(), latestCluster)
-				g.Expect(err).ToNot(HaveOccurred())
-			}).Should(Succeed(), "Should be able to update cluster to remove agentSchedulingCustomization")
-
-			Eventually(func(g Gomega) {
-				latestCluster := &fleet.Cluster{}
-				err := clientUpstream.Get(context.TODO(), client.ObjectKey{
-					Namespace: env.Namespace,
-					Name:      "local",
-				}, latestCluster)
-				g.Expect(err).ToNot(HaveOccurred())
-				g.Expect(cluster.Status.AgentSchedulingCustomizationHash).To(Equal(""))
-			}).Should(Succeed(), "Should have cleared the AgentSchedulingCustomizationHash")
-
-			// Wait for PriorityClass to be deleted
-			Eventually(func() bool {
-				pc := &schedulingv1.PriorityClass{}
-				err := clientUpstream.Get(context.TODO(), client.ObjectKey{
-					Name: "fleet-agent-priority-class",
-				}, pc)
-				return errors.IsNotFound(err)
-			}).Should(BeTrue(), "PriorityClass should be deleted")
-		})
+		AfterEach(removeAgentSchedulingCustomization)
 
 		It("should create a PriorityClass on the cluster", func() {
 			By("waiting for the PriorityClass to be created")
 			Eventually(func(g Gomega) {
 				pc := &schedulingv1.PriorityClass{}
 				err := clientUpstream.Get(context.TODO(), client.ObjectKey{
-					Name: "fleet-agent-priority-class",
+					Name: agentPriorityClass,
 				}, pc)
 				g.Expect(err).ToNot(HaveOccurred(), "PriorityClass should be created")
 
@@ -108,12 +121,12 @@ var _ = Describe("Agent Scheduling Customization", func() {
 			}).Should(Succeed())
 
 			By("checking that the agent deployment uses the priority class")
-			k := env.Kubectl.Namespace("cattle-fleet-local-system")
+			k := env.Kubectl.Namespace(localAgentNamespace)
 			Eventually(func(g Gomega) {
 				out, err := k.Get("deployment", "fleet-agent", "-o", "jsonpath={.spec.template.spec.priorityClassName}")
 				g.Expect(err).ToNot(HaveOccurred())
 				priorityClassName := strings.TrimSpace(out)
-				g.Expect(priorityClassName).To(Equal("fleet-agent-priority-class"))
+				g.Expect(priorityClassName).To(Equal(agentPriorityClass))
 			}).Should(Succeed())
 		})
 
@@ -154,38 +167,13 @@ var _ = Describe("Agent Scheduling Customization", func() {
 			}).Should(Succeed(), "Should be able to update cluster with agentSchedulingCustomization")
 		})
 
-		AfterEach(func() {
-			// Clean up by removing the agentSchedulingCustomization
-			Eventually(func(g Gomega) {
-				// Re-fetch the cluster to get the latest version
-				latestCluster := &fleet.Cluster{}
-				err := clientUpstream.Get(context.TODO(), client.ObjectKey{
-					Namespace: env.Namespace,
-					Name:      "local",
-				}, latestCluster)
-				g.Expect(err).ToNot(HaveOccurred())
-
-				latestCluster.Spec.AgentSchedulingCustomization = nil
-				err = clientUpstream.Update(context.TODO(), latestCluster)
-				g.Expect(err).ToNot(HaveOccurred())
-			}).Should(Succeed(), "Should be able to update cluster to remove agentSchedulingCustomization")
-
-			Eventually(func(g Gomega) {
-				latestCluster := &fleet.Cluster{}
-				err := clientUpstream.Get(context.TODO(), client.ObjectKey{
-					Namespace: env.Namespace,
-					Name:      "local",
-				}, latestCluster)
-				g.Expect(err).ToNot(HaveOccurred())
-				g.Expect(cluster.Status.AgentSchedulingCustomizationHash).To(Equal(""))
-			}).Should(Succeed(), "Should have cleared the AgentSchedulingCustomizationHash")
-		})
+		AfterEach(removeAgentSchedulingCustomization)
 
 		It("should create a PodDisruptionBudget on the cluster", func() {
 			By("waiting for the PodDisruptionBudget to be created")
-			k := env.Kubectl.Namespace("cattle-fleet-local-system")
+			k := env.Kubectl.Namespace(localAgentNamespace)
 			Eventually(func(g Gomega) {
-				out, err := k.Get("pdb", "fleet-agent-pod-disruption-budget", "-o", "jsonpath={.spec.maxUnavailable}")
+				out, err := k.Get("pdb", agentDisruptionBudget, "-o", "jsonpath={.spec.maxUnavailable}")
 				g.Expect(err).ToNot(HaveOccurred(), "PodDisruptionBudget should be created")
 				maxUnavailable := strings.TrimSpace(out)
 				g.Expect(maxUnavailable).To(Equal("1"), "PodDisruptionBudget should have correct maxUnavailable")
@@ -193,7 +181,7 @@ var _ = Describe("Agent Scheduling Customization", func() {
 
 			By("checking that the PDB has correct selector")
 			Eventually(func(g Gomega) {
-				out, err := k.Get("pdb", "fleet-agent-pod-disruption-budget", "-o", "jsonpath={.spec.selector.matchLabels.app}")
+				out, err := k.Get("pdb", agentDisruptionBudget, "-o", "jsonpath={.spec.selector.matchLabels.app}")
 				g.Expect(err).ToNot(HaveOccurred())
 				app := strings.TrimSpace(out)
 				g.Expect(app).To(Equal("fleet-agent"))
@@ -227,38 +215,23 @@ var _ = Describe("Agent Scheduling Customization", func() {
 			}).Should(Succeed(), "Should be able to update cluster with agentSchedulingCustomization")
 		})
 
-		AfterEach(func() {
-			// Clean up by removing the agentSchedulingCustomization
-			Eventually(func(g Gomega) {
-				// Re-fetch the cluster to get the latest version
-				latestCluster := &fleet.Cluster{}
-				err := clientUpstream.Get(context.TODO(), client.ObjectKey{
-					Namespace: env.Namespace,
-					Name:      "local",
-				}, latestCluster)
-				g.Expect(err).ToNot(HaveOccurred())
-
-				latestCluster.Spec.AgentSchedulingCustomization = nil
-				err = clientUpstream.Update(context.TODO(), latestCluster)
-				g.Expect(err).ToNot(HaveOccurred())
-			}).Should(Succeed(), "Should be able to update cluster to remove agentSchedulingCustomization")
-		})
+		AfterEach(removeAgentSchedulingCustomization)
 
 		It("should create both PriorityClass and PodDisruptionBudget", func() {
 			By("checking PriorityClass is created")
 			Eventually(func(g Gomega) {
 				pc := &schedulingv1.PriorityClass{}
 				err := clientUpstream.Get(context.TODO(), client.ObjectKey{
-					Name: "fleet-agent-priority-class",
+					Name: agentPriorityClass,
 				}, pc)
 				g.Expect(err).ToNot(HaveOccurred())
 				g.Expect(pc.Value).To(Equal(int32(500)))
 			}).Should(Succeed())
 
 			By("checking PodDisruptionBudget is created")
-			k := env.Kubectl.Namespace("cattle-fleet-local-system")
+			k := env.Kubectl.Namespace(localAgentNamespace)
 			Eventually(func(g Gomega) {
-				out, err := k.Get("pdb", "fleet-agent-pod-disruption-budget", "-o", "jsonpath={.spec.minAvailable}")
+				out, err := k.Get("pdb", agentDisruptionBudget, "-o", "jsonpath={.spec.minAvailable}")
 				g.Expect(err).ToNot(HaveOccurred())
 				minAvailable := strings.TrimSpace(out)
 				g.Expect(minAvailable).To(Equal("1"))

--- a/integrationtests/controller/schedule/schedule_test.go
+++ b/integrationtests/controller/schedule/schedule_test.go
@@ -1,6 +1,7 @@
 package schedule
 
 import (
+	"fmt"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -90,6 +91,65 @@ var _ = Describe("Schedule updates triggered by cluster updates", func() {
 				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(cluster.Status.Scheduled).To(BeTrue())
 			}).Should(Succeed())
+		})
+	})
+
+	When("a schedule becomes active", func() {
+		// Starting the schedule flags the cluster as active, and that cluster update triggers a
+		// reconcile of the schedule itself. That reconcile must not mistake the running job for a
+		// missing one and recreate it, as recreating it un-flags the cluster and the active window
+		// is lost.
+		It("keeps the cluster active for the schedule's duration, on every cycle", func() {
+			By("creating the cluster and a schedule which starts every 5 seconds for 2 seconds")
+			cluster, err := utils.CreateCluster(ctx, k8sClient, "cluster", namespace, nil, namespace)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cluster).To(Not(BeNil()))
+
+			schedule := v1alpha1.Schedule{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-schedule",
+					Namespace: namespace,
+				},
+				Spec: v1alpha1.ScheduleSpec{
+					Schedule: "*/5 * * * * *",
+					Duration: metav1.Duration{Duration: 2 * time.Second},
+					Targets: v1alpha1.ScheduleTargets{
+						Clusters: []v1alpha1.ScheduleTarget{
+							{
+								ClusterSelector: &metav1.LabelSelector{},
+							},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, &schedule)).NotTo(HaveOccurred())
+
+			DeferCleanup(func() {
+				Expect(k8sClient.Delete(ctx, &v1alpha1.Schedule{ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-schedule",
+					Namespace: namespace,
+				}})).NotTo(HaveOccurred())
+			})
+
+			activeSchedule := func(g Gomega) bool {
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "cluster"}, cluster)).
+					NotTo(HaveOccurred())
+				return cluster.Status.ActiveSchedule
+			}
+
+			// Each cycle is observed on its own, so that a cycle whose window is cancelled fails
+			// the test instead of being skipped over by a longer timeout.
+			for cycle := range 2 {
+				By(fmt.Sprintf("waiting for cycle %d to start", cycle))
+				Eventually(func(g Gomega) bool {
+					return activeSchedule(g)
+				}).WithTimeout(6 * time.Second).WithPolling(100 * time.Millisecond).Should(BeTrue())
+
+				By(fmt.Sprintf("waiting for cycle %d to end", cycle))
+				Eventually(func(g Gomega) bool {
+					return activeSchedule(g)
+				}).WithTimeout(4 * time.Second).WithPolling(100 * time.Millisecond).Should(BeFalse())
+			}
 		})
 	})
 

--- a/integrationtests/controller/schedule/suite_test.go
+++ b/integrationtests/controller/schedule/suite_test.go
@@ -28,6 +28,7 @@ var (
 	k8sClient  client.Client
 	testenv    *envtest.Environment
 	logsBuffer bytes.Buffer
+	scheduler  quartz.Scheduler
 
 	namespace string
 )
@@ -69,14 +70,20 @@ var _ = BeforeSuite(func() {
 	}).SetupWithManager(mgr)
 	Expect(err).ToNot(HaveOccurred(), "failed to set up manager")
 
+	// As the operator does: without a running scheduler, schedules never start nor stop.
+	sched.Start(ctx)
+
 	go func() {
 		defer GinkgoRecover()
 		err = mgr.Start(ctx)
 		Expect(err).ToNot(HaveOccurred(), "failed to run manager")
 	}()
+
+	scheduler = sched
 })
 
 var _ = AfterSuite(func() {
+	scheduler.Stop()
 	cancel()
 	Expect(testenv.Stop()).ToNot(HaveOccurred())
 })

--- a/internal/cmd/controller/reconciler/cronduration_job.go
+++ b/internal/cmd/controller/reconciler/cronduration_job.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"slices"
+	"sync"
 	"time"
 
 	fleetutil "github.com/rancher/fleet/internal/cmd/controller/errorutil"
@@ -29,6 +30,15 @@ type CronDurationJob struct {
 	client           client.Client
 	hash             string
 	key              *quartz.JobKey
+
+	// mu guards the fields above against concurrent access by the job's own start and stop
+	// actions, which quartz runs in their own goroutine, and by reconciles of the job's Schedule,
+	// which may replace or delete the job.
+	mu sync.Mutex
+	// stale marks a job which has been replaced or deleted by a reconcile. Quartz may already have
+	// dispatched a start or stop action for it by then; that action must not run, as it would
+	// re-arm this job over the one which replaced it.
+	stale bool
 }
 
 // newCronDurationJob constructs a new CronDurationJob.
@@ -78,12 +88,34 @@ func newCronDurationJob(ctx context.Context, schedule *fleet.Schedule, scheduler
 
 // Execute implements the quartz.Job interface function to run a scheduled job.
 func (c *CronDurationJob) Execute(ctx context.Context) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.stale {
+		// The job has been replaced or deleted while quartz was dispatching this execution.
+		// Whichever job now owns the schedule, if any, is responsible for it.
+		return nil
+	}
+
 	if c.Started {
 		// If the job has already started, this execution is for the "stop" action,
 		// which was scheduled to run after the specified duration.
 		return c.executeStop(ctx)
 	}
 	return c.executeStart(ctx)
+}
+
+// targets returns true if the job's Schedule lives in the given namespace and currently matches the
+// given cluster.
+func (c *CronDurationJob) targets(cluster, namespace string) bool {
+	if c.Schedule.Namespace != namespace {
+		return false
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return slices.Contains(c.MatchingClusters, cluster)
 }
 
 // Description implements the quartz.Job interface function to describe a scheduled job.
@@ -281,38 +313,4 @@ func matchingClusters(ctx context.Context, matcher *matcher.ScheduleMatch, c cli
 	}
 
 	return clusterNames, nil
-}
-
-// ClusterScheduledMatcher implements the quarts.Matcher interface to match for
-// Scheduled clusters.
-type ClusterScheduledMatcher struct {
-	name      string
-	namespace string
-}
-
-func NewClusterScheduledMatcher(namespace, name string) *ClusterScheduledMatcher {
-	return &ClusterScheduledMatcher{
-		namespace: namespace,
-		name:      name,
-	}
-}
-
-// IsMatch implements the quartz.Matcher interface and returns true if the cluster stored
-// in the matcher is found in any of the matching clusters of the given job.
-// Returns false otherwise.
-func (n *ClusterScheduledMatcher) IsMatch(job quartz.ScheduledJob) bool {
-	cronDurationJob, ok := job.JobDetail().Job().(*CronDurationJob)
-	if !ok {
-		return false
-	}
-
-	if cronDurationJob.Schedule.Namespace != n.namespace {
-		return false
-	}
-	return slices.Contains(cronDurationJob.MatchingClusters, n.name)
-}
-
-// getClusterScheduleKeys returns the keys of the scheduled jobs that reference the given cluster.
-func getClusterScheduleKeys(scheduler quartz.Scheduler, cluster, namespace string) ([]*quartz.JobKey, error) {
-	return scheduler.GetJobKeys(NewClusterScheduledMatcher(namespace, cluster))
 }

--- a/internal/cmd/controller/reconciler/cronduration_job_test.go
+++ b/internal/cmd/controller/reconciler/cronduration_job_test.go
@@ -367,56 +367,45 @@ var _ = Describe("CronDurationJob", func() {
 		})
 	})
 
-	Context("ClusterScheduledMatcher", func() {
-		It("should match a job if the cluster is in MatchingClusters", func() {
-			job, err := newCronDurationJob(ctx, schedule, scheduler, k8sclient)
-			Expect(err).NotTo(HaveOccurred())
-			err = job.scheduleJob(ctx)
-			Expect(err).NotTo(HaveOccurred())
+	Context("targets", func() {
+		var job *CronDurationJob
 
-			matcher := NewClusterScheduledMatcher("default", "test-cluster")
-			keys, err := scheduler.GetJobKeys(matcher)
+		JustBeforeEach(func() {
+			var err error
+			job, err = newCronDurationJob(ctx, schedule, scheduler, k8sclient)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(keys).To(HaveLen(1))
-			Expect(keys[0].String()).To(Equal(job.key.String()))
+			Expect(job.MatchingClusters).To(ConsistOf("test-cluster"))
 		})
 
-		It("should not match a job if the cluster is not in MatchingClusters", func() {
-			job, err := newCronDurationJob(ctx, schedule, scheduler, k8sclient)
-			Expect(err).NotTo(HaveOccurred())
-			err = job.scheduleJob(ctx)
-			Expect(err).NotTo(HaveOccurred())
-
-			matcher := NewClusterScheduledMatcher("default", "another-cluster")
-			keys, err := scheduler.GetJobKeys(matcher)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(keys).To(BeEmpty())
+		It("should target a cluster in MatchingClusters", func() {
+			Expect(job.targets("test-cluster", "default")).To(BeTrue())
 		})
 
-		It("should not match a job if the namespace is different", func() {
-			job, err := newCronDurationJob(ctx, schedule, scheduler, k8sclient)
-			Expect(err).NotTo(HaveOccurred())
-			err = job.scheduleJob(ctx)
-			Expect(err).NotTo(HaveOccurred())
+		It("should not target a cluster which is not in MatchingClusters", func() {
+			Expect(job.targets("another-cluster", "default")).To(BeFalse())
+		})
 
-			matcher := NewClusterScheduledMatcher("other-ns", "test-cluster")
-			keys, err := scheduler.GetJobKeys(matcher)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(keys).To(BeEmpty())
+		It("should not target a cluster in another namespace", func() {
+			Expect(job.targets("test-cluster", "other-ns")).To(BeFalse())
 		})
 	})
 
-	Context("getClusterScheduleKeys", func() {
-		It("should return keys for scheduled jobs matching a cluster", func() {
+	Context("Execute", func() {
+		It("should do nothing when the job is stale", func() {
 			job, err := newCronDurationJob(ctx, schedule, scheduler, k8sclient)
 			Expect(err).NotTo(HaveOccurred())
-			err = job.scheduleJob(ctx)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(job.scheduleJob(ctx)).To(Succeed())
 
-			keys, err := getClusterScheduleKeys(scheduler, "test-cluster", "default")
-			Expect(err).NotTo(HaveOccurred())
-			Expect(keys).To(HaveLen(1))
-			Expect(keys[0].String()).To(Equal(job.key.String()))
+			job.stale = true
+
+			Expect(job.Execute(ctx)).To(Succeed())
+
+			Expect(job.Started).To(BeFalse())
+
+			updatedCluster := &fleet.Cluster{}
+			key := types.NamespacedName{Name: "test-cluster", Namespace: "default"}
+			Expect(k8sclient.Get(ctx, key, updatedCluster)).To(Succeed())
+			Expect(updatedCluster.Status.ActiveSchedule).To(BeFalse())
 		})
 	})
 

--- a/internal/cmd/controller/reconciler/job_registry.go
+++ b/internal/cmd/controller/reconciler/job_registry.go
@@ -1,0 +1,113 @@
+package reconciler
+
+import (
+	"slices"
+	"sync"
+
+	"github.com/reugn/go-quartz/quartz"
+)
+
+// jobRegistry tracks the CronDurationJobs owned by a ScheduleReconciler, keyed by quartz job key.
+//
+// It exists because the quartz scheduler cannot answer the question "does this Schedule have a
+// job?": quartz pops a job off its queue before running it, and a CronDurationJob only puts itself
+// back once its start or stop action is done. A running job is therefore reported as missing by
+// quartz.GetScheduledJob, and re-creating a job from that answer would cancel the active window the
+// running job has just opened.
+//
+// The zero value is ready to use.
+type jobRegistry struct {
+	mu   sync.RWMutex
+	jobs map[string]*CronDurationJob
+}
+
+func (r *jobRegistry) get(key *quartz.JobKey) (*CronDurationJob, bool) {
+	if key == nil {
+		return nil, false
+	}
+
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	job, found := r.jobs[key.String()]
+
+	return job, found
+}
+
+func (r *jobRegistry) store(key *quartz.JobKey, job *CronDurationJob) {
+	if key == nil {
+		return
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.jobs == nil {
+		r.jobs = map[string]*CronDurationJob{}
+	}
+	r.jobs[key.String()] = job
+}
+
+func (r *jobRegistry) delete(key *quartz.JobKey) {
+	if key == nil {
+		return
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	delete(r.jobs, key.String())
+}
+
+func (r *jobRegistry) list() []*CronDurationJob {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	jobs := make([]*CronDurationJob, 0, len(r.jobs))
+	for _, job := range r.jobs {
+		jobs = append(jobs, job)
+	}
+
+	return jobs
+}
+
+// jobsForCluster returns the registered jobs which currently target the given cluster.
+func (r *jobRegistry) jobsForCluster(cluster, namespace string) []*CronDurationJob {
+	jobs := []*CronDurationJob{}
+	for _, job := range r.list() {
+		if job.targets(cluster, namespace) {
+			jobs = append(jobs, job)
+		}
+	}
+
+	return jobs
+}
+
+// isClusterScheduled returns true if the given cluster is targeted by any registered job.
+func (r *jobRegistry) isClusterScheduled(cluster, namespace string) bool {
+	return clusterHasJob(r.list(), cluster, namespace)
+}
+
+// clustersNotScheduled returns those of the given clusters which are targeted by no registered job.
+func (r *jobRegistry) clustersNotScheduled(clusters []string, namespace string) []string {
+	// A single snapshot serves every cluster, instead of re-listing the registry once per cluster.
+	jobs := r.list()
+
+	notScheduled := []string{}
+	for _, cluster := range clusters {
+		if !clusterHasJob(jobs, cluster, namespace) {
+			notScheduled = append(notScheduled, cluster)
+		}
+	}
+
+	return notScheduled
+}
+
+// clusterHasJob returns true as soon as one of jobs targets the given cluster. Unlike
+// jobsForCluster, it answers that question without allocating a slice, and without locking the
+// jobs past the first match.
+func clusterHasJob(jobs []*CronDurationJob, cluster, namespace string) bool {
+	return slices.ContainsFunc(jobs, func(job *CronDurationJob) bool {
+		return job.targets(cluster, namespace)
+	})
+}

--- a/internal/cmd/controller/reconciler/job_registry_test.go
+++ b/internal/cmd/controller/reconciler/job_registry_test.go
@@ -1,0 +1,94 @@
+package reconciler
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/reugn/go-quartz/quartz"
+
+	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("jobRegistry", func() {
+	var registry *jobRegistry
+
+	BeforeEach(func() {
+		registry = &jobRegistry{}
+	})
+
+	Context("when the key is nil", func() {
+		It("reports a miss on get", func() {
+			job, found := registry.get(nil)
+
+			Expect(found).To(BeFalse())
+			Expect(job).To(BeNil())
+		})
+
+		It("does not store the job", func() {
+			registry.store(nil, &CronDurationJob{})
+
+			Expect(registry.list()).To(BeEmpty())
+		})
+
+		It("leaves registered jobs untouched on delete", func() {
+			key := quartz.NewJobKey("schedule-default/test-schedule")
+			job := &CronDurationJob{}
+			registry.store(key, job)
+
+			registry.delete(nil)
+
+			stored, found := registry.get(key)
+			Expect(found).To(BeTrue())
+			Expect(stored).To(BeIdenticalTo(job))
+		})
+	})
+
+	Context("when looking up clusters", func() {
+		BeforeEach(func() {
+			registry.store(quartz.NewJobKey("schedule-default/one"), jobTargeting("default", "cluster1"))
+			registry.store(quartz.NewJobKey("schedule-default/two"), jobTargeting("default", "cluster1", "cluster2"))
+			registry.store(quartz.NewJobKey("schedule-other/three"), jobTargeting("other", "cluster3"))
+		})
+
+		It("reports targeted clusters as scheduled", func() {
+			Expect(registry.isClusterScheduled("cluster1", "default")).To(BeTrue())
+			Expect(registry.isClusterScheduled("cluster2", "default")).To(BeTrue())
+			Expect(registry.isClusterScheduled("cluster3", "other")).To(BeTrue())
+		})
+
+		It("does not report untargeted clusters as scheduled", func() {
+			Expect(registry.isClusterScheduled("cluster4", "default")).To(BeFalse())
+		})
+
+		It("does not match a cluster targeted in another namespace", func() {
+			Expect(registry.isClusterScheduled("cluster3", "default")).To(BeFalse())
+			Expect(registry.isClusterScheduled("cluster1", "other")).To(BeFalse())
+		})
+
+		It("returns only clusters which no job targets", func() {
+			notScheduled := registry.clustersNotScheduled(
+				[]string{"cluster1", "cluster2", "cluster3", "cluster4"},
+				"default",
+			)
+
+			Expect(notScheduled).To(Equal([]string{"cluster3", "cluster4"}))
+		})
+
+		It("returns all clusters as not scheduled when the registry is empty", func() {
+			Expect((&jobRegistry{}).clustersNotScheduled([]string{"cluster1"}, "default")).
+				To(Equal([]string{"cluster1"}))
+		})
+	})
+})
+
+// jobTargeting builds a job whose schedule lives in the given namespace and which targets the
+// given clusters.
+func jobTargeting(namespace string, clusters ...string) *CronDurationJob {
+	return &CronDurationJob{
+		Schedule: &fleet.Schedule{
+			ObjectMeta: metav1.ObjectMeta{Namespace: namespace},
+		},
+		MatchingClusters: clusters,
+	}
+}

--- a/internal/cmd/controller/reconciler/schedule_controller.go
+++ b/internal/cmd/controller/reconciler/schedule_controller.go
@@ -39,6 +39,7 @@ type ScheduleReconciler struct {
 	ShardID   string
 	Workers   int
 	Scheduler quartz.Scheduler
+	jobs      jobRegistry
 }
 
 //+kubebuilder:rbac:groups=fleet.cattle.io,resources=schedules,verbs=get;list;watch;create;update;patch;delete
@@ -103,40 +104,33 @@ func (r *ScheduleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 
 func (r *ScheduleReconciler) handleSchedule(ctx context.Context, s *fleet.Schedule) error {
 	k := scheduleKey(s)
-	schedJob, err := r.Scheduler.GetScheduledJob(k)
-	if err != nil && !errors.Is(err, quartz.ErrJobNotFound) {
-		return fmt.Errorf("an unknown error occurred when looking for a schedule job: %w", err)
+
+	job, found := r.jobs.get(k)
+	if !found {
+		return r.scheduleNewCronDurationJob(ctx, s)
 	}
 
-	if errors.Is(err, quartz.ErrJobNotFound) {
-		return scheduleNewCronDurationJob(ctx, s, r.Scheduler, r.Client)
-	}
+	// The job exists: hold its lock for the whole update
+	job.mu.Lock()
+	defer job.mu.Unlock()
 
-	// the job already exists, check if an update is needed
 	newJob, err := newCronDurationJob(ctx, s, r.Scheduler, r.Client)
 	if err != nil {
 		return err
 	}
-	existingJob := schedJob.JobDetail().Job()
-	existingCronJob, ok := existingJob.(*CronDurationJob)
-	if !ok {
-		return fmt.Errorf("unexpected job found for key: %s", k.String())
+
+	if !jobNeedsUpdate(newJob, job) {
+		return nil
 	}
 
-	if jobNeedsUpdate(newJob, existingCronJob) {
-		if err := newJob.updateJob(ctx); err != nil {
-			return err
-		}
-		return updateScheduledClusters(
-			ctx,
-			r.Scheduler,
-			r.Client,
-			newJob.MatchingClusters,
-			existingCronJob.MatchingClusters,
-			s.Namespace,
-		)
+	if err := newJob.updateJob(ctx); err != nil {
+		return err
 	}
-	return nil
+
+	job.stale = true
+	r.jobs.store(k, newJob)
+
+	return r.updateScheduledClusters(ctx, newJob.MatchingClusters, job.MatchingClusters, s.Namespace)
 }
 
 func (r *ScheduleReconciler) handleDelete(ctx context.Context, schedule *fleet.Schedule) (ctrl.Result, error) {
@@ -144,7 +138,7 @@ func (r *ScheduleReconciler) handleDelete(ctx context.Context, schedule *fleet.S
 		return ctrl.Result{}, nil
 	}
 
-	if err := deleteSchedule(ctx, schedule, r.Scheduler); err != nil {
+	if err := r.deleteSchedule(ctx, schedule); err != nil {
 		return ctrl.Result{}, err
 	}
 
@@ -165,7 +159,7 @@ func (r *ScheduleReconciler) mapClustersToSchedules(ctx context.Context, a clien
 	cluster := a.(*fleet.Cluster)
 
 	// check if the cluster is scheduled
-	schedules, err := getClusterSchedules(ctx, r.Client, r.Scheduler, cluster, r.ShardID)
+	schedules, err := r.getClusterSchedules(ctx, cluster)
 	if err != nil {
 		logger.Error(err, "Failed to get cluster schedules")
 		return nil
@@ -193,46 +187,48 @@ func jobNeedsUpdate(newJob, existingJob *CronDurationJob) bool {
 		!slices.Equal(newJob.MatchingClusters, existingJob.MatchingClusters)
 }
 
-func scheduleNewCronDurationJob(ctx context.Context, s *fleet.Schedule, scheduler quartz.Scheduler, c client.Client) error {
-	job, err := newCronDurationJob(ctx, s, scheduler, c)
+func (r *ScheduleReconciler) scheduleNewCronDurationJob(ctx context.Context, s *fleet.Schedule) error {
+	job, err := newCronDurationJob(ctx, s, r.Scheduler, r.Client)
 	if err != nil {
 		return err
 	}
 
+	k := scheduleKey(s)
+	// Register the job before arming it, so that it is never running while unknown to the registry.
+	r.jobs.store(k, job)
+
 	if err := job.scheduleJob(ctx); err != nil {
+		r.jobs.delete(k)
 		return err
 	}
 
-	return setClustersScheduled(ctx, c, job.MatchingClusters, s.Namespace, true)
+	return setClustersScheduled(ctx, r.Client, job.MatchingClusters, s.Namespace, true)
 }
 
-func deleteSchedule(ctx context.Context, s *fleet.Schedule, scheduler quartz.Scheduler) error {
+func (r *ScheduleReconciler) deleteSchedule(ctx context.Context, s *fleet.Schedule) error {
 	k := scheduleKey(s)
-	schedJob, err := scheduler.GetScheduledJob(k)
-	if err != nil && !errors.Is(err, quartz.ErrJobNotFound) {
-		return fmt.Errorf("an unknown error occurred when trying to delete a schedule job: %w", err)
-	}
-	if errors.Is(err, quartz.ErrJobNotFound) {
+	job, found := r.jobs.get(k)
+	if !found {
 		return nil
 	}
 
-	cronDurationJob, ok := schedJob.JobDetail().Job().(*CronDurationJob)
-	if !ok {
-		return fmt.Errorf("found an unexpected job type for key: %s", k.String())
-	}
+	job.mu.Lock()
+	job.stale = true
+	clusters := slices.Clone(job.MatchingClusters)
+	job.mu.Unlock()
 
-	if err := scheduler.DeleteJob(k); err != nil {
-		return err
+	// A job which quartz has popped for execution is not in the scheduler's queue, so there may be
+	// nothing to delete there. Marking it stale above is what stops it in that case.
+	if err := r.Scheduler.DeleteJob(k); err != nil && !errors.Is(err, quartz.ErrJobNotFound) {
+		return fmt.Errorf("an unknown error occurred when trying to delete a schedule job: %w", err)
 	}
+	r.jobs.delete(k)
 
 	// get the list of clusters that are no longer in any schedule
-	noLongerScheduled, err := getClustersNotScheduled(scheduler, cronDurationJob.MatchingClusters, s.Namespace)
-	if err != nil {
-		return err
-	}
+	noLongerScheduled := r.jobs.clustersNotScheduled(clusters, s.Namespace)
 
 	// set the Scheduled property of those not scheduled to false
-	return setClustersScheduled(ctx, cronDurationJob.client, noLongerScheduled, s.Namespace, false)
+	return setClustersScheduled(ctx, r.Client, noLongerScheduled, s.Namespace, false)
 }
 
 func setClusterActiveSchedule(ctx context.Context, c client.Client, name, namespace string, active bool) error {
@@ -347,60 +343,32 @@ func updateScheduleStatus(ctx context.Context, c client.Client, old *fleet.Sched
 	})
 }
 
-// isClusterScheduled returns true if the given cluster is part of
-// any scheduled job as a matching cluster.
-func isClusterScheduled(scheduler quartz.Scheduler, cluster, namespace string) (bool, error) {
-	keys, err := getClusterScheduleKeys(scheduler, cluster, namespace)
-	if err != nil {
-		return false, err
-	}
-
-	return len(keys) != 0, nil
-}
-
 // getClusterSchedules returns all the fleet Schedules with a matching shardID, in which the given cluster is found as a
 // matching target. To this end, it looks at two sources of data:
-// * keys of already scheduled jobs
+// * jobs which already target the cluster
 // * schedules which targets match the cluster, to include schedules for which no job may have been scheduled yet.
-func getClusterSchedules(
+func (r *ScheduleReconciler) getClusterSchedules(
 	ctx context.Context,
-	c client.Client,
-	scheduler quartz.Scheduler,
 	cluster *fleet.Cluster,
-	shardID string,
 ) ([]*fleet.Schedule, error) {
-	keys, err := getClusterScheduleKeys(scheduler, cluster.Name, cluster.Namespace)
-	if err != nil {
-		return nil, err
-	}
-
 	schedules := []*fleet.Schedule{}
 	scheduleNames := map[string]struct{}{}
-	for _, key := range keys {
-		job, err := scheduler.GetScheduledJob(key)
-		if err != nil {
-			return nil, err
-		}
-		cronDurationJob, ok := job.JobDetail().Job().(*CronDurationJob)
-		if !ok {
-			return nil, fmt.Errorf("unexpected job type for key: %s", key.String())
-		}
-
-		if !sharding.ShouldProcess(cronDurationJob.Schedule, shardID) {
+	for _, job := range r.jobs.jobsForCluster(cluster.Name, cluster.Namespace) {
+		if !sharding.ShouldProcess(job.Schedule, r.ShardID) {
 			continue
 		}
 
-		schedules = append(schedules, cronDurationJob.Schedule)
-		scheduleNames[cronDurationJob.Schedule.Name] = struct{}{}
+		schedules = append(schedules, job.Schedule)
+		scheduleNames[job.Schedule.Name] = struct{}{}
 	}
 
 	// Consider schedules which may exist but for which no job may have been created yet.
 	allSchedules := &fleet.ScheduleList{}
-	if err := c.List(ctx, allSchedules, client.InNamespace(cluster.Namespace)); err != nil {
+	if err := r.List(ctx, allSchedules, client.InNamespace(cluster.Namespace)); err != nil {
 		return nil, fmt.Errorf("%w, listing schedules: %w", fleetutil.ErrRetryable, err)
 	}
 
-	groups, err := target.ClusterGroupsForCluster(ctx, c, cluster)
+	groups, err := target.ClusterGroupsForCluster(ctx, r.Client, cluster)
 	if err != nil {
 		return nil, fmt.Errorf("%w, getting cluster groups from clusters: %w", fleetutil.ErrRetryable, err)
 	}
@@ -408,7 +376,7 @@ func getClusterSchedules(
 	cgs := target.ClusterGroupsToLabelMap(groups)
 
 	for i, s := range allSchedules.Items {
-		if !sharding.ShouldProcess(&s, shardID) {
+		if !sharding.ShouldProcess(&s, r.ShardID) {
 			continue
 		}
 
@@ -430,23 +398,6 @@ func getClusterSchedules(
 	return schedules, nil
 }
 
-// getClustersNotScheduled returns the list of the given clusters
-// that are not part of any scheduled job.
-func getClustersNotScheduled(scheduler quartz.Scheduler, clusters []string, namespace string) ([]string, error) {
-	notScheduled := []string{}
-	for _, cluster := range clusters {
-		scheduled, err := isClusterScheduled(scheduler, cluster, namespace)
-		if err != nil {
-			return nil, err
-		}
-		if !scheduled {
-			notScheduled = append(notScheduled, cluster)
-		}
-	}
-
-	return notScheduled, nil
-}
-
 func setClustersScheduled(ctx context.Context, c client.Client, clusters []string, namespace string, scheduled bool) error {
 	for _, cluster := range clusters {
 		if err := setClusterScheduled(ctx, c, cluster, namespace, scheduled); err != nil {
@@ -457,9 +408,9 @@ func setClustersScheduled(ctx context.Context, c client.Client, clusters []strin
 	return nil
 }
 
-func updateScheduledClusters(ctx context.Context, scheduler quartz.Scheduler, c client.Client, clustersNew []string, clustersOld []string, namespace string) error {
+func (r *ScheduleReconciler) updateScheduledClusters(ctx context.Context, clustersNew []string, clustersOld []string, namespace string) error {
 	for _, cluster := range clustersNew {
-		if err := setClusterScheduled(ctx, c, cluster, namespace, true); err != nil {
+		if err := setClusterScheduled(ctx, r.Client, cluster, namespace, true); err != nil {
 			return err
 		}
 	}
@@ -467,16 +418,14 @@ func updateScheduledClusters(ctx context.Context, scheduler quartz.Scheduler, c 
 	// now check for clusters that are flagged as scheduled and should no longer be flagged because
 	// they are no longer targeted by any schedule
 	for _, cluster := range clustersOld {
-		if !slices.Contains(clustersNew, cluster) {
-			targeted, err := isClusterScheduled(scheduler, cluster, namespace)
-			if err != nil {
-				return err
-			}
-			if !targeted {
-				if err := setClusterScheduled(ctx, c, cluster, namespace, false); err != nil {
-					return err
-				}
-			}
+		if slices.Contains(clustersNew, cluster) {
+			continue
+		}
+		if r.jobs.isClusterScheduled(cluster, namespace) {
+			continue
+		}
+		if err := setClusterScheduled(ctx, r.Client, cluster, namespace, false); err != nil {
+			return err
 		}
 	}
 	return nil

--- a/internal/cmd/controller/reconciler/schedule_controller_test.go
+++ b/internal/cmd/controller/reconciler/schedule_controller_test.go
@@ -192,6 +192,72 @@ var _ = Describe("ScheduleReconciler", func() {
 			Expect(newDescription).NotTo(Equal(originalDescription))
 		})
 
+		It("should leave an active schedule alone when its job is running", func() {
+			// Initial reconcile: the schedule gets a job and the cluster is scheduled.
+			_, err := reconciler.Reconcile(ctx, req)
+			Expect(err).NotTo(HaveOccurred())
+
+			jobKey := scheduleKey(schedule)
+			job, found := reconciler.jobs.get(jobKey)
+			Expect(found).To(BeTrue())
+
+			// Reproduce the state the job is in while quartz runs its start action: quartz has
+			// popped the job off its queue, and the job has flagged the cluster as active but has
+			// not yet re-armed itself with the stop action. The cluster status update it performs
+			// triggers a reconcile which lands right here.
+			Expect(scheduler.DeleteJob(jobKey)).To(Succeed())
+			Expect(setClusterActiveSchedule(ctx, k8sclient, cluster.Name, cluster.Namespace, true)).To(Succeed())
+
+			_, err = reconciler.Reconcile(ctx, req)
+			Expect(err).NotTo(HaveOccurred())
+
+			// The running job must be left in place, rather than treated as missing and recreated.
+			currentJob, found := reconciler.jobs.get(jobKey)
+			Expect(found).To(BeTrue())
+			Expect(currentJob).To(BeIdenticalTo(job))
+
+			// The active window must survive the reconcile.
+			updatedCluster := &fleet.Cluster{}
+			err = k8sclient.Get(ctx, client.ObjectKeyFromObject(cluster), updatedCluster)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(updatedCluster.Status.ActiveSchedule).To(BeTrue())
+		})
+
+		It("should not let a job which has been replaced start", func() {
+			_, err := reconciler.Reconcile(ctx, req)
+			Expect(err).NotTo(HaveOccurred())
+
+			jobKey := scheduleKey(schedule)
+			oldJob, found := reconciler.jobs.get(jobKey)
+			Expect(found).To(BeTrue())
+
+			// Update the schedule's spec, which replaces its job.
+			err = k8sclient.Get(ctx, req.NamespacedName, schedule)
+			Expect(err).NotTo(HaveOccurred())
+			schedule.Spec.Schedule = "0 */2 * * * *"
+			Expect(k8sclient.Update(ctx, schedule)).To(Succeed())
+
+			_, err = reconciler.Reconcile(ctx, req)
+			Expect(err).NotTo(HaveOccurred())
+
+			newJob, found := reconciler.jobs.get(jobKey)
+			Expect(found).To(BeTrue())
+			Expect(newJob).NotTo(BeIdenticalTo(oldJob))
+
+			// Quartz may already have dispatched a start for the old job. Running it would flag the
+			// cluster as active and re-arm the old job over the one which replaced it.
+			Expect(oldJob.Execute(ctx)).To(Succeed())
+
+			updatedCluster := &fleet.Cluster{}
+			err = k8sclient.Get(ctx, client.ObjectKeyFromObject(cluster), updatedCluster)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(updatedCluster.Status.ActiveSchedule).To(BeFalse())
+
+			scheduledJob, err := scheduler.GetScheduledJob(jobKey)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(scheduledJob.JobDetail().Job()).To(BeIdenticalTo(newJob))
+		})
+
 		It("should update the cluster's scheduled status when its labels no longer match", func() {
 			// Initial reconcile
 			_, err := reconciler.Reconcile(ctx, req)
@@ -312,13 +378,13 @@ var _ = Describe("ScheduleReconciler", func() {
 
 			// clusters 1, 2 and 3 should be scheduled in the quartz.Scheduler and also
 			// be flagged as Scheduled
-			checkState(scheduler, k8sclient, "test-cluster", "default",
+			checkState(reconciler, k8sclient, "test-cluster", "default",
 				expected{scheduledJob: true, statusScheduled: true, statusActiveSchedule: false})
-			checkState(scheduler, k8sclient, "test-cluster2", "default",
+			checkState(reconciler, k8sclient, "test-cluster2", "default",
 				expected{scheduledJob: true, statusScheduled: true, statusActiveSchedule: false})
-			checkState(scheduler, k8sclient, "test-cluster3", "default",
+			checkState(reconciler, k8sclient, "test-cluster3", "default",
 				expected{scheduledJob: true, statusScheduled: true, statusActiveSchedule: false})
-			checkState(scheduler, k8sclient, "test-cluster4", "default",
+			checkState(reconciler, k8sclient, "test-cluster4", "default",
 				expected{scheduledJob: false, statusScheduled: false, statusActiveSchedule: false})
 
 			// force the start of the schedule (so it sets .Status.ActiveSchedule=true)
@@ -334,13 +400,13 @@ var _ = Describe("ScheduleReconciler", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			// check now that the clusters have the expected values, specially Status.ActiveSchedule
-			checkState(scheduler, k8sclient, "test-cluster", "default",
+			checkState(reconciler, k8sclient, "test-cluster", "default",
 				expected{scheduledJob: true, statusScheduled: true, statusActiveSchedule: true})
-			checkState(scheduler, k8sclient, "test-cluster2", "default",
+			checkState(reconciler, k8sclient, "test-cluster2", "default",
 				expected{scheduledJob: true, statusScheduled: true, statusActiveSchedule: true})
-			checkState(scheduler, k8sclient, "test-cluster3", "default",
+			checkState(reconciler, k8sclient, "test-cluster3", "default",
 				expected{scheduledJob: true, statusScheduled: true, statusActiveSchedule: true})
-			checkState(scheduler, k8sclient, "test-cluster4", "default",
+			checkState(reconciler, k8sclient, "test-cluster4", "default",
 				expected{scheduledJob: false, statusScheduled: false, statusActiveSchedule: false})
 
 			// update the schedule, now it only looks for the label foo=bar
@@ -360,15 +426,15 @@ var _ = Describe("ScheduleReconciler", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			// cluster 2 and 4 should be still targeted.
-			checkState(scheduler, k8sclient, "test-cluster", "default",
+			checkState(reconciler, k8sclient, "test-cluster", "default",
 				expected{scheduledJob: false, statusScheduled: false, statusActiveSchedule: false})
 			// cluster 2 had Status.ActiveSchedule set to true, but because we updated the Schedule
 			// it should be back to false.
-			checkState(scheduler, k8sclient, "test-cluster2", "default",
+			checkState(reconciler, k8sclient, "test-cluster2", "default",
 				expected{scheduledJob: true, statusScheduled: true, statusActiveSchedule: false})
-			checkState(scheduler, k8sclient, "test-cluster3", "default",
+			checkState(reconciler, k8sclient, "test-cluster3", "default",
 				expected{scheduledJob: false, statusScheduled: false, statusActiveSchedule: false})
-			checkState(scheduler, k8sclient, "test-cluster4", "default",
+			checkState(reconciler, k8sclient, "test-cluster4", "default",
 				expected{scheduledJob: true, statusScheduled: true, statusActiveSchedule: false})
 		})
 	})
@@ -376,17 +442,15 @@ var _ = Describe("ScheduleReconciler", func() {
 
 //nolint:unparam // namespace is always default, for now. That may change.
 func checkState(
-	scheduler quartz.Scheduler,
+	reconciler *ScheduleReconciler,
 	k8sclient client.Client,
 	cluster, namespace string,
 	expectedState expected) {
-	isScheduled, err := isClusterScheduled(scheduler, cluster, namespace)
-	Expect(err).NotTo(HaveOccurred())
-	Expect(isScheduled).To(Equal(expectedState.scheduledJob))
+	Expect(reconciler.jobs.isClusterScheduled(cluster, namespace)).To(Equal(expectedState.scheduledJob))
 
 	key := client.ObjectKey{Name: cluster, Namespace: namespace}
 	clusterObj := &fleet.Cluster{}
-	err = k8sclient.Get(context.Background(), key, clusterObj)
+	err := k8sclient.Get(context.Background(), key, clusterObj)
 	Expect(err).NotTo(HaveOccurred())
 	Expect(clusterObj.Status.Scheduled).To(Equal(expectedState.statusScheduled))
 	Expect(clusterObj.Status.ActiveSchedule).To(Equal(expectedState.statusActiveSchedule))


### PR DESCRIPTION
Fixes the following annoying Flaky test:

 ```
[FAILED] Timed out after 300.001s.
  Expected
      <bool>: false
  to be true
Error: It 08/27/26 09:21:01.513

  Full Stack Trace
    github.com/onsi/gomega/internal.(*AsyncAssertion).Should(0x261d6281c2a0, {0x273e048, 0x261d62802ad0}, {0x0, 0x0, 0x0})
    	/home/runner/go/pkg/mod/github.com/onsi/gomega@v1.42.1/internal/async_assertion.go:145 +0x85
    github.com/rancher/fleet/e2e/single-cluster_test.init.func1.2()
    	/home/runner/work/fleet/fleet/e2e/single-cluster/schedule_test.go:111 +0x48d
------------------------------
SSSSSSSSSSSSSS••••••••••SSSS

Summarizing 1 Failure:
  [FAIL] Schedules [It] deploys and pauses based on the schedule [infra-setup]
  /home/runner/go/pkg/mod/github.com/onsi/gomega@v1.42.1/internal/async_assertion.go:145

Ran 23 of 108 Specs in 982.138 seconds
FAIL! -- 22 Passed | 1 Failed | 0 Pending | 85 Skipped
--- FAIL: TestE2E (982.14s)
FAIL

Ginkgo ran 1 suite in 17m17.878919096s

Test Suite Failed
Error: Process completed with exit code 1.
```
Backports: https://github.com/rancher/fleet/pull/5436