### PR TITLE
Fix GitHub App auth to respect spec.caBundle

### DIFF
--- a/internal/cmd/cli/gitcloner/cloner.go
+++ b/internal/cmd/cli/gitcloner/cloner.go
@@ -57,13 +57,14 @@ func (c *Cloner) CloneRepo(opts *GitCloner) error {
 	transport.UnsupportedCapabilities = []capability.Capability{
 		capability.ThinPack,
 	}
-	auth, err := createAuthFromOpts(opts)
-	if err != nil {
-		return fmt.Errorf("failed to create auth from options for %s: %w", repo(opts), err)
-	}
+
 	caBundle, err := getCABundleFromFile(opts.CABundleFile)
 	if err != nil {
 		return fmt.Errorf("failed to read CA bundle from file for %s: %w", repo(opts), err)
+	}
+	auth, err := createAuthFromOpts(opts, caBundle)
+	if err != nil {
+		return fmt.Errorf("failed to create auth from options for %s: %w", repo(opts), err)
 	}
 
 	if opts.Branch == "" && opts.Revision == "" {
@@ -251,7 +252,7 @@ func getCABundleFromFile(path string) ([]byte, error) {
 }
 
 // createAuthFromOpts adds auth for cloning git repos based on the parameters provided in opts.
-func createAuthFromOpts(opts *GitCloner) (transport.AuthMethod, error) {
+func createAuthFromOpts(opts *GitCloner, caBundle []byte) (transport.AuthMethod, error) {
 	knownHosts, isKnownHostsSet := os.LookupEnv(fleetssh.KnownHostsEnvVar)
 	if knownHosts == "" {
 		isKnownHostsSet = false
@@ -287,7 +288,7 @@ func createAuthFromOpts(opts *GitCloner) (transport.AuthMethod, error) {
 			return nil, fmt.Errorf("failed to read GitHub app private key from file: %w", err)
 		}
 
-		auth, err := appAuthGetter.Get(opts.Repo, opts.GitHubAppID, opts.GitHubAppInstallation, key)
+		auth, err := appAuthGetter.Get(opts.Repo, opts.GitHubAppID, opts.GitHubAppInstallation, key, caBundle)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/cmd/cli/gitcloner/cloner_test.go
+++ b/internal/cmd/cli/gitcloner/cloner_test.go
@@ -29,7 +29,7 @@ import (
 
 type fakeGetter struct{}
 
-func (fakeGetter) Get(_ string, appID, instID int64, key []byte) (*httpgit.BasicAuth, error) {
+func (fakeGetter) Get(_ string, appID, instID int64, key []byte, _ []byte) (*httpgit.BasicAuth, error) {
 	return &httpgit.BasicAuth{
 		Username: "x-access-token",
 		Password: "token",
@@ -831,7 +831,7 @@ func TestCreateAuthFromOpts(t *testing.T) {
 
 	t.Run("no SSH key returns nil auth", func(t *testing.T) {
 		opts := &GitCloner{Repo: "https://github.com/example/repo"}
-		auth, err := createAuthFromOpts(opts)
+		auth, err := createAuthFromOpts(opts, nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -845,7 +845,7 @@ func TestCreateAuthFromOpts(t *testing.T) {
 			Repo:              "ssh://git@example.com/org/repo",
 			SSHPrivateKeyFile: writeTempKey(t),
 		}
-		auth, err := createAuthFromOpts(opts)
+		auth, err := createAuthFromOpts(opts, nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -865,7 +865,7 @@ func TestCreateAuthFromOpts(t *testing.T) {
 			Repo:              "ssh://git@example.com/org/repo",
 			SSHPrivateKeyFile: writeTempKey(t),
 		}
-		auth, err := createAuthFromOpts(opts)
+		auth, err := createAuthFromOpts(opts, nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -889,7 +889,7 @@ func TestCreateAuthFromOpts(t *testing.T) {
 			Repo:              "ssh://example.com/org/repo",
 			SSHPrivateKeyFile: writeTempKey(t),
 		}
-		auth, err := createAuthFromOpts(opts)
+		auth, err := createAuthFromOpts(opts, nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}

--- a/internal/cmd/controller/imagescan/gitcommit_job.go
+++ b/internal/cmd/controller/imagescan/gitcommit_job.go
@@ -317,7 +317,7 @@ func readAuth(ctx context.Context, logger logr.Logger, c client.Client, gitrepo 
 		}
 		return publicKey, nil
 	default:
-		auth, err := fleetgithub.GetGithubAppAuthFromSecret(gitrepo.Spec.Repo, secret, fleetgithub.DefaultAppAuthGetter{})
+		auth, err := fleetgithub.GetGithubAppAuthFromSecret(gitrepo.Spec.Repo, secret, fleetgithub.DefaultAppAuthGetter{}, gitrepo.Spec.CABundle)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/github/app.go
+++ b/internal/github/app.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"context"
+	"crypto/tls"
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
@@ -27,13 +28,17 @@ func NewApp(repo string, appID, installID int64, pem []byte) *GitHubApp {
 // GetToken retrieves a GitHub App installation token using the provided app ID,
 // installation ID, and private key (PEM format). It returns the token as a string
 // or an error if the process fails.
-func (app *GitHubApp) GetToken(ctx context.Context) (string, error) {
+func (app *GitHubApp) GetToken(ctx context.Context, caBundle []byte) (string, error) {
 	err := app.checkIfPrivateKeyIsValid()
 	if err != nil {
 		return "", err
 	}
 
-	tr := http.DefaultTransport
+	tr, err := transportWithCABundle(caBundle)
+	if err != nil {
+		return "", err
+	}
+
 	itr, err := newGithubApp(tr, app.repoURL, app.appID, app.installID, app.pem)
 	if err != nil {
 		return "", err
@@ -45,6 +50,25 @@ func (app *GitHubApp) GetToken(ctx context.Context) (string, error) {
 	}
 
 	return token, nil
+}
+
+func transportWithCABundle(caBundle []byte) (http.RoundTripper, error) {
+	if len(caBundle) == 0 {
+		return http.DefaultTransport, nil
+	}
+	pool, err := x509.SystemCertPool()
+	if err != nil || pool == nil {
+		pool = x509.NewCertPool()
+	}
+	if ok := pool.AppendCertsFromPEM(caBundle); !ok {
+		return nil, fmt.Errorf("githubapp: failed to append custom CA bundle to cert pool")
+	}
+
+	base := http.DefaultTransport.(*http.Transport).Clone()
+	base.TLSClientConfig = &tls.Config{
+		RootCAs: pool,
+	}
+	return base, nil
 }
 
 func (app *GitHubApp) checkIfPrivateKeyIsValid() error {

--- a/internal/github/app.go
+++ b/internal/github/app.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -61,7 +62,7 @@ func transportWithCABundle(caBundle []byte) (http.RoundTripper, error) {
 		pool = x509.NewCertPool()
 	}
 	if ok := pool.AppendCertsFromPEM(caBundle); !ok {
-		return nil, fmt.Errorf("githubapp: failed to append custom CA bundle to cert pool")
+		return nil, errors.New("githubapp: failed to append custom CA bundle to cert pool")
 	}
 
 	base := http.DefaultTransport.(*http.Transport).Clone()

--- a/internal/github/app_test.go
+++ b/internal/github/app_test.go
@@ -62,7 +62,7 @@ func TestGitHubApp_GetToken_Success(t *testing.T) {
 
 	app := NewApp("https://github.com/foo/bar", 123, 456, []byte(validRSA))
 
-	token, err := app.GetToken(context.Background())
+	token, err := app.GetToken(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("GetToken returned error: %v", err)
 	}
@@ -108,7 +108,7 @@ func TestGitHubApp_GetToken_NonGithubDotCom(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			app := NewApp(tc.repoURL, 123, 456, []byte(validRSA))
 
-			_, err := app.GetToken(context.Background())
+			_, err := app.GetToken(context.Background(), nil)
 			if err == nil {
 				t.Fatal("expected error when getting token, got nil")
 			}
@@ -124,7 +124,7 @@ func TestGitHubApp_GetToken_NonGithubDotCom(t *testing.T) {
 func TestGitHubApp_GetToken_InvalidPEM(t *testing.T) {
 	app := NewApp("https://github.com/foo/bar", 123, 456, []byte("definitely-not-a-PEM-block"))
 
-	_, err := app.GetToken(context.Background())
+	_, err := app.GetToken(context.Background(), nil)
 	if err == nil {
 		t.Fatalf("expected error for invalid PEM, got nil")
 	}
@@ -137,7 +137,7 @@ func TestGitHubApp_GetToken_InvalidPEM(t *testing.T) {
 func TestGitHubApp_GetToken_NotRSA(t *testing.T) {
 	app := NewApp("https://github.com/foo/bar", 123, 456, []byte(notRSA))
 
-	_, err := app.GetToken(context.Background())
+	_, err := app.GetToken(context.Background(), nil)
 	if err == nil {
 		t.Fatalf("expected error for not RSA PEM, got nil")
 	}
@@ -150,7 +150,7 @@ func TestGitHubApp_GetToken_NotRSA(t *testing.T) {
 func TestGitHubApp_GetToken_InvalidRSA(t *testing.T) {
 	app := NewApp("https://github.com/foo/bar", 123, 456, []byte(invalidRSA))
 
-	_, err := app.GetToken(context.Background())
+	_, err := app.GetToken(context.Background(), nil)
 	if err == nil {
 		t.Fatalf("expected error for not RSA PEM, got nil")
 	}

--- a/internal/github/auth.go
+++ b/internal/github/auth.go
@@ -19,13 +19,13 @@ const (
 var ErrNotGithubAppSecret = errors.New("not a GitHub App secret")
 
 type AppAuthGetter interface {
-	Get(repo string, appID, insID int64, pem []byte) (*httpgit.BasicAuth, error)
+	Get(repo string, appID, insID int64, pem []byte, caBundle []byte) (*httpgit.BasicAuth, error)
 }
 
 type DefaultAppAuthGetter struct{}
 
-func (DefaultAppAuthGetter) Get(repo string, appID, insID int64, pem []byte) (*httpgit.BasicAuth, error) {
-	tok, err := NewApp(repo, appID, insID, pem).GetToken(context.Background())
+func (DefaultAppAuthGetter) Get(repo string, appID, insID int64, pem []byte, caBundle []byte) (*httpgit.BasicAuth, error) {
+	tok, err := NewApp(repo, appID, insID, pem).GetToken(context.Background(), caBundle)
 	if err != nil {
 		return nil, fmt.Errorf("could not authenticate as GitHub App installation: %w", err)
 	}
@@ -36,7 +36,7 @@ func (DefaultAppAuthGetter) Get(repo string, appID, insID int64, pem []byte) (*h
 	}, nil
 }
 
-func GetGithubAppAuthFromSecret(repo string, creds *corev1.Secret, getter AppAuthGetter) (*httpgit.BasicAuth, error) {
+func GetGithubAppAuthFromSecret(repo string, creds *corev1.Secret, getter AppAuthGetter, caBundle []byte) (*httpgit.BasicAuth, error) {
 	idBytes, okID := creds.Data[GitHubAppAuthIDKey]
 	insBytes, okIns := creds.Data[GitHubAppAuthInstallationIDKey]
 	pemBytes, okPem := creds.Data[GitHubAppAuthPrivateKeyKey]
@@ -53,7 +53,7 @@ func GetGithubAppAuthFromSecret(repo string, creds *corev1.Secret, getter AppAut
 		return nil, fmt.Errorf("github-app installation id is not numeric: %w", err)
 	}
 
-	auth, err := getter.Get(repo, appID, insID, pemBytes)
+	auth, err := getter.Get(repo, appID, insID, pemBytes, caBundle)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/github/auth_test.go
+++ b/internal/github/auth_test.go
@@ -14,7 +14,7 @@ type fakeGetter struct {
 	err  error
 }
 
-func (f fakeGetter) Get(_ string, appID, instID int64, pem []byte) (*httpgit.BasicAuth, error) {
+func (f fakeGetter) Get(_ string, appID, instID int64, pem []byte, _ []byte) (*httpgit.BasicAuth, error) {
 	return f.auth, f.err
 }
 
@@ -95,7 +95,7 @@ func TestGetGithubAppAuthFromSecret(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotAuth, err := GetGithubAppAuthFromSecret("https://github.com/foo/bar", tt.secret, tt.getter)
+			gotAuth, err := GetGithubAppAuthFromSecret("https://github.com/foo/bar", tt.secret, tt.getter, nil)
 
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("error mismatch: got %v, wantErr %v", err, tt.wantErr)

--- a/pkg/git/netutils.go
+++ b/pkg/git/netutils.go
@@ -22,7 +22,7 @@ var GitHubAppGetter fleetgithub.AppAuthGetter = fleetgithub.DefaultAppAuthGetter
 // Known hosts are sourced from the creds, if provided there. Otherwise, they will be sourced from the provided
 // knownHosts if non-empty.
 // The credentials secret is expected to be either basic-auth or ssh-auth (with extra known_hosts data option)
-func GetAuthFromSecret(url string, creds *corev1.Secret, knownHosts string) (transport.AuthMethod, error) {
+func GetAuthFromSecret(url string, creds *corev1.Secret, knownHosts string, caBundle []byte) (transport.AuthMethod, error) {
 	if creds == nil {
 		// no auth information was provided
 		return nil, nil
@@ -64,7 +64,7 @@ func GetAuthFromSecret(url string, creds *corev1.Secret, knownHosts string) (tra
 		}
 		return auth, nil
 	default:
-		auth, err := fleetgithub.GetGithubAppAuthFromSecret(url, creds, GitHubAppGetter)
+		auth, err := fleetgithub.GetGithubAppAuthFromSecret(url, creds, GitHubAppGetter, caBundle)
 		if err != nil {
 			if errors.Is(err, fleetgithub.ErrNotGithubAppSecret) {
 				return nil, nil

--- a/pkg/git/netutils_test.go
+++ b/pkg/git/netutils_test.go
@@ -21,7 +21,7 @@ type fakeGetter struct {
 	err  error
 }
 
-func (f fakeGetter) Get(_ string, appID, instID int64, pem []byte) (*httpgit.BasicAuth, error) {
+func (f fakeGetter) Get(_ string, appID, instID int64, pem []byte, _ []byte) (*httpgit.BasicAuth, error) {
 	return f.auth, f.err
 }
 
@@ -34,11 +34,11 @@ var _ = Describe("git's GetAuthFromSecret tests", func() {
 
 	Context("Nil secret", func() {
 		It("returns no error and no auth when known hosts are empty", func() {
-			auth, err := git.GetAuthFromSecret("ssh://foo.bar", nil, "")
+			auth, err := git.GetAuthFromSecret("ssh://foo.bar", nil, "", nil)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(auth).To(BeNil())
 
-			auth, err = git.GetAuthFromSecret("http://foo.bar", nil, "")
+			auth, err = git.GetAuthFromSecret("http://foo.bar", nil, "", nil)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(auth).To(BeNil())
 		})
@@ -51,7 +51,7 @@ var _ = Describe("git's GetAuthFromSecret tests", func() {
 			}
 		})
 		It("returns no error and no auth", func() {
-			auth, err := git.GetAuthFromSecret("test-url.com", secret, "")
+			auth, err := git.GetAuthFromSecret("test-url.com", secret, "", nil)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(auth).To(BeNil())
 		})
@@ -65,7 +65,7 @@ var _ = Describe("git's GetAuthFromSecret tests", func() {
 		})
 
 		It("returns no error and no auth", func() {
-			auth, err := git.GetAuthFromSecret("test-url.com", secret, "")
+			auth, err := git.GetAuthFromSecret("test-url.com", secret, "", nil)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(auth).To(BeNil())
 		})
@@ -87,7 +87,7 @@ var _ = Describe("git's GetAuthFromSecret tests", func() {
 		})
 
 		It("returns no error and no auth", func() {
-			auth, err := git.GetAuthFromSecret("test-url.com", secret, "")
+			auth, err := git.GetAuthFromSecret("test-url.com", secret, "", nil)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(auth).To(BeNil())
 		})
@@ -141,7 +141,7 @@ YcwLYudAztZeA/A4aM5Y0MA6PlNIeoHohuMkSZNOBcvkNEWdzGBpKb34yLfMarNm
 		})
 		AfterEach(func() { git.GitHubAppGetter = origGetter })
 		It("returns the basic auth Auth and no error", func() {
-			auth, err := git.GetAuthFromSecret("test-url.com", secret, "")
+			auth, err := git.GetAuthFromSecret("test-url.com", secret, "", nil)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(auth).To(Equal(&httpgit.BasicAuth{
 				Username: "x-access-token",
@@ -167,7 +167,7 @@ YcwLYudAztZeA/A4aM5Y0MA6PlNIeoHohuMkSZNOBcvkNEWdzGBpKb34yLfMarNm
 			}
 		})
 		It("returns an error and no auth", func() {
-			auth, err := git.GetAuthFromSecret("test-url.com", secret, "")
+			auth, err := git.GetAuthFromSecret("test-url.com", secret, "", nil)
 			Expect(err).To(HaveOccurred())
 			Expect(auth).To(BeNil())
 			Expect(err.Error()).To(ContainSubstring("pem decode failed for app"))
@@ -217,7 +217,7 @@ YcwLYudAztZeA/A4aM5Y0MA6PlNIeoHohuMkSZNOBcvkNEWdzGBpKb34yLfMarNm
 			}
 		})
 		It("returns an error and no auth", func() {
-			auth, err := git.GetAuthFromSecret("test-url.com", secret, "")
+			auth, err := git.GetAuthFromSecret("test-url.com", secret, "", nil)
 			Expect(err).To(HaveOccurred())
 			Expect(auth).To(BeNil())
 			Expect(err.Error()).To(ContainSubstring("parsing \"abc\": invalid syntax"))
@@ -239,7 +239,7 @@ YcwLYudAztZeA/A4aM5Y0MA6PlNIeoHohuMkSZNOBcvkNEWdzGBpKb34yLfMarNm
 			}
 		})
 		It("returns the basic auth Auth and no error", func() {
-			auth, err := git.GetAuthFromSecret("test-url.com", secret, "")
+			auth, err := git.GetAuthFromSecret("test-url.com", secret, "", nil)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(auth).To(Equal(&httpgit.BasicAuth{
 				Username: string(username),
@@ -255,7 +255,7 @@ YcwLYudAztZeA/A4aM5Y0MA6PlNIeoHohuMkSZNOBcvkNEWdzGBpKb34yLfMarNm
 			}
 		})
 		It("returns an error and no auth", func() {
-			auth, err := git.GetAuthFromSecret("notavalidurl", secret, "")
+			auth, err := git.GetAuthFromSecret("notavalidurl", secret, "", nil)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("failed to parse \"notavalidurl\""))
 			Expect(auth).To(BeNil())
@@ -269,7 +269,7 @@ YcwLYudAztZeA/A4aM5Y0MA6PlNIeoHohuMkSZNOBcvkNEWdzGBpKb34yLfMarNm
 			}
 		})
 		It("returns an error and no auth", func() {
-			auth, err := git.GetAuthFromSecret("git@github.com:rancher/fleet.git", secret, "")
+			auth, err := git.GetAuthFromSecret("git@github.com:rancher/fleet.git", secret, "", nil)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("ssh: no key found"))
 			Expect(auth).To(BeNil())
@@ -321,7 +321,7 @@ YcwLYudAztZeA/A4aM5Y0MA6PlNIeoHohuMkSZNOBcvkNEWdzGBpKb34yLfMarNm
 			_, _, publicKey, _, _, err := ssh.ParseKnownHosts([]byte(knownHosts))
 			Expect(err).ToNot(HaveOccurred())
 
-			auth, err := git.GetAuthFromSecret("git@github.com:rancher/fleet.git", secret, "")
+			auth, err := git.GetAuthFromSecret("git@github.com:rancher/fleet.git", secret, "", nil)
 			Expect(err).ToNot(HaveOccurred())
 			expectedSigner, err := ssh.ParsePrivateKey(privateKey)
 			Expect(err).ToNot(HaveOccurred())
@@ -340,7 +340,7 @@ YcwLYudAztZeA/A4aM5Y0MA6PlNIeoHohuMkSZNOBcvkNEWdzGBpKb34yLfMarNm
 			Expect(err).ToNot(HaveOccurred())
 
 			url := "git@foo.bar:rancher/fleet.git"
-			auth, err := git.GetAuthFromSecret(url, secret, knownHosts)
+			auth, err := git.GetAuthFromSecret(url, secret, knownHosts, nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			expectedSigner, err := ssh.ParsePrivateKey(privateKey)
@@ -399,7 +399,7 @@ YcwLYudAztZeA/A4aM5Y0MA6PlNIeoHohuMkSZNOBcvkNEWdzGBpKb34yLfMarNm
 		})
 
 		It("returns no error and the ssh auth", func() {
-			auth, err := git.GetAuthFromSecret("git@github.com:rancher/fleet.git", secret, "")
+			auth, err := git.GetAuthFromSecret("git@github.com:rancher/fleet.git", secret, "", nil)
 			Expect(err).ToNot(HaveOccurred())
 			expectedSigner, err := ssh.ParsePrivateKey(privateKey)
 			Expect(err).ToNot(HaveOccurred())
@@ -419,7 +419,7 @@ YcwLYudAztZeA/A4aM5Y0MA6PlNIeoHohuMkSZNOBcvkNEWdzGBpKb34yLfMarNm
 
 		It("ignores known hosts provided separately", func() {
 			knownHosts := "foo.bar ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl"
-			auth, err := git.GetAuthFromSecret("git@github.com:rancher/fleet.git", secret, knownHosts)
+			auth, err := git.GetAuthFromSecret("git@github.com:rancher/fleet.git", secret, knownHosts, nil)
 			Expect(err).ToNot(HaveOccurred())
 			expectedSigner, err := ssh.ParsePrivateKey(privateKey)
 			Expect(err).ToNot(HaveOccurred())
@@ -478,7 +478,7 @@ YcwLYudAztZeA/A4aM5Y0MA6PlNIeoHohuMkSZNOBcvkNEWdzGBpKb34yLfMarNm
 			}
 		})
 		It("returns an error and no auth", func() {
-			auth, err := git.GetAuthFromSecret("git@github.com:rancher/fleet.git", secret, "")
+			auth, err := git.GetAuthFromSecret("git@github.com:rancher/fleet.git", secret, "", nil)
 			Expect(err).To(HaveOccurred())
 			Expect(auth).To(BeNil())
 			Expect(err.Error()).To(ContainSubstring("knownhosts: missing host pattern"))

--- a/pkg/git/remote.go
+++ b/pkg/git/remote.go
@@ -77,7 +77,14 @@ type Remote struct {
 }
 
 func NewRemote(url string, opts *options) (*Remote, error) {
-	auth, err := GetAuthFromSecret(url, opts.Credential, opts.KnownHosts)
+	caBundle := append([]byte(nil), opts.CABundle...)
+	if proxyCAPEM, ok := os.LookupEnv(ProxyCABundleEnvVar); ok && proxyCAPEM != "" {
+		if len(caBundle) > 0 && caBundle[len(caBundle)-1] != '\n' {
+			caBundle = append(caBundle, '\n')
+		}
+		caBundle = append(caBundle, []byte(proxyCAPEM)...)
+	}
+	auth, err := GetAuthFromSecret(url, opts.Credential, opts.KnownHosts, caBundle)
 	if err != nil {
 		return nil, err
 	}
@@ -90,14 +97,6 @@ func NewRemote(url string, opts *options) (*Remote, error) {
 
 	if auth == nil && strings.HasPrefix(u.String(), "ssh://") {
 		return nil, fmt.Errorf("SSH private key file is required for SSH/SCP-style URLs: %s", url)
-	}
-
-	caBundle := append([]byte(nil), opts.CABundle...) // defensive copy
-	if proxyCAPEM, ok := os.LookupEnv(ProxyCABundleEnvVar); ok && proxyCAPEM != "" {
-		if len(caBundle) > 0 && caBundle[len(caBundle)-1] != '\n' {
-			caBundle = append(caBundle, '\n')
-		}
-		caBundle = append(caBundle, []byte(proxyCAPEM)...)
 	}
 
 	return &Remote{


### PR DESCRIPTION


<!-- Specify the issue ID that this pull request is solving -->
Refers to #5738
<!-- Make sure that the referenced issue provides steps to reproduce it -->

<!-- Describe the changes introduced by this pull request -->

**Summary of the changes**
GitHub App authentication never used `spec.caBundle`, `GetToken()` built its transport from `http.DefaultTransport` unmodified, so the GitHub API token-exchange call only trusted the system CA pool. Behind an inspecting proxy or a private GitHub Enterprise CA, this failed with `x509: certificate signed by unknown authority` even when `caBundle` was correctly configured.

This threads `caBundle` through both callers of the shared GitHub App auth path, the reconciler's pre-flight commit check (`pkg/git`) and the `gitcloner-initializer` Job (`internal/cmd/cli/gitcloner`), plus the imagescan controller's GitHub App lookup. When `caBundle` is empty, behavior is unchanged (falls back to `http.DefaultTransport`).