### PR TITLE
[v0.16] Constrain Helm values file paths

### DIFF
--- a/internal/bundlereader/loaddirectory.go
+++ b/internal/bundlereader/loaddirectory.go
@@ -300,15 +300,12 @@ func GetContent(ctx context.Context, base, source, version string, auth Auth, di
 			if err != nil {
 				return fmt.Errorf("GetContent: resolving symlink %q: %w", name, err)
 			}
-			cleanRoot := filepath.Clean(temp)
-			rel, relErr := filepath.Rel(cleanRoot, resolved)
-			if relErr != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+			if !pathWithinDir(filepath.Clean(temp), resolved) {
 				return fmt.Errorf("GetContent: symlink %q: target escapes bundle directory", name)
 			}
 			// Target is within bundle; fall through to os.ReadFile which follows the link.
 		}
 
-		//nolint:gosec // G304: path is from WalkDir over a downloaded temp directory
 		content, err := os.ReadFile(path)
 		if err != nil {
 			return err
@@ -426,6 +423,11 @@ func safeJoinSubDir(base, sub string) (string, error) {
 		return "", fmt.Errorf("subdir %q escapes base directory", sub)
 	}
 	return joined, nil
+}
+
+func pathWithinDir(base, path string) bool {
+	rel, err := filepath.Rel(base, path)
+	return err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(os.PathSeparator))
 }
 
 // fetchToDir resolves source (relative to pwd), downloads or copies it, and

