### PR TITLE
Free disk space before the single-cluster e2e jobs

### DIFF
--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -51,6 +51,9 @@ jobs:
         with:
           go-version-file: 'go.mod'
       -
+        name: Free Disk Space
+        run: ./.github/scripts/free-disk-space.sh
+      -
         name: Cache crust-gather CLI
         id: cache-crust
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0


### PR DESCRIPTION
The runners start with about 10 GiB free on a 72 GiB root filesystem, and k3s evicts pods once less than 5% (3.58 GiB) is left. Building the test binary on top of the dev images and the k3d import crosses that floor, so kubelet evicts git-server, zot, chartmuseum, gitjob and helmops, taints both nodes with disk-pressure:NoSchedule and leaves the replacements pending. The specs then fail with connection refused against the service load balancers, or time out waiting for a load balancer IP that is never assigned.

Run the same cleanup script the multi-cluster job already uses, which reclaims about 25 GiB by removing the preinstalled Android, dotnet, ghcup, Swift and CodeQL toolchains.

<!-- Specify the issue ID that this pull request is solving -->
<!-- Make sure that the referenced issue provides steps to reproduce it -->

<!-- Describe the changes introduced by this pull request -->

<!--
  Please provide a unit, integration (`./integrationtests/`) or e2e (`./e2e/`) test if possible.
-->

## Additional Information

### Checklist

- [ ] <!-- If applicable,--> I have updated the documentation via a pull request in the [fleet-product-docs](https://github.com/rancher/fleet-product-docs) repository.
