### PR TITLE
Update Rancher reference and Fleet platform support metadata and CI for Kubernetes 1.37

### DIFF
--- a/.github/scripts/run-integration-tests-group1.sh
+++ b/.github/scripts/run-integration-tests-group1.sh
@@ -3,8 +3,8 @@
 set -euxo pipefail
 
 # renovate: datasource=go depName=sigs.k8s.io/controller-runtime
-SETUP_ENVTEST_VER=${SETUP_ENVTEST_VER-v0.24.0}
-ENVTEST_K8S_VERSION=${ENVTEST_K8S_VERSION-1.37}
+SETUP_ENVTEST_VER=${SETUP_ENVTEST_VER:-v0.24.0}
+ENVTEST_K8S_VERSION=${ENVTEST_K8S_VERSION:-1.37}
 
 # install and prepare setup-envtest
 go install sigs.k8s.io/controller-runtime/tools/setup-envtest@"$SETUP_ENVTEST_VER"

--- a/.github/scripts/run-integration-tests-group1.sh
+++ b/.github/scripts/run-integration-tests-group1.sh
@@ -4,7 +4,7 @@ set -euxo pipefail
 
 # renovate: datasource=go depName=sigs.k8s.io/controller-runtime
 SETUP_ENVTEST_VER=${SETUP_ENVTEST_VER-v0.24.0}
-ENVTEST_K8S_VERSION=${ENVTEST_K8S_VERSION-1.36}
+ENVTEST_K8S_VERSION=${ENVTEST_K8S_VERSION-1.37}
 
 # install and prepare setup-envtest
 go install sigs.k8s.io/controller-runtime/tools/setup-envtest@"$SETUP_ENVTEST_VER"

--- a/.github/scripts/run-integration-tests-group2.sh
+++ b/.github/scripts/run-integration-tests-group2.sh
@@ -3,8 +3,8 @@
 set -euxo pipefail
 
 # renovate: datasource=go depName=sigs.k8s.io/controller-runtime
-SETUP_ENVTEST_VER=${SETUP_ENVTEST_VER-v0.24.0}
-ENVTEST_K8S_VERSION=${ENVTEST_K8S_VERSION-1.37}
+SETUP_ENVTEST_VER=${SETUP_ENVTEST_VER:-v0.24.0}
+ENVTEST_K8S_VERSION=${ENVTEST_K8S_VERSION:-1.37}
 
 # install and prepare setup-envtest
 go install sigs.k8s.io/controller-runtime/tools/setup-envtest@"$SETUP_ENVTEST_VER"

--- a/.github/scripts/run-integration-tests-group2.sh
+++ b/.github/scripts/run-integration-tests-group2.sh
@@ -4,7 +4,7 @@ set -euxo pipefail
 
 # renovate: datasource=go depName=sigs.k8s.io/controller-runtime
 SETUP_ENVTEST_VER=${SETUP_ENVTEST_VER-v0.24.0}
-ENVTEST_K8S_VERSION=${ENVTEST_K8S_VERSION-1.36}
+ENVTEST_K8S_VERSION=${ENVTEST_K8S_VERSION-1.37}
 
 # install and prepare setup-envtest
 go install sigs.k8s.io/controller-runtime/tools/setup-envtest@"$SETUP_ENVTEST_VER"

--- a/.github/scripts/run-integration-tests.sh
+++ b/.github/scripts/run-integration-tests.sh
@@ -3,8 +3,8 @@
 set -euxo pipefail
 
 # renovate: datasource=go depName=sigs.k8s.io/controller-runtime
-SETUP_ENVTEST_VER=${SETUP_ENVTEST_VER-v0.24.0}
-ENVTEST_K8S_VERSION=${ENVTEST_K8S_VERSION-1.37}
+SETUP_ENVTEST_VER=${SETUP_ENVTEST_VER:-v0.24.0}
+ENVTEST_K8S_VERSION=${ENVTEST_K8S_VERSION:-1.37}
 
 # install and prepare setup-envtest
 go install sigs.k8s.io/controller-runtime/tools/setup-envtest@"$SETUP_ENVTEST_VER"