--- a/internal/bundlereader/resources.go
+++ b/internal/bundlereader/resources.go
@@ -190,12 +190,16 @@ func generateValues(base string, chart *fleet.HelmOptions) (valuesMap *fleet.Gen
 	if chart.Values != nil {
 		valuesMap = chart.Values
 	}
-	resolvedBase, err := filepath.EvalSymlinks(base)
+	absBase, err := filepath.Abs(base)
+	if err != nil {
+		return nil, fmt.Errorf("resolving values base %q: %w", base, err)
+	}
+	resolvedBase, err := filepath.EvalSymlinks(absBase)
 	if err != nil {
 		return nil, fmt.Errorf("resolving values base %q: %w", base, err)
 	}
 	for _, value := range chart.ValuesFiles {
-		valuesPath, err := safeJoinSubDir(base, value)
+		valuesPath, err := safeJoinSubDir(absBase, value)
 		if err != nil {
 			return nil, fmt.Errorf("invalid values file %q: %w", value, err)
 		}

--- a/internal/bundlereader/resources.go
+++ b/internal/bundlereader/resources.go
@@ -190,15 +190,30 @@ func generateValues(base string, chart *fleet.HelmOptions) (valuesMap *fleet.Gen
 	if chart.Values != nil {
 		valuesMap = chart.Values
 	}
+	resolvedBase, err := filepath.EvalSymlinks(base)
+	if err != nil {
+		return nil, fmt.Errorf("resolving values base %q: %w", base, err)
+	}
 	for _, value := range chart.ValuesFiles {
-		valuesByte, err := os.ReadFile(base + "/" + value)
+		valuesPath, err := safeJoinSubDir(base, value)
 		if err != nil {
-			return nil, fmt.Errorf("reading values file: %s/%s: %w", base, value, err)
+			return nil, fmt.Errorf("invalid values file %q: %w", value, err)
+		}
+		resolvedValuesPath, err := filepath.EvalSymlinks(valuesPath)
+		if err != nil {
+			return nil, fmt.Errorf("resolving values file %q: %w", valuesPath, err)
+		}
+		if !pathWithinDir(resolvedBase, resolvedValuesPath) {
+			return nil, fmt.Errorf("invalid values file %q: target escapes bundle directory", value)
+		}
+		valuesByte, err := os.ReadFile(resolvedValuesPath)
+		if err != nil {
+			return nil, fmt.Errorf("reading values file %q: %w", resolvedValuesPath, err)
 		}
 		tmpDataOpt := &fleet.GenericMap{}
 		err = yaml.Unmarshal(valuesByte, tmpDataOpt)
 		if err != nil {
-			return nil, fmt.Errorf("reading values file: %s/%s: %w", base, value, err)
+			return nil, fmt.Errorf("reading values file %q: %w", resolvedValuesPath, err)
 		}
 		valuesMap = mergeGenericMap(valuesMap, tmpDataOpt)
 	}

--- a/internal/bundlereader/resources_test.go
+++ b/internal/bundlereader/resources_test.go
@@ -154,6 +154,28 @@ func TestGenerateValuesReadsFileWithinBase(t *testing.T) {
 	assert.Equal(t, "bar", valuesMap.Data["foo"])
 }
 
+// A relative base (the common case: gitjob invokes fleet apply with base ".")
+// combined with a values file that is an absolute symlink resolving inside
+// that base must still be accepted.
+func TestGenerateValuesAllowsAbsoluteSymlinkWithinRelativeBase(t *testing.T) {
+	base := t.TempDir()
+	target := filepath.Join(base, "actual-values.yaml")
+	require.NoError(t, os.WriteFile(target, []byte("foo: bar"), 0644))
+	require.NoError(t, os.Symlink(target, filepath.Join(base, "values.yaml")))
+
+	t.Chdir(base)
+
+	chart := &fleet.HelmOptions{
+		GitOpsHelmOptions: fleet.GitOpsHelmOptions{
+			ValuesFiles: []string{"values.yaml"},
+		},
+	}
+
+	valuesMap, err := generateValues(".", chart)
+	require.NoError(t, err)
+	assert.Equal(t, "bar", valuesMap.Data["foo"])
+}
+
 func TestShouldAddAuthToRequest(t *testing.T) {
 	cases := []struct {
 		name             string

--- a/internal/bundlereader/resources_test.go
+++ b/internal/bundlereader/resources_test.go
@@ -3,6 +3,8 @@ package bundlereader
 import (
 	"bytes"
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/sirupsen/logrus"
@@ -99,6 +101,57 @@ func TestValueMerge(t *testing.T) {
 			t.Fatalf("unable to find key replicas in values for service %s", serviceName)
 		}
 	}
+}
+
+func TestGenerateValuesRejectsPathOutsideBase(t *testing.T) {
+	dir := t.TempDir()
+	base := filepath.Join(dir, "bundle")
+	require.NoError(t, os.MkdirAll(base, 0755))
+
+	outsidePath := filepath.Join(dir, "outside-secret.yaml")
+	require.NoError(t, os.WriteFile(outsidePath, []byte("leaked: true"), 0644))
+
+	chart := &fleet.HelmOptions{
+		GitOpsHelmOptions: fleet.GitOpsHelmOptions{
+			ValuesFiles: []string{"../outside-secret.yaml"},
+		},
+	}
+	_, err := generateValues(base, chart)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid values file")
+}
+
+func TestGenerateValuesRejectsSymlinkPointingOutsideBase(t *testing.T) {
+	dir := t.TempDir()
+	base := filepath.Join(dir, "bundle")
+	require.NoError(t, os.MkdirAll(base, 0755))
+
+	outsidePath := filepath.Join(dir, "outside-secret.yaml")
+	require.NoError(t, os.WriteFile(outsidePath, []byte("leaked: true"), 0644))
+	require.NoError(t, os.Symlink(outsidePath, filepath.Join(base, "values.yaml")))
+
+	chart := &fleet.HelmOptions{
+		GitOpsHelmOptions: fleet.GitOpsHelmOptions{
+			ValuesFiles: []string{"values.yaml"},
+		},
+	}
+	_, err := generateValues(base, chart)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "escapes bundle directory")
+}
+
+func TestGenerateValuesReadsFileWithinBase(t *testing.T) {
+	base := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(base, "values.yaml"), []byte("foo: bar"), 0644))
+
+	chart := &fleet.HelmOptions{
+		GitOpsHelmOptions: fleet.GitOpsHelmOptions{
+			ValuesFiles: []string{"values.yaml"},
+		},
+	}
+	valuesMap, err := generateValues(base, chart)
+	require.NoError(t, err)
+	assert.Equal(t, "bar", valuesMap.Data["foo"])
 }
 
 func TestShouldAddAuthToRequest(t *testing.T) {


### PR DESCRIPTION
Resolve each `valuesFiles` entry relative to its bundle or checkout root before reading. Constrain resolved paths to that root.