### PR TITLE
Load shared Renovate preset once

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["github>rancher/renovate-config//default#main"],
   "baseBranchPatterns": [
     "main",
     "release/v0.16",


### PR DESCRIPTION
Load `default` at top level so branch-specific presets do not duplicate custom managers.