### PR TITLE
[v0.13] Constrain Helm values file paths

### DIFF
--- a/internal/bundlereader/resources.go
+++ b/internal/bundlereader/resources.go
@@ -184,12 +184,16 @@ func generateValues(base string, chart *fleet.HelmOptions) (valuesMap *fleet.Gen
 	if chart.Values != nil {
 		valuesMap = chart.Values
 	}
-	resolvedBase, err := filepath.EvalSymlinks(base)
+	absBase, err := filepath.Abs(base)
+	if err != nil {
+		return nil, fmt.Errorf("resolving values base %q: %w", base, err)
+	}
+	resolvedBase, err := filepath.EvalSymlinks(absBase)
 	if err != nil {
 		return nil, fmt.Errorf("resolving values base %q: %w", base, err)
 	}
 	for _, value := range chart.ValuesFiles {
-		valuesPath, err := safeJoinSubDir(base, value)
+		valuesPath, err := safeJoinSubDir(absBase, value)
 		if err != nil {
 			return nil, fmt.Errorf("invalid values file %q: %w", value, err)
 		}

--- a/internal/bundlereader/resources.go
+++ b/internal/bundlereader/resources.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"sort"
+	"strings"
 	"sync"
 
 	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
@@ -183,20 +184,59 @@ func generateValues(base string, chart *fleet.HelmOptions) (valuesMap *fleet.Gen
 	if chart.Values != nil {
 		valuesMap = chart.Values
 	}
+	resolvedBase, err := filepath.EvalSymlinks(base)
+	if err != nil {
+		return nil, fmt.Errorf("resolving values base %q: %w", base, err)
+	}
 	for _, value := range chart.ValuesFiles {
-		valuesByte, err := os.ReadFile(base + "/" + value)
+		valuesPath, err := safeJoinSubDir(base, value)
 		if err != nil {
-			return nil, fmt.Errorf("reading values file: %s/%s: %w", base, value, err)
+			return nil, fmt.Errorf("invalid values file %q: %w", value, err)
+		}
+		resolvedValuesPath, err := filepath.EvalSymlinks(valuesPath)
+		if err != nil {
+			return nil, fmt.Errorf("resolving values file %q: %w", valuesPath, err)
+		}
+		if !pathWithinDir(resolvedBase, resolvedValuesPath) {
+			return nil, fmt.Errorf("invalid values file %q: target escapes bundle directory", value)
+		}
+		valuesByte, err := os.ReadFile(resolvedValuesPath)
+		if err != nil {
+			return nil, fmt.Errorf("reading values file %q: %w", resolvedValuesPath, err)
 		}
 		tmpDataOpt := &fleet.GenericMap{}
 		err = yaml.Unmarshal(valuesByte, tmpDataOpt)
 		if err != nil {
-			return nil, fmt.Errorf("reading values file: %s/%s: %w", base, value, err)
+			return nil, fmt.Errorf("reading values file %q: %w", resolvedValuesPath, err)
 		}
 		valuesMap = mergeGenericMap(valuesMap, tmpDataOpt)
 	}
 
 	return valuesMap, nil
+}
+
+func safeJoinSubDir(base, sub string) (string, error) {
+	cleanSub := filepath.Clean(filepath.FromSlash(sub))
+	if filepath.IsAbs(cleanSub) {
+		return "", fmt.Errorf("subdir must be relative, got %q", sub)
+	}
+	if cleanSub == "." {
+		return base, nil
+	}
+	joined := filepath.Join(base, cleanSub)
+	rel, err := filepath.Rel(base, joined)
+	if err != nil {
+		return "", err
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+		return "", fmt.Errorf("subdir %q escapes base directory", sub)
+	}
+	return joined, nil
+}
+
+func pathWithinDir(base, path string) bool {
+	rel, err := filepath.Rel(base, path)
+	return err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(os.PathSeparator))
 }
 
 func mergeGenericMap(first, second *fleet.GenericMap) *fleet.GenericMap {
@@ -237,12 +277,12 @@ func addRemoteCharts(directories []directory, base string, charts []*fleet.HelmO
 			}
 
 			directories = append(directories, directory{
-				prefix:  checksum(chart),
-				base:    base,
-				source:  chartURL,
-				auth:    auth,
-				version: chart.Version,
-					strippedCreds: strippedCredentialsForEmptyRegex,
+				prefix:        checksum(chart),
+				base:          base,
+				source:        chartURL,
+				auth:          auth,
+				version:       chart.Version,
+				strippedCreds: strippedCredentialsForEmptyRegex,
 			})
 		}
 	}

