### PR TITLE
Pin Renovate Vault workflow to v1.0.10

### DIFF
--- a/.github/workflows/renovate-vault.yml
+++ b/.github/workflows/renovate-vault.yml
@@ -48,7 +48,7 @@ jobs:
       contents: read
       id-token: write # Required for Vault OIDC authentication.
     # https://github.com/rancher/renovate-config/releases
-    uses: rancher/renovate-config/.github/workflows/renovate-vault.yml@a1a645d20a4c3d46bc5d1a00f45b87362fce5abc # v1.0.9
+    uses: rancher/renovate-config/.github/workflows/renovate-vault.yml@b20e059a3642b4f6add6f9db276349daca5ea54e # v1.0.10
     # Note: github.event.inputs.<name> with '||' fallbacks is used across all inputs
     # so that scheduled cron runs (where github.event.inputs is null) safely default.
     with:


### PR DESCRIPTION
this introduces [among others](https://github.com/rancher/renovate-config/pull/888) caching for Renovate.