--- a/.github/scripts/run-integration-tests.sh
+++ b/.github/scripts/run-integration-tests.sh
@@ -4,7 +4,7 @@ set -euxo pipefail
 
 # renovate: datasource=go depName=sigs.k8s.io/controller-runtime
 SETUP_ENVTEST_VER=${SETUP_ENVTEST_VER-v0.24.0}
-ENVTEST_K8S_VERSION=${ENVTEST_K8S_VERSION-1.36}
+ENVTEST_K8S_VERSION=${ENVTEST_K8S_VERSION-1.37}
 
 # install and prepare setup-envtest
 go install sigs.k8s.io/controller-runtime/tools/setup-envtest@"$SETUP_ENVTEST_VER"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -25,7 +25,7 @@ concurrency:
 env:
   GOARCH: amd64
   CGO_ENABLED: 0
-  SETUP_K3S_VERSION: "v1.36.0-k3s1"
+  SETUP_K3S_VERSION: "v1.36.4-k3s1"
   # Defaults for both manual and scheduled runs
   BENCH_TIMEOUT: ${{ github.event.inputs.timeout || '2m' }}
   BENCH_NAMESPACE: ${{ github.event.inputs.namespace || 'fleet-local' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
         env:
           # renovate: datasource=go depName=sigs.k8s.io/controller-runtime
           SETUP_ENVTEST_VER: v0.24.0
-          ENVTEST_K8S_VERSION: 1.36
+          ENVTEST_K8S_VERSION: 1.37
         run: ./.github/scripts/run-integration-tests-group1.sh
 
   integration-tests-group2:
@@ -89,5 +89,5 @@ jobs:
         env:
           # renovate: datasource=go depName=sigs.k8s.io/controller-runtime
           SETUP_ENVTEST_VER: v0.24.0
-          ENVTEST_K8S_VERSION: 1.36
+          ENVTEST_K8S_VERSION: 1.37
         run: ./.github/scripts/run-integration-tests-group2.sh

--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -25,9 +25,9 @@ jobs:
           # k3d version list k3s | sed 's/+/-/' | sort -h
           # https://hub.docker.com/r/rancher/k3s/tags
           - name: k3s-new
-            version: v1.36.0-k3s1
+            version: v1.36.4-k3s1
           - name: k3s-old
-            version: v1.34.7-k3s1
+            version: v1.35.0-k3s1
         test_type:
           - name: default
           - name: sharding

--- a/.github/workflows/e2e-fleet-upgrade-ci.yml
+++ b/.github/workflows/e2e-fleet-upgrade-ci.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         k3s:
           - name: k3s-new
-            version: v1.36.0-k3s1
+            version: v1.36.4-k3s1
     name: fleet-upgrade-test-${{ matrix.k3s.name }}
 
     steps:

--- a/.github/workflows/e2e-nightly-ci.yml
+++ b/.github/workflows/e2e-nightly-ci.yml
@@ -8,9 +8,9 @@ on:
   workflow_dispatch:
     inputs:
       k3s_version:
-        description: 'K3s version to test (e.g., v1.36.0-k3s1)'
+        description: 'K3s version to test (e.g., v1.36.4-k3s1)'
         required: false
-        default: 'v1.36.0-k3s1'
+        default: 'v1.36.4-k3s1'
       test_type:
         description: 'Test type to run'
         required: false
@@ -37,8 +37,8 @@ jobs:
         k3s_version:
           # k3d version list k3s | sed 's/+/-/' | sort -h
           # https://hub.docker.com/r/rancher/k3s/tags
-          - ${{ github.event.inputs.k3s_version || 'v1.36.0-k3s1' }}
-          - ${{ github.event_name == 'schedule' && 'v1.34.7-k3s1' || '' }}
+          - ${{ github.event.inputs.k3s_version || 'v1.36.4-k3s1' }}
+          - ${{ github.event_name == 'schedule' && 'v1.35.0-k3s1' || '' }}
         test_type:
           - ${{ github.event.inputs.test_type || 'acceptance' }}
           - ${{ github.event_name == 'schedule' && 'e2e-secrets' || '' }}

--- a/.github/workflows/e2e-rancher-upgrade-fleet-to-head-ci.yml
+++ b/.github/workflows/e2e-rancher-upgrade-fleet-to-head-ci.yml
@@ -22,7 +22,7 @@ permissions:
 env:
   GOARCH: amd64
   CGO_ENABLED: 0
-  SETUP_K3S_VERSION: 'v1.36.0-k3s1'
+  SETUP_K3S_VERSION: 'v1.36.4-k3s1'
 
 jobs:
   rancher-fleet-integration:

--- a/.github/workflows/e2e-rancher-upgrade-fleet.yml
+++ b/.github/workflows/e2e-rancher-upgrade-fleet.yml
@@ -13,7 +13,7 @@ on:
         # k3d version list k3s | sed 's/+/-/' | sort -h
         description: "K3s version to use"
         required: true
-        default: "v1.36.0-k3s1"
+        default: "v1.36.4-k3s1"
       rancher_version:
         description: "Rancher version to install"
         required: true

--- a/.github/workflows/e2e-test-fleet-in-rancher.yml
+++ b/.github/workflows/e2e-test-fleet-in-rancher.yml
@@ -28,7 +28,7 @@ permissions:
 env:
   GOARCH: amd64
   CGO_ENABLED: 0
-  SETUP_K3S_VERSION: 'v1.35.6-k3s1'
+  SETUP_K3S_VERSION: 'v1.36.4-k3s1'
 
 jobs:
   release-against-test-charts:
@@ -110,8 +110,8 @@ jobs:
         run: |
           mkdir -p ~/.local/bin
           if [ "$DEPS_CACHE_HIT" != "true" ]; then
-            KUBECTL_VERSION="v1.35.0"
-            KUBECTL_SUM_amd64="a2e984a18a0c063279d692533031c1eff93a262afcc0afdc517375432d060989"
+            KUBECTL_VERSION="v1.37.0"
+            KUBECTL_SUM_amd64="6129359f4e1f3848a5572ccb0b26cf28b8ca08cef38c95a765b2f64a2c961a2f"
             curl -sSfL "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" -o kubectl
             echo "${KUBECTL_SUM_amd64}  kubectl" | sha256sum -c -
             mv kubectl ~/.local/bin/

--- a/charts/fleet-agent/Chart.yaml
+++ b/charts/fleet-agent/Chart.yaml
@@ -1,11 +1,11 @@
 annotations:
   catalog.cattle.io/certified: rancher
   catalog.cattle.io/hidden: "true"
-  catalog.cattle.io/kube-version: '>= 1.34.0-0 < 1.37.0-0'
+  catalog.cattle.io/kube-version: '>= 1.35.0-0 < 1.38.0-0'
   catalog.cattle.io/namespace: cattle-fleet-system
   catalog.cattle.io/os: linux
   catalog.cattle.io/permits-os: linux,windows
-  catalog.cattle.io/rancher-version: '>= 2.15.0-0 < 2.16.0-0'
+  catalog.cattle.io/rancher-version: '>= 2.16.0-0 < 2.17.0-0'
   catalog.cattle.io/release-name: fleet-agent
 apiVersion: v2
 appVersion: 0.0.0

--- a/charts/fleet/Chart.yaml
+++ b/charts/fleet/Chart.yaml
@@ -3,12 +3,12 @@ annotations:
   catalog.cattle.io/certified: rancher
   catalog.cattle.io/experimental: "true"
   catalog.cattle.io/hidden: "true"
-  catalog.cattle.io/kube-version: '>= 1.34.0-0 < 1.37.0-0'
+  catalog.cattle.io/kube-version: '>= 1.35.0-0 < 1.38.0-0'
   catalog.cattle.io/namespace: cattle-fleet-system
   catalog.cattle.io/os: linux
   catalog.cattle.io/permits-os: linux,windows
   catalog.cattle.io/provides-gvr: clusters.fleet.cattle.io/v1alpha1
-  catalog.cattle.io/rancher-version: '>= 2.15.0-0 < 2.16.0-0'
+  catalog.cattle.io/rancher-version: '>= 2.16.0-0 < 2.17.0-0'
   catalog.cattle.io/release-name: fleet
 apiVersion: v2
 appVersion: 0.0.0


### PR DESCRIPTION
- Bump chart Kubernetes range to 1.35 through 1.37.
- Bump chart Rancher range to 2.16.
- Update envtest and kubectl CI versions to 1.37.
- Use published k3s v1.36.4 images until 1.37 images are available.