### PR TITLE
Fix GitRepo/HelmOp status races that drop concurrent conditions

### DIFF
--- a/integrationtests/gitjob/controller/status_conflict_test.go
+++ b/integrationtests/gitjob/controller/status_conflict_test.go
@@ -1,0 +1,424 @@
+package controller
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/events"
+	"k8s.io/client-go/util/retry"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/rancher/fleet/integrationtests/utils"
+	"github.com/reugn/go-quartz/quartz"
+
+	"github.com/rancher/fleet/internal/cmd/controller/gitops/reconciler"
+	"github.com/rancher/fleet/internal/ssh"
+	v1alpha1 "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
+	"github.com/rancher/fleet/pkg/sharding"
+	"github.com/rancher/wrangler/v3/pkg/genericcondition"
+)
+
+// isGitRepo matches GitRepo reads, for the test clients in integrationtests/utils.
+func isGitRepo(obj client.Object) bool {
+	_, ok := obj.(*v1alpha1.GitRepo)
+	return ok
+}
+
+// copyGitRepoInto returns a CopyInto function serving the given stale GitRepo.
+func copyGitRepoInto(stale *v1alpha1.GitRepo) func(client.Object) bool {
+	return func(into client.Object) bool {
+		gitrepo, ok := into.(*v1alpha1.GitRepo)
+		if !ok {
+			return false
+		}
+		stale.DeepCopyInto(gitrepo)
+
+		return true
+	}
+}
+
+var _ = Describe("GitRepo status conflicts", func() {
+	var gitrepoName types.NamespacedName
+
+	BeforeEach(func() {
+		var err error
+		namespace, err = utils.NewNamespaceName()
+		Expect(err).ToNot(HaveOccurred())
+
+		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}
+		Expect(k8sClient.Create(ctx, ns)).To(Succeed())
+		DeferCleanup(func() {
+			Expect(k8sClient.Delete(ctx, ns)).To(Succeed())
+		})
+
+		gitrepoName = types.NamespacedName{Name: "conflict-gitrepo", Namespace: namespace}
+
+		// The shard-ref label keeps the manager-run reconcilers (which use the
+		// default, unsharded ShardID) away from this GitRepo, so the only writers
+		// are the ones this test drives explicitly.
+		gitrepo := &v1alpha1.GitRepo{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      gitrepoName.Name,
+				Namespace: gitrepoName.Namespace,
+				Labels:    map[string]string{sharding.ShardingRefLabel: "conflict-test-shard"},
+			},
+			Spec: v1alpha1.GitRepoSpec{
+				Repo: "https://github.com/rancher/fleet-test-data",
+			},
+		}
+		Expect(k8sClient.Create(ctx, gitrepo)).To(Succeed())
+	})
+
+	When("another controller writes a condition between the status reconciler's read and its patch", func() {
+		It("does not drop that condition", func() {
+			// Simulates the gitjob reconciler publishing Accepted=True while the
+			// status reconciler is mid-flight, holding a copy that predates it.
+			injector := &utils.ConflictInjector{
+				Client: k8sClient,
+				Target: gitrepoName,
+				Match:  isGitRepo,
+			}
+			injector.Inject = func() {
+				defer GinkgoRecover()
+				Expect(retry.RetryOnConflict(retry.DefaultRetry, func() error {
+					live := &v1alpha1.GitRepo{}
+					if err := k8sClient.Get(ctx, gitrepoName, live); err != nil {
+						return err
+					}
+					live.Status.Conditions = append(live.Status.Conditions, genericcondition.GenericCondition{
+						Type:    v1alpha1.GitRepoAcceptedCondition,
+						Status:  corev1.ConditionTrue,
+						Message: "set by a concurrent writer",
+					})
+					return k8sClient.Status().Update(ctx, live)
+				})).To(Succeed())
+			}
+
+			r := &reconciler.StatusReconciler{
+				Client: injector,
+				Scheme: k8sClient.Scheme(),
+			}
+
+			res, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: gitrepoName})
+			Expect(err).ToNot(HaveOccurred())
+
+			By("leaving the concurrently written condition intact")
+			live := &v1alpha1.GitRepo{}
+			Expect(k8sClient.Get(ctx, gitrepoName, live)).To(Succeed())
+			cond, found := utils.FindCondition(live.Status.Conditions, v1alpha1.GitRepoAcceptedCondition)
+			Expect(found).To(BeTrue(), "Accepted condition was dropped by the status reconciler")
+			Expect(cond.Message).To(Equal("set by a concurrent writer"))
+
+			By("requeuing instead of overwriting the newer version")
+			Expect(res.RequeueAfter).To(BeNumerically(">", 0))
+		})
+	})
+
+	When("no concurrent write happens", func() {
+		It("still updates the status", func() {
+			r := &reconciler.StatusReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+			}
+
+			res, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: gitrepoName})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(res.RequeueAfter).To(BeZero())
+
+			live := &v1alpha1.GitRepo{}
+			Expect(k8sClient.Get(ctx, gitrepoName, live)).To(Succeed())
+			Expect(live.Status.Display.State).To(Equal("GitUpdating"))
+		})
+	})
+})
+
+// stubFetcher is a GitFetcher returning a fixed commit.
+type stubFetcher struct{ commit string }
+
+func (f stubFetcher) LatestCommit(_ context.Context, _ *v1alpha1.GitRepo, _ client.Client) (string, error) {
+	return f.commit, nil
+}
+
+var _ = Describe("GitRepo polling job status conflicts", func() {
+	var gitrepoName types.NamespacedName
+
+	BeforeEach(func() {
+		var err error
+		namespace, err = utils.NewNamespaceName()
+		Expect(err).ToNot(HaveOccurred())
+
+		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}
+		Expect(k8sClient.Create(ctx, ns)).To(Succeed())
+		DeferCleanup(func() {
+			Expect(k8sClient.Delete(ctx, ns)).To(Succeed())
+		})
+
+		gitrepoName = types.NamespacedName{Name: "polling-gitrepo", Namespace: namespace}
+
+		// See above: the shard-ref label keeps the manager-run reconcilers away.
+		gitrepo := &v1alpha1.GitRepo{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      gitrepoName.Name,
+				Namespace: gitrepoName.Namespace,
+				Labels:    map[string]string{sharding.ShardingRefLabel: "polling-test-shard"},
+			},
+			Spec: v1alpha1.GitRepoSpec{
+				Repo: "https://github.com/rancher/fleet-test-data",
+			},
+		}
+		Expect(k8sClient.Create(ctx, gitrepo)).To(Succeed())
+	})
+
+	When("the polling job reads a GitRepo from a lagging cache", func() {
+		It("does not drop conditions written since that read", func() {
+			staleCopy := &v1alpha1.GitRepo{}
+			wrapped := &utils.StaleReadClient{
+				Client:   k8sClient,
+				Target:   gitrepoName,
+				CopyInto: copyGitRepoInto(staleCopy),
+			}
+
+			sched, err := quartz.NewStdScheduler()
+			Expect(err).ToNot(HaveOccurred())
+			DeferCleanup(func() { sched.Stop() })
+
+			r := &reconciler.GitJobReconciler{
+				Client:          wrapped,
+				Scheme:          k8sClient.Scheme(),
+				Image:           "image",
+				Scheduler:       sched,
+				GitFetcher:      stubFetcher{commit: "1883fd54bc5dfd225acf02aecbb6cb8020458e33"},
+				Clock:           reconciler.RealClock{},
+				Recorder:        &events.FakeRecorder{},
+				Workers:         1,
+				SystemNamespace: "default",
+				KnownHosts:      ssh.KnownHosts{},
+			}
+
+			By("reconciling once so the polling job is scheduled with the wrapped client")
+			_, err = r.Reconcile(ctx, ctrl.Request{NamespacedName: gitrepoName})
+			Expect(err).ToNot(HaveOccurred())
+
+			gitrepo := &v1alpha1.GitRepo{}
+			Expect(k8sClient.Get(ctx, gitrepoName, gitrepo)).To(Succeed())
+			gitrepo.DeepCopyInto(staleCopy)
+
+			By("having another controller publish a condition after that snapshot")
+			gitrepo.Status.Conditions = append(gitrepo.Status.Conditions, genericcondition.GenericCondition{
+				Type:    v1alpha1.GitRepoAcceptedCondition,
+				Status:  corev1.ConditionTrue,
+				Message: "set by a concurrent writer",
+			})
+			Expect(k8sClient.Status().Update(ctx, gitrepo)).To(Succeed())
+
+			// The polling job reads the GitRepo twice before patching: once up
+			// front, then again inside its retry loop. Serve the pre-condition
+			// snapshot to both, so the job patches entirely from a version that
+			// predates the concurrent write. Reads after that (the retry) see the
+			// real object, as a cache that has caught up would.
+			wrapped.Arm(2)
+
+			By("running the scheduled polling job")
+			scheduled, err := sched.GetScheduledJob(quartz.NewJobKey(string(gitrepo.UID)))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(scheduled.JobDetail().Job().Execute(ctx)).To(Succeed())
+
+			By("leaving the concurrently written condition intact")
+			live := &v1alpha1.GitRepo{}
+			Expect(k8sClient.Get(ctx, gitrepoName, live)).To(Succeed())
+			cond, found := utils.FindCondition(live.Status.Conditions, v1alpha1.GitRepoAcceptedCondition)
+			Expect(found).To(BeTrue(), "Accepted condition was dropped by the polling job")
+			Expect(cond.Message).To(Equal("set by a concurrent writer"))
+
+			By("still recording the polling result")
+			Expect(live.Status.PollingCommit).To(Equal("1883fd54bc5dfd225acf02aecbb6cb8020458e33"))
+		})
+	})
+})
+
+var _ = Describe("GitRepo reconciler status conflicts", func() {
+	var gitrepoName types.NamespacedName
+
+	BeforeEach(func() {
+		var err error
+		namespace, err = utils.NewNamespaceName()
+		Expect(err).ToNot(HaveOccurred())
+
+		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}
+		Expect(k8sClient.Create(ctx, ns)).To(Succeed())
+		DeferCleanup(func() {
+			Expect(k8sClient.Delete(ctx, ns)).To(Succeed())
+		})
+
+		gitrepoName = types.NamespacedName{Name: "merge-gitrepo", Namespace: namespace}
+
+		gitrepo := &v1alpha1.GitRepo{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      gitrepoName.Name,
+				Namespace: gitrepoName.Namespace,
+				Labels:    map[string]string{sharding.ShardingRefLabel: "merge-test-shard"},
+			},
+			Spec: v1alpha1.GitRepoSpec{
+				Repo: "https://github.com/rancher/fleet-test-data",
+			},
+		}
+		Expect(k8sClient.Create(ctx, gitrepo)).To(Succeed())
+	})
+
+	When("another writer adds a condition while the reconcile is in flight", func() {
+		It("does not drop it when writing the status", func() {
+			// The reconciler rebuilds the conditions array from the status it read
+			// at the top of Reconcile. Its patch base is a fresh read, so the
+			// optimistic lock never fires here; only merging against what it read
+			// keeps a condition added since then from being dropped.
+			//
+			// The condition type is one no GitRepo controller writes, so the only
+			// way it can survive is by being carried over from the live object.
+			const foreignCondition = "ConcurrentWriter"
+
+			staleCopy := &v1alpha1.GitRepo{}
+			wrapped := &utils.StaleReadClient{
+				Client:   k8sClient,
+				Target:   gitrepoName,
+				CopyInto: copyGitRepoInto(staleCopy),
+			}
+
+			sched, err := quartz.NewStdScheduler()
+			Expect(err).ToNot(HaveOccurred())
+			DeferCleanup(func() { sched.Stop() })
+
+			r := &reconciler.GitJobReconciler{
+				Client:          wrapped,
+				Scheme:          k8sClient.Scheme(),
+				Image:           "image",
+				Scheduler:       sched,
+				GitFetcher:      stubFetcher{commit: "1883fd54bc5dfd225acf02aecbb6cb8020458e33"},
+				Clock:           reconciler.RealClock{},
+				Recorder:        &events.FakeRecorder{},
+				Workers:         1,
+				SystemNamespace: "default",
+				KnownHosts:      ssh.KnownHosts{},
+			}
+
+			By("reconciling once so the finalizer and polling job are in place")
+			_, err = r.Reconcile(ctx, ctrl.Request{NamespacedName: gitrepoName})
+			Expect(err).ToNot(HaveOccurred())
+
+			By("capturing the GitRepo as the next reconcile would read it")
+			gitrepo := &v1alpha1.GitRepo{}
+			Expect(k8sClient.Get(ctx, gitrepoName, gitrepo)).To(Succeed())
+			gitrepo.DeepCopyInto(staleCopy)
+
+			By("having another controller add a condition after that read")
+			gitrepo.Status.Conditions = append(gitrepo.Status.Conditions, genericcondition.GenericCondition{
+				Type:    foreignCondition,
+				Status:  corev1.ConditionTrue,
+				Message: "set by a concurrent writer",
+			})
+			Expect(k8sClient.Status().Update(ctx, gitrepo)).To(Succeed())
+
+			// Only the read at the top of Reconcile is stale. Everything after it,
+			// including the read updateStatus patches from, sees the live object,
+			// so the write itself does not conflict.
+			wrapped.Arm(1)
+
+			By("reconciling from that stale read")
+			_, err = r.Reconcile(ctx, ctrl.Request{NamespacedName: gitrepoName})
+			Expect(err).ToNot(HaveOccurred())
+
+			live := &v1alpha1.GitRepo{}
+			Expect(k8sClient.Get(ctx, gitrepoName, live)).To(Succeed())
+
+			By("having written its own status")
+			_, found := utils.FindCondition(live.Status.Conditions, v1alpha1.GitRepoAcceptedCondition)
+			Expect(found).To(BeTrue(), "the reconciler did not write its own conditions, so the merge was not exercised")
+
+			By("leaving the concurrently written condition intact")
+			cond, found := utils.FindCondition(live.Status.Conditions, foreignCondition)
+			Expect(found).To(BeTrue(), "condition added since the reconcile's read was dropped")
+			Expect(cond.Message).To(Equal("set by a concurrent writer"))
+		})
+	})
+
+	When("the polling job records a new commit while the reconcile is in flight", func() {
+		It("does not revert the polling fields when writing the status", func() {
+			// PollingCommit and LastPollingTime belong to the polling job. On this
+			// path the reconciler computes neither: polling is enabled and no
+			// webhook is pending, so fetchLatestCommit never runs. Assigning them
+			// from the status read at the top of Reconcile would therefore write
+			// back values that predate the poll.
+			//
+			// That is not a lost update the optimistic lock can catch: the write
+			// happens on a fresh read and never conflicts, it just carries stale
+			// values. And because getNextCommit reads PollingCommit, reverting it
+			// hides the new commit until the next poll.
+			const polledCommit = "d87ef1f9ba09e0b8b0b06d18ac9c0f0e75d5e0aa"
+			polledAt := metav1.NewTime(time.Now().Truncate(time.Second))
+
+			staleCopy := &v1alpha1.GitRepo{}
+			wrapped := &utils.StaleReadClient{
+				Client:   k8sClient,
+				Target:   gitrepoName,
+				CopyInto: copyGitRepoInto(staleCopy),
+			}
+
+			sched, err := quartz.NewStdScheduler()
+			Expect(err).ToNot(HaveOccurred())
+			DeferCleanup(func() { sched.Stop() })
+
+			r := &reconciler.GitJobReconciler{
+				Client:          wrapped,
+				Scheme:          k8sClient.Scheme(),
+				Image:           "image",
+				Scheduler:       sched,
+				GitFetcher:      stubFetcher{commit: "1883fd54bc5dfd225acf02aecbb6cb8020458e33"},
+				Clock:           reconciler.RealClock{},
+				Recorder:        &events.FakeRecorder{},
+				Workers:         1,
+				SystemNamespace: "default",
+				KnownHosts:      ssh.KnownHosts{},
+			}
+
+			By("reconciling once so the finalizer and polling job are in place")
+			_, err = r.Reconcile(ctx, ctrl.Request{NamespacedName: gitrepoName})
+			Expect(err).ToNot(HaveOccurred())
+
+			By("capturing the GitRepo as the next reconcile would read it")
+			gitrepo := &v1alpha1.GitRepo{}
+			Expect(k8sClient.Get(ctx, gitrepoName, gitrepo)).To(Succeed())
+			gitrepo.DeepCopyInto(staleCopy)
+			Expect(staleCopy.Status.PollingCommit).To(BeEmpty(), "the snapshot must predate the poll for this to test anything")
+
+			By("having the polling job record a new commit after that read")
+			gitrepo.Status.PollingCommit = polledCommit
+			gitrepo.Status.LastPollingTime = polledAt
+			Expect(k8sClient.Status().Update(ctx, gitrepo)).To(Succeed())
+
+			// Only the read at the top of Reconcile is stale, as in the condition
+			// case above: the read updateStatus writes from sees the live object.
+			wrapped.Arm(1)
+
+			By("reconciling from that stale read")
+			_, err = r.Reconcile(ctx, ctrl.Request{NamespacedName: gitrepoName})
+			Expect(err).ToNot(HaveOccurred())
+
+			live := &v1alpha1.GitRepo{}
+			Expect(k8sClient.Get(ctx, gitrepoName, live)).To(Succeed())
+
+			By("having written its own status")
+			_, found := utils.FindCondition(live.Status.Conditions, v1alpha1.GitRepoAcceptedCondition)
+			Expect(found).To(BeTrue(), "the reconciler did not write its status, so the polling fields were not exercised")
+
+			By("leaving the polling result intact")
+			Expect(live.Status.PollingCommit).To(Equal(polledCommit), "PollingCommit was reverted to the reconcile's stale read")
+			Expect(live.Status.LastPollingTime.Time).To(BeTemporally("==", polledAt.Time), "LastPollingTime was reverted to the reconcile's stale read")
+		})
+	})
+})

