### PR TITLE
Confine webhook-triggered Spec mutation to verified requests

### DIFF
--- a/integrationtests/gitjob/controller/webhook_handler_test.go
+++ b/integrationtests/gitjob/controller/webhook_handler_test.go
@@ -2,6 +2,9 @@ package controller
 
 import (
 	"bytes"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
 	"net/http"
 	"net/http/httptest"
 	"time"
@@ -9,6 +12,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -19,8 +23,11 @@ import (
 // webhookTestRepo is a unique URL that won't match any GitRepo created by other tests.
 const webhookTestRepo = "https://github.com/rancher/fleet-webhook-integration-test"
 
-// sendGitHubPush fires a simulated GitHub push event for the given commit against
-// the integration test's k8sClient (backed by the envtest API server).
+// webhookSecretName mirrors the unexported webhookSecretName constant in pkg/webhook.
+const webhookSecretName = "gitjob-webhook"
+
+// sendGitHubPush fires a simulated, unauthenticated GitHub push event for the given
+// commit against the integration test's k8sClient (backed by the envtest API server).
 func sendGitHubPush(commit string) {
 	w, err := webhook.New(gitRepoNamespace, k8sClient)
 	Expect(err).ToNot(HaveOccurred())
@@ -30,6 +37,27 @@ func sendGitHubPush(commit string) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "/", bytes.NewReader(body))
 	Expect(err).ToNot(HaveOccurred())
 	req.Header.Set("X-GitHub-Event", "push")
+
+	rr := httptest.NewRecorder()
+	w.ServeHTTP(rr, req)
+	Expect(rr.Code).To(Equal(http.StatusOK))
+}
+
+// sendGitHubPushSigned fires a GitHub push event signed with secretValue, simulating a
+// properly configured, verified webhook delivery.
+func sendGitHubPushSigned(commit, secretValue string) {
+	w, err := webhook.New(gitRepoNamespace, k8sClient)
+	Expect(err).ToNot(HaveOccurred())
+
+	body := []byte(`{"ref":"refs/heads/main","after":"` + commit +
+		`","repository":{"html_url":"` + webhookTestRepo + `"}}`)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "/", bytes.NewReader(body))
+	Expect(err).ToNot(HaveOccurred())
+	req.Header.Set("X-GitHub-Event", "push")
+
+	mac := hmac.New(sha256.New, []byte(secretValue))
+	mac.Write(body)
+	req.Header.Set("X-Hub-Signature-256", "sha256="+hex.EncodeToString(mac.Sum(nil)))
 
 	rr := httptest.NewRecorder()
 	w.ServeHTTP(rr, req)
@@ -63,11 +91,42 @@ var _ = Describe("Webhook handler", func() {
 		waitDeleteGitrepo(gitRepo)
 	})
 
-	When("no PollingInterval is configured", func() {
+	When("no PollingInterval is configured and the request is unauthenticated", func() {
 		const pushCommit = "aaaa1111bbbb2222cccc3333dddd4444eeee5555"
 
-		It("sets WebhookCommit and PollingInterval to 1h", func() {
+		It("sets WebhookCommit but does not mutate PollingInterval", func() {
 			sendGitHubPush(pushCommit)
+
+			var updated v1alpha1.GitRepo
+			Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name: gitRepo.Name, Namespace: gitRepo.Namespace,
+			}, &updated)).To(Succeed())
+
+			Expect(updated.Status.WebhookCommit).To(Equal(pushCommit))
+			Expect(updated.Spec.PollingInterval).To(BeNil())
+		})
+	})
+
+	When("no PollingInterval is configured and the request is verified against a secret", func() {
+		const pushCommit = "aaaa2222bbbb3333cccc4444dddd5555eeee6666"
+		const secretValue = "test-webhook-secret"
+
+		BeforeEach(func() {
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      webhookSecretName,
+					Namespace: gitRepoNamespace,
+				},
+				Data: map[string][]byte{"github": []byte(secretValue)},
+			}
+			Expect(k8sClient.Create(ctx, secret)).To(Succeed())
+			DeferCleanup(func() {
+				Expect(k8sClient.Delete(ctx, secret)).To(Succeed())
+			})
+		})
+
+		It("sets WebhookCommit and PollingInterval to 1h", func() {
+			sendGitHubPushSigned(pushCommit, secretValue)
 
 			var updated v1alpha1.GitRepo
 			Expect(k8sClient.Get(ctx, types.NamespacedName{

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -199,7 +199,10 @@ func (w *Webhook) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 				// if PollingInterval is not set, set it to 1 hour to reduce polling load
 				// now that a webhook handles commit notifications. Use a separate spec
 				// patch because Status().Patch() only applies status subresource changes.
-				if orig.Spec.PollingInterval == nil {
+				// Only do this once the request's signature has been verified: without a
+				// verified secret, an unauthenticated caller must not be able to mutate
+				// GitRepo.Spec.
+				if secret != nil && orig.Spec.PollingInterval == nil {
 					specOrig := gitRepoFromCluster.DeepCopy()
 					gitRepoFromCluster.Spec.PollingInterval = &metav1.Duration{
 						Duration: webhookDefaultSyncInterval * time.Second,

--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -477,6 +477,67 @@ func TestGitHubWrongSecret(t *testing.T) {
 	}
 }
 
+func TestNoWebhookSecretDoesNotMutateSpec(t *testing.T) {
+	// No webhookSecretName Secret exists, and the GitRepo has no Spec.WebhookSecret set —
+	// this is Fleet's default, out-of-the-box configuration.
+	gitRepo := &v1alpha1.GitRepo{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "default",
+		},
+		Spec: v1alpha1.GitRepoSpec{
+			Repo:   "https://github.com/example/repo",
+			Branch: "main",
+		},
+	}
+
+	sch := scheme.Scheme
+	if err := v1alpha1.AddToScheme(sch); err != nil {
+		t.Fatalf("unable to add to scheme: %v", err)
+	}
+	client := cfake.NewClientBuilder().WithScheme(sch).WithRuntimeObjects(gitRepo).WithStatusSubresource(gitRepo).Build()
+
+	w := &Webhook{
+		client:    client,
+		namespace: "default",
+	}
+
+	const commit = "af69d162de5a276abc86e0686b2b44033cd3f442"
+	jsonBody := []byte(`
+	{
+	  "ref":"refs/heads/main",
+	  "after":"` + commit + `",
+	  "repository":{
+		"html_url":"https://github.com/example/repo"
+      }
+    }`)
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, "/", bytes.NewReader(jsonBody))
+	if err != nil {
+		t.Fatalf("Failed to create HTTP request: %v", err)
+	}
+	req.Header.Set("X-Github-Event", "push")
+	// Deliberately no X-Hub-Signature-256 header: an unauthenticated forged request.
+
+	rr := httptest.NewRecorder()
+	w.ServeHTTP(rr, req)
+
+	if status := rr.Code; status != http.StatusOK {
+		t.Fatalf("handler returned wrong status code: got %v want %v", status, http.StatusOK)
+	}
+
+	updatedGitRepo := &v1alpha1.GitRepo{}
+	if err := client.Get(context.TODO(), types.NamespacedName{Name: gitRepo.Name, Namespace: gitRepo.Namespace}, updatedGitRepo); err != nil {
+		t.Fatalf("unexpected err %v", err)
+	}
+	if updatedGitRepo.Status.WebhookCommit != commit {
+		t.Errorf("expected webhook commit %v, but got %v", commit, updatedGitRepo.Status.WebhookCommit)
+	}
+	if updatedGitRepo.Spec.PollingInterval != nil {
+		t.Errorf("unauthenticated webhook request must not mutate Spec.PollingInterval, got %v", updatedGitRepo.Spec.PollingInterval)
+	}
+}
+
 func TestGitHubSecretAndCommitUpdated(t *testing.T) {
 	expectedCommit := "af69d162de5a276abc86e0686b2b44033cd3f442"
 	gitrepoSecretName := "gitrepoSecret"
@@ -491,6 +552,10 @@ func TestGitHubSecretAndCommitUpdated(t *testing.T) {
 		setSecretInGitrepo   bool
 		expectedResCode      int
 		expectedCommitUpdate bool
+		// expectedSpecPatch is true only when the request was verified against an
+		// actually configured secret; Spec.PollingInterval must never be mutated
+		// by an unverified/unauthenticated request.
+		expectedSpecPatch bool
 	}{
 		"global-secret-ok-no-gitrepo-secret": {
 			secretValueInRequest: "supersecretvalue",
@@ -503,6 +568,7 @@ func TestGitHubSecretAndCommitUpdated(t *testing.T) {
 			setSecretInGitrepo:   false,
 			expectedResCode:      http.StatusOK,
 			expectedCommitUpdate: true,
+			expectedSpecPatch:    true,
 		},
 		"global-secret-wrong-no-gitrepo-secret": {
 			secretValueInRequest: "supersecretvalue",
@@ -527,6 +593,7 @@ func TestGitHubSecretAndCommitUpdated(t *testing.T) {
 			setSecretInGitrepo:   true,
 			expectedResCode:      http.StatusOK,
 			expectedCommitUpdate: true,
+			expectedSpecPatch:    true,
 		},
 		// does not matter that global secret is wrong because
 		// gitrepo secret takes preference
@@ -541,6 +608,7 @@ func TestGitHubSecretAndCommitUpdated(t *testing.T) {
 			setSecretInGitrepo:   true,
 			expectedResCode:      http.StatusOK,
 			expectedCommitUpdate: true,
+			expectedSpecPatch:    true,
 		},
 		// does not matter that global secret is correct because
 		// gitrepo secret takes preference
@@ -579,6 +647,7 @@ func TestGitHubSecretAndCommitUpdated(t *testing.T) {
 			setSecretInGitrepo:   true,
 			expectedResCode:      http.StatusOK,
 			expectedCommitUpdate: true,
+			expectedSpecPatch:    true,
 		},
 		"global-secret-wrong-key-no-gitrepo-secret": {
 			secretValueInRequest: "supersecretvalue",
@@ -618,6 +687,7 @@ func TestGitHubSecretAndCommitUpdated(t *testing.T) {
 			setSecretInGitrepo:   false,
 			expectedResCode:      http.StatusOK,
 			expectedCommitUpdate: true,
+			expectedSpecPatch:    false, // no secret at all: request is unverified, must not mutate Spec
 		},
 
 		// when a referenced secret does not exist, we throw an error
@@ -719,14 +789,19 @@ func TestGitHubSecretAndCommitUpdated(t *testing.T) {
 					}
 				},
 			).Times(1)
-			// PollingInterval is nil on the GitRepo fixture, so a separate spec Patch() must follow
-			mockClient.EXPECT().Patch(gomock.Any(), gomock.Any(), gomock.Any()).Do(
-				func(ctx context.Context, repo *v1alpha1.GitRepo, _ client.Patch, opts ...any) {
-					if repo.Spec.PollingInterval == nil || repo.Spec.PollingInterval.Duration != time.Hour {
-						t.Errorf("expecting polling interval 1h in spec patch, got %v", repo.Spec.PollingInterval)
-					}
-				},
-			).Times(1)
+			// PollingInterval is nil on the GitRepo fixture; a separate spec Patch() must
+			// follow only when the request was verified against an actually configured secret.
+			if tt.expectedSpecPatch {
+				mockClient.EXPECT().Patch(gomock.Any(), gomock.Any(), gomock.Any()).Do(
+					func(ctx context.Context, repo *v1alpha1.GitRepo, _ client.Patch, opts ...any) {
+						if repo.Spec.PollingInterval == nil || repo.Spec.PollingInterval.Duration != time.Hour {
+							t.Errorf("expecting polling interval 1h in spec patch, got %v", repo.Spec.PollingInterval)
+						}
+					},
+				).Times(1)
+			} else {
+				mockClient.EXPECT().Patch(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+			}
 		}
 
 		w := &Webhook{
@@ -969,14 +1044,8 @@ func TestGitRepoURLMatch(t *testing.T) {
 					}
 				},
 			).Times(1)
-			// PollingInterval is nil on the fixtures, so a spec Patch() must follow for the matching one
-			mockClient.EXPECT().Patch(gomock.Any(), gomock.Any(), gomock.Any()).Do(
-				func(ctx context.Context, repo *v1alpha1.GitRepo, _ client.Patch, opts ...any) {
-					if repo.Spec.PollingInterval == nil || repo.Spec.PollingInterval.Duration != time.Hour {
-						t.Errorf("expecting polling interval 1h in spec patch, got %v", repo.Spec.PollingInterval)
-					}
-				},
-			).Times(1)
+			// No webhook secret is configured, so request is unverified and must not mutate Spec.
+			mockClient.EXPECT().Patch(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 
 			req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, "/", bytes.NewReader([]byte(tc.body)))
 			if err != nil {


### PR DESCRIPTION
The git webhook receiver sets GitRepo.Status.WebhookCommit and, when PollingInterval was unset, patches Spec.PollingInterval to 1h to reduce polling load. Previously both writes ran before secret verification, so the Spec patch applied regardless of whether the request carried a valid webhook secret.

Only apply the Spec.PollingInterval patch once the request has been verified against a configured secret. The Status update (used purely as a reconciliation trigger, and always re-checked against the real remote HEAD) is unaffected.