### PR TITLE
Remove `--import` flag from Rancher cluster creation

### DIFF
--- a/.github/scripts/register-downstream-clusters.sh
+++ b/.github/scripts/register-downstream-clusters.sh
@@ -34,7 +34,7 @@ kubectl get secret tls-rancher -n cattle-system -o jsonpath='{.data.tls\.crt}' |
 # Log into the 4th project listed by `rancher login`, which should be the local cluster's default project.
 echo -e "4\n" | $rancher_cli login "https://$public_hostname" --token "$token" --cacert "${TMPCRT}"
 
-$rancher_cli clusters create second --import
+$rancher_cli clusters create second
 until $rancher_cli cluster ls --format json | jq -r 'select(.Name=="second") | .ID' | grep -Eq "c-[a-z0-9]" ; do sleep 1; done
 id=$( $rancher_cli cluster ls --format json | jq -r 'select(.Name=="second") | .ID' )
 


### PR DESCRIPTION
Flag `--import` has been [removed](https://github.com/rancher/cli/pull/613) in Rancher CLI [v2.15.0](https://github.com/rancher/cli/releases/tag/v2.15.0).

Removing it enables the `E2E Upgrade Fleet in Rancher To HEAD` workflow to stop [failing](https://github.com/rancher/fleet/actions/runs/33840575073/job/100921866674) ([success example](https://github.com/rancher/fleet/actions/runs/33847557353/job/100942727872)).

## Additional Information

### Checklist

~- [ ] <!-- If applicable,--> I have updated the documentation via a pull request in the [fleet-product-docs](https://github.com/rancher/fleet-product-docs) repository.~