--- a/integrationtests/helmops/controller/status_conflict_test.go
+++ b/integrationtests/helmops/controller/status_conflict_test.go
@@ -1,0 +1,346 @@
+package controller
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/events"
+	"k8s.io/client-go/util/retry"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/reugn/go-quartz/quartz"
+
+	"github.com/rancher/fleet/integrationtests/utils"
+	"github.com/rancher/fleet/internal/cmd/controller/helmops/reconciler"
+	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
+	"github.com/rancher/fleet/pkg/sharding"
+	"github.com/rancher/wrangler/v3/pkg/genericcondition"
+)
+
+// isHelmOp matches HelmOp reads, for the test clients in integrationtests/utils.
+func isHelmOp(obj client.Object) bool {
+	_, ok := obj.(*fleet.HelmOp)
+	return ok
+}
+
+// copyHelmOpInto returns a CopyInto function serving the given stale HelmOp.
+func copyHelmOpInto(stale *fleet.HelmOp) func(client.Object) bool {
+	return func(into client.Object) bool {
+		helmop, ok := into.(*fleet.HelmOp)
+		if !ok {
+			return false
+		}
+		stale.DeepCopyInto(helmop)
+
+		return true
+	}
+}
+
+// newChartRepo serves the package's helm repo index for the duration of a spec.
+func newChartRepo() string {
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, helmRepoIndex)
+	}))
+	DeferCleanup(svr.Close)
+
+	return svr.URL
+}
+
+// newHelmOp returns a HelmOp carrying a shard-ref label, which keeps the
+// manager-run reconcilers (using the default, unsharded ShardID) away from it so
+// that the only writers are the ones a test drives explicitly.
+func newHelmOp(name types.NamespacedName, shard, chart string) *fleet.HelmOp {
+	return &fleet.HelmOp{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name.Name,
+			Namespace: name.Namespace,
+			Labels:    map[string]string{sharding.ShardingRefLabel: shard},
+		},
+		Spec: fleet.HelmOpSpec{
+			BundleSpec: fleet.BundleSpec{
+				BundleDeploymentOptions: fleet.BundleDeploymentOptions{
+					Helm: &fleet.HelmOptions{
+						Chart: chart,
+					},
+				},
+			},
+		},
+	}
+}
+
+var _ = Describe("HelmOp status conflicts", func() {
+	var helmOpName types.NamespacedName
+
+	BeforeEach(func() {
+		var err error
+		namespace, err = utils.NewNamespaceName()
+		Expect(err).ToNot(HaveOccurred())
+
+		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}
+		Expect(k8sClient.Create(ctx, ns)).To(Succeed())
+		DeferCleanup(func() {
+			Expect(k8sClient.Delete(ctx, ns)).To(Succeed())
+		})
+
+		helmOpName = types.NamespacedName{Name: "conflict-helmop", Namespace: namespace}
+		Expect(k8sClient.Create(
+			ctx,
+			newHelmOp(helmOpName, "conflict-test-shard", "http://foo.bar/baz/test.tgz"),
+		)).To(Succeed())
+	})
+
+	When("another controller writes a condition between the status reconciler's read and its patch", func() {
+		It("does not drop that condition", func() {
+			// Simulates the HelmOp reconciler publishing Accepted=True while the
+			// status reconciler is mid-flight, holding a copy that predates it.
+			injector := &utils.ConflictInjector{
+				Client: k8sClient,
+				Target: helmOpName,
+				Match:  isHelmOp,
+			}
+			injector.Inject = func() {
+				defer GinkgoRecover()
+				Expect(retry.RetryOnConflict(retry.DefaultRetry, func() error {
+					live := &fleet.HelmOp{}
+					if err := k8sClient.Get(ctx, helmOpName, live); err != nil {
+						return err
+					}
+					live.Status.Conditions = append(live.Status.Conditions, genericcondition.GenericCondition{
+						Type:    fleet.HelmOpAcceptedCondition,
+						Status:  corev1.ConditionTrue,
+						Message: "set by a concurrent writer",
+					})
+					return k8sClient.Status().Update(ctx, live)
+				})).To(Succeed())
+			}
+
+			r := &reconciler.HelmOpStatusReconciler{
+				Client: injector,
+				Scheme: k8sClient.Scheme(),
+			}
+
+			res, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: helmOpName})
+			Expect(err).ToNot(HaveOccurred())
+
+			By("leaving the concurrently written condition intact")
+			live := &fleet.HelmOp{}
+			Expect(k8sClient.Get(ctx, helmOpName, live)).To(Succeed())
+			cond, found := utils.FindCondition(live.Status.Conditions, fleet.HelmOpAcceptedCondition)
+			Expect(found).To(BeTrue(), "Accepted condition was dropped by the status reconciler")
+			Expect(cond.Message).To(Equal("set by a concurrent writer"))
+
+			By("requeuing instead of overwriting the newer version")
+			Expect(res.RequeueAfter).To(BeNumerically(">", 0))
+		})
+	})
+
+	When("no concurrent write happens", func() {
+		It("still updates the status", func() {
+			r := &reconciler.HelmOpStatusReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+			}
+
+			res, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: helmOpName})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(res.RequeueAfter).To(BeZero())
+
+			live := &fleet.HelmOp{}
+			Expect(k8sClient.Get(ctx, helmOpName, live)).To(Succeed())
+			cond, found := utils.FindCondition(live.Status.Conditions, "Ready")
+			Expect(found).To(BeTrue(), "expected the status reconciler to write a Ready condition")
+			Expect(cond.Status).To(Equal(corev1.ConditionTrue))
+		})
+	})
+})
+
+var _ = Describe("HelmOp polling job status conflicts", func() {
+	var helmOpName types.NamespacedName
+
+	BeforeEach(func() {
+		var err error
+		namespace, err = utils.NewNamespaceName()
+		Expect(err).ToNot(HaveOccurred())
+
+		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}
+		Expect(k8sClient.Create(ctx, ns)).To(Succeed())
+		DeferCleanup(func() {
+			Expect(k8sClient.Delete(ctx, ns)).To(Succeed())
+		})
+
+		helmOpName = types.NamespacedName{Name: "polling-helmop", Namespace: namespace}
+	})
+
+	When("the polling job reads a HelmOp from a lagging cache", func() {
+		It("does not drop conditions written since that read", func() {
+			helmop := newHelmOp(helmOpName, "polling-test-shard", "alpine")
+			helmop.Spec.Helm.Repo = newChartRepo()
+			helmop.Spec.Helm.Version = "<= 0.2.0"
+			helmop.Spec.PollingInterval = &metav1.Duration{Duration: time.Hour}
+			Expect(k8sClient.Create(ctx, helmop)).To(Succeed())
+
+			staleCopy := &fleet.HelmOp{}
+			wrapped := &utils.StaleReadClient{
+				Client:   k8sClient,
+				Target:   helmOpName,
+				CopyInto: copyHelmOpInto(staleCopy),
+			}
+
+			sched, err := quartz.NewStdScheduler()
+			Expect(err).ToNot(HaveOccurred())
+			DeferCleanup(func() { sched.Stop() })
+
+			r := &reconciler.HelmOpReconciler{
+				Client:    wrapped,
+				Scheme:    k8sClient.Scheme(),
+				Scheduler: sched,
+				Workers:   1,
+				Recorder:  &events.FakeRecorder{},
+			}
+
+			By("reconciling once so the polling job is scheduled with the wrapped client")
+			_, err = r.Reconcile(ctx, ctrl.Request{NamespacedName: helmOpName})
+			Expect(err).ToNot(HaveOccurred())
+
+			live := &fleet.HelmOp{}
+			Expect(k8sClient.Get(ctx, helmOpName, live)).To(Succeed())
+			live.DeepCopyInto(staleCopy)
+
+			By("having another controller publish a condition after that snapshot")
+			live.Status.Conditions = append(live.Status.Conditions, genericcondition.GenericCondition{
+				Type:    "ConcurrentWriter",
+				Status:  corev1.ConditionTrue,
+				Message: "set by a concurrent writer",
+			})
+			Expect(k8sClient.Status().Update(ctx, live)).To(Succeed())
+
+			// The polling job reads the HelmOp twice before patching its status:
+			// once up front, then again inside its retry loop. Serve the
+			// pre-condition snapshot to both, so the job patches entirely from a
+			// version that predates the concurrent write. Reads after that (the
+			// retry) see the real object, as a cache that has caught up would.
+			wrapped.Arm(2)
+
+			By("running the scheduled polling job")
+			scheduled, err := sched.GetScheduledJob(quartz.NewJobKey(string(staleCopy.UID)))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(scheduled.JobDetail().Job().Execute(ctx)).To(Succeed())
+
+			By("leaving the concurrently written condition intact")
+			Expect(k8sClient.Get(ctx, helmOpName, live)).To(Succeed())
+			cond, found := utils.FindCondition(live.Status.Conditions, "ConcurrentWriter")
+			Expect(found).To(BeTrue(), "condition was dropped by the polling job")
+			Expect(cond.Message).To(Equal("set by a concurrent writer"))
+
+			By("still recording the polling result")
+			Expect(live.Status.Version).To(Equal("0.2.0"))
+		})
+	})
+})
+
+var _ = Describe("HelmOp reconciler status conflicts", func() {
+	var helmOpName types.NamespacedName
+
+	BeforeEach(func() {
+		var err error
+		namespace, err = utils.NewNamespaceName()
+		Expect(err).ToNot(HaveOccurred())
+
+		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}
+		Expect(k8sClient.Create(ctx, ns)).To(Succeed())
+		DeferCleanup(func() {
+			Expect(k8sClient.Delete(ctx, ns)).To(Succeed())
+		})
+
+		helmOpName = types.NamespacedName{Name: "merge-helmop", Namespace: namespace}
+	})
+
+	When("another writer adds a condition while the reconcile is in flight", func() {
+		It("does not drop it, and still publishes the resolved version", func() {
+			// The reconciler used to rebuild the conditions array from the status
+			// it read at the top of Reconcile. Its patch base is a fresh read, so
+			// the optimistic lock never fires here; only merging against what it
+			// read keeps a condition added since then from being dropped.
+			//
+			// The condition type is one no HelmOp controller writes, so the only
+			// way it can survive is by being carried over from the live object.
+			const foreignCondition = "ConcurrentWriter"
+
+			helmop := newHelmOp(helmOpName, "merge-test-shard", "alpine")
+			helmop.Spec.Helm.Repo = newChartRepo()
+			helmop.Spec.Helm.Version = "0.1.0"
+			Expect(k8sClient.Create(ctx, helmop)).To(Succeed())
+
+			staleCopy := &fleet.HelmOp{}
+			wrapped := &utils.StaleReadClient{
+				Client:   k8sClient,
+				Target:   helmOpName,
+				CopyInto: copyHelmOpInto(staleCopy),
+			}
+
+			sched, err := quartz.NewStdScheduler()
+			Expect(err).ToNot(HaveOccurred())
+			DeferCleanup(func() { sched.Stop() })
+
+			r := &reconciler.HelmOpReconciler{
+				Client:    wrapped,
+				Scheme:    k8sClient.Scheme(),
+				Scheduler: sched,
+				Workers:   1,
+				Recorder:  &events.FakeRecorder{},
+			}
+
+			By("reconciling once so the finalizer and bundle are in place")
+			_, err = r.Reconcile(ctx, ctrl.Request{NamespacedName: helmOpName})
+			Expect(err).ToNot(HaveOccurred())
+
+			By("capturing the HelmOp as the next reconcile would read it")
+			live := &fleet.HelmOp{}
+			Expect(k8sClient.Get(ctx, helmOpName, live)).To(Succeed())
+			live.DeepCopyInto(staleCopy)
+
+			By("having another controller add a condition after that read")
+			live.Status.Conditions = append(live.Status.Conditions, genericcondition.GenericCondition{
+				Type:    foreignCondition,
+				Status:  corev1.ConditionTrue,
+				Message: "set by a concurrent writer",
+			})
+			// Clear the version too, so the assertion below shows the reconciler
+			// still republishes it. This is the case the removed #3883 workaround
+			// used to handle, and it must survive a conflict retry.
+			live.Status.Version = ""
+			Expect(k8sClient.Status().Update(ctx, live)).To(Succeed())
+
+			// Only the read at the top of Reconcile is stale. Everything after it,
+			// including the read updateStatus patches from, sees the live object,
+			// so the write itself does not conflict.
+			wrapped.Arm(1)
+
+			By("reconciling from that stale read")
+			_, err = r.Reconcile(ctx, ctrl.Request{NamespacedName: helmOpName})
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(k8sClient.Get(ctx, helmOpName, live)).To(Succeed())
+
+			By("having written its own status")
+			_, found := utils.FindCondition(live.Status.Conditions, fleet.HelmOpAcceptedCondition)
+			Expect(found).To(BeTrue(), "the reconciler did not write its own conditions, so the merge was not exercised")
+			Expect(live.Status.Version).To(Equal("0.1.0"))
+
+			By("leaving the concurrently written condition intact")
+			cond, found := utils.FindCondition(live.Status.Conditions, foreignCondition)
+			Expect(found).To(BeTrue(), "condition added since the reconcile's read was dropped")
+			Expect(cond.Message).To(Equal("set by a concurrent writer"))
+		})
+	})
+})

