### PR TITLE
Output all linting issues on PRs

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -38,8 +38,8 @@ jobs:
 
           args: --timeout=10m --config=.golangci.json
 
-          # Optional: show only new issues if it's a pull request. The default value is `false`.
-          # The condition sets this to true for PR events.
-          only-new-issues: "${{ github.event_name == 'pull_request'}}"
+          # Output all issues even on pull requests, which prevents issues from going unnoticed until after a PR is
+          # merged, then surfacing in scheduled runs.
+          only-new-issues: false
 
           skip-cache: true

--- a/internal/bundlereader/charturl.go
+++ b/internal/bundlereader/charturl.go
@@ -200,8 +200,7 @@ func GetOCITag(ctx context.Context, r *remote.Repository, v string) (string, err
 
 	availableTags, err := registry.Tags(ctx, r)
 	if err != nil {
-		var regErr errcode.Error
-		if errors.As(err, &regErr) {
+		if regErr, ok := errors.AsType[errcode.Error](err); ok {
 			err = regErr
 
 			if regErr.Code == errcode.ErrorCodeNameUnknown {

--- a/internal/bundlereader/source.go
+++ b/internal/bundlereader/source.go
@@ -316,8 +316,7 @@ func redactSensitiveText(src string) string {
 // the error is wrapped into a message and logged. Other errors are returned
 // unchanged.
 func redactParseError(err error) error {
-	var ue *url.Error
-	if errors.As(err, &ue) {
+	if ue, ok := errors.AsType[*url.Error](err); ok {
 		return ue.Err
 	}
 	return err

--- a/internal/cmd/agent/deployer/deployer.go
+++ b/internal/cmd/agent/deployer/deployer.go
@@ -350,7 +350,11 @@ func updateNamespace(ctx context.Context, c client.Client, ns *corev1.Namespace)
 // fetchNamespace gets the namespace matching the release ID. Returns an error if none is found.
 // releaseID is composed of release.Namespace/release.Name/release.Version
 func fetchNamespace(ctx context.Context, c client.Client, releaseID string) (*corev1.Namespace, error) {
-	namespace := strings.Split(releaseID, "/")[0]
+	namespace, _, found := strings.Cut(releaseID, "/")
+	if !found {
+		return nil, fmt.Errorf("malformed release ID, without slash separator after namespace: %q", releaseID)
+	}
+
 	ns := &corev1.Namespace{}
 	if err := c.Get(ctx, types.NamespacedName{Name: namespace}, ns); err != nil {
 		if apierrors.IsForbidden(err) {

--- a/internal/cmd/agent/deployer/deployer_test.go
+++ b/internal/cmd/agent/deployer/deployer_test.go
@@ -265,16 +265,14 @@ func TestSetNamespaceLabelsAndAnnotations_ForbiddenSurfaces(t *testing.T) {
 }
 
 // TestNamespaceForbiddenError verifies that the typed error DeployBundle
-// returns for a denied namespace patch is both detectable via errors.As (so the
-// controller can do a controlled requeue) and still unwraps to a Forbidden
-// error.
+// returns for a denied namespace patch is both detectable via errors.AsType (so the controller can do a controlled
+// requeue) and still unwraps to a Forbidden error.
 func TestNamespaceForbiddenError(t *testing.T) {
 	forbidden := apierrors.NewForbidden(
 		schema.GroupResource{Resource: "namespaces"}, "namespace", errors.New("nope"))
 	err := error(&NamespaceForbiddenError{err: forbidden})
 
-	var nsErr *NamespaceForbiddenError
-	if !errors.As(err, &nsErr) {
+	if _, ok := errors.AsType[*NamespaceForbiddenError](err); !ok {
 		t.Errorf("expected error to be detectable as *NamespaceForbiddenError, got %v", err)
 	}
 	if !apierrors.IsForbidden(err) {

--- a/internal/cmd/controller/agentmanagement/controllers/controllers.go
+++ b/internal/cmd/controller/agentmanagement/controllers/controllers.go
@@ -242,7 +242,7 @@ func controllerFactory(rest *rest.Config) (controller.SharedControllerFactory, e
 		DefaultRateLimiter:     rateLimit,
 		DefaultWorkers:         50,
 		SyncOnlyChangedObjects: true,
-		KindRateLimiter: map[schema.GroupVersionKind]workqueue.RateLimiter{
+		KindRateLimiter: map[schema.GroupVersionKind]workqueue.RateLimiter{ //nolint:staticcheck // rancher/lasso needs to migrate to typed rate limiters
 			v1alpha1.SchemeGroupVersion.WithKind("Cluster"): clusterRateLimiter,
 		},
 	}), nil

--- a/internal/cmd/controller/cleanup/controllers/controllers.go
+++ b/internal/cmd/controller/cleanup/controllers/controllers.go
@@ -158,7 +158,7 @@ func controllerFactory(rest *rest.Config) (controller.SharedControllerFactory, e
 		DefaultRateLimiter:     rateLimit,
 		DefaultWorkers:         50,
 		SyncOnlyChangedObjects: true,
-		KindRateLimiter: map[schema.GroupVersionKind]workqueue.RateLimiter{
+		KindRateLimiter: map[schema.GroupVersionKind]workqueue.RateLimiter{ //nolint:staticcheck // rancher/lasso needs to migrate to typed rate limiters
 			v1alpha1.SchemeGroupVersion.WithKind("Cluster"): clusterRateLimiter,
 		},
 	}), nil

--- a/internal/cmd/controller/reconciler/cluster_controller.go
+++ b/internal/cmd/controller/reconciler/cluster_controller.go
@@ -144,7 +144,7 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	if patched, err := r.normalizeAgentSchedulingCustomization(ctx, cluster); err != nil {
 		return ctrl.Result{}, err
 	} else if patched {
-		return ctrl.Result{Requeue: true}, nil
+		return ctrl.Result{RequeueAfter: durations.DefaultRequeueAfter}, nil
 	}
 
 	if cluster.Status.Namespace == "" {

--- a/internal/resourcestatus/resourcekey.go
+++ b/internal/resourcestatus/resourcekey.go
@@ -75,7 +75,8 @@ func resourceId(namespace, name string) string {
 }
 
 func toType(apiVersion, kind string) string {
-	group := strings.Split(apiVersion, "/")[0]
+	group, _, _ := strings.Cut(apiVersion, "/")
+
 	if group == "v1" {
 		group = ""
 	} else if len(group) > 0 {

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -406,7 +406,7 @@ func parsePayload(payload any) (revision, branch, tag string, repoURLs []string)
 				continue
 			}
 			if strings.HasSuffix(parsed.Hostname(), ".visualstudio.com") {
-				org := strings.SplitN(parsed.Hostname(), ".", 2)[0]
+				org, _, _ := strings.Cut(parsed.Hostname(), ".")
 				parsed.Host = "dev.azure.com"
 				// parsed.Path is prefixed with a slash, hence no need to add it to the formatting
 				// string.


### PR DESCRIPTION
Some PRs bring changes causing linter errors which may not be directly visible in the patches themselves. This is the case for dependency bumps, causing errors to fly under the radar when merging a PR, then to surface during the next (e.g. scheduled) linter runs.

Updating linter configuration to output all errors on PRs mitigates this.

See the failing CI build against the first commit, as the `golangci-lint` job failed as a result of updating linter config, reflecting recent failures such as [this one](https://github.com/rancher/fleet/actions/runs/33719554383); raised errors are fixed in subsequent commits.

## Additional Information

### Checklist

~- [ ] <!-- If applicable,--> I have updated the documentation via a pull request in the [fleet-product-docs](https://github.com/rancher/fleet-product-docs) repository.~