--- a/internal/bundlereader/resources_test.go
+++ b/internal/bundlereader/resources_test.go
@@ -2,6 +2,8 @@ package bundlereader
 
 import (
 	"bytes"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/sirupsen/logrus"
@@ -98,6 +100,60 @@ func TestValueMerge(t *testing.T) {
 			t.Fatalf("unable to find key replicas in values for service %s", serviceName)
 		}
 	}
+}
+
+func TestGenerateValuesRejectsPathOutsideBase(t *testing.T) {
+	dir := t.TempDir()
+	base := filepath.Join(dir, "bundle")
+	require.NoError(t, os.MkdirAll(base, 0755))
+
+	outsidePath := filepath.Join(dir, "outside-secret.yaml")
+	require.NoError(t, os.WriteFile(outsidePath, []byte("leaked: true"), 0644))
+
+	chart := &fleet.HelmOptions{
+		GitOpsHelmOptions: fleet.GitOpsHelmOptions{
+			ValuesFiles: []string{"../outside-secret.yaml"},
+		},
+	}
+
+	_, err := generateValues(base, chart)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid values file")
+}
+
+func TestGenerateValuesRejectsSymlinkPointingOutsideBase(t *testing.T) {
+	dir := t.TempDir()
+	base := filepath.Join(dir, "bundle")
+	require.NoError(t, os.MkdirAll(base, 0755))
+
+	outsidePath := filepath.Join(dir, "outside-secret.yaml")
+	require.NoError(t, os.WriteFile(outsidePath, []byte("leaked: true"), 0644))
+	require.NoError(t, os.Symlink(outsidePath, filepath.Join(base, "values.yaml")))
+
+	chart := &fleet.HelmOptions{
+		GitOpsHelmOptions: fleet.GitOpsHelmOptions{
+			ValuesFiles: []string{"values.yaml"},
+		},
+	}
+
+	_, err := generateValues(base, chart)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "escapes bundle directory")
+}
+
+func TestGenerateValuesReadsFileWithinBase(t *testing.T) {
+	base := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(base, "values.yaml"), []byte("foo: bar"), 0644))
+
+	chart := &fleet.HelmOptions{
+		GitOpsHelmOptions: fleet.GitOpsHelmOptions{
+			ValuesFiles: []string{"values.yaml"},
+		},
+	}
+
+	valuesMap, err := generateValues(base, chart)
+	require.NoError(t, err)
+	assert.Equal(t, "bar", valuesMap.Data["foo"])
 }
 
 func TestShouldAddAuthToRequest(t *testing.T) {

--- a/internal/bundlereader/resources_test.go
+++ b/internal/bundlereader/resources_test.go
@@ -156,6 +156,28 @@ func TestGenerateValuesReadsFileWithinBase(t *testing.T) {
 	assert.Equal(t, "bar", valuesMap.Data["foo"])
 }
 
+// A relative base (the common case: gitjob invokes fleet apply with base ".")
+// combined with a values file that is an absolute symlink resolving inside
+// that base must still be accepted.
+func TestGenerateValuesAllowsAbsoluteSymlinkWithinRelativeBase(t *testing.T) {
+	base := t.TempDir()
+	target := filepath.Join(base, "actual-values.yaml")
+	require.NoError(t, os.WriteFile(target, []byte("foo: bar"), 0644))
+	require.NoError(t, os.Symlink(target, filepath.Join(base, "values.yaml")))
+
+	t.Chdir(base)
+
+	chart := &fleet.HelmOptions{
+		GitOpsHelmOptions: fleet.GitOpsHelmOptions{
+			ValuesFiles: []string{"values.yaml"},
+		},
+	}
+
+	valuesMap, err := generateValues(".", chart)
+	require.NoError(t, err)
+	assert.Equal(t, "bar", valuesMap.Data["foo"])
+}
+
 func TestShouldAddAuthToRequest(t *testing.T) {
 	cases := []struct {
 		name             string


### PR DESCRIPTION


Resolve each `valuesFiles` entry relative to its bundle or checkout root before reading. Constrain resolved paths to that root.