--- a/integrationtests/utils/statusrace.go
+++ b/integrationtests/utils/statusrace.go
@@ -1,0 +1,120 @@
+package utils
+
+import (
+	"context"
+	"sync"
+
+	"github.com/rancher/wrangler/v3/pkg/genericcondition"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// ConflictInjector wraps a client and runs Inject once, the first time the
+// target object is read. That makes the caller's in-memory copy stale by the
+// time it patches the status, deterministically reproducing the race between a
+// status reconciler and the controller that owns the same object.
+//
+// Match narrows which reads trigger the injection, so that reads of other kinds
+// of object are ignored; it is required.
+type ConflictInjector struct {
+	client.Client
+
+	Target types.NamespacedName
+	Match  func(client.Object) bool
+	Inject func()
+
+	once sync.Once
+}
+
+func (c *ConflictInjector) Get(
+	ctx context.Context,
+	key client.ObjectKey,
+	obj client.Object,
+	opts ...client.GetOption,
+) error {
+	if err := c.Client.Get(ctx, key, obj, opts...); err != nil {
+		return err
+	}
+
+	if key == c.Target && c.Match(obj) {
+		c.once.Do(c.Inject)
+	}
+
+	return nil
+}
+
+// StaleReadClient wraps a client and serves a pre-captured, out-of-date copy of
+// the target object for the first N reads, simulating a lagging informer cache.
+// Later reads pass through to the real client, as a cache that has caught up
+// would.
+//
+// CopyInto writes the armed stale copy into the object being read, and reports
+// whether that object was one this client should serve staleness for; it is
+// required.
+type StaleReadClient struct {
+	client.Client
+
+	Target   types.NamespacedName
+	CopyInto func(into client.Object) bool
+
+	mu            sync.Mutex
+	staleUntilGet int
+	reads         int
+}
+
+// Arm serves the stale copy for the next staleUntilGet reads of the target.
+func (c *StaleReadClient) Arm(staleUntilGet int) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.staleUntilGet = staleUntilGet
+	c.reads = 0
+}
+
+func (c *StaleReadClient) serveStale(key client.ObjectKey, obj client.Object) bool {
+	if key != c.Target {
+		return false
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.staleUntilGet == 0 || c.reads >= c.staleUntilGet {
+		return false
+	}
+
+	// CopyInto rejects objects of a kind this client does not serve, so only
+	// count reads it actually handled.
+	if !c.CopyInto(obj) {
+		return false
+	}
+	c.reads++
+
+	return true
+}
+
+func (c *StaleReadClient) Get(
+	ctx context.Context,
+	key client.ObjectKey,
+	obj client.Object,
+	opts ...client.GetOption,
+) error {
+	if c.serveStale(key, obj) {
+		return nil
+	}
+
+	return c.Client.Get(ctx, key, obj, opts...)
+}
+
+// FindCondition returns the condition of the given type, and whether it exists.
+func FindCondition(
+	conds []genericcondition.GenericCondition,
+	condType string,
+) (genericcondition.GenericCondition, bool) {
+	for _, c := range conds {
+		if c.Type == condType {
+			return c, true
+		}
+	}
+
+	return genericcondition.GenericCondition{}, false
+}

--- a/internal/cmd/controller/gitops/reconciler/gitjob_controller.go
+++ b/internal/cmd/controller/gitops/reconciler/gitjob_controller.go
@@ -21,6 +21,7 @@ import (
 	"github.com/rancher/fleet/internal/cmd/controller/imagescan"
 	ctrlquartz "github.com/rancher/fleet/internal/cmd/controller/quartz"
 	"github.com/rancher/fleet/internal/cmd/controller/reconciler"
+	fleetstatus "github.com/rancher/fleet/internal/cmd/controller/status"
 	"github.com/rancher/fleet/internal/config"
 	"github.com/rancher/fleet/internal/metrics"
 	v1alpha1 "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
@@ -218,7 +219,7 @@ func (r *GitJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 			err,
 		)
 
-		return ctrl.Result{}, updateErrorStatus(ctx, r.Client, req.NamespacedName, *oldStatus, err)
+		return ctrl.Result{}, updateErrorStatus(ctx, r.Client, req.NamespacedName, *oldStatus, *oldStatus, err)
 	}
 	// Persist any spec defaults injected by AuthorizeAndAssignDefaults (e.g. defaultServiceAccount).
 	// The spec update bumps the generation and triggers a fresh reconcile.
@@ -259,7 +260,7 @@ func (r *GitJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 
 	if gitrepo.Spec.Repo == "" {
 		if err := r.deletePollingJob(*gitrepo); err != nil {
-			return ctrl.Result{}, updateErrorStatus(ctx, r.Client, req.NamespacedName, gitrepo.Status, err)
+			return ctrl.Result{}, updateErrorStatus(ctx, r.Client, req.NamespacedName, gitrepo.Status, *oldStatus, err)
 		}
 		// TODO: return an error here, similar to what we already do for HelmOps
 		return ctrl.Result{}, nil
@@ -267,7 +268,7 @@ func (r *GitJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 
 	jobUpdatedOrCreated, err := r.managePollingJob(logger, *gitrepo)
 	if err != nil {
-		return ctrl.Result{}, updateErrorStatus(ctx, r.Client, req.NamespacedName, gitrepo.Status, err)
+		return ctrl.Result{}, updateErrorStatus(ctx, r.Client, req.NamespacedName, gitrepo.Status, *oldStatus, err)
 	}
 
 	if jobUpdatedOrCreated {
@@ -294,7 +295,7 @@ func (r *GitJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		gitrepo.Status.Commit = oldCommit
 		gitrepo.Status.UpdateGeneration = oldUpdateGeneration
 		gitrepo.Status.ObservedGeneration = oldObservedGeneration
-		return res, updateErrorStatus(ctx, r.Client, req.NamespacedName, gitrepo.Status, err)
+		return res, updateErrorStatus(ctx, r.Client, req.NamespacedName, gitrepo.Status, *oldStatus, err)
 	}
 
 	// Update secret data hash annotations after successful job management
@@ -305,7 +306,7 @@ func (r *GitJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 
 	reconciler.SetCondition(v1alpha1.GitRepoAcceptedCondition, &gitrepo.Status, nil)
 
-	err = updateStatus(ctx, r.Client, req.NamespacedName, gitrepo.Status)
+	err = updateStatus(ctx, r.Client, req.NamespacedName, gitrepo.Status, *oldStatus)
 	if err != nil {
 		logger.Error(err, "Reconcile failed final update to git repo status", "status", gitrepo.Status)
 
@@ -1267,11 +1268,26 @@ func setStatusFromGitjob(ctx context.Context, c client.Client, gitRepo *v1alpha1
 	return nil
 }
 
-// updateErrorStatus sets the condition in the status and tries to update the resource
-func updateErrorStatus(ctx context.Context, c client.Client, req types.NamespacedName, status v1alpha1.GitRepoStatus, orgErr error) error {
+// updateErrorStatus sets the condition in the status and tries to update the resource.
+//
+// base is the GitRepo status as this reconcile first read it; see updateStatus.
+func updateErrorStatus(
+	ctx context.Context,
+	c client.Client,
+	req types.NamespacedName,
+	status v1alpha1.GitRepoStatus,
+	base v1alpha1.GitRepoStatus,
+	orgErr error,
+) error {
+	// SetCondition edits conditions in place, and status is a struct copy which
+	// may share its conditions backing array with base (and with the caller's
+	// GitRepo). Detach it, so that base keeps describing the status as read and
+	// the merge below can still tell what this reconciler computed.
+	status.Conditions = append([]genericcondition.GenericCondition(nil), status.Conditions...)
+
 	reconciler.SetCondition(v1alpha1.GitRepoAcceptedCondition, &status, orgErr)
 
-	if statusErr := updateStatus(ctx, c, req, status); statusErr != nil {
+	if statusErr := updateStatus(ctx, c, req, status, base); statusErr != nil {
 		merr := []error{orgErr, fmt.Errorf("failed to update the status: %w", statusErr)}
 		return errutil.NewAggregate(merr)
 	}
@@ -1281,7 +1297,17 @@ func updateErrorStatus(ctx context.Context, c client.Client, req types.Namespace
 // updateStatus updates the status for the GitRepo resource. It retries on
 // conflict. If the status was updated successfully, it also collects (as in
 // updates) metrics for the resource GitRepo resource.
-func updateStatus(ctx context.Context, c client.Client, req types.NamespacedName, status v1alpha1.GitRepoStatus) error {
+//
+// base is the GitRepo status as this reconcile first read it, used to tell the
+// conditions and polling fields this reconciler computed apart from the ones it
+// merely carried over from that read. See status.MergeConditions.
+func updateStatus(
+	ctx context.Context,
+	c client.Client,
+	req types.NamespacedName,
+	status v1alpha1.GitRepoStatus,
+	base v1alpha1.GitRepoStatus,
+) error {
 	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		t := &v1alpha1.GitRepo{}
 		err := c.Get(ctx, req, t)
@@ -1294,26 +1320,36 @@ func updateStatus(ctx context.Context, c client.Client, req types.NamespacedName
 		// selectively update the status fields this reconciler is responsible for
 		t.Status.Commit = status.Commit
 		t.Status.GitJobStatus = status.GitJobStatus
-		t.Status.PollingCommit = status.PollingCommit
-		t.Status.LastPollingTime = status.LastPollingTime
 		t.Status.ObservedGeneration = status.ObservedGeneration
 		t.Status.UpdateGeneration = status.UpdateGeneration
 
-		// only keep the Ready condition from live status, it's calculated by the status reconciler
-		conds := []genericcondition.GenericCondition{}
-		for _, c := range t.Status.Conditions {
-			if c.Type == "Ready" {
-				conds = append(conds, c)
-				break
-			}
+		// LastPollingTime and PollingCommit belong to the polling job. This
+		// reconciler never computes LastPollingTime, and computes PollingCommit
+		// only on the fetchLatestCommit paths, so assigning either from the
+		// reconcile-start snapshot would revert whatever the polling job wrote
+		// while this reconcile was running. That matters most with polling
+		// enabled: PollingCommit is then the only channel by which a new commit
+		// reaches getNextCommit, so reverting it hides the commit until the next
+		// poll, and the revert itself re-triggers this reconciler through
+		// commitChangedPredicate.
+		//
+		// base tells the two apart. Unlike the conditions below, a value the
+		// reconciler recomputed to what base already held needs no special care:
+		// live then holds either that same value or something newer from the
+		// polling job, and keeping live is right either way.
+		if status.PollingCommit != base.PollingCommit {
+			t.Status.PollingCommit = status.PollingCommit
 		}
-		for _, c := range status.Conditions {
-			if c.Type == "Ready" {
-				continue
-			}
-			conds = append(conds, c)
-		}
-		t.Status.Conditions = conds
+
+		// Merge rather than replace: the Ready condition belongs to the status
+		// reconciler, and the polling job owns GitPolling and the kstatus
+		// conditions, which it may well have written since base was read.
+		t.Status.Conditions = fleetstatus.MergeConditions(
+			t.Status.Conditions,
+			base.Conditions,
+			status.Conditions,
+			"Ready",
+		)
 
 		if commit != "" && status.Commit == "" {
 			// we could incur in a race condition between the poller job

--- a/internal/cmd/controller/gitops/reconciler/polling_job.go
+++ b/internal/cmd/controller/gitops/reconciler/polling_job.go
@@ -16,6 +16,7 @@ import (
 	"github.com/rancher/wrangler/v3/pkg/kstatus"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	errutil "k8s.io/apimachinery/pkg/util/errors"
@@ -67,7 +68,15 @@ func (j *gitPollingJob) Execute(ctx context.Context) error {
 	}
 	defer j.sem.Release(1)
 
-	return j.pollGitRepo(ctx)
+	err := j.pollGitRepo(ctx)
+	if err != nil {
+		// Quartz schedulers are built with the default logger.NoOpLogger and no
+		// job retries, so an error returned from here is discarded. Log it
+		// before handing it back, or polling failures are invisible.
+		logger.Error(err, "GitRepo polling job failed, retrying on the next poll")
+	}
+
+	return err
 }
 
 // Description returns a description for the job.
@@ -126,20 +135,35 @@ func (j *gitPollingJob) pollGitRepo(ctx context.Context) error {
 			return fmt.Errorf("could not get GitRepo to update its status: %w", err)
 		}
 
+		orig := t.DeepCopy()
+
 		t.Status.LastPollingTime = metav1.Time{Time: pollingTimestamp}
 		t.Status.PollingCommit = commit
 
 		condition.Cond(gitPollingCondition).SetError(&t.Status, "", nil)
 
-		statusPatch := client.MergeFrom(gitrepo)
-		if patchData, err := statusPatch.Data(t); err == nil && string(patchData) == "{}" {
-			// skip update if patch is empty
+		if equality.Semantic.DeepEqual(orig.Status, t.Status) {
+			// skip update if nothing changed
 			return nil
 		}
-		return j.client.Status().Patch(ctx, t, statusPatch)
+
+		// Patch under an optimistic lock, against a base read in this same attempt.
+		// A merge patch replaces the whole conditions array, so patching from a
+		// stale base drops conditions written concurrently by the gitjob
+		// reconciler. RetryOnConflict re-reads and recomputes on conflict.
+		return j.client.Status().Patch(
+			ctx,
+			t,
+			client.MergeFromWithOptions(orig, client.MergeFromWithOptimisticLock{}),
+		)
 	})
 	if err != nil {
-		return fail(fmt.Errorf("could not update GitRepo status with polling timestamp: %w", err))
+		// The commit check itself succeeded here; only the status write lost a
+		// race. Reporting that through fail() would emit a FailedToCheckCommit
+		// event and mark the GitRepo stalled over a transient conflict. Return
+		// the error instead, for Execute to log: the next scheduled poll
+		// recomputes the status from a fresh read.
+		return fmt.Errorf("could not update GitRepo status with polling timestamp: %w", err)
 	}
 
 	return nil
@@ -162,6 +186,8 @@ func (j *gitPollingJob) updateErrorStatus(
 			return fmt.Errorf("could not get GitRepo to update its status: %w", err)
 		}
 
+		orig := t.DeepCopy()
+
 		condition.Cond(gitPollingCondition).SetError(&t.Status, "", orgErr)
 		kstatus.SetError(t, orgErr.Error())
 
@@ -169,8 +195,17 @@ func (j *gitPollingJob) updateErrorStatus(
 			t.Status.LastPollingTime = metav1.Time{Time: pollingTimestamp}
 		}
 
-		statusPatch := client.MergeFrom(gitrepo)
-		return j.client.Status().Patch(ctx, t, statusPatch)
+		if equality.Semantic.DeepEqual(orig.Status, t.Status) {
+			return nil
+		}
+
+		// See pollGitRepo: patch under an optimistic lock against a base read in
+		// this same attempt, so a stale base cannot drop foreign conditions.
+		return j.client.Status().Patch(
+			ctx,
+			t,
+			client.MergeFromWithOptions(orig, client.MergeFromWithOptimisticLock{}),
+		)
 	})
 	if err != nil {
 		merr = append(merr, err)

--- a/internal/cmd/controller/gitops/reconciler/polling_job_test.go
+++ b/internal/cmd/controller/gitops/reconciler/polling_job_test.go
@@ -10,9 +10,12 @@ import (
 	gitmocks "github.com/rancher/fleet/pkg/git/mocks"
 	"github.com/rancher/wrangler/v3/pkg/genericcondition"
 	"go.uber.org/mock/gomock"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/events"
+	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -28,7 +31,8 @@ func TestPollGitRepo(t *testing.T) {
 		name            string
 		gitrepo         *v1alpha1.GitRepo
 		setupMocks      func(*mocks.MockK8sClient, *mocks.MockStatusWriter, *gitmocks.MockGitFetcher, *events.FakeRecorder)
-		patchErr        string
+		patchErr        error
+		patchTimes      int // number of expected Status().Patch() calls; 0 means 1
 		expectedErr     string
 		expectedEvents  []string
 		validateGitRepo func(*testing.T, *v1alpha1.GitRepo)
@@ -130,7 +134,7 @@ func TestPollGitRepo(t *testing.T) {
 			},
 			setupMocks: func(c *mocks.MockK8sClient, sw *mocks.MockStatusWriter, gf *gitmocks.MockGitFetcher, r *events.FakeRecorder) {
 				nsName := types.NamespacedName{Name: name, Namespace: namespace}
-				c.EXPECT().Get(gomock.Any(), nsName, gomock.Any()).Times(3).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *v1alpha1.GitRepo, _ ...client.GetOption) error {
+				c.EXPECT().Get(gomock.Any(), nsName, gomock.Any()).Times(2).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *v1alpha1.GitRepo, _ ...client.GetOption) error {
 					obj.Name = name
 					obj.Namespace = namespace
 					obj.Spec.Repo = repoURL
@@ -139,10 +143,47 @@ func TestPollGitRepo(t *testing.T) {
 					return nil
 				})
 				gf.EXPECT().LatestCommit(gomock.Any(), gomock.Any(), gomock.Any()).Return("new-commit", nil)
-				c.EXPECT().Status().Return(sw).Times(2)
+				c.EXPECT().Status().Return(sw)
 			},
-			patchErr:    "update error",
+			patchErr:    errors.New("update error"),
 			expectedErr: "could not update GitRepo status with polling timestamp: update error",
+			// Only the commit event: a failed status write must not additionally be
+			// reported as a failed commit check.
+			expectedEvents: []string{"Normal GotNewCommit new-commit"},
+		},
+		{
+			// The status patch is made under an optimistic lock, so a concurrent
+			// writer makes it conflict. Losing that race says nothing about the
+			// commit check, which already succeeded, so it must not emit a
+			// FailedToCheckCommit event or mark the GitRepo as stalled.
+			name: "Status update conflict",
+			gitrepo: &v1alpha1.GitRepo{
+				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+				Spec:       v1alpha1.GitRepoSpec{Repo: repoURL, Branch: branch},
+			},
+			setupMocks: func(c *mocks.MockK8sClient, sw *mocks.MockStatusWriter, gf *gitmocks.MockGitFetcher, r *events.FakeRecorder) {
+				nsName := types.NamespacedName{Name: name, Namespace: namespace}
+				// One read up front, then one per retry attempt.
+				c.EXPECT().Get(gomock.Any(), nsName, gomock.Any()).Times(1 + retry.DefaultRetry.Steps).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *v1alpha1.GitRepo, _ ...client.GetOption) error {
+					obj.Name = name
+					obj.Namespace = namespace
+					obj.Spec.Repo = repoURL
+					obj.Spec.Branch = branch
+					obj.Status.Commit = "commit"
+					return nil
+				})
+				gf.EXPECT().LatestCommit(gomock.Any(), gomock.Any(), gomock.Any()).Return("new-commit", nil)
+				c.EXPECT().Status().Return(sw).Times(retry.DefaultRetry.Steps)
+			},
+			patchErr: apierrors.NewConflict(
+				schema.GroupResource{Group: "fleet.cattle.io", Resource: "gitrepos"},
+				name,
+				errors.New("the object has been modified"),
+			),
+			patchTimes: retry.DefaultRetry.Steps,
+			expectedErr: "could not update GitRepo status with polling timestamp: " +
+				`Operation cannot be fulfilled on gitrepos.fleet.cattle.io "test-repo": the object has been modified`,
+			expectedEvents: []string{"Normal GotNewCommit new-commit"},
 		},
 	}
 
@@ -167,22 +208,16 @@ func TestPollGitRepo(t *testing.T) {
 			// The patch function in the mock will be our capture point.
 			var finalGitRepo *v1alpha1.GitRepo
 
+			patchTimes := tc.patchTimes
+			if patchTimes == 0 {
+				patchTimes = 1
+			}
+
 			mockStatusWriter.EXPECT().Patch(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
 				func(_ context.Context, obj *v1alpha1.GitRepo, _ client.Patch, _ ...client.PatchOption) error {
 					finalGitRepo = obj.DeepCopy()
-					if tc.patchErr != "" {
-						return errors.New(tc.patchErr)
-					}
-					return nil
-				}).Times(1)
-			if tc.patchErr != "" {
-				// this second call is to set the error in the condition
-				mockStatusWriter.EXPECT().Patch(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
-					func(_ context.Context, obj *v1alpha1.GitRepo, _ client.Patch, _ ...client.PatchOption) error {
-						finalGitRepo = obj.DeepCopy()
-						return nil
-					}).Times(1)
-			}
+					return tc.patchErr
+				}).Times(patchTimes)
 
 			err := job.pollGitRepo(context.Background())
 
@@ -195,14 +230,12 @@ func TestPollGitRepo(t *testing.T) {
 			}
 
 			close(recorder.Events)
-			if len(tc.expectedEvents) > 0 {
-				if len(recorder.Events) != len(tc.expectedEvents) {
-					t.Errorf("expected %d events, got %d", len(tc.expectedEvents), len(recorder.Events))
-				}
-				for i, expectedEvent := range tc.expectedEvents {
-					if event, ok := <-recorder.Events; ok && event != expectedEvent {
-						t.Errorf("expected event %d to be '%q', got '%q'", i, expectedEvent, event)
-					}
+			if len(recorder.Events) != len(tc.expectedEvents) {
+				t.Errorf("expected %d events, got %d", len(tc.expectedEvents), len(recorder.Events))
+			}
+			for i, expectedEvent := range tc.expectedEvents {
+				if event, ok := <-recorder.Events; ok && event != expectedEvent {
+					t.Errorf("expected event %d to be '%q', got '%q'", i, expectedEvent, event)
 				}
 			}
 

--- a/internal/cmd/controller/gitops/reconciler/status_controller.go
+++ b/internal/cmd/controller/gitops/reconciler/status_controller.go
@@ -14,6 +14,7 @@ import (
 	"github.com/rancher/fleet/pkg/sharding"
 	"github.com/rancher/wrangler/v3/pkg/genericcondition"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -146,7 +147,18 @@ func (r *StatusReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	}
 
 	if err := r.updateStatus(ctx, orig, gitrepo); err != nil {
+		if errors.IsConflict(err) {
+			// Expected under the optimistic lock: another controller wrote the
+			// status first. Requeuing recomputes it from a fresh read, so this
+			// is not worth reporting as an error. Come back sooner than the
+			// status delay, which exists to wait for a write that has by
+			// definition already happened here.
+			logger.V(1).Info("Conflict updating git repo status, retrying", "error", err)
+			return ctrl.Result{RequeueAfter: durations.StatusConflictRequeue}, nil
+		}
+
 		logger.Error(err, "Reconcile failed update to git repo status", "status", gitrepo.Status)
+
 		return ctrl.Result{RequeueAfter: durations.GitRepoStatusDelay}, nil
 	}
 
@@ -154,12 +166,21 @@ func (r *StatusReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 }
 
 func (r *StatusReconciler) updateStatus(ctx context.Context, orig *fleet.GitRepo, obj *fleet.GitRepo) error {
-	statusPatch := client.MergeFrom(orig)
-	if patchData, err := statusPatch.Data(obj); err == nil && string(patchData) == "{}" {
-		// skip update if patch is empty
+	if equality.Semantic.DeepEqual(orig.Status, obj.Status) {
+		// skip update if nothing changed
 		return nil
 	}
-	return r.Client.Status().Patch(ctx, obj, statusPatch)
+
+	// Patch under an optimistic lock. A merge patch replaces the whole conditions
+	// array, so without the lock a stale read here silently drops conditions owned
+	// by the gitjob reconciler (Accepted in particular). That reconciler ignores
+	// status-only changes, so a dropped condition is never restored.
+	// On conflict the caller requeues and recomputes from a fresh read.
+	return r.Client.Status().Patch(
+		ctx,
+		obj,
+		client.MergeFromWithOptions(orig, client.MergeFromWithOptimisticLock{}),
+	)
 }
 
 func setStatus(list *fleet.BundleDeploymentList, gitrepo *fleet.GitRepo) error {

--- a/internal/cmd/controller/helmops/reconciler/helmop_controller.go
+++ b/internal/cmd/controller/helmops/reconciler/helmop_controller.go
@@ -27,13 +27,13 @@ import (
 	"github.com/Masterminds/semver/v3"
 	"github.com/go-logr/logr"
 	"github.com/rancher/wrangler/v3/pkg/condition"
-	"github.com/rancher/wrangler/v3/pkg/genericcondition"
 	"github.com/reugn/go-quartz/quartz"
 
 	"github.com/rancher/fleet/internal/bundlereader"
 	fleetutil "github.com/rancher/fleet/internal/cmd/controller/errorutil"
 	"github.com/rancher/fleet/internal/cmd/controller/finalize"
 	ctrlquartz "github.com/rancher/fleet/internal/cmd/controller/quartz"
+	"github.com/rancher/fleet/internal/cmd/controller/status"
 	"github.com/rancher/fleet/internal/metrics"
 	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
 	"github.com/rancher/fleet/pkg/cert"
@@ -90,6 +90,11 @@ func (r *HelmOpReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		return ctrl.Result{}, nil
 	}
 
+	// The status as read, before this reconcile computes anything from it. Status
+	// updates below merge against it, so that conditions written by the polling
+	// job while this reconcile runs are not reverted to what was read here.
+	baseStatus := helmop.Status.DeepCopy()
+
 	if userID := helmop.Labels[fleet.CreatedByUserIDLabel]; userID != "" {
 		logger = logger.WithValues("userID", userID)
 	}
@@ -130,7 +135,7 @@ func (r *HelmOpReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		if delErr := r.deletePollingJob(*helmop); delErr != nil {
 			err = errutil.NewAggregate([]error{err, delErr})
 		}
-		return ctrl.Result{}, updateErrorStatusHelm(ctx, r.Client, req.NamespacedName, helmop, err)
+		return ctrl.Result{}, updateErrorStatusHelm(ctx, r.Client, req.NamespacedName, helmop, baseStatus, err)
 	}
 
 	// Policy restrictions: validate and apply defaults before producing the Bundle.
@@ -144,7 +149,7 @@ func (r *HelmOpReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 			"%v",
 			err,
 		)
-		return ctrl.Result{}, updateErrorStatusHelm(ctx, r.Client, req.NamespacedName, helmop, err)
+		return ctrl.Result{}, updateErrorStatusHelm(ctx, r.Client, req.NamespacedName, helmop, baseStatus, err)
 	}
 
 	// Reconciling
@@ -154,15 +159,15 @@ func (r *HelmOpReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	logger.V(1).Info("Reconciling HelmOp")
 
 	if _, err := r.createUpdateBundle(ctx, helmop); err != nil {
-		return ctrl.Result{}, updateErrorStatusHelm(ctx, r.Client, req.NamespacedName, helmop, err)
+		return ctrl.Result{}, updateErrorStatusHelm(ctx, r.Client, req.NamespacedName, helmop, baseStatus, err)
 	}
 
 	// Running this logic after creating/updating the bundle to avoid scheduling a job if the bundle has not been created.
 	if err := r.managePollingJob(logger, *helmop); err != nil {
-		return ctrl.Result{}, updateErrorStatusHelm(ctx, r.Client, req.NamespacedName, helmop, err)
+		return ctrl.Result{}, updateErrorStatusHelm(ctx, r.Client, req.NamespacedName, helmop, baseStatus, err)
 	}
 
-	err := updateStatus(ctx, r.Client, req.NamespacedName, helmop, nil)
+	err := updateStatus(ctx, r.Client, req.NamespacedName, helmop, baseStatus, nil)
 	if err != nil {
 		logger.Error(err, "Reconcile failed final update to HelmOp status", "status", helmop.Status)
 
@@ -441,12 +446,30 @@ func usesPolling(helmop fleet.HelmOp) bool {
 // updateStatus updates the status for the HelmOp resource. It retries on
 // conflict. If the status was updated successfully, it also collects (as in
 // updates) metrics for the HelmOp resource.
-func updateStatus(ctx context.Context, c client.Client, req types.NamespacedName, helmop *fleet.HelmOp, orgErr error) error {
+//
+// base is the HelmOp status as the caller first read it, used to tell the
+// conditions this reconciler computed apart from the ones it merely carried
+// over from that read. See status.MergeConditions.
+func updateStatus(
+	ctx context.Context,
+	c client.Client,
+	req types.NamespacedName,
+	helmop *fleet.HelmOp,
+	base *fleet.HelmOpStatus,
+	orgErr error,
+) error {
 	if helmop == nil {
 		return errors.New("the HelmOp provided for a status update is nil; this should not happen")
 	}
 
-	objToPatchFrom := helmop.DeepCopy()
+	// The status this reconciler wants to publish. It is only a source of values:
+	// the patch is always computed against a copy read inside the retry loop, so
+	// this stale copy can never serve as the patch base.
+	desired := helmop.DeepCopy()
+
+	if base == nil {
+		base = &desired.Status
+	}
 
 	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		t := &fleet.HelmOp{}
@@ -454,45 +477,40 @@ func updateStatus(ctx context.Context, c client.Client, req types.NamespacedName
 			return err
 		}
 
+		orig := t.DeepCopy()
+
 		// selectively update the status fields this reconciler is responsible for
-		if t.Status.Version != objToPatchFrom.Status.Version && objToPatchFrom.Status.Version != "" {
-			t.Status.Version = objToPatchFrom.Status.Version
-			// (#3883)
-			// If orig.Status.Version is, for example, equal to 1.0.0, when
-			// assigning the Version to t.Status.Version both will be 1.0.0.
-			// When calculating the Patch data, Status.Version will be ignored because
-			// both objects have the same value.
-			// The following cleanup prevents that so Status.Version is taken into
-			// account when calculating the patch data.
-			objToPatchFrom.Status.Version = ""
+		if desired.Status.Version != "" {
+			t.Status.Version = desired.Status.Version
 		}
 
-		// only keep the Ready condition from live status, it's calculated by the status reconciler
-		conds := []genericcondition.GenericCondition{}
-		for _, c := range t.Status.Conditions {
-			if c.Type == "Ready" {
-				conds = append(conds, c)
-				break
-			}
-		}
-		for _, c := range objToPatchFrom.Status.Conditions {
-			if c.Type == "Ready" {
-				continue
-			}
-			conds = append(conds, c)
-		}
-		t.Status.Conditions = conds
+		// Merge rather than replace: the Ready condition belongs to the status
+		// reconciler, and the polling job owns Polled and the kstatus conditions,
+		// which it may well have written since desired was read.
+		t.Status.Conditions = status.MergeConditions(
+			t.Status.Conditions,
+			base.Conditions,
+			desired.Status.Conditions,
+			"Ready",
+		)
 
 		setAcceptedConditionHelm(&t.Status, orgErr)
 
-		statusPatch := client.MergeFrom(objToPatchFrom)
-		if patchData, err := statusPatch.Data(t); err == nil && string(patchData) == "{}" {
+		if equality.Semantic.DeepEqual(orig.Status, t.Status) {
 			metrics.HelmCollector.Collect(ctx, t)
-			// skip update if patch is empty
+			// skip update if nothing changed
 			return nil
 		}
 
-		if err := c.Status().Patch(ctx, t, statusPatch); err != nil {
+		// Patch under an optimistic lock, against a base read in this same attempt.
+		// A merge patch replaces the whole conditions array, so patching from a
+		// stale base drops conditions written concurrently by the status
+		// reconciler. RetryOnConflict re-reads and recomputes on conflict.
+		if err := c.Status().Patch(
+			ctx,
+			t,
+			client.MergeFromWithOptions(orig, client.MergeFromWithOptimisticLock{}),
+		); err != nil {
 			return err
 		}
 
@@ -503,8 +521,15 @@ func updateStatus(ctx context.Context, c client.Client, req types.NamespacedName
 }
 
 // updateErrorStatusHelm sets the condition in the status and tries to update the resource
-func updateErrorStatusHelm(ctx context.Context, c client.Client, req types.NamespacedName, helmOp *fleet.HelmOp, orgErr error) error {
-	if statusErr := updateStatus(ctx, c, req, helmOp, orgErr); statusErr != nil {
+func updateErrorStatusHelm(
+	ctx context.Context,
+	c client.Client,
+	req types.NamespacedName,
+	helmOp *fleet.HelmOp,
+	base *fleet.HelmOpStatus,
+	orgErr error,
+) error {
+	if statusErr := updateStatus(ctx, c, req, helmOp, base, orgErr); statusErr != nil {
 		merr := []error{orgErr, fmt.Errorf("failed to update the status: %w", statusErr)}
 		return errutil.NewAggregate(merr)
 	}

--- a/internal/cmd/controller/helmops/reconciler/helmop_status.go
+++ b/internal/cmd/controller/helmops/reconciler/helmop_status.go
@@ -13,6 +13,7 @@ import (
 	"github.com/rancher/fleet/pkg/sharding"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
+	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -98,13 +99,31 @@ func (r *HelmOpStatusReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return ctrl.Result{}, err
 	}
 
-	statusPatch := client.MergeFrom(orig)
-	if patchData, err := statusPatch.Data(helmop); err == nil && string(patchData) != "{}" {
-		// skip update if patch is empty
-		if err := r.Status().Patch(ctx, helmop, statusPatch); err != nil {
-			logger.Error(err, "Reconcile failed update to HelmOp status", "status", helmop.Status)
-			return ctrl.Result{RequeueAfter: durations.HelmOpStatusDelay}, nil
+	if equality.Semantic.DeepEqual(orig.Status, helmop.Status) {
+		// skip update if nothing changed
+		return ctrl.Result{}, nil
+	}
+
+	// Patch under an optimistic lock. A merge patch replaces the whole conditions
+	// array, so without the lock a stale read here silently drops conditions owned
+	// by the HelmOp reconciler (Accepted in particular). That reconciler ignores
+	// status-only changes, so a dropped condition is never restored.
+	// On conflict we requeue and recompute from a fresh read.
+	statusPatch := client.MergeFromWithOptions(orig, client.MergeFromWithOptimisticLock{})
+	if err := r.Status().Patch(ctx, helmop, statusPatch); err != nil {
+		if errors.IsConflict(err) {
+			// Expected under the optimistic lock: another controller wrote the
+			// status first. Requeuing recomputes it from a fresh read, so this
+			// is not worth reporting as an error. Come back sooner than the
+			// status delay, which exists to wait for a write that has by
+			// definition already happened here.
+			logger.V(1).Info("Conflict updating HelmOp status, retrying", "error", err)
+			return ctrl.Result{RequeueAfter: durations.StatusConflictRequeue}, nil
 		}
+
+		logger.Error(err, "Reconcile failed update to HelmOp status", "status", helmop.Status)
+
+		return ctrl.Result{RequeueAfter: durations.HelmOpStatusDelay}, nil
 	}
 
 	return ctrl.Result{}, nil

--- a/internal/cmd/controller/helmops/reconciler/polling_job.go
+++ b/internal/cmd/controller/helmops/reconciler/polling_job.go
@@ -20,6 +20,7 @@ import (
 	"github.com/rancher/wrangler/v3/pkg/kstatus"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	errutil "k8s.io/apimachinery/pkg/util/errors"
@@ -77,7 +78,15 @@ func (j *helmPollingJob) Execute(ctx context.Context) error {
 	}
 	defer j.sem.Release(1)
 
-	return j.pollHelm(ctx)
+	err := j.pollHelm(ctx)
+	if err != nil {
+		// Quartz schedulers are built with the default logger.NoOpLogger and no
+		// job retries, so an error returned from here is discarded. Log it
+		// before handing it back, or polling failures are invisible.
+		logger.Error(err, "HelmOp polling job failed, retrying on the next poll")
+	}
+
+	return err
 }
 
 // Description returns a description for the job.
@@ -192,6 +201,8 @@ func (j *helmPollingJob) pollHelm(ctx context.Context) error {
 			return fmt.Errorf("could not get HelmOp to update its status: %w", err)
 		}
 
+		orig := t.DeepCopy()
+
 		t.Status.LastPollingTime = metav1.Time{Time: pollingTimestamp}
 		t.Status.Version = version
 
@@ -201,19 +212,27 @@ func (j *helmPollingJob) pollHelm(ctx context.Context) error {
 		condition.Cond(fleet.HelmOpPolledCondition).Reason(&t.Status, "")
 		kstatus.SetActive(&t.Status)
 
-		statusPatch := client.MergeFrom(h)
-		if patchData, err := statusPatch.Data(t); err == nil && string(patchData) == "{}" {
-			// skip update if patch is empty
+		if equality.Semantic.DeepEqual(orig.Status, t.Status) {
+			// skip update if nothing changed
 			return nil
 		}
-		return j.client.Status().Patch(ctx, t, statusPatch)
+
+		// Patch under an optimistic lock, against a base read in this same attempt.
+		// A merge patch replaces the whole conditions array, so patching from a
+		// stale base drops conditions written concurrently by the HelmOp
+		// reconciler. RetryOnConflict re-reads and recomputes on conflict.
+		return j.client.Status().Patch(
+			ctx,
+			t,
+			client.MergeFromWithOptions(orig, client.MergeFromWithOptimisticLock{}),
+		)
 	})
 	if err != nil {
-		return fail(
-			fmt.Errorf("could not update HelmOp status with polling timestamp: %w", err),
-			"FailedToUpdateHelmOpStatus",
-			"UpdateHelmOpStatus",
-		)
+		// The version resolution itself succeeded here; only the status write lost
+		// a race. Reporting that through fail() would mark the HelmOp stalled over
+		// a transient conflict. Return the error instead, for Execute to log: the
+		// next scheduled poll recomputes the status from a fresh read.
+		return fmt.Errorf("could not update HelmOp status with polling timestamp: %w", err)
 	}
 
 	return nil
@@ -236,6 +255,8 @@ func (j *helmPollingJob) updateErrorStatus(
 			return fmt.Errorf("could not get HelmOp to update its status: %w", err)
 		}
 
+		orig := t.DeepCopy()
+
 		condition.Cond(fleet.HelmOpPolledCondition).SetError(&t.Status, "", orgErr)
 		kstatus.SetError(t, orgErr.Error())
 
@@ -243,12 +264,18 @@ func (j *helmPollingJob) updateErrorStatus(
 			t.Status.LastPollingTime = metav1.Time{Time: pollingTimestamp}
 		}
 
-		statusPatch := client.MergeFrom(helmOp)
-		if patchData, err := statusPatch.Data(t); err == nil && string(patchData) == "{}" {
-			// skip update if patch is empty
+		if equality.Semantic.DeepEqual(orig.Status, t.Status) {
+			// skip update if nothing changed
 			return nil
 		}
-		return j.client.Status().Patch(ctx, t, statusPatch)
+
+		// See pollHelm: patch under an optimistic lock against a base read in this
+		// same attempt, so a stale base cannot drop foreign conditions.
+		return j.client.Status().Patch(
+			ctx,
+			t,
+			client.MergeFromWithOptions(orig, client.MergeFromWithOptimisticLock{}),
+		)
 	})
 	if err != nil {
 		merr = append(merr, err)

--- a/internal/cmd/controller/status/conditions.go
+++ b/internal/cmd/controller/status/conditions.go
@@ -1,0 +1,86 @@
+package status
+
+import (
+	"slices"
+
+	"github.com/rancher/wrangler/v3/pkg/genericcondition"
+	"k8s.io/apimachinery/pkg/api/equality"
+)
+
+// MergeConditions merges the condition list a controller wants to publish into
+// the list currently live on the object.
+//
+// A merge patch replaces the whole conditions array, so a controller which
+// rebuilds that array from a snapshot taken at the start of its reconcile
+// silently reverts, or outright deletes, conditions another controller wrote
+// while it was working. Fleet has several writers per object (the GitRepo and
+// HelmOp reconcilers, their polling jobs and their status reconcilers), so that
+// window is real: a polling job clearing Stalled can be undone seconds later by
+// a reconciler that started before the clear.
+//
+// Comparing desired against base, the list as the caller first read it, tells
+// the two cases apart. A condition type whose value the caller actually changed
+// is one it computed, and wins. Every other type is only a stale echo of the
+// read, and keeps whatever is live. Types named in foreign are owned by another
+// controller entirely and are always taken from live.
+//
+// Conditions are never removed, only added or updated, so live ordering is
+// preserved and types the caller newly computed are appended.
+func MergeConditions(
+	live, base, desired []genericcondition.GenericCondition,
+	foreign ...string,
+) []genericcondition.GenericCondition {
+	byType := func(conds []genericcondition.GenericCondition) map[string]genericcondition.GenericCondition {
+		m := make(map[string]genericcondition.GenericCondition, len(conds))
+		for _, c := range conds {
+			m[c.Type] = c
+		}
+		return m
+	}
+
+	baseByType := byType(base)
+	desiredByType := byType(desired)
+
+	isForeign := func(condType string) bool {
+		return slices.Contains(foreign, condType)
+	}
+
+	// computed reports whether the caller changed this condition type itself,
+	// rather than merely carrying it over from the object it read.
+	computed := func(condType string) bool {
+		if isForeign(condType) {
+			return false
+		}
+		d, inDesired := desiredByType[condType]
+		if !inDesired {
+			return false
+		}
+		b, inBase := baseByType[condType]
+
+		return !inBase || !equality.Semantic.DeepEqual(b, d)
+	}
+
+	merged := make([]genericcondition.GenericCondition, 0, len(live)+len(desired))
+	seen := make(map[string]struct{}, len(live))
+
+	for _, c := range live {
+		seen[c.Type] = struct{}{}
+		if computed(c.Type) {
+			merged = append(merged, desiredByType[c.Type])
+			continue
+		}
+		merged = append(merged, c)
+	}
+
+	// Types the caller computed which do not exist on the live object yet.
+	for _, c := range desired {
+		if _, ok := seen[c.Type]; ok {
+			continue
+		}
+		if computed(c.Type) {
+			merged = append(merged, c)
+		}
+	}
+
+	return merged
+}

--- a/internal/cmd/controller/status/conditions_test.go
+++ b/internal/cmd/controller/status/conditions_test.go
@@ -1,0 +1,157 @@
+package status
+
+import (
+	"testing"
+
+	"github.com/rancher/wrangler/v3/pkg/genericcondition"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func cond(condType string, status corev1.ConditionStatus, message string) genericcondition.GenericCondition {
+	return genericcondition.GenericCondition{Type: condType, Status: status, Message: message}
+}
+
+func types(conds []genericcondition.GenericCondition) []string {
+	out := make([]string, 0, len(conds))
+	for _, c := range conds {
+		out = append(out, c.Type)
+	}
+	return out
+}
+
+func find(conds []genericcondition.GenericCondition, condType string) (genericcondition.GenericCondition, bool) {
+	for _, c := range conds {
+		if c.Type == condType {
+			return c, true
+		}
+	}
+	return genericcondition.GenericCondition{}, false
+}
+
+func TestMergeConditions(t *testing.T) {
+	cases := []struct {
+		name     string
+		live     []genericcondition.GenericCondition
+		base     []genericcondition.GenericCondition
+		desired  []genericcondition.GenericCondition
+		foreign  []string
+		expected []genericcondition.GenericCondition
+	}{
+		{
+			name:     "a condition the caller never saw is kept",
+			live:     []genericcondition.GenericCondition{cond("Polled", corev1.ConditionTrue, "fresh")},
+			base:     nil,
+			desired:  nil,
+			expected: []genericcondition.GenericCondition{cond("Polled", corev1.ConditionTrue, "fresh")},
+		},
+		{
+			// The core regression: the caller read Polled=False, another writer
+			// then set it to True. The caller did not touch it, so its stale copy
+			// must not win.
+			name:     "a condition the caller carried over unchanged keeps the live value",
+			live:     []genericcondition.GenericCondition{cond("Polled", corev1.ConditionTrue, "fresh")},
+			base:     []genericcondition.GenericCondition{cond("Polled", corev1.ConditionFalse, "stale")},
+			desired:  []genericcondition.GenericCondition{cond("Polled", corev1.ConditionFalse, "stale")},
+			expected: []genericcondition.GenericCondition{cond("Polled", corev1.ConditionTrue, "fresh")},
+		},
+		{
+			name:     "a condition the caller changed wins over the live value",
+			live:     []genericcondition.GenericCondition{cond("Accepted", corev1.ConditionTrue, "old")},
+			base:     []genericcondition.GenericCondition{cond("Accepted", corev1.ConditionTrue, "old")},
+			desired:  []genericcondition.GenericCondition{cond("Accepted", corev1.ConditionFalse, "computed")},
+			expected: []genericcondition.GenericCondition{cond("Accepted", corev1.ConditionFalse, "computed")},
+		},
+		{
+			name:     "a condition the caller newly computed is appended",
+			live:     []genericcondition.GenericCondition{cond("Polled", corev1.ConditionTrue, "fresh")},
+			base:     nil,
+			desired:  []genericcondition.GenericCondition{cond("Accepted", corev1.ConditionTrue, "computed")},
+			expected: []genericcondition.GenericCondition{cond("Polled", corev1.ConditionTrue, "fresh"), cond("Accepted", corev1.ConditionTrue, "computed")},
+		},
+		{
+			name:     "a stale condition absent from live is not resurrected",
+			live:     nil,
+			base:     []genericcondition.GenericCondition{cond("Polled", corev1.ConditionTrue, "stale")},
+			desired:  []genericcondition.GenericCondition{cond("Polled", corev1.ConditionTrue, "stale")},
+			expected: nil,
+		},
+		{
+			name:     "a foreign condition is always taken from live",
+			live:     []genericcondition.GenericCondition{cond("Ready", corev1.ConditionTrue, "fresh")},
+			base:     []genericcondition.GenericCondition{cond("Ready", corev1.ConditionFalse, "stale")},
+			desired:  []genericcondition.GenericCondition{cond("Ready", corev1.ConditionFalse, "stale-changed")},
+			foreign:  []string{"Ready"},
+			expected: []genericcondition.GenericCondition{cond("Ready", corev1.ConditionTrue, "fresh")},
+		},
+		{
+			name:     "a foreign condition missing from live is not added",
+			live:     nil,
+			base:     nil,
+			desired:  []genericcondition.GenericCondition{cond("Ready", corev1.ConditionTrue, "computed")},
+			foreign:  []string{"Ready"},
+			expected: nil,
+		},
+		{
+			name: "live ordering is preserved",
+			live: []genericcondition.GenericCondition{
+				cond("Ready", corev1.ConditionTrue, ""),
+				cond("Polled", corev1.ConditionTrue, "fresh"),
+				cond("Accepted", corev1.ConditionTrue, "old"),
+			},
+			base: []genericcondition.GenericCondition{
+				cond("Polled", corev1.ConditionFalse, "stale"),
+				cond("Accepted", corev1.ConditionTrue, "old"),
+			},
+			desired: []genericcondition.GenericCondition{
+				cond("Polled", corev1.ConditionFalse, "stale"),
+				cond("Accepted", corev1.ConditionFalse, "computed"),
+				cond("Stalled", corev1.ConditionFalse, "computed"),
+			},
+			foreign: []string{"Ready"},
+			expected: []genericcondition.GenericCondition{
+				cond("Ready", corev1.ConditionTrue, ""),
+				cond("Polled", corev1.ConditionTrue, "fresh"),
+				cond("Accepted", corev1.ConditionFalse, "computed"),
+				cond("Stalled", corev1.ConditionFalse, "computed"),
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := MergeConditions(tc.live, tc.base, tc.desired, tc.foreign...)
+
+			if len(got) != len(tc.expected) {
+				t.Fatalf("expected conditions %v, got %v", types(tc.expected), types(got))
+			}
+			for i, want := range tc.expected {
+				if got[i].Type != want.Type {
+					t.Fatalf("expected conditions %v, got %v", types(tc.expected), types(got))
+				}
+				if got[i] != want {
+					t.Errorf("condition %q: expected %+v, got %+v", want.Type, want, got[i])
+				}
+			}
+		})
+	}
+}
+
+func TestMergeConditionsDoesNotAliasInputs(t *testing.T) {
+	live := []genericcondition.GenericCondition{cond("Polled", corev1.ConditionTrue, "fresh")}
+	desired := []genericcondition.GenericCondition{cond("Accepted", corev1.ConditionTrue, "computed")}
+
+	merged := MergeConditions(live, nil, desired)
+
+	accepted, ok := find(merged, "Accepted")
+	if !ok {
+		t.Fatal("expected the newly computed Accepted condition to be merged in")
+	}
+	accepted.Message = "mutated"
+
+	if desired[0].Message != "computed" {
+		t.Errorf("mutating the merged result changed the desired input: %+v", desired[0])
+	}
+	if len(live) != 1 {
+		t.Errorf("merging appended to the live slice: %+v", live)
+	}
+}

--- a/internal/cmd/controller/status/conditions_test.go
+++ b/internal/cmd/controller/status/conditions_test.go
@@ -142,16 +142,22 @@ func TestMergeConditionsDoesNotAliasInputs(t *testing.T) {
 
 	merged := MergeConditions(live, nil, desired)
 
-	accepted, ok := find(merged, "Accepted")
-	if !ok {
+	idx := -1
+	for i, c := range merged {
+		if c.Type == "Accepted" {
+			idx = i
+			break
+		}
+	}
+	if idx == -1 {
 		t.Fatal("expected the newly computed Accepted condition to be merged in")
 	}
-	accepted.Message = "mutated"
+	merged[idx].Message = "mutated"
 
 	if desired[0].Message != "computed" {
 		t.Errorf("mutating the merged result changed the desired input: %+v", desired[0])
 	}
-	if len(live) != 1 {
-		t.Errorf("merging appended to the live slice: %+v", live)
+	if live[0].Message != "fresh" {
+		t.Errorf("mutating the merged result changed the live input: %+v", live[0])
 	}
 }

--- a/internal/cmd/controller/status/conditions_test.go
+++ b/internal/cmd/controller/status/conditions_test.go
@@ -19,15 +19,6 @@ func types(conds []genericcondition.GenericCondition) []string {
 	return out
 }
 
-func find(conds []genericcondition.GenericCondition, condType string) (genericcondition.GenericCondition, bool) {
-	for _, c := range conds {
-		if c.Type == condType {
-			return c, true
-		}
-	}
-	return genericcondition.GenericCondition{}, false
-}
-
 func TestMergeConditions(t *testing.T) {
 	cases := []struct {
 		name     string

--- a/pkg/durations/durations.go
+++ b/pkg/durations/durations.go
@@ -38,6 +38,11 @@ const (
 	// the helmop status first, before the status controller looks at
 	// bundledeployments.
 	HelmOpStatusDelay = time.Second * 5
+	// StatusConflictRequeue is how long a status controller waits before
+	// recomputing a status whose write lost an optimistic lock. A conflict
+	// means the object was just written, so its cache entry is refreshed
+	// almost immediately and there is no reason to wait a full status delay.
+	StatusConflictRequeue = time.Second
 	// WaitForDependenciesReadyRequeueInterval is the wait time after the Fleet agent finds a BundleDeployment has non-ready dependencies
 	WaitForDependenciesReadyRequeueInterval = time.Second * 15
 	// NamespacePermissionRequeueInterval is the wait time after the Fleet


### PR DESCRIPTION
Fleet has multiple writers per GitRepo/HelmOp status (main reconciler, status reconciler, polling job), each patching from a stale snapshot — a merge patch replaces the whole conditions array, so one writer could silently overwrite conditions another had just set (e.g. Accepted reverted by a concurrent poll).

- Add status.MergeConditions to merge a reconciler's desired conditions into live instead of replacing wholesale, and apply it in the GitRepo/HelmOp reconcilers.
- Add an optimistic lock to every status patch/update path, retrying on conflict; new StatusConflictRequeue (1s) requeues fast when that happens.
- Stop reverting PollingCommit/LastPollingTime from the stale snapshot in the GitRepo reconciler, which was delaying new-commit pickup by a full polling interval.
- New integration tests exercise concurrent writers via a stale-read test client.

## Additional Information

### Checklist

~- [ ] <!-- If applicable,--> I have updated the documentation via a pull request in the [fleet-product-docs](https://github.com/rancher/fleet-product-docs) repository.